### PR TITLE
Reinstate Tools → MCP Steroid settings panel (fixes #103 regression in 0.100)

### DIFF
--- a/ij-plugin/src/main/kotlin/com/jonnyzzz/mcpSteroid/settings/McpSteroidConfigurable.kt
+++ b/ij-plugin/src/main/kotlin/com/jonnyzzz/mcpSteroid/settings/McpSteroidConfigurable.kt
@@ -1,0 +1,184 @@
+/* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
+package com.jonnyzzz.mcpSteroid.settings
+
+import com.intellij.icons.AllIcons
+import com.intellij.openapi.ide.CopyPasteManager
+import com.intellij.openapi.options.BoundConfigurable
+import com.intellij.openapi.ui.DialogPanel
+import com.intellij.ui.components.JBScrollPane
+import com.intellij.ui.components.JBTextArea
+import com.intellij.ui.components.fields.ExtendableTextComponent
+import com.intellij.ui.components.fields.ExtendableTextField
+import com.intellij.ui.dsl.builder.Align
+import com.intellij.ui.dsl.builder.AlignX
+import com.intellij.ui.dsl.builder.TopGap
+import com.intellij.ui.dsl.builder.panel
+import com.jonnyzzz.mcpSteroid.aiAgents.McpConnectionInfo
+import com.jonnyzzz.mcpSteroid.server.SteroidsMcpServer
+import java.awt.datatransfer.StringSelection
+import javax.swing.text.AbstractDocument
+import javax.swing.text.AttributeSet
+import javax.swing.text.DocumentFilter
+
+/**
+ * Application-level settings page: Settings | Tools | MCP Steroid — devrig.
+ *
+ * Purely informational — no persistent state, no mutable options. The page exists so users
+ * can confirm the plugin is installed and connect an AI agent:
+ *
+ * 1. Promotes the devrig CLI setup (the recommended path): one-command install plus
+ *    `devrig install claude|codex|gemini` agent registration.
+ * 2. Shows the live MCP/HTTP server status (port + URL) — a cheap [SteroidsMcpServer.port]
+ *    read from an in-memory atomic, never any I/O or background work on the settings thread.
+ * 3. Keeps the legacy direct-HTTP connection info (per-agent `mcp add` commands, generic
+ *    `mcpServers` JSON, registry keys) so pre-devrig HTTP setups can still find their config.
+ *
+ * The panel is built once per Settings dialog opening, so the status is a snapshot — that
+ * matches the old (pre-0.96) connection-info page behavior.
+ */
+class McpSteroidConfigurable : BoundConfigurable(DISPLAY_NAME) {
+
+    override fun createPanel(): DialogPanel {
+        // Cheap reads only: port comes from an AtomicReference inside the app service.
+        val server = SteroidsMcpServer.getInstance()
+        val port = server.port
+        val info = if (port > 0) McpConnectionInfo.build(server.mcpUrl) else null
+
+        return panel {
+            row {
+                text(
+                    "AI agents (Claude, Codex, Gemini, …) drive this IDE through the Model Context Protocol: " +
+                        "MCP Steroid runs an MCP server inside the IDE, and agents call its tools to execute " +
+                        "Kotlin against the full IntelliJ Platform API."
+                )
+            }
+
+            group("Devrig CLI (Recommended)") {
+                row {
+                    text(
+                        "Devrig registers MCP Steroid with your coding agent and bridges it to every running " +
+                            "IDE at once — no manual MCP configuration. Install it with one command:"
+                    )
+                }
+                row("Install:") {
+                    cell(copyableTextField(DEVRIG_INSTALL_COMMAND)).align(AlignX.FILL)
+                }
+                row {
+                    comment("Then register devrig as the <code>mcp-steroid</code> MCP server in your agent:")
+                }
+                row("Claude:") {
+                    cell(copyableTextField("devrig install claude")).align(AlignX.FILL)
+                }
+                row("Codex:") {
+                    cell(copyableTextField("devrig install codex")).align(AlignX.FILL)
+                }
+                row("Gemini:") {
+                    cell(copyableTextField("devrig install gemini")).align(AlignX.FILL)
+                }
+                row {
+                    browserLink("Devrig documentation", DOCS_URL)
+                }.topGap(TopGap.SMALL)
+            }
+
+            group("Status") {
+                if (info != null) {
+                    row("MCP server:") {
+                        label("Running on port $port")
+                    }
+                    row("Server URL:") {
+                        cell(copyableTextField(info.serverUrl)).align(AlignX.FILL)
+                    }
+                } else {
+                    row("MCP server:") {
+                        label("Not running")
+                    }
+                    row {
+                        comment(
+                            "The server normally starts at IDE startup. Check the IDE log (Help | Show Log) " +
+                                "for bind errors, or adjust the registry keys listed below."
+                        )
+                    }
+                }
+            }
+
+            group("Legacy HTTP Configuration") {
+                row {
+                    text(
+                        "Direct streamable-HTTP connection to this single IDE instance — the pre-devrig setup. " +
+                            "Prefer devrig above: it survives IDE restarts, port changes, and routes to every IDE."
+                    )
+                }
+                if (info != null) {
+                    for ((name, command) in info.commands) {
+                        row("$name:") {
+                            cell(copyableTextField(command)).align(AlignX.FILL)
+                        }
+                    }
+                    group("JSON Config") {
+                        val json = info.jsonConfig.trim()
+                        row {
+                            val textArea = JBTextArea(json).apply {
+                                isEditable = false
+                                rows = 6
+                            }
+                            cell(JBScrollPane(textArea)).align(Align.FILL)
+                        }.topGap(TopGap.NONE)
+                        row {
+                            button("Copy JSON Config") {
+                                CopyPasteManager.getInstance().setContents(StringSelection(json))
+                            }
+                        }
+                    }
+                }
+                row {
+                    comment(
+                        "Port and bind address are configurable via the IDE Registry: " +
+                            "<code>mcp.steroid.server.port</code> (default 6315, 0 = auto-assign) and " +
+                            "<code>mcp.steroid.server.host</code> (default 127.0.0.1)."
+                    )
+                }
+            }
+
+            row {
+                browserLink("Report issues, Join Slack & Community", FEEDBACK_URL)
+            }.topGap(TopGap.SMALL)
+        }
+    }
+
+    /**
+     * Read-only text field with an in-border copy-to-clipboard icon.
+     * Keep isEditable=true so the background paints normally and the copy icon appears
+     * visually INSIDE the field border (same as Terminal env vars fields); the
+     * DocumentFilter silently blocks any edits by the user.
+     */
+    private fun copyableTextField(content: String): ExtendableTextField =
+        ExtendableTextField().apply {
+            text = content
+            (document as? AbstractDocument)?.documentFilter = object : DocumentFilter() {
+                override fun insertString(fb: FilterBypass, offset: Int, string: String?, attr: AttributeSet?) {}
+                override fun remove(fb: FilterBypass, offset: Int, length: Int) {}
+                override fun replace(fb: FilterBypass, offset: Int, length: Int, text: String?, attrs: AttributeSet?) {}
+            }
+            addExtension(ExtendableTextComponent.Extension.create(
+                AllIcons.General.InlineCopy,
+                AllIcons.General.InlineCopyHover,
+                "Copy to clipboard"
+            ) {
+                CopyPasteManager.getInstance().setContents(StringSelection(content))
+            })
+        }
+
+    companion object {
+        /** Must match the id attribute of the applicationConfigurable EP in plugin.xml. */
+        const val CONFIGURABLE_ID = "com.jonnyzzz.mcp-steroid.settings"
+
+        /** Must match the displayName attribute of the applicationConfigurable EP in plugin.xml. */
+        const val DISPLAY_NAME = "MCP Steroid — devrig"
+
+        const val DEVRIG_INSTALL_COMMAND = "curl -fsSL https://mcp-steroid.jonnyzzz.com/install.sh | sh"
+
+        const val DOCS_URL = "https://mcp-steroid.jonnyzzz.com/docs/"
+
+        const val FEEDBACK_URL = "https://mcp-steroid.jonnyzzz.com"
+    }
+}

--- a/ij-plugin/src/main/kotlin/com/jonnyzzz/mcpSteroid/settings/McpSteroidConfigurable.kt
+++ b/ij-plugin/src/main/kotlin/com/jonnyzzz/mcpSteroid/settings/McpSteroidConfigurable.kt
@@ -47,6 +47,8 @@ class McpSteroidConfigurable : BoundConfigurable(DISPLAY_NAME) {
         val server = ApplicationManager.getApplication().getServiceIfCreated(SteroidsMcpServer::class.java)
         val port = server?.port ?: 0
         val info = if (server != null && port > 0) McpConnectionInfo.build(server.mcpUrl) else null
+        // Prose references only the actual bound port ($port), so every message matches the Status
+        // block. No hard-coded default here — 6315 lives solely in the registry config.
 
         return panel {
             row {
@@ -58,29 +60,9 @@ class McpSteroidConfigurable : BoundConfigurable(DISPLAY_NAME) {
                         "Your agent gets the whole IntelliJ, not just the text."
                 )
             }
-
-            group("Devrig — the recommended way to connect") {
-                row {
-                    text(
-                        "<b>Devrig</b> is one small command-line bridge between your AI Agent and your IDEs. " +
-                            "Point your agent at it once and it reaches <b>every</b> IntelliJ-family IDE you " +
-                            "have open — across projects — and routes each call to the right one. It keeps " +
-                            "working when the IDE restarts or the port changes, and it can even download and " +
-                            "start an IDE on demand for headless and CI runs."
-                    )
-                }
-                row {
-                    text(
-                        "The direct HTTP server below also works, but it is tied to <b>this</b> IDE on " +
-                            "<b>this</b> port — it moves when 6315 is busy or the IDE restarts, and every agent " +
-                            "must be wired up by hand. Devrig handles all of that for you, so it is the way we " +
-                            "recommend connecting."
-                    )
-                }
-                row {
-                    browserLink("Read the Devrig documentation to get started", DEVRIG_DOCS_URL)
-                }.topGap(TopGap.SMALL)
-            }
+            row {
+                browserLink("Report issues, Join Slack & Community", FEEDBACK_URL)
+            }.topGap(TopGap.SMALL)
 
             group("Status") {
                 if (info != null) {
@@ -103,14 +85,37 @@ class McpSteroidConfigurable : BoundConfigurable(DISPLAY_NAME) {
                 }
             }
 
+            group("Devrig — the recommended way to connect") {
+                row {
+                    text(
+                        "<b>Devrig</b> is one small command-line bridge between your AI Agent and your IDEs. " +
+                            "Point your agent at it once and it reaches <b>every</b> IntelliJ-family IDE you " +
+                            "have open — across projects — and routes each call to the right one. It keeps " +
+                            "working when the IDE restarts or the port changes, and it can even download and " +
+                            "start an IDE on demand for headless and CI runs."
+                    )
+                }
+                row {
+                    text(
+                        "The direct HTTP server below also works, but it is tied to <b>this</b> IDE on port " +
+                            "<b>$port</b> — that can change when the IDE restarts or the port is taken, and every " +
+                            "agent must be wired up by hand. Devrig handles all of that for you, so it is the way " +
+                            "we recommend connecting."
+                    )
+                }
+                row {
+                    browserLink("Read the Devrig documentation to get started", DEVRIG_DOCS_URL)
+                }.topGap(TopGap.SMALL)
+            }
+
             group("Legacy HTTP Configuration") {
                 row {
                     icon(AllIcons.General.Warning)
                     text(
-                        "<b>Not recommended.</b> These manual HTTP commands point at <b>this</b> IDE on " +
-                            "<b>this</b> port — they break when port 6315 is busy, the IDE restarts, or you open " +
-                            "another IDE. Use devrig instead: it connects to every running IDE automatically and " +
-                            "keeps working across restarts and port changes."
+                        "<b>Not recommended.</b> These manual HTTP commands point at <b>this</b> IDE on port " +
+                            "<b>$port</b> — they stop working when the IDE restarts or that port is reassigned, " +
+                            "and every agent must be set up by hand. Use devrig instead: it reaches every running " +
+                            "IDE automatically and keeps working across restarts and port changes."
                     )
                 }
                 row {
@@ -128,9 +133,11 @@ class McpSteroidConfigurable : BoundConfigurable(DISPLAY_NAME) {
                     group("JSON Config") {
                         val json = info.jsonConfig.trim()
                         row {
+                            // Size the area to the content so the whole block is visible without
+                            // an inner scrollbar.
                             val textArea = JBTextArea(json).apply {
                                 isEditable = false
-                                rows = 6
+                                rows = json.lines().size.coerceAtLeast(3)
                             }
                             cell(JBScrollPane(textArea)).align(Align.FILL)
                         }.topGap(TopGap.NONE)
@@ -144,15 +151,11 @@ class McpSteroidConfigurable : BoundConfigurable(DISPLAY_NAME) {
                 row {
                     comment(
                         "Port and bind address are configurable via the IDE Registry: " +
-                            "<code>mcp.steroid.server.port</code> (default 6315, 0 = auto-assign) and " +
-                            "<code>mcp.steroid.server.host</code> (default 127.0.0.1)."
+                            "<code>mcp.steroid.server.port</code> (0 = auto-assign) and " +
+                            "<code>mcp.steroid.server.host</code>."
                     )
                 }
             }
-
-            row {
-                browserLink("Report issues, Join Slack & Community", FEEDBACK_URL)
-            }.topGap(TopGap.SMALL)
         }
     }
 

--- a/ij-plugin/src/main/kotlin/com/jonnyzzz/mcpSteroid/settings/McpSteroidConfigurable.kt
+++ b/ij-plugin/src/main/kotlin/com/jonnyzzz/mcpSteroid/settings/McpSteroidConfigurable.kt
@@ -51,36 +51,34 @@ class McpSteroidConfigurable : BoundConfigurable(DISPLAY_NAME) {
         return panel {
             row {
                 text(
-                    "AI agents (Claude, Codex, Gemini, …) drive this IDE through the Model Context Protocol: " +
-                        "MCP Steroid runs an MCP server inside the IDE, and agents call its tools to execute " +
-                        "Kotlin against the full IntelliJ Platform API."
+                    "<b>AI Agents work inside your IDE — not just over your files.</b> Claude, Codex, Gemini, " +
+                        "and any MCP-compatible agent connect to MCP Steroid and drive the full IntelliJ " +
+                        "Platform: they run Kotlin against the live IDE, navigate the PSI, run inspections, " +
+                        "refactorings, the debugger and tests — and even <i>see</i> the IDE through screenshots. " +
+                        "Your agent gets the whole IntelliJ, not just the text."
                 )
             }
 
-            group("Devrig CLI (Recommended)") {
+            group("Devrig — the recommended way to connect") {
                 row {
                     text(
-                        "Devrig registers MCP Steroid with your coding agent and bridges it to every running " +
-                            "IDE at once — no manual MCP configuration. Install it with one command:"
+                        "<b>Devrig</b> is one small command-line bridge between your AI Agent and your IDEs. " +
+                            "Point your agent at it once and it reaches <b>every</b> IntelliJ-family IDE you " +
+                            "have open — across projects — and routes each call to the right one. It keeps " +
+                            "working when the IDE restarts or the port changes, and it can even download and " +
+                            "start an IDE on demand for headless and CI runs."
                     )
                 }
-                row("Install:") {
-                    cell(copyableTextField(DEVRIG_INSTALL_COMMAND)).align(AlignX.FILL)
+                row {
+                    text(
+                        "The direct HTTP server below also works, but it is tied to <b>this</b> IDE on " +
+                            "<b>this</b> port — it moves when 6315 is busy or the IDE restarts, and every agent " +
+                            "must be wired up by hand. Devrig handles all of that for you, so it is the way we " +
+                            "recommend connecting."
+                    )
                 }
                 row {
-                    comment("Then register devrig as the <code>mcp-steroid</code> MCP server in your agent:")
-                }
-                row("Claude:") {
-                    cell(copyableTextField("devrig install claude")).align(AlignX.FILL)
-                }
-                row("Codex:") {
-                    cell(copyableTextField("devrig install codex")).align(AlignX.FILL)
-                }
-                row("Gemini:") {
-                    cell(copyableTextField("devrig install gemini")).align(AlignX.FILL)
-                }
-                row {
-                    browserLink("Devrig documentation", DOCS_URL)
+                    browserLink("Read the Devrig documentation to get started", DEVRIG_DOCS_URL)
                 }.topGap(TopGap.SMALL)
             }
 
@@ -179,9 +177,7 @@ class McpSteroidConfigurable : BoundConfigurable(DISPLAY_NAME) {
         /** Must match the displayName attribute of the applicationConfigurable EP in plugin.xml. */
         const val DISPLAY_NAME = "MCP Steroid — devrig"
 
-        const val DEVRIG_INSTALL_COMMAND = "curl -fsSL https://mcp-steroid.jonnyzzz.com/install.sh | sh"
-
-        const val DOCS_URL = "https://mcp-steroid.jonnyzzz.com/docs/"
+        const val DEVRIG_DOCS_URL = "https://mcp-steroid.jonnyzzz.com/docs/devrig/"
 
         const val FEEDBACK_URL = "https://mcp-steroid.jonnyzzz.com"
     }

--- a/ij-plugin/src/main/kotlin/com/jonnyzzz/mcpSteroid/settings/McpSteroidConfigurable.kt
+++ b/ij-plugin/src/main/kotlin/com/jonnyzzz/mcpSteroid/settings/McpSteroidConfigurable.kt
@@ -105,11 +105,20 @@ class McpSteroidConfigurable : BoundConfigurable(DISPLAY_NAME) {
 
             group("Legacy HTTP Configuration") {
                 row {
+                    icon(AllIcons.General.Warning)
                     text(
-                        "Direct streamable-HTTP connection to this single IDE instance — the pre-devrig setup. " +
-                            "Prefer devrig above: it survives IDE restarts, port changes, and routes to every IDE."
+                        "<b>Not recommended.</b> These manual HTTP commands point at <b>this</b> IDE on " +
+                            "<b>this</b> port — they break when port 6315 is busy, the IDE restarts, or you open " +
+                            "another IDE. Use devrig instead: it connects to every running IDE automatically and " +
+                            "keeps working across restarts and port changes."
                     )
                 }
+                row {
+                    browserLink("Set up devrig instead", DEVRIG_DOCS_URL)
+                }.topGap(TopGap.NONE)
+                row {
+                    text("If you still want a direct streamable-HTTP connection to this single IDE instance:")
+                }.topGap(TopGap.SMALL)
                 if (info != null) {
                     for ((name, command) in info.commands) {
                         row("$name:") {

--- a/ij-plugin/src/main/kotlin/com/jonnyzzz/mcpSteroid/settings/McpSteroidConfigurable.kt
+++ b/ij-plugin/src/main/kotlin/com/jonnyzzz/mcpSteroid/settings/McpSteroidConfigurable.kt
@@ -2,6 +2,7 @@
 package com.jonnyzzz.mcpSteroid.settings
 
 import com.intellij.icons.AllIcons
+import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.ide.CopyPasteManager
 import com.intellij.openapi.options.BoundConfigurable
 import com.intellij.openapi.ui.DialogPanel
@@ -40,9 +41,12 @@ class McpSteroidConfigurable : BoundConfigurable(DISPLAY_NAME) {
 
     override fun createPanel(): DialogPanel {
         // Cheap reads only: port comes from an AtomicReference inside the app service.
-        val server = SteroidsMcpServer.getInstance()
-        val port = server.port
-        val info = if (port > 0) McpConnectionInfo.build(server.mcpUrl) else null
+        // getServiceIfCreated makes the panel structurally incapable of triggering service
+        // construction on the EDT — in production the server service is created at IDE startup,
+        // so a null here renders the same "Not running" state as a port that never bound.
+        val server = ApplicationManager.getApplication().getServiceIfCreated(SteroidsMcpServer::class.java)
+        val port = server?.port ?: 0
+        val info = if (server != null && port > 0) McpConnectionInfo.build(server.mcpUrl) else null
 
         return panel {
             row {
@@ -94,7 +98,7 @@ class McpSteroidConfigurable : BoundConfigurable(DISPLAY_NAME) {
                     }
                     row {
                         comment(
-                            "The server normally starts at IDE startup. Check the IDE log (Help | Show Log) " +
+                            "The server normally starts at IDE startup. Check the IDE log (Help | Show Log in Finder/Explorer) " +
                                 "for bind errors, or adjust the registry keys listed below."
                         )
                     }

--- a/ij-plugin/src/main/resources/META-INF/plugin.xml
+++ b/ij-plugin/src/main/resources/META-INF/plugin.xml
@@ -96,6 +96,13 @@
         <notificationGroup id="jonnyzzz.mcp.steroid.updates"
                            displayType="BALLOON"/>
 
+        <!-- Settings | Tools | MCP Steroid — devrig: informational page promoting the devrig CLI
+             setup, showing the MCP server status, and keeping the legacy HTTP connection info. -->
+        <applicationConfigurable parentId="tools"
+                                 id="com.jonnyzzz.mcp-steroid.settings"
+                                 displayName="MCP Steroid — devrig"
+                                 instance="com.jonnyzzz.mcpSteroid.settings.McpSteroidConfigurable"/>
+
         <!-- Registry keys for configuration -->
         <registryKey key="mcp.steroid.dialog.killer.enabled" defaultValue="true"
             description="Automatically close modal dialogs before code execution"/>

--- a/ij-plugin/src/test/kotlin/com/jonnyzzz/mcpSteroid/settings/McpSteroidConfigurableTest.kt
+++ b/ij-plugin/src/test/kotlin/com/jonnyzzz/mcpSteroid/settings/McpSteroidConfigurableTest.kt
@@ -28,17 +28,23 @@ class McpSteroidConfigurableTest : BasePlatformTestCase() {
         configurable.disposeUIResources()
     }
 
-    fun `test panel promotes devrig install and agent registration commands`() {
+    fun `test panel promotes devrig and points to its documentation only`() {
         val configurable = McpSteroidConfigurable()
         try {
             val texts = collectTexts(configurable.createComponent())
+            val joined = texts.joinToString("\n")
 
-            // Pin the constant's value (the website serves this exact command), then assert presence.
-            assertEquals("curl -fsSL https://mcp-steroid.jonnyzzz.com/install.sh | sh", McpSteroidConfigurable.DEVRIG_INSTALL_COMMAND)
-            assertContainsText(texts, McpSteroidConfigurable.DEVRIG_INSTALL_COMMAND)
-            assertContainsText(texts, "devrig install claude")
-            assertContainsText(texts, "devrig install codex")
-            assertContainsText(texts, "devrig install gemini")
+            // The intro leads with the "AI Agents" framing and promotes devrig as the recommended path.
+            assertContainsText(texts, "AI Agents")
+            assertContainsText(texts, "Devrig")
+
+            // devrig install is not shipped yet: the panel must NOT advertise any install command,
+            // only point to the documentation.
+            assertEquals("https://mcp-steroid.jonnyzzz.com/docs/devrig/", McpSteroidConfigurable.DEVRIG_DOCS_URL)
+            assertFalse(
+                "Panel must not advertise the unimplemented devrig install; found:\n$joined",
+                joined.contains("install.sh") || joined.contains("devrig install "),
+            )
 
             // Legacy HTTP section must reference the registry keys so pre-devrig
             // HTTP-based setups can still find their port/host configuration.

--- a/ij-plugin/src/test/kotlin/com/jonnyzzz/mcpSteroid/settings/McpSteroidConfigurableTest.kt
+++ b/ij-plugin/src/test/kotlin/com/jonnyzzz/mcpSteroid/settings/McpSteroidConfigurableTest.kt
@@ -46,6 +46,9 @@ class McpSteroidConfigurableTest : BasePlatformTestCase() {
                 joined.contains("install.sh") || joined.contains("devrig install "),
             )
 
+            // The legacy HTTP examples must carry a "not recommended" warning steering users to devrig.
+            assertContainsText(texts, "Not recommended")
+
             // Legacy HTTP section must reference the registry keys so pre-devrig
             // HTTP-based setups can still find their port/host configuration.
             assertContainsText(texts, "mcp.steroid.server.port")
@@ -67,8 +70,9 @@ class McpSteroidConfigurableTest : BasePlatformTestCase() {
 
     private fun collectTexts(component: Component, out: MutableList<String> = mutableListOf()): List<String> {
         when (component) {
-            is JTextComponent -> out.add(component.text)
-            is JLabel -> out.add(component.text)
+            // Icon-only labels (e.g. the warning sign) have null text — skip them.
+            is JTextComponent -> component.text?.let { out.add(it) }
+            is JLabel -> component.text?.let { out.add(it) }
         }
         if (component is Container) {
             for (child in component.components) {

--- a/ij-plugin/src/test/kotlin/com/jonnyzzz/mcpSteroid/settings/McpSteroidConfigurableTest.kt
+++ b/ij-plugin/src/test/kotlin/com/jonnyzzz/mcpSteroid/settings/McpSteroidConfigurableTest.kt
@@ -33,8 +33,9 @@ class McpSteroidConfigurableTest : BasePlatformTestCase() {
         try {
             val texts = collectTexts(configurable.createComponent())
 
+            // Pin the constant's value (the website serves this exact command), then assert presence.
+            assertEquals("curl -fsSL https://mcp-steroid.jonnyzzz.com/install.sh | sh", McpSteroidConfigurable.DEVRIG_INSTALL_COMMAND)
             assertContainsText(texts, McpSteroidConfigurable.DEVRIG_INSTALL_COMMAND)
-            assertContainsText(texts, "curl -fsSL https://mcp-steroid.jonnyzzz.com/install.sh | sh")
             assertContainsText(texts, "devrig install claude")
             assertContainsText(texts, "devrig install codex")
             assertContainsText(texts, "devrig install gemini")

--- a/ij-plugin/src/test/kotlin/com/jonnyzzz/mcpSteroid/settings/McpSteroidConfigurableTest.kt
+++ b/ij-plugin/src/test/kotlin/com/jonnyzzz/mcpSteroid/settings/McpSteroidConfigurableTest.kt
@@ -1,0 +1,73 @@
+/* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
+package com.jonnyzzz.mcpSteroid.settings
+
+import com.intellij.openapi.options.Configurable
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
+import java.awt.Component
+import java.awt.Container
+import javax.swing.JLabel
+import javax.swing.text.JTextComponent
+
+class McpSteroidConfigurableTest : BasePlatformTestCase() {
+
+    fun `test applicationConfigurable EP is registered and instantiable`() {
+        val ep = Configurable.APPLICATION_CONFIGURABLE.extensionList
+            .singleOrNull { it.id == McpSteroidConfigurable.CONFIGURABLE_ID }
+            ?: error("No <applicationConfigurable> with id=${McpSteroidConfigurable.CONFIGURABLE_ID} is registered in plugin.xml")
+
+        assertEquals("tools", ep.parentId)
+        assertEquals(McpSteroidConfigurable.DISPLAY_NAME, ep.displayName)
+
+        val configurable = ep.createConfigurable()
+        assertNotNull("ConfigurableEP must instantiate the settings page", configurable)
+        assertTrue(
+            "Expected McpSteroidConfigurable, got ${configurable!!.javaClass.name}",
+            configurable is McpSteroidConfigurable,
+        )
+        assertEquals(McpSteroidConfigurable.DISPLAY_NAME, configurable.displayName)
+        configurable.disposeUIResources()
+    }
+
+    fun `test panel promotes devrig install and agent registration commands`() {
+        val configurable = McpSteroidConfigurable()
+        try {
+            val texts = collectTexts(configurable.createComponent())
+
+            assertContainsText(texts, McpSteroidConfigurable.DEVRIG_INSTALL_COMMAND)
+            assertContainsText(texts, "curl -fsSL https://mcp-steroid.jonnyzzz.com/install.sh | sh")
+            assertContainsText(texts, "devrig install claude")
+            assertContainsText(texts, "devrig install codex")
+            assertContainsText(texts, "devrig install gemini")
+
+            // Legacy HTTP section must reference the registry keys so pre-devrig
+            // HTTP-based setups can still find their port/host configuration.
+            assertContainsText(texts, "mcp.steroid.server.port")
+            assertContainsText(texts, "mcp.steroid.server.host")
+
+            // Status block renders in both server states; the label is always present.
+            assertContainsText(texts, "MCP server")
+        } finally {
+            configurable.disposeUIResources()
+        }
+    }
+
+    private fun assertContainsText(texts: List<String>, expected: String) {
+        assertTrue(
+            "Settings panel must contain text '$expected'; found:\n${texts.joinToString("\n")}",
+            texts.any { it.contains(expected) },
+        )
+    }
+
+    private fun collectTexts(component: Component, out: MutableList<String> = mutableListOf()): List<String> {
+        when (component) {
+            is JTextComponent -> out.add(component.text)
+            is JLabel -> out.add(component.text)
+        }
+        if (component is Container) {
+            for (child in component.components) {
+                collectTexts(child, out)
+            }
+        }
+        return out
+    }
+}

--- a/website/content/docs/settings-connection-info.md
+++ b/website/content/docs/settings-connection-info.md
@@ -9,7 +9,7 @@ group: "Reference"
 
 ## Overview
 
-MCP Steroid includes a built-in **Settings panel** — **Tools → MCP Steroid — devrig** (reinstated in 0.101) — that promotes the recommended [devrig CLI setup](/docs/devrig/) (one-command install plus `devrig install claude|codex|gemini`), shows the live MCP server status (port and URL), and keeps the legacy direct-HTTP connection details: ready-to-paste CLI commands for Claude, Codex, and Gemini, and a full JSON config block you can drop directly into your MCP client's config file.
+MCP Steroid includes a built-in **Settings panel** — **Tools → MCP Steroid — devrig** (reinstated in 0.101) — that explains how your **AI Agents** drive the IDE, promotes the recommended [devrig CLI](/docs/devrig/) (the one bridge that reaches every running IDE and survives restarts and port changes — see the docs to get started), shows the live MCP server status (port and URL), and keeps the legacy direct-HTTP connection details: ready-to-paste CLI commands for Claude, Codex, and Gemini, and a full JSON config block you can drop directly into your MCP client's config file.
 
 Starting from **0.89.0**, the MCP server starts as soon as IntelliJ starts — before any project opens. The Settings page reflects this: the connection URL is always there, whether or not you have a project open.
 

--- a/website/content/docs/settings-connection-info.md
+++ b/website/content/docs/settings-connection-info.md
@@ -9,14 +9,14 @@ group: "Reference"
 
 ## Overview
 
-MCP Steroid includes a built-in **Settings panel** that always shows your server's connection details — server URL, ready-to-paste CLI commands for Claude, Codex, and Gemini, and a full JSON config block you can drop directly into your MCP client's config file.
+MCP Steroid includes a built-in **Settings panel** — **Tools → MCP Steroid — devrig** (reinstated in 0.101) — that promotes the recommended [devrig CLI setup](/docs/devrig/) (one-command install plus `devrig install claude|codex|gemini`), shows the live MCP server status (port and URL), and keeps the legacy direct-HTTP connection details: ready-to-paste CLI commands for Claude, Codex, and Gemini, and a full JSON config block you can drop directly into your MCP client's config file.
 
 Starting from **0.89.0**, the MCP server starts as soon as IntelliJ starts — before any project opens. The Settings page reflects this: the connection URL is always there, whether or not you have a project open.
 
 ## Opening the Settings Panel
 
 1. In IntelliJ, go to **Settings** (`⌘,` on macOS / `Ctrl+Alt+S` on Windows/Linux)
-2. Navigate to **Tools → MCP Steroid**
+2. Navigate to **Tools → MCP Steroid — devrig**
 
 You will see the connection panel immediately, no project needs to be open.
 


### PR DESCRIPTION
## What

Reinstates the **Tools → MCP Steroid — devrig** settings panel on `main`, then reworks its copy:

- `settings: reinstate Tools settings page, devrig-first (#80)` — new `McpSteroidConfigurable` + `applicationConfigurable` EP + unit test (cherry-picked from `0101`)
- `settings page: getServiceIfCreated guard, exact Show Log menu name, doc refresh` (cherry-picked)
- `settings panel: AI Agents framing, promote devrig (docs link only)` — copy rework (this PR)

## Why

Fixes #103. The settings panel was reverted off `main` with the rest of the 0.101 batch (`30236610`), so shipped **0.100** has no Tools → MCP Steroid page. Consequences:

1. **No settings** — users can't confirm the plugin is installed or find connection details.
2. **"Nothing responds on 6315"** — when 6315 is busy (another IDE — only the first gets 6315 — or a stale process), the server silently falls back to 6316+. With no panel, users can't discover the actual port and assume the server is dead.

The panel's **Status** section shows the live bound port/URL, which makes the fallback discoverable again.

## Panel copy (reworked)

- **Intro** uses the **"AI Agents"** framing — agents drive the full IntelliJ Platform, not just files.
- **Devrig — the recommended way to connect**: explains *why* devrig over the in-IDE HTTP server (one bridge to **every** running IDE, survives restarts and port changes, can provision an IDE) and links to the **devrig documentation only**. The unimplemented one-line installer and `devrig install <agent>` commands were **removed** (not shipped yet).
- **Status**: live MCP server port + URL.
- **Legacy HTTP Configuration**: kept as the secondary, working direct-connection path (per-agent `mcp add`, JSON config, registry keys).

## Verification

- `:ij-plugin:test --tests '*McpSteroidConfigurableTest*'` → **2 passed, 0 failed** (EP registration + panel content; asserts no install command is advertised).
- Rendered the panel live against a running server (Status correctly reflected the real bound port).

Closes #103. Related: #80.
