### PR TITLE
Fixed exception in steroid_action_discovery (missing read action)

### DIFF
--- a/ij-plugin/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/ActionDiscoveryToolHandler.kt
+++ b/ij-plugin/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/ActionDiscoveryToolHandler.kt
@@ -379,11 +379,12 @@ class ActionDiscoveryToolHandler : McpRegistrar {
             } else {
                 emptyList()
             }
+            val tooltipText = readAction { renderer.tooltipText }
             GutterIconInfo(
                 line = document.getLineNumber(marker.startOffset) + 1,
                 startOffset = marker.startOffset,
                 endOffset = marker.endOffset,
-                tooltip = renderer.tooltipText,
+                tooltip = tooltipText,
                 clickAction = clickAction,
                 popupActions = popupActions
             )


### PR DESCRIPTION
## Summary

`steroid_action_discovery` throws `KaInaccessibleLifetimeOwnerAccessException` when called on a Kotlin file that has override/implementation gutter icons (e.g. `SuperDeclarationMarkerTooltip`).

## Reproduction

```
mcpc @steroid tools-call steroid_action_discovery \
  project_name:='"mcp-steroid"' \
  file_path:='"ij-plugin/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/ExecuteCodeToolHandler.kt"'
```

## Error

```
Tool execution error: org.jetbrains.kotlin.analysis.api.platform.lifetime.KotlinReadActionConfinementLifetimeToken@233fad13 is inaccessible: Called outside a read action.

org.jetbrains.kotlin.analysis.api.lifetime.KaInaccessibleLifetimeOwnerAccessException
    at KaBaseSymbolProvider.getSymbol(KaBaseSymbolProvider.kt:59)
    at SuperDeclarationMarkerTooltip.fun(KotlinLineMarkerProvider.kt:264)
    at LineMarkerInfo.getLineMarkerTooltip(LineMarkerInfo.java:194)
    at LineMarkerInfo$LineMarkerGutterIconRenderer.getTooltipText(LineMarkerInfo.java:256)
    at ActionDiscoveryToolHandler.collectGutterIcons(ActionDiscoveryToolHandler.kt:386)
```

## Root Cause

`collectGutterIcons` in `ActionDiscoveryToolHandler.kt:386` calls `renderer.tooltipText` outside a read action:

```kotlin
// line 373 — outside readAction { }
return lineMarkers.mapNotNull { marker ->
    val renderer = marker.createGutterRenderer() ?: return@mapNotNull null
    ...
    GutterIconInfo(
        ...
        tooltip = renderer.tooltipText,  // ← line 386: crashes for Kotlin markers
        ...
    )
}
```

The `readAction { }` block ends at line 372 (after collecting `lineMarkers`). The subsequent `mapNotNull` block runs outside any read action. When `renderer.tooltipText` is called for a Kotlin gutter icon (`SuperDeclarationMarkerTooltip`), it accesses the Kotlin Analysis API which requires a read action — and throws.

## Fix

Wrap `renderer.tooltipText` in a `readAction { }`:

```kotlin
tooltip = readAction { renderer.tooltipText },
```

## Affected Files

- `ij-plugin/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/ActionDiscoveryToolHandler.kt:386`

## Fix commit

`af253673` — Adjusted read action for reading tooltip text as it required read action in some cases.
