### PR TITLE
ci: compileAllClasses task + Compile Check merge gate

### DIFF
--- a/.github/workflows/compile-check.yml
+++ b/.github/workflows/compile-check.yml
@@ -1,0 +1,71 @@
+# Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Compile Check
+
+# Merge gate: confirm the whole repo still COMPILES (every module, every source set —
+# main / test / integrationTest / …) before a PR can be merged. Compilation only — no tests
+# run and no artifacts are packaged; full test coverage stays on TeamCity (see build-plugin.yml).
+# Mark the `compile` job as a required status check in branch protection to enforce it.
+on:
+  pull_request:
+    branches: [main]
+  # Also run on main so the default branch stays green and the Gradle/SDK cache layer stays warm.
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  # One run per ref (PR head branch or main); a newer push cancels the in-flight outdated run.
+  group: compile-check-${{ github.ref }}
+  cancel-in-progress: true
+
+# Opt JavaScript actions (actions/checkout) onto Node 24 — Node 20 is deprecated on
+# GitHub-hosted runners and removed 2026-09-16. Matches build-plugin.yml.
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
+jobs:
+  compile:
+    name: compile
+    runs-on: ubuntu-latest
+    # Compiling :ij-plugin resolves the IntelliJ Platform SDK on a cold cache; 45m leaves head-room.
+    timeout-minutes: 45
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # Same toolchain as the plugin build: the docker/build image pins JDK 25 (the Gradle daemon
+      # JVM the project requires) and the rest of the build environment, so GitHub and TeamCity
+      # compile against an identical setup.
+      - name: Build Docker build image
+        run: docker build -t mcp-steroid-build:ci docker/build
+
+      - name: Compile all classes (Docker)
+        # compileAllClasses (defined in the root build.gradle.kts) depends on the per-source-set
+        # `*Classes` lifecycle task of every module, so this fails on the first compilation error
+        # anywhere — production, test, or auxiliary (integrationTest/tartTest) code.
+        run: |
+          set -euo pipefail
+          mkdir -p "$GITHUB_WORKSPACE/.gradle-home"
+          docker run --rm \
+            -u "$(id -u):$(id -g)" \
+            -e HOME=/tmp \
+            -e GRADLE_USER_HOME=/build/.gradle-home \
+            -v "$GITHUB_WORKSPACE:/build" \
+            -w /build \
+            mcp-steroid-build:ci \
+            ./gradlew compileAllClasses \
+              --no-daemon \
+              --stacktrace

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -386,6 +386,60 @@ val ciDevrigTests by tasks.registering {
 }
 
 /**
+ * Merge-gate **compile check**: compile every source set of every module and stop there.
+ *
+ * "Every source set" is taken literally — for each project Gradle exposes one lifecycle
+ * `<sourceSet>Classes` task per source set (`main` → `classes`, `test` → `testClasses`, and any
+ * extra set a module declares, e.g. `:ij-plugin`'s `integrationTest` → `integrationTestClasses`).
+ * Depending on all of them compiles production AND test AND auxiliary code without running a single
+ * test or packaging an artifact. New modules and new source sets are picked up automatically — there
+ * is no hand-maintained list to drift.
+ *
+ * Wiring lives in [gradle.projectsEvaluated] because a source set's `*Classes` task is only created
+ * while its owning subproject is being evaluated; at root-script configuration time most of them do
+ * not exist yet. The hard `require(...)` guards turn a silently-empty graph (e.g. the Kotlin/JVM
+ * plugin failing to apply, or a module being renamed out of existence) into a fast, loud failure
+ * instead of a green build that compiled nothing.
+ */
+val compileAllClasses by tasks.registering {
+    group = "build"
+    description = "Compile every source set (classes / testClasses / extra source sets) across all modules — no tests, no packaging."
+}
+
+gradle.projectsEvaluated {
+    // Use `tasks.names` (lazy — lists registered task names without realizing the tasks) and depend
+    // on path strings. Realizing the actual task objects here (e.g. via `tasks.matching { }`) would
+    // force-create unrelated tasks such as `:ocr-tesseract:extractWindowsNatives`, which resolve a
+    // configuration at creation time and fail with "unsafe configuration resolution". String paths
+    // realize only the `*Classes` tasks themselves, and only when the execution graph is built.
+    val classesTaskPaths = subprojects.flatMap { p ->
+        p.tasks.names
+            .filter { it == "classes" || it.endsWith("Classes") }
+            .map { "${p.path}:$it" }
+    }
+    require(classesTaskPaths.isNotEmpty()) {
+        "compileAllClasses resolved to zero *Classes tasks — the Kotlin/JVM plugins likely failed to apply to the subprojects."
+    }
+    // Fail fast if a structurally-important compile target silently drops out of the graph
+    // (renamed module, lost source set, plugin regression). These are the load-bearing ones:
+    // the IntelliJ plugin (+ its test and integrationTest sets) and the generated prompt corpus.
+    val resolvedPaths = classesTaskPaths.toSet()
+    val mustInclude = listOf(
+        ":ij-plugin:classes",
+        ":ij-plugin:testClasses",
+        ":ij-plugin:integrationTestClasses",
+        ":mcp-steroid-server:classes",
+        ":prompts:classes",
+        ":prompts:testClasses",
+    )
+    val missing = mustInclude.filterNot { it in resolvedPaths }
+    require(missing.isEmpty()) {
+        "compileAllClasses is missing expected compile target(s): $missing\nResolved targets:\n  ${resolvedPaths.sorted().joinToString("\n  ")}"
+    }
+    compileAllClasses.configure { dependsOn(classesTaskPaths) }
+}
+
+/**
  * Enforce strict ordering between the three steps. Configured inside
  * `gradle.projectsEvaluated` because the tasks live in subprojects that are not yet
  * evaluated when this script runs; `tasks.named(...)` on a not-yet-known task would


### PR DESCRIPTION
Adds a fast compilation merge gate, separate from the TeamCity-hosted test suites.

## What

- **`compileAllClasses` root Gradle task** — compiles **every source set of every module** and stops there (no tests, no packaging). It depends, per subproject, on each `*Classes` lifecycle task:
  - `main` → `classes`, `test` → `testClasses`
  - every extra source set a module declares — `:ij-plugin` / `:npx-kt` `integrationTest` → `integrationTestClasses`, `:test-integration` `tartTest` → `tartTestClasses`
  - new modules / source sets are picked up automatically (no hand-maintained list)
- **`.github/workflows/compile-check.yml`** — runs `./gradlew compileAllClasses` on `pull_request` (the gate), on push to `main`, and via `workflow_dispatch`, inside the same `docker/build` image (JDK 25) the plugin build uses, so GitHub and TeamCity compile against an identical toolchain.

## Gradle correctness notes

- Wired in `gradle.projectsEvaluated` because a source set's `*Classes` task is only registered while its owning subproject is evaluated.
- Uses `tasks.names` (lazy — lists registered names without realizing tasks) + path-string `dependsOn`. Realizing the task objects (e.g. `tasks.matching { }`) force-creates unrelated tasks such as `:ocr-tesseract:extractWindowsNatives`, which resolve a configuration at creation time and fail with *"unsafe configuration resolution"*.
- `require(...)` guards fail loud if the graph resolves to zero `*Classes` tasks or drops a load-bearing target (`:ij-plugin` + its test/integrationTest sets, `:prompts`, `:mcp-steroid-server`).

## To enable as a required gate

After merge, add the **`compile`** job as a required status check in branch protection for `main`.

## Verification

- `./gradlew compileAllClasses` → BUILD SUCCESSFUL (87 tasks, all modules compile).
- `./gradlew compileAllClasses --dry-run` → shows the full `*Classes` graph across every module; guards pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)