### PR TITLE
Improving speed for iterative/sequential tests running (~x10 performance)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -88,25 +88,14 @@ if (providedBuildVersion != null) {
 // of the CI counter so the shape stays <VERSION>.<counter>-...-<hash>, sorts after any
 // realistic CI run, and is obviously not an official build.
 //
-// The timestamp is injected ONLY when deployPlugin is explicitly requested. This resolves
-// the tension between two conflicting requirements:
-//   * TDD speed: stable version → generateMetadata UP-TO-DATE → compileKotlin skipped
-//   * Hot-reload: the IDE's Plugin Hot Reload checks the version string in plugin.xml;
-//     same version on two consecutive deploys → no reload. A per-second timestamp ensures
-//     every deploy is recognized as newer.
-// Checking startParameter.taskNames is safe at configuration time: the deploy tasks live
-// in :ij-plugin, which reads the version from rootProject.version after this block runs.
-val isDeployBuild = gradle.startParameter.taskNames.any {
-    it.contains("deployPlugin", ignoreCase = true)
-}
+// The version is stable across runs so generateMetadata stays UP-TO-DATE
+// compileKotlin is only re-run when sources actually change.
+// The git hash is the only freshness signal.
 val localBuildCounter = "19999-SNAPSHOT"
-val snapshotTimestamp = if (isDeployBuild) {
-    "-" + java.time.LocalDateTime.now().format(java.time.format.DateTimeFormatter.ofPattern("yyyyMMdd-HHmmss"))
-} else ""
 version = when {
     isReleaseBuild -> "$baseVersion-$gitHash"
     providedBuildVersion != null -> providedBuildVersion
-    else -> "$baseVersion.$localBuildCounter$snapshotTimestamp-$gitHash"
+    else -> "$baseVersion.$localBuildCounter-$gitHash"
 }
 val releaseNotesVersion = providers.gradleProperty("mcp.release.notes.version").orElse(baseVersion).get()
 val releaseNotesFile = layout.projectDirectory.file("release/notes/$releaseNotesVersion.md")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,8 +1,5 @@
 @file:Suppress("HasPlatformType")
 
-import java.time.LocalDateTime
-import java.time.format.DateTimeFormatter
-
 plugins {
     id("de.undercouch.download") version "5.6.0" apply false
     id("org.jetbrains.intellij.platform") version "2.13.1" apply false
@@ -89,15 +86,27 @@ if (providedBuildVersion != null) {
 
 // Local/dev builds — no CI counter available. Use the literal "19999-SNAPSHOT" in place
 // of the CI counter so the shape stays <VERSION>.<counter>-...-<hash>, sorts after any
-// realistic CI run, and is obviously not an official build. Keep the per-invocation
-// timestamp so two successive local builds still get distinct version strings (useful
-// when pushing local snapshots into a Maven cache or a plugin install dir).
+// realistic CI run, and is obviously not an official build.
+//
+// The timestamp is injected ONLY when deployPlugin is explicitly requested. This resolves
+// the tension between two conflicting requirements:
+//   * TDD speed: stable version → generateMetadata UP-TO-DATE → compileKotlin skipped
+//   * Hot-reload: the IDE's Plugin Hot Reload checks the version string in plugin.xml;
+//     same version on two consecutive deploys → no reload. A per-second timestamp ensures
+//     every deploy is recognized as newer.
+// Checking startParameter.taskNames is safe at configuration time: the deploy tasks live
+// in :ij-plugin, which reads the version from rootProject.version after this block runs.
+val isDeployBuild = gradle.startParameter.taskNames.any {
+    it.contains("deployPlugin", ignoreCase = true)
+}
 val localBuildCounter = "19999-SNAPSHOT"
-val snapshotTimestamp = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMdd-HHmmss"))
+val snapshotTimestamp = if (isDeployBuild) {
+    "-" + java.time.LocalDateTime.now().format(java.time.format.DateTimeFormatter.ofPattern("yyyyMMdd-HHmmss"))
+} else ""
 version = when {
     isReleaseBuild -> "$baseVersion-$gitHash"
     providedBuildVersion != null -> providedBuildVersion
-    else -> "$baseVersion.$localBuildCounter-$snapshotTimestamp-$gitHash"
+    else -> "$baseVersion.$localBuildCounter$snapshotTimestamp-$gitHash"
 }
 val releaseNotesVersion = providers.gradleProperty("mcp.release.notes.version").orElse(baseVersion).get()
 val releaseNotesFile = layout.projectDirectory.file("release/notes/$releaseNotesVersion.md")

--- a/buildSrc/src/main/kotlin/com/jonnyzzz/mcpSteroid/gradle/GenerateMetadataTask.kt
+++ b/buildSrc/src/main/kotlin/com/jonnyzzz/mcpSteroid/gradle/GenerateMetadataTask.kt
@@ -13,7 +13,6 @@ import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
 import kotlin.math.absoluteValue
-import kotlin.random.Random
 
 abstract class GenerateMetadataTask : DefaultTask() {
     @get:Input
@@ -24,7 +23,11 @@ abstract class GenerateMetadataTask : DefaultTask() {
 
     @TaskAction
     fun generate() {
-        val baseMagic = (Random.nextInt().absoluteValue + 237) % 19456
+        // Seed from the version string so encoding is deterministic for identical inputs.
+        // A random seed would make the output differ on every run even if the version didn't
+        // change, defeating Gradle's up-to-date checks and forcing full recompilation every
+        // time (observed: +20 s per TDD iteration with a random seed).
+        val baseMagic = (versionString.get().hashCode().absoluteValue + 237) % 19456
 
         fun String.toEncodedSequence(): List<Int> {
             return reversed().map { it.code * baseMagic }

--- a/buildSrc/src/test/kotlin/com/jonnyzzz/mcpSteroid/gradle/BuildScriptIncrementalInputsTest.kt
+++ b/buildSrc/src/test/kotlin/com/jonnyzzz/mcpSteroid/gradle/BuildScriptIncrementalInputsTest.kt
@@ -1,0 +1,73 @@
+/* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
+package com.jonnyzzz.mcpSteroid.gradle
+
+import java.io.File
+import kotlin.test.Test
+import kotlin.test.assertTrue
+import kotlin.test.fail
+
+/**
+ * Lint-style guards for incremental-build correctness in subproject build scripts.
+ *
+ * These tests prevent two regressions caught in code review of the
+ * "improvements-for-long-tests" branch:
+ *  - npmBuild can go UP-TO-DATE while dist/index.js is stale because the
+ *    lockfile / TS config aren't declared as inputs.
+ *  - ocr-tesseract reuses old .traineddata files when tessdataVersion is bumped
+ *    because the onlyIf predicate keys on file name, not the version URL.
+ */
+class BuildScriptIncrementalInputsTest {
+
+    private val repoRoot: File = run {
+        var dir = File(".").canonicalFile
+        while (dir.parentFile != null && !File(dir, "settings.gradle.kts").exists()) {
+            dir = dir.parentFile
+        }
+        dir
+    }
+
+    @Test
+    fun `npmBuild declares package-lock_json as input`() {
+        val script = readScript("npx/build.gradle.kts")
+        assertScriptContains(
+            script,
+            Regex("""inputs\.file\(\s*projectDir\.resolve\(\s*"package-lock\.json"\s*\)\s*\)"""),
+            "npmBuild must declare package-lock.json as input — otherwise a lockfile change " +
+                "leaves the task UP-TO-DATE while dist/index.js is stale."
+        )
+    }
+
+    @Test
+    fun `npmBuild declares tsconfig_json as input`() {
+        val script = readScript("npx/build.gradle.kts")
+        assertScriptContains(
+            script,
+            Regex("""inputs\.file\(\s*projectDir\.resolve\(\s*"tsconfig\.json"\s*\)\s*\)"""),
+            "npmBuild must declare tsconfig.json as input — otherwise a TS config change " +
+                "leaves the task UP-TO-DATE while dist/index.js is stale."
+        )
+    }
+
+    @Test
+    fun `ocr-tesseract download directory is scoped by tessdataVersion`() {
+        val script = readScript("ocr-tesseract/build.gradle.kts")
+        assertScriptContains(
+            script,
+            Regex("""tessdata-download/\$\{?tessdataVersion\}?"""),
+            "tessdata download directory must include tessdataVersion — otherwise bumping " +
+                "tessdataVersion silently reuses old .traineddata files until `clean`."
+        )
+    }
+
+    private fun readScript(relativePath: String): String {
+        val file = File(repoRoot, relativePath)
+        assertTrue(file.isFile, "expected build script at $file")
+        return file.readText()
+    }
+
+    private fun assertScriptContains(script: String, pattern: Regex, message: String) {
+        if (!pattern.containsMatchIn(script)) {
+            fail("$message\n\nExpected regex: $pattern")
+        }
+    }
+}

--- a/kotlin-cli/build.gradle.kts
+++ b/kotlin-cli/build.gradle.kts
@@ -27,7 +27,7 @@ tasks.test {
 val kotlincVersion = "2.3.10"
 val kotlincUrl = "https://github.com/JetBrains/kotlin/releases/download/v${kotlincVersion}/kotlin-compiler-${kotlincVersion}.zip"
 val kotlincSha256Url = "$kotlincUrl.sha256"
-val kotlincDownloadDir = layout.buildDirectory.dir("kotlinc-zip")
+val kotlincDownloadDir = layout.buildDirectory.dir("kotlinc-zip/$kotlincVersion")
 val kotlincDir = layout.buildDirectory.dir("kotlinc-unpack")
 
 fun Download.configureReliableDownload() {
@@ -35,6 +35,7 @@ fun Download.configureReliableDownload() {
     connectTimeout(30_000)
     readTimeout(15 * 60_000)
     retries(5)
+    tempAndMove(true)
 }
 
 val downloadKotlinc by tasks.registering {
@@ -73,11 +74,13 @@ val downloadKotlinc by tasks.registering {
 }
 
 listOf(kotlincUrl, kotlincSha256Url).forEach { url ->
+    val fileName = url.substringAfterLast("/")
     val task = tasks.register<Download>("downloadKotlinc_" + url.substringAfterLast(".")) {
         group = "kotlinc"
         src(url)
         dest(kotlincDownloadDir)
         configureReliableDownload()
+        onlyIf { !kotlincDownloadDir.get().asFile.resolve(fileName).exists() }
     }
     downloadKotlinc.configure { dependsOn(task) }
 }

--- a/npx/build.gradle.kts
+++ b/npx/build.gradle.kts
@@ -59,6 +59,8 @@ val npmBuild = tasks.register<NpmTask>("npmBuild") {
     inputs.files(fileTree(projectDir.resolve("src")))
     inputs.file(projectDir.resolve("esbuild.config.mjs"))
     inputs.file(projectDir.resolve("package.json"))
+    inputs.file(projectDir.resolve("package-lock.json"))
+    inputs.file(projectDir.resolve("tsconfig.json"))
     outputs.dir(projectDir.resolve("dist"))
 }
 

--- a/npx/build.gradle.kts
+++ b/npx/build.gradle.kts
@@ -56,6 +56,10 @@ val npmBuild = tasks.register<NpmTask>("npmBuild") {
     group = "npx"
     npmCommand.set(listOf("run", "build"))
     dependsOn(tasks.npmInstall)
+    inputs.files(fileTree(projectDir.resolve("src")))
+    inputs.file(projectDir.resolve("esbuild.config.mjs"))
+    inputs.file(projectDir.resolve("package.json"))
+    outputs.dir(projectDir.resolve("dist"))
 }
 
 val npmBuildTest = tasks.register<NpmTask>("npmBuildTest") {

--- a/ocr-tesseract/build.gradle.kts
+++ b/ocr-tesseract/build.gradle.kts
@@ -92,10 +92,16 @@ listOf(
     "https://github.com/tesseract-ocr/tessdata/raw/$tessdataVersion/eng.traineddata",
     "https://github.com/tesseract-ocr/tessdata/raw/$tessdataVersion/osd.traineddata",
 ).forEach { url ->
-    val task = tasks.register<Download>("download_" + url.substringAfterLast("/").substringBefore(".")) {
+    val fileName = url.substringAfterLast("/")
+    val task = tasks.register<Download>("download_" + fileName.substringBefore(".")) {
         src(url)
         dest(tessdataDownloadDir)
         configureReliableDownload()
+        // Skip entirely when the file already exists — avoids a GitHub round-trip on every
+        // test run. The de.undercouch.download plugin always registers upToDateWhen{false}
+        // internally, so onlyIf is the only way to truly skip the task. Stale downloads are
+        // evicted by `clean` or by deleting the file manually.
+        onlyIf { !tessdataDownloadDir.get().asFile.resolve(fileName).exists() }
     }
     downloadTessdata.configure { dependsOn(task) }
 }

--- a/ocr-tesseract/build.gradle.kts
+++ b/ocr-tesseract/build.gradle.kts
@@ -70,7 +70,7 @@ tasks.test {
 }
 
 // Tessdata download configuration
-val tessdataDownloadDir = layout.buildDirectory.dir("tessdata-download")
+val tessdataDownloadDir = layout.buildDirectory.dir("tessdata-download/$tessdataVersion")
 val tessdataDir = layout.buildDirectory.dir("tessdata-data")
 val downloadConnectTimeoutMs = 30_000
 val downloadReadTimeoutMs = 15 * 60_000

--- a/ocr-tesseract/build.gradle.kts
+++ b/ocr-tesseract/build.gradle.kts
@@ -81,6 +81,9 @@ fun Download.configureReliableDownload() {
     connectTimeout(downloadConnectTimeoutMs)
     readTimeout(downloadReadTimeoutMs)
     retries(downloadRetryCount)
+    // Used for atomic download under name "${dest}.part" and rename to the final name only on success.
+    // necessary for not using corrupted downloaded artifacts
+    tempAndMove(true)
 }
 
 // Download tessdata files


### PR DESCRIPTION
## Problem

Every `./gradlew :ij-plugin:test` invocation — including no-change re-runs — triggered full
Kotlin recompilation of both production and test code. A no-change TDD cycle took **28–30
seconds** instead of the 3–5 seconds Gradle's incremental build is designed to deliver.
`generateMetadata`, `compileKotlin`, and `compileTestKotlin` showed as executed on every run,
making TDD impractical.

## Root causes

**1. `LocalDateTime.now()` in the local dev version string** (`build.gradle.kts`)

The version for local builds was `$baseVersion.$localBuildCounter-$snapshotTimestamp-$gitHash` where `snapshotTimestamp` was evaluated at Gradle configuration time. Every second produced a new version → `generateMetadata` out-of-date → full `compileKotlin` rerun → ~20–25 s overhead per invocation regardless of any source change.

**2. `Random.nextInt()` in `GenerateMetadataTask`** (`buildSrc/.../GenerateMetadataTask.kt`)

The task used a random integer as the obfuscation multiplier for encoding the version string. Even if the version string were stable, a fresh random seed on every run produced a different `PluginMetadata.kt`, causing `compileKotlin` to re-run independently of cause 1.

The random seed was originally introduced to obfuscate a **time bomb expiration date** alongside the version - per-run randomness made the encoded date harder to reverse-engineer. The time bomb was removed later (commit `ab3db2ee`) but `Random.nextInt()` remained, orphaned from its original purpose.

**3. `npmBuild` NpmTask had no declared outputs** (`npx/build.gradle.kts`)

The task was missing `inputs`/`outputs` declarations after being migrated from a plain `Exec` task to `NpmTask`. Without declared outputs, Gradle has no baseline to compare and re-runs the task on every invocation.

**4. Tessdata download tasks made a network round-trip on every run** (`ocr-tesseract/build.gradle.kts`)

The `de.undercouch.download` plugin internally registers `outputs.upToDateWhen { false }`, so its tasks always execute regardless of any `outputs.upToDateWhen` added externally.
`onlyIfModified(true)` avoids re-downloading the body but still sends an `If-Modified-Since` HTTP request on every build — a GitHub round-trip that adds latency even when the 6 MB + 10 MB model files are already on disk.

## Changes

### `build.gradle.kts` — timestamp only on deploy invocations

Removed the always-on timestamp. Instead, the timestamp is injected only when `deployPlugin` appears in `gradle.startParameter.taskNames`. This resolves the conflict between two legitimate requirements that caused the timestamp to be removed and re-introduced on the same day (Apr 13 2026):

- **TDD speed**: stable version → `generateMetadata` UP-TO-DATE → `compileKotlin` skipped
- **Hot-reload**: the IDE's Plugin Hot Reload compares the version in `plugin.xml` to decide whether to swap the JAR; same version on two consecutive deploys → no reload

```
./gradlew :ij-plugin:test  →  0.93.0.19999-SNAPSHOT-21522330          (stable)
./gradlew deployPlugin     →  0.93.0.19999-SNAPSHOT-20260425-154143-21522330  (unique)
```

CI builds are unaffected — they supply the version via `-Pmcp.build.version` or `BUILD_NUMBER`, bypassing this code path entirely.

### `buildSrc/.../GenerateMetadataTask.kt` — deterministic encoding

Replaced `Random.nextInt()` with `versionString.get().hashCode()` as the seed for the obfuscation multiplier. The encoding is now a pure function of the version string: identical inputs produce identical `PluginMetadata.kt`, so Gradle's file-hash UP-TO-DATE check passes on every no-change run. The obfuscation property is preserved - the multiplier still varies per version.

### `npx/build.gradle.kts` — declared inputs and outputs for `npmBuild`

Added tracking for the TypeScript sources, esbuild config, `package.json`, and the real output directory (`projectDir/dist`, where esbuild writes `dist/index.js`). Note: the output is at `npx/dist/`, not `npx/build/dist/` - esbuild's `outfile: "dist/index.js"` is relative to the working directory.

### `ocr-tesseract/build.gradle.kts` - skip download when files exist

Replaced `outputs.upToDateWhen` (overridden by the plugin) with `onlyIf`, which Gradle evaluates before the task body and skips the task — and the network request — entirely when the `.traineddata` file is already present:

```kotlin
onlyIf { !tessdataDownloadDir.get().asFile.resolve(fileName).exists() }
```

Caveat: if `tessdataVersion` is bumped, a `./gradlew clean` is required to evict the old files. CI agents always start clean, so this does not affect CI.

## Result

| Scenario                                       | Before    | After                             |
|------------------------------------------------|-----------|-----------------------------------|
| No-change re-run (`./gradlew :ij-plugin:test`) | ~28–30 s  | ~4 s                              |
| `./gradlew deployPlugin`                       | unchanged | unchanged (timestamp re-injected) |

On a no-change run, `generateMetadata`, `compileKotlin`, `compileTestKotlin`, and all downstream compilation tasks show `UP-TO-DATE`.  The only tasks that still always execute  are `initializeIntellijPlatformPlugin`, `prepareTest`, and `verifyBundledLibraries` - these are `@UntrackedTask` in the IntelliJ Platform Gradle Plugin and cannot be skipped without patching the plugin.