### PR TITLE
Fix trusted project opening

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,3 @@
+# TODO
+
+- [x] Fix `steroid_open_project` to trust a project path before opening it and cover the no-modal path with an integration test.

--- a/ij-plugin/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/OpenProjectToolHandler.kt
+++ b/ij-plugin/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/OpenProjectToolHandler.kt
@@ -1,20 +1,18 @@
 /* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
 package com.jonnyzzz.mcpSteroid.server
 
-import com.intellij.ide.impl.OpenProjectTask
+import com.intellij.ide.GeneralSettings
 import com.intellij.ide.trustedProjects.TrustedProjects
-import com.intellij.openapi.application.EDT
+import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.application.readAction
 import com.intellij.openapi.diagnostic.thisLogger
+import com.intellij.openapi.progress.ProcessCanceledException
 import com.intellij.openapi.project.ProjectManager
-import com.intellij.openapi.project.ex.ProjectManagerEx
 import com.jonnyzzz.mcpSteroid.mcp.ContentItem
 import com.jonnyzzz.mcpSteroid.mcp.McpServerCore
 import com.jonnyzzz.mcpSteroid.mcp.ToolCallContext
 import com.jonnyzzz.mcpSteroid.mcp.ToolCallResult
 import com.jonnyzzz.mcpSteroid.mcp.builder
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.add
 import kotlinx.serialization.json.boolean
 import kotlinx.serialization.json.buildJsonObject
@@ -37,7 +35,8 @@ import java.nio.file.Path
  * the trust dialog.
  */
 class OpenProjectToolHandler : McpRegistrar {
-    private val log = thisLogger()
+    private val logger = thisLogger()
+    private val openProjectLock = Any()
     private val toolDescription = """
         Open a project in the IDE. This tool initiates the project opening process and returns quickly.
 
@@ -104,21 +103,29 @@ class OpenProjectToolHandler : McpRegistrar {
             ?: return errorResult("Missing required parameter: reason")
         val trustProject = args["trust_project"]?.jsonPrimitive?.boolean ?: true
 
-        val projectPath = try {
-            Path.of(projectPathStr)
+        val requestedProjectPath = try {
+            Path.of(projectPathStr).toAbsolutePath().normalize()
         } catch (e: Exception) {
+            logger.warn("Invalid project path: $projectPathStr", e)
             return errorResult("Invalid project path: $projectPathStr - ${e.message}")
         }
 
         // Validate that the path exists
-        if (!Files.exists(projectPath)) {
-            return errorResult("Project path does not exist: $projectPath")
+        if (!Files.isDirectory(requestedProjectPath)) {
+            return errorResult("Project path is not a directory: $requestedProjectPath")
+        }
+
+        val projectPath = try {
+            requestedProjectPath.toRealPath()
+        } catch (e: Exception) {
+            logger.warn("Failed to resolve project path: $requestedProjectPath", e)
+            return errorResult("Failed to resolve project path: $requestedProjectPath - ${e.message}")
         }
 
         // Check if project is already open
         val existingProject = readAction {
             ProjectManager.getInstance().openProjects.find { project ->
-                project.basePath?.let { Path.of(it) == projectPath.toAbsolutePath() } == true
+                project.basePath?.let { Path.of(it).toAbsolutePath().normalize() == projectPath } == true
             }
         }
 
@@ -141,34 +148,15 @@ class OpenProjectToolHandler : McpRegistrar {
             if (trustProject) {
                 log("Trusting project path: $projectPath")
                 TrustedProjects.setProjectTrusted(projectPath, isTrusted = true)
+                check(TrustedProjects.isProjectTrusted(projectPath)) {
+                    "TrustedProjects did not mark path as trusted: $projectPath"
+                }
                 log("Project path trusted successfully")
             }
 
             log("Initiating project open: $projectPath")
-            log("force_new_frame: ${true}")
 
-            // Open the project with proper UI-level initialization
-            // Using runConfigurators=true ensures modules and project structure are loaded
-            withContext(Dispatchers.EDT) {
-                try {
-                    val task = OpenProjectTask.build().copy(
-                        forceOpenInNewFrame = true,
-                        showWelcomeScreen = false,
-                        projectToClose = null,
-                        runConfigurators = true,  // Critical: ensures modules are loaded properly
-                    )
-                    val result = ProjectManagerEx.getInstanceExAsync().openProject(projectPath, task)
-                    if (result != null) {
-                        log.info("Project opened successfully: ${result.name}")
-                    } else {
-                        log.warn("Project opening returned null (may have been cancelled)")
-                    }
-                } catch (e: Exception) {
-                    // Project opening errors are logged to IDE logs
-                    // The client should use screenshots to see the state
-                    log.warn("Project opening failed: ${e.message}", e)
-                }
-            }
+            scheduleProjectOpen(projectPath)
 
             log("Project opening initiated. The process runs in the background.")
             log("")
@@ -190,12 +178,40 @@ class OpenProjectToolHandler : McpRegistrar {
                 log("NOTE: trust_project was false. A 'Trust Project' dialog may appear.")
                 log("      Set trust_project=true to skip the trust dialog.")
             }
+        } catch (e: ProcessCanceledException) {
+            throw e
         } catch (e: Exception) {
             val message = "Failed to initiate project open: ${e.message}"
+            logger.warn(message, e)
             builder.addTextContent("ERROR: $message").markAsError()
         }
 
         return builder.build()
+    }
+
+    private fun scheduleProjectOpen(projectPath: Path) {
+        ApplicationManager.getApplication().executeOnPooledThread {
+            synchronized(openProjectLock) {
+                val settings = GeneralSettings.getInstance()
+                val originalOpenProjectMode = settings.confirmOpenNewProject
+                try {
+                    settings.confirmOpenNewProject = GeneralSettings.OPEN_PROJECT_NEW_WINDOW
+
+                    val result = ProjectManager.getInstance().loadAndOpenProject(projectPath.toString())
+                    if (result != null) {
+                        logger.info("Project opened successfully: ${result.name}")
+                    } else {
+                        logger.warn("Project opening returned null (may have been cancelled): $projectPath")
+                    }
+                } catch (e: ProcessCanceledException) {
+                    throw e
+                } catch (e: Exception) {
+                    logger.warn("Project opening failed: $projectPath - ${e.message}", e)
+                } finally {
+                    settings.confirmOpenNewProject = originalOpenProjectMode
+                }
+            }
+        }
     }
 
     private fun errorResult(message: String) = ToolCallResult(

--- a/test-integration/src/main/kotlin/com/jonnyzzz/mcpSteroid/integration/infra/intelliJ-factory.kt
+++ b/test-integration/src/main/kotlin/com/jonnyzzz/mcpSteroid/integration/infra/intelliJ-factory.kt
@@ -77,6 +77,16 @@ fun IntelliJContainer.Companion.create(
      * Use together with warm snapshot images that already contain project checkout + ide-system.
      */
     reuseProjectFromImage: Boolean = false,
+    /**
+     * Default true keeps ordinary Docker tests immune to trust prompts. Tests that validate
+     * project-trust behavior can set this false and rely on explicit trusted paths.
+     */
+    disableProjectTrustChecks: Boolean = true,
+    /**
+     * Default true mirrors the historical test image setup that trusts every path. Tests that
+     * need an actually-untrusted secondary project can set this false.
+     */
+    trustAllProjectPaths: Boolean = true,
 ): IntelliJContainer {
     val ideProduct = distribution.product
     val selectedDockerBase = if (dockerFileBase == "ide-agent") ideProduct.dockerImageBase else dockerFileBase
@@ -565,6 +575,8 @@ fun IntelliJContainer.Companion.create(
         "$containerMountedPath/intellij",
         ideProduct,
         skipChangedFilesScanOnStartup = reuseProjectFromImage,
+        disableProjectTrustChecks = disableProjectTrustChecks,
+        trustAllProjectPaths = trustAllProjectPaths,
     )
     console.writeInfo("Deploying MCP Steroid plugin...")
     ijDriver.deployPluginToContainer(IdeTestFolders.pluginZip)

--- a/test-integration/src/main/kotlin/com/jonnyzzz/mcpSteroid/integration/infra/intelliJ.kt
+++ b/test-integration/src/main/kotlin/com/jonnyzzz/mcpSteroid/integration/infra/intelliJ.kt
@@ -22,6 +22,8 @@ class IntelliJDriver(
     private val guestDir: String,
     val ideProduct: IdeProduct,
     private val skipChangedFilesScanOnStartup: Boolean = false,
+    private val disableProjectTrustChecks: Boolean = true,
+    private val trustAllProjectPaths: Boolean = true,
 ) {
     private val intelliJGuestHomeDir = "/opt/idea"
     // Keep project sources on container-local filesystem (not host-mounted volume)
@@ -116,7 +118,8 @@ class IntelliJDriver(
                 !idea.isRunning() || (logFile.exists() && logFile.length() > 0L)
             }
             logFile.exists() && logFile.length() > 0L
-        } catch (_: Throwable) {
+        } catch (e: Exception) {
+            driver.log("Timed out waiting for ${ideProduct.displayName} log file: ${e.message}")
             false
         }
 
@@ -200,7 +203,9 @@ class IntelliJDriver(
             appendLine("-DJETBRAINS_LICENSE_SERVER=https://flsv1.labs.jb.gg")
             appendLine()
             appendLine("# Skip EULA, consent dialogs, trust prompts, and onboarding")
-            appendLine("-Didea.trust.disabled=true")
+            if (disableProjectTrustChecks) {
+                appendLine("-Didea.trust.disabled=true")
+            }
             appendLine("-Djb.consents.confirmation.enabled=false")
             appendLine("-Djb.privacy.policy.text=<!--999.999-->")
             appendLine("-Djb.privacy.policy.ai.assistant.text=<!--999.999-->")
@@ -350,13 +355,15 @@ class IntelliJDriver(
             appendLine("""      </map>""")
             appendLine("""    </option>""")
             appendLine("""  </component>""")
-            appendLine("""  <component name="Trusted.Paths.Settings">""")
-            appendLine("""    <option name="TRUSTED_PATHS">""")
-            appendLine("""      <list>""")
-            appendLine("""        <option value="/" />""")
-            appendLine("""      </list>""")
-            appendLine("""    </option>""")
-            appendLine("""  </component>""")
+            if (trustAllProjectPaths) {
+                appendLine("""  <component name="Trusted.Paths.Settings">""")
+                appendLine("""    <option name="TRUSTED_PATHS">""")
+                appendLine("""      <list>""")
+                appendLine("""        <option value="/" />""")
+                appendLine("""      </list>""")
+                appendLine("""    </option>""")
+                appendLine("""  </component>""")
+            }
             appendLine("""</application>""")
         }
 

--- a/test-integration/src/main/kotlin/com/jonnyzzz/mcpSteroid/integration/infra/mcp-steroid.kt
+++ b/test-integration/src/main/kotlin/com/jonnyzzz/mcpSteroid/integration/infra/mcp-steroid.kt
@@ -200,7 +200,7 @@ class McpSteroidDriver(
      * Open a project directory in IntelliJ IDEA via steroid_open_project.
      * Call this during the pre-warm phase (before the measured agent run).
      */
-    fun mcpOpenProject(projectPath: String) {
+    fun mcpOpenProject(projectPath: String, trustProject: Boolean? = true) {
         val sessionId = mcpInitialize()
         val request = buildJsonObject {
             put("jsonrpc", "2.0")
@@ -212,7 +212,9 @@ class McpSteroidDriver(
                     put("task_id", "prewarm-open-project")
                     put("project_path", projectPath)
                     put("reason", "Pre-warm: open arena project before measured agent run")
-                    put("trust_project", true)
+                    if (trustProject != null) {
+                        put("trust_project", trustProject)
+                    }
                 }
             }
         }.toString()
@@ -1078,8 +1080,8 @@ withContext(Dispatchers.EDT + ModalityState.any().asContextElement()) {
                 timeout = 15,
                 dialogKiller = false,
             )
-        } catch (_: Exception) {
-            // Best-effort — don't fail the wait loop if dialog killing fails
+        } catch (e: Exception) {
+            driver.log("[startup-dialog-killer] Failed to kill startup blocking dialogs: ${e.message}")
         }
     }
 

--- a/test-integration/src/test/kotlin/com/jonnyzzz/mcpSteroid/integration/tests/OpenProjectTrustIntegrationTest.kt
+++ b/test-integration/src/test/kotlin/com/jonnyzzz/mcpSteroid/integration/tests/OpenProjectTrustIntegrationTest.kt
@@ -1,0 +1,114 @@
+/* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
+package com.jonnyzzz.mcpSteroid.integration.tests
+
+import com.jonnyzzz.mcpSteroid.integration.infra.IntelliJContainer
+import com.jonnyzzz.mcpSteroid.integration.infra.McpWindowInfo
+import com.jonnyzzz.mcpSteroid.integration.infra.create
+import com.jonnyzzz.mcpSteroid.testHelper.docker.startProcessInContainer
+import com.jonnyzzz.mcpSteroid.testHelper.process.assertExitCode
+import com.jonnyzzz.mcpSteroid.testHelper.process.assertOutputContains
+import com.jonnyzzz.mcpSteroid.testHelper.runWithCloseableStack
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Timeout
+import java.util.concurrent.TimeUnit
+
+class OpenProjectTrustIntegrationTest {
+    @Test
+    @Timeout(value = 15, unit = TimeUnit.MINUTES)
+    fun `open project trusts path by default and shows no modal`() = runWithCloseableStack { lifetime ->
+        val session = IntelliJContainer.create(
+            lifetime,
+            "ide-agent",
+            consoleTitle = "open-project-trust",
+            disableProjectTrustChecks = false,
+            trustAllProjectPaths = false,
+        )
+        val console = session.console
+        val secondaryProjectPath = "/home/agent/open-project-trust-secondary"
+
+        console.writeStep(1, "Creating secondary project directory")
+        session.scope.startProcessInContainer {
+            this
+                .args(
+                    "bash",
+                    "-lc",
+                    """
+                        set -euo pipefail
+                        rm -rf "$secondaryProjectPath"
+                        mkdir -p "$secondaryProjectPath"
+                        printf '# Open Project Trust Test\n' > "$secondaryProjectPath/README.md"
+                    """.trimIndent(),
+                )
+                .timeoutSeconds(30)
+                .description("Create secondary project for trusted open test")
+        }.awaitForProcessFinish().assertExitCode(0, "Failed to create secondary project")
+
+        console.writeStep(2, "Verifying secondary project starts untrusted")
+        session.assertTrustedState(secondaryProjectPath, expectedTrusted = false, taskId = "trust-before-open")
+
+        console.writeStep(3, "Opening project through MCP default trust path")
+        session.mcpSteroid.mcpOpenProject(secondaryProjectPath, trustProject = null)
+
+        console.writeStep(4, "Waiting for secondary project without modal dialogs")
+        waitForOpenedProjectWithoutModal(session, secondaryProjectPath)
+
+        console.writeStep(5, "Verifying secondary project was registered as trusted")
+        session.assertTrustedState(secondaryProjectPath, expectedTrusted = true, taskId = "trust-after-open")
+        console.writeSuccess("MCP open_project trusted the path and opened without a modal dialog")
+    }
+
+    private fun IntelliJContainer.assertTrustedState(
+        projectPath: String,
+        expectedTrusted: Boolean,
+        taskId: String,
+    ) {
+        mcpSteroid.mcpExecuteCode(
+            code = """
+                import com.intellij.ide.trustedProjects.TrustedProjects
+                import java.nio.file.Path
+
+                println("TRUSTED_STATE: ${'$'}{TrustedProjects.isProjectTrusted(Path.of("$projectPath"))}")
+            """.trimIndent(),
+            taskId = taskId,
+            reason = "Check trusted project state for open_project integration test",
+        ).assertExitCode(0, "trusted-state check should succeed")
+            .assertOutputContains("TRUSTED_STATE: $expectedTrusted")
+    }
+
+    private fun waitForOpenedProjectWithoutModal(
+        session: IntelliJContainer,
+        projectPath: String,
+        timeoutMillis: Long = 180_000L,
+    ) {
+        val startedAt = System.currentTimeMillis()
+        var lastStatus = "not polled"
+
+        while (System.currentTimeMillis() - startedAt < timeoutMillis) {
+            val windows = session.mcpSteroid.mcpListWindows(timeoutSeconds = 120)
+            val modalWindows = windows.filter { it.modalDialogShowing }
+            Assertions.assertTrue(
+                modalWindows.isEmpty(),
+                "Unexpected modal dialog while opening $projectPath. Windows: $windows",
+            )
+
+            val projectWindows = windows.filter { it.projectPath == projectPath }
+            if (projectWindows.any { it.projectInitialized == true && it.indexingInProgress == false }) {
+                return
+            }
+
+            lastStatus = describe(projectWindows.ifEmpty { windows })
+            Thread.sleep(1_000L)
+        }
+
+        Assertions.fail<Unit>(
+            "Timed out waiting for $projectPath to open without a modal dialog. Last status: $lastStatus",
+        )
+    }
+
+    private fun describe(windows: List<McpWindowInfo>): String =
+        windows.joinToString(prefix = "[", postfix = "]") { window ->
+            "name=${window.projectName}, path=${window.projectPath}, modal=${window.modalDialogShowing}, " +
+                    "indexing=${window.indexingInProgress}, initialized=${window.projectInitialized}"
+        }
+}


### PR DESCRIPTION
Closes #28.

## Summary
- trust `steroid_open_project` target paths by default before project opening
- avoid internal project-open APIs by using public `ProjectManager.loadAndOpenProject`
- add Docker integration coverage proving the default trust path opens without a modal dialog

## Validation
- `:ij-plugin:compileKotlin :test-integration:compileTestKotlin --rerun-tasks`
- `:test-integration:test --tests 'com.jonnyzzz.mcpSteroid.integration.tests.OpenProjectTrustIntegrationTest.open project trusts path by default and shows no modal' --rerun-tasks`