### PR TITLE
devrig: the binary owns ~/.mcp-steroid/bin/devrig (self-heal each start + PATH + registration)

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -1,4 +1,45 @@
 
+# Active focus — bin/devrig is the devrig binary's responsibility (PR `devrig/bin-launcher`, 2026-06-18)
+
+New PR off `origin/main` (NOT PR #113, which is parked on `installer/version-json-driven`). Contract: the
+**devrig BINARY** owns `~/.mcp-steroid/bin/devrig` — the install script owns none of it.
+
+## Done (implemented + validated)
+
+- `HomePaths.binDir` = `~/.mcp-steroid/bin`; created by `mkdirsAll()`.
+- `BinLauncher.kt` — `ensureBinLauncher(home)` runs on EVERY devrig start (wired at the top of
+  `Main.mainImpl2`, best-effort, stderr-only). It:
+  - (re)writes `bin/devrig` (POSIX) / `bin/devrig.cmd` (Windows, CMD-only) **atomically** (temp +
+    ATOMIC_MOVE), rewrite-only-on-change (normalized compare) — safe to change while the file is in use.
+  - wrapper records **ABSOLUTE** paths (no `$HOME`-relative — works from any install location incl.
+    `/tmp/devrig` in tests) and always pins the bundled JDK via `DEVRIG_JAVA_HOME` (start script honors it).
+  - **owns PATH reachability**: POSIX symlinks `bin/devrig` into the first writable PATH dir under `$HOME`
+    (never self-links, never clobbers a foreign devrig); Windows appends the bin dir to the **user** PATH
+    via PowerShell `[Environment]::SetEnvironmentVariable(...,'User')` (guarded; no `setx` truncation).
+  - **NO location guard** — the only safety is the gate below (per the "always on each start" contract).
+- `DevrigUserLauncher.kt` — single source of truth for the wrapper path + how to invoke it
+  (`cmd.exe /d /c "…devrig.cmd" …` on Windows; direct exec on POSIX; no JAVA_HOME at the call site).
+- `InstallCommand.kt` — `devrig install` now calls `ensureBinLauncher` first, then registers the STABLE
+  wrapper `~/.mcp-steroid/bin/devrig` (NOT the content-addressed install tree) so upgrades need no
+  re-registration. Dropped `selfMcpCommand` / `resolveDevrigLauncher` / the explicit-JAVA_HOME narration.
+- **Undocumented gate** `DEVRIG_BIN_NO_AUTO_REGISTER` (yes/true/1/on = OFF; no/false/0/off = ON). Default
+  (unset) = ON for release, **OFF for SNAPSHOT/dev/test** builds (SNAPSHOT in `DevrigVersionMetadata`),
+  so a dev/test build never clobbers the real launcher. Version read internally (no param).
+- Tests: `BinLauncherTest` (gate matrix, render, idempotent rewrite, symlink, foreign-not-clobbered),
+  updated `InstallCommandTest`/`HomePathsTest`; Docker `CliBinLauncherIntegrationTest` (self-heal + symlink
+  + wrapper-actually-runs with opt-in; default-off without) + updated `CliInstallIntegrationTest`
+  (opt-in env + asserts wrapper registration + wrapper written). All green. IDE inspections = 0 WARNING+.
+
+## Pending
+
+- **eugene-x220 (Windows host) live test** — BLOCKED on SSH auth (`eugene-x220.local` resolves via mDNS
+  but rejects my pubkey for all users). Need: user authorizes key OR runs the deploy+run via `!`. Goal:
+  copy a fresh `devrig` dist, run `devrig version` with `DEVRIG_BIN_NO_AUTO_REGISTER=no`, confirm
+  `%USERPROFILE%\.mcp-steroid\bin\devrig.cmd` is written + the bin dir is on the user PATH, then
+  `devrig install <agent>` registers the `cmd.exe /d /c …devrig.cmd` command.
+- 3× adversarial quorum running (Workflow `wf_4c531b7e-a96`); commit after GO.
+- Not yet committed/pushed — confirm push with the user.
+
 # Active focus — 0.96 release quality check: devrig + ij-plugin (2026-05-29)
 
 Scope: keep the 0.96 version; quality-check **devrig** (`:npx-kt`) and

--- a/TASKS.md
+++ b/TASKS.md
@@ -14,8 +14,11 @@ New PR off `origin/main` (NOT PR #113, which is parked on `installer/version-jso
   - wrapper records **ABSOLUTE** paths (no `$HOME`-relative — works from any install location incl.
     `/tmp/devrig` in tests) and always pins the bundled JDK via `DEVRIG_JAVA_HOME` (start script honors it).
   - **owns PATH reachability**: POSIX symlinks `bin/devrig` into the first writable PATH dir under `$HOME`
-    (never self-links, never clobbers a foreign devrig); Windows appends the bin dir to the **user** PATH
-    via PowerShell `[Environment]::SetEnvironmentVariable(...,'User')` (guarded; no `setx` truncation).
+    (pure Java, never self-links, never clobbers a foreign devrig, returns silently when already correct).
+    Windows: **NO PowerShell / no subprocess at startup** (per user) — the JDK cannot persist the user
+    PATH in pure Java, so it only CHECKS membership (`System.getenv("PATH")` + `File.pathSeparator`) and
+    prints a one-time manual hint if absent. Agents launch the wrapper by ABSOLUTE path, so MCP works
+    regardless of PATH.
   - **NO location guard** — the only safety is the gate below (per the "always on each start" contract).
 - `DevrigUserLauncher.kt` — single source of truth for the wrapper path + how to invoke it
   (`cmd.exe /d /c "…devrig.cmd" …` on Windows; direct exec on POSIX; no JAVA_HOME at the call site).
@@ -30,15 +33,21 @@ New PR off `origin/main` (NOT PR #113, which is parked on `installer/version-jso
   + wrapper-actually-runs with opt-in; default-off without) + updated `CliInstallIntegrationTest`
   (opt-in env + asserts wrapper registration + wrapper written). All green. IDE inspections = 0 WARNING+.
 
+## Done (cont.)
+
+- **eugene-x220 (Windows 10, Corretto 25) live test — PASSED.** SSH works as `jonnyzzz@eugene-x220.local`
+  (cmd.exe shell). Deployed a fresh SNAPSHOT dist, ran `devrig version` with
+  `DEVRIG_BIN_NO_AUTO_REGISTER=no`: `%USERPROFILE%\.mcp-steroid\bin\devrig.cmd` written with the correct
+  absolute `call` + `DEVRIG_JAVA_HOME` pin; the wrapper itself launched devrig; a 2nd start was idempotent
+  (no rewrite); NO PowerShell at startup. Test artifacts cleaned up afterward (a dangling
+  `%USERPROFILE%\.mcp-steroid\bin` user-PATH entry remains — harmless).
+- 3× adversarial quorum: GO (correctness=GO, safety=GO, tests=GO_WITH_CHANGES, no blocking issues). Its
+  non-blocking notes applied: symlink already-correct fast-path, writeAtomically temp-file cleanup.
+- **Committed** `926763f9` on `devrig/bin-launcher` (author Eugene Petrenko). NOT pushed — confirm with user.
+
 ## Pending
 
-- **eugene-x220 (Windows host) live test** — BLOCKED on SSH auth (`eugene-x220.local` resolves via mDNS
-  but rejects my pubkey for all users). Need: user authorizes key OR runs the deploy+run via `!`. Goal:
-  copy a fresh `devrig` dist, run `devrig version` with `DEVRIG_BIN_NO_AUTO_REGISTER=no`, confirm
-  `%USERPROFILE%\.mcp-steroid\bin\devrig.cmd` is written + the bin dir is on the user PATH, then
-  `devrig install <agent>` registers the `cmd.exe /d /c …devrig.cmd` command.
-- 3× adversarial quorum running (Workflow `wf_4c531b7e-a96`); commit after GO.
-- Not yet committed/pushed — confirm push with the user.
+- Push `devrig/bin-launcher` + open PR (awaiting user confirmation).
 
 # Active focus — 0.96 release quality check: devrig + ij-plugin (2026-05-29)
 

--- a/TASKS.md
+++ b/TASKS.md
@@ -45,9 +45,19 @@ New PR off `origin/main` (NOT PR #113, which is parked on `installer/version-jso
   non-blocking notes applied: symlink already-correct fast-path, writeAtomically temp-file cleanup.
 - **Committed** `926763f9` on `devrig/bin-launcher` (author Eugene Petrenko). NOT pushed — confirm with user.
 
+## Done (cont. 2)
+
+- **3× independent `run-agent.sh` peer review** (2× claude PASS_WITH_NOTES, 1× codex HOLD). All findings fixed:
+  (A, consensus) `devrig install` could register a wrapper it never wrote on SNAPSHOT → now `force=true`
+  writes it (explicit opt-out still wins) + warns if absent; (D, codex HOLD) `writeIfChanged` now restores
+  a lost `+x` bit; (B) relative pre-existing symlink resolved via `resolveSibling`; (C) PowerShell PATH
+  registration no longer runs on the `devrig mcp` hot path (`registerWindowsPath=false` for MCP). New unit
+  tests + re-verified live on Windows. Commit `4eb6cfa3`.
+- **PR opened: https://github.com/jonnyzzz/mcp-steroid/pull/117** (`devrig/bin-launcher` → `main`), pushed to origin.
+
 ## Pending
 
-- Push `devrig/bin-launcher` + open PR (awaiting user confirmation).
+- PR #117 review/merge. Windows PATH registration is user-scope only (not system); fine per design.
 
 # Active focus — 0.96 release quality check: devrig + ij-plugin (2026-05-29)
 

--- a/TASKS.md
+++ b/TASKS.md
@@ -55,9 +55,29 @@ New PR off `origin/main` (NOT PR #113, which is parked on `installer/version-jso
   tests + re-verified live on Windows. Commit `4eb6cfa3`.
 - **PR opened: https://github.com/jonnyzzz/mcp-steroid/pull/117** (`devrig/bin-launcher` → `main`), pushed to origin.
 
+## Done (cont. 3) — PR #117 author-comment review loop
+
+Author left 3 inline comments on PR #117; fed them through the run-agent.sh loop (round 3 → HOLD, round 4
+→ unanimous PASS_WITH_NOTES). Resolutions:
+- **C1** (`@Suppress("FunctionName")` on CliBinLauncherIntegrationTest): removed; live IDE CodeSmellDetector
+  = 0 warnings (backtick @Test names aren't flagged). Done.
+- **C2** ("container must not have JAVA installed"): the Docker test leaned on the container's system java,
+  never proving DEVRIG_JAVA_HOME is the SOLE JDK source. A literal no-Java image is infeasible (dist bundles
+  no JDK; first run needs java). Fix: after seeding the wrapper, the proof run poisons `java` on PATH
+  (exit-97 stub, first on PATH) + `env -u JAVA_HOME`, then runs the symlinked wrapper and asserts a version
+  still prints — proving the start script used `$DEVRIG_JAVA_HOME/bin/java` (absolute), not ambient java.
+  Docker-validated. Commit `c7b8de15`.
+- **C3** ("not looking for writable PATH on Windows?"): KEEP — all 3 reviewers confirm the HKCU user-PATH
+  registry approach is the correct Windows idiom (no ~/.local/bin convention; symlinks need admin). No change.
+- Also fixed loose "bundled JDK" wording (devrig pins the JDK it runs under) — commit `e686c7bd`.
+
+PR #117 commits now: 926763f9, b270101d, 978f8bf9, 4eb6cfa3, c7b8de15, e686c7bd (+ TASKS bookkeeping).
+
 ## Pending
 
-- PR #117 review/merge. Windows PATH registration is user-scope only (not system); fine per design.
+- PR #117 review/merge. Known non-blocking notes (deferred, not raised by the author): Windows PATH dedup
+  compares literal strings so `%USERPROFILE%`-spelled / trailing-slash variants could survive (codex r2);
+  the "no writable PATH dir" POSIX hint can false-alarm when binDir itself is on PATH.
 
 # Active focus — 0.96 release quality check: devrig + ij-plugin (2026-05-29)
 

--- a/npx-kt/src/integrationTest/kotlin/com/jonnyzzz/mcpSteroid/devrig/cli/CliBinLauncherIntegrationTest.kt
+++ b/npx-kt/src/integrationTest/kotlin/com/jonnyzzz/mcpSteroid/devrig/cli/CliBinLauncherIntegrationTest.kt
@@ -1,0 +1,82 @@
+/* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
+package com.jonnyzzz.mcpSteroid.devrig.cli
+
+import com.jonnyzzz.mcpSteroid.testHelper.CloseableStackHost
+import com.jonnyzzz.mcpSteroid.testHelper.docker.startProcessInContainer
+import com.jonnyzzz.mcpSteroid.testHelper.process.ProcessResult
+import com.jonnyzzz.mcpSteroid.testHelper.process.assertExitCode
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+import kotlin.test.assertTrue
+
+/**
+ * End-to-end Docker coverage for the devrig binary OWNING `~/.mcp-steroid/bin/devrig` — the launcher is
+ * (re)written on EVERY start, symlinked onto PATH, and the whole chain (wrapper → DEVRIG_JAVA_HOME →
+ * install-tree launcher) actually runs. Also pins the undocumented `DEVRIG_BIN_NO_AUTO_REGISTER` gate:
+ * OFF by default on this SNAPSHOT dist, ON when the env opt-in is given.
+ *
+ * Runs the REAL devrig dist inside a throwaway Linux container (see [startDevrigCliContainer]); never on
+ * the host, which would create the developer's real `~/.mcp-steroid`.
+ */
+@Suppress("FunctionName")
+class CliBinLauncherIntegrationTest {
+    private val lifetime = CloseableStackHost()
+
+    @AfterEach
+    fun tearDown() {
+        lifetime.closeAllStacks()
+    }
+
+    @Test
+    fun `with the opt-in, every start writes bin devrig, symlinks it onto PATH, and the wrapper runs`() {
+        val devrig = lifetime.startDevrigCliContainer()
+        // One shell: make a PATH dir under HOME, opt in, start devrig once (self-heal fires), then prove
+        // the launcher was written, symlinked, and the symlinked wrapper actually launches devrig.
+        val script = """
+            set -eu
+            mkdir -p "${'$'}HOME/.local/bin"
+            export PATH="${'$'}HOME/.local/bin:${'$'}PATH"
+            export DEVRIG_BIN_NO_AUTO_REGISTER=false
+            "${devrig.launcher}" version >/dev/null 2>&1 || true
+            echo "WRAPPER_EXISTS=${'$'}([ -x "${'$'}HOME/.mcp-steroid/bin/devrig" ] && echo yes || echo no)"
+            echo "SYMLINK_TARGET=${'$'}(readlink "${'$'}HOME/.local/bin/devrig" 2>/dev/null || echo none)"
+            echo "===WRAPPER==="
+            cat "${'$'}HOME/.mcp-steroid/bin/devrig"
+            echo "===RUN_VIA_SYMLINK==="
+            devrig version 2>/dev/null | head -1
+        """.trimIndent()
+
+        val out = devrig.runShell(script).assertExitCode(0, "bin-launcher self-heal").stdout
+
+        assertTrue(out.contains("WRAPPER_EXISTS=yes"), out)
+        assertTrue(Regex("SYMLINK_TARGET=.*/\\.mcp-steroid/bin/devrig").containsMatchIn(out), out)
+        // The wrapper pins the bundled JDK itself and execs the install-tree launcher (absolute path).
+        assertTrue(out.contains("DEVRIG_JAVA_HOME="), out)
+        assertTrue(out.contains("exec \"${devrig.launcher}\""), out)
+        // The whole chain works: invoking the PATH symlink (→ wrapper → DEVRIG_JAVA_HOME → devrig) runs
+        // `devrig version`, which prints a real version string (here a SNAPSHOT dist).
+        val ranVersion = out.substringAfter("===RUN_VIA_SYMLINK===")
+        assertTrue(Regex("\\d+\\.\\d+").containsMatchIn(ranVersion), "the symlinked wrapper should launch devrig:\n$out")
+    }
+
+    @Test
+    fun `without the opt-in, a SNAPSHOT build does NOT touch bin devrig (disabled by default)`() {
+        val devrig = lifetime.startDevrigCliContainer()
+        val script = """
+            "${devrig.launcher}" version >/dev/null 2>&1 || true
+            echo "WRAPPER_EXISTS=${'$'}([ -e "${'$'}HOME/.mcp-steroid/bin/devrig" ] && echo yes || echo no)"
+        """.trimIndent()
+
+        val out = devrig.runShell(script).assertExitCode(0, "default-off gate").stdout
+        assertTrue(out.contains("WRAPPER_EXISTS=no"), "SNAPSHOT default must not write the launcher:\n$out")
+    }
+
+    /** Run a `/bin/sh -c <script>` in the devrig container, returning the finished process result. */
+    private fun DevrigCliContainer.runShell(script: String, timeoutSeconds: Long = 120): ProcessResult =
+        container.startProcessInContainer {
+            args("sh", "-c", script)
+                .timeoutSeconds(timeoutSeconds)
+                .description("bin-launcher shell")
+                .quietly()
+        }.awaitForProcessFinish()
+}

--- a/npx-kt/src/integrationTest/kotlin/com/jonnyzzz/mcpSteroid/devrig/cli/CliBinLauncherIntegrationTest.kt
+++ b/npx-kt/src/integrationTest/kotlin/com/jonnyzzz/mcpSteroid/devrig/cli/CliBinLauncherIntegrationTest.kt
@@ -18,7 +18,6 @@ import kotlin.test.assertTrue
  * Runs the REAL devrig dist inside a throwaway Linux container (see [startDevrigCliContainer]); never on
  * the host, which would create the developer's real `~/.mcp-steroid`.
  */
-@Suppress("FunctionName")
 class CliBinLauncherIntegrationTest {
     private val lifetime = CloseableStackHost()
 
@@ -31,10 +30,20 @@ class CliBinLauncherIntegrationTest {
     fun `with the opt-in, every start writes bin devrig, symlinks it onto PATH, and the wrapper runs`() {
         val devrig = lifetime.startDevrigCliContainer()
         // One shell: make a PATH dir under HOME, opt in, start devrig once (self-heal fires), then prove
-        // the launcher was written, symlinked, and the symlinked wrapper actually launches devrig.
+        // the launcher was written, symlinked, and the symlinked wrapper actually launches devrig — and
+        // that the wrapper's DEVRIG_JAVA_HOME is the SOLE JDK source (no ambient java masking it).
+        //
+        // The proof for the JDK pin (PR #117 review): the container has a system `java` (the image's
+        // temurin), which the FIRST run needs (the dist bundles no JDK — chicken-and-egg). So we seed the
+        // wrapper with that system java, then for the proof run we POISON `java` on PATH with a stub that
+        // exits 97 and UNSET JAVA_HOME. The wrapper exports DEVRIG_JAVA_HOME and the install-tree start
+        // script resolves `$JAVA_HOME/bin/java` by absolute path, so it must NOT touch the poisoned PATH
+        // java. If the wrapper ever stopped pinning DEVRIG_JAVA_HOME, JAVA_HOME would be empty → the start
+        // script falls back to PATH `java` → the stub fires (exit 97, no version) → this test fails.
+        // /usr/bin:/bin stay on PATH because the start script needs coreutils (dirname/uname/basename).
         val script = """
             set -eu
-            mkdir -p "${'$'}HOME/.local/bin"
+            mkdir -p "${'$'}HOME/.local/bin" "${'$'}HOME/poison"
             export PATH="${'$'}HOME/.local/bin:${'$'}PATH"
             export DEVRIG_BIN_NO_AUTO_REGISTER=false
             "${devrig.launcher}" version >/dev/null 2>&1 || true
@@ -42,20 +51,24 @@ class CliBinLauncherIntegrationTest {
             echo "SYMLINK_TARGET=${'$'}(readlink "${'$'}HOME/.local/bin/devrig" 2>/dev/null || echo none)"
             echo "===WRAPPER==="
             cat "${'$'}HOME/.mcp-steroid/bin/devrig"
-            echo "===RUN_VIA_SYMLINK==="
-            devrig version 2>/dev/null | head -1
+            printf '#!/bin/sh\necho AMBIENT_JAVA_USED >&2\nexit 97\n' > "${'$'}HOME/poison/java"
+            chmod +x "${'$'}HOME/poison/java"
+            echo "===RUN_VIA_SYMLINK_NO_AMBIENT_JAVA==="
+            env -u JAVA_HOME PATH="${'$'}HOME/poison:${'$'}HOME/.local/bin:/usr/bin:/bin" devrig version 2>/dev/null | head -1
         """.trimIndent()
 
         val out = devrig.runShell(script).assertExitCode(0, "bin-launcher self-heal").stdout
 
         assertTrue(out.contains("WRAPPER_EXISTS=yes"), out)
         assertTrue(Regex("SYMLINK_TARGET=.*/\\.mcp-steroid/bin/devrig").containsMatchIn(out), out)
-        // The wrapper pins the bundled JDK itself and execs the install-tree launcher (absolute path).
+        // The wrapper pins the JDK devrig runs under (via DEVRIG_JAVA_HOME) and execs the install-tree
+        // launcher by absolute path.
         assertTrue(out.contains("DEVRIG_JAVA_HOME="), out)
         assertTrue(out.contains("exec \"${devrig.launcher}\""), out)
-        // The whole chain works: invoking the PATH symlink (→ wrapper → DEVRIG_JAVA_HOME → devrig) runs
-        // `devrig version`, which prints a real version string (here a SNAPSHOT dist).
-        val ranVersion = out.substringAfter("===RUN_VIA_SYMLINK===")
+        // The whole chain works AND DEVRIG_JAVA_HOME is the sole JDK source: invoking the PATH symlink
+        // (→ wrapper → DEVRIG_JAVA_HOME → devrig) prints a real version even with PATH `java` poisoned and
+        // JAVA_HOME unset. A version means the poisoned ambient java was never used.
+        val ranVersion = out.substringAfter("===RUN_VIA_SYMLINK_NO_AMBIENT_JAVA===")
         assertTrue(Regex("\\d+\\.\\d+").containsMatchIn(ranVersion), "the symlinked wrapper should launch devrig:\n$out")
     }
 

--- a/npx-kt/src/integrationTest/kotlin/com/jonnyzzz/mcpSteroid/devrig/cli/CliInstallIntegrationTest.kt
+++ b/npx-kt/src/integrationTest/kotlin/com/jonnyzzz/mcpSteroid/devrig/cli/CliInstallIntegrationTest.kt
@@ -61,6 +61,9 @@ class CliInstallIntegrationTest {
         val result = container.startProcessInContainer {
             this
                 .args("/tmp/${installDir.name}/bin/devrig", "install", agent.cliName)
+                // This dist is a SNAPSHOT, so the bin/devrig self-heal is OFF by default; opt in so
+                // `devrig install` writes ~/.mcp-steroid/bin/devrig and registers THAT stable wrapper.
+                .addEnv("DEVRIG_BIN_NO_AUTO_REGISTER", "false")
                 .description("devrig install ${agent.cliName}")
                 .timeoutSeconds(120)
                 .quietly()
@@ -69,9 +72,19 @@ class CliInstallIntegrationTest {
         val combined = result.stdout + "\n" + result.stderr
         // The install narrates what it did and confirms the registration (idempotent upsert).
         assertTrue(combined.contains("'mcp-steroid' is registered for ${agent.displayName}."), combined)
-        assertTrue(combined.contains("JAVA_HOME"), combined)
-        assertTrue(combined.contains("/tmp/${installDir.name}/bin/devrig mcp"), combined)
+        assertTrue(combined.contains("DEVRIG_JAVA_HOME"), combined)
+        // It registers the STABLE user-facing wrapper (~/.mcp-steroid/bin/devrig), NOT the install tree.
+        assertTrue(combined.contains(".mcp-steroid/bin/devrig mcp"), combined)
+        assertTrue(!combined.contains("/tmp/${installDir.name}/bin/devrig mcp"), combined)
         assertTrue(combined.contains("${agent.cliName} mcp list"), combined)
+
+        // The wrapper it registered must actually exist (install calls ensureBinLauncher first).
+        val wrapper = container.startProcessInContainer {
+            this.args("sh", "-c", "test -x \"\$HOME/.mcp-steroid/bin/devrig\" && cat \"\$HOME/.mcp-steroid/bin/devrig\"")
+                .description("inspect wrapper").timeoutSeconds(30).quietly()
+        }.awaitForProcessFinish().assertExitCode(0, "wrapper must be written by install")
+        assertTrue(wrapper.stdout.contains("DEVRIG_JAVA_HOME="), wrapper.stdout)
+        assertTrue(wrapper.stdout.contains("exec \"/tmp/${installDir.name}/bin/devrig\""), wrapper.stdout)
     }
 
     private data class InstallAgentCase(

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/BinLauncher.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/BinLauncher.kt
@@ -137,20 +137,20 @@ internal fun ensureBinLauncher(
     }
 }
 
-/** The POSIX wrapper: pins the bundled JDK via DEVRIG_JAVA_HOME, then execs the install-tree launcher. */
+/** The POSIX wrapper: pins the JDK devrig runs under via DEVRIG_JAVA_HOME, then execs the install-tree launcher. */
 internal fun renderPosixLauncher(launcher: Path, jdkHome: Path): String =
     "#!/bin/sh\n" +
         "# devrig launcher — managed by the devrig binary. Writes nothing to stdout (MCP stdio channel).\n" +
-        "# Always pins the bundled JDK via DEVRIG_JAVA_HOME (the bundled runtime is the supported one),\n" +
-        "# then hands off to the devrig binary.\n" +
+        "# Pins the JDK devrig runs under via DEVRIG_JAVA_HOME (its supported runtime), then hands off to\n" +
+        "# the install-tree devrig launcher.\n" +
         "DEVRIG_JAVA_HOME=\"$jdkHome\"; export DEVRIG_JAVA_HOME\n" +
         "exec \"$launcher\" \"\$@\"\n"
 
 /**
- * The self-contained Windows launcher: pure batch, NO PowerShell at launch. It ALWAYS pins the bundled
- * JDK via DEVRIG_JAVA_HOME (the bundled runtime is the supported one), then `call`s the bundled
- * devrig.bat. STDOUT cleanliness (the MCP JSON-RPC channel): `@echo off` + `set`/`call` emit nothing to
- * stdout; only the inner devrig.bat → java does. The agent invokes this via `cmd.exe /d /c` — see
+ * The self-contained Windows launcher: pure batch, NO PowerShell at launch. It ALWAYS pins the JDK devrig
+ * runs under via DEVRIG_JAVA_HOME (its supported runtime), then `call`s the install-tree devrig.bat.
+ * STDOUT cleanliness (the MCP JSON-RPC channel): `@echo off` + `set`/`call` emit nothing to stdout; only
+ * the inner devrig.bat → java does. The agent invokes this via `cmd.exe /d /c` — see
  * [DevrigUserLauncher.invocation].
  */
 internal fun renderWindowsCmd(launcher: Path, jdkHome: Path): String =

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/BinLauncher.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/BinLauncher.kt
@@ -32,10 +32,22 @@ internal const val ENV_BIN_NO_AUTO_REGISTER = "DEVRIG_BIN_NO_AUTO_REGISTER"
  * The build version is read straight from the generated [DevrigVersionMetadata]; only the env value is a
  * parameter, so the env-override branches stay unit-testable without faking the version.
  */
-internal fun binAutoRegisterEnabled(envValue: String? = System.getenv(ENV_BIN_NO_AUTO_REGISTER)): Boolean {
-    parseBinAutoRegisterOptOut(envValue)?.let { optedOut -> return !optedOut }
-    return !DevrigVersionMetadata.getDevrigVersion().contains("SNAPSHOT", ignoreCase = true)
-}
+internal fun binAutoRegisterEnabled(envValue: String? = System.getenv(ENV_BIN_NO_AUTO_REGISTER)): Boolean =
+    shouldWriteLauncher(envValue, force = false)
+
+/**
+ * Whether to (re)write the launcher. Explicit env wins both ways. With no env: a passive start follows
+ * the SNAPSHOT default (off for dev/test, on for release); an explicit `devrig install` ([force]) writes
+ * regardless of that default — install is explicit user intent, so it must never leave a dangling
+ * registration (a wrapper path registered for the agent but never written) on a dev/SNAPSHOT dist. An
+ * explicit opt-out (`DEVRIG_BIN_NO_AUTO_REGISTER=yes`) still wins, even over [force].
+ */
+internal fun shouldWriteLauncher(envValue: String?, force: Boolean): Boolean =
+    when (parseBinAutoRegisterOptOut(envValue)) {
+        true -> false
+        false -> true
+        null -> force || !DevrigVersionMetadata.getDevrigVersion().contains("SNAPSHOT", ignoreCase = true)
+    }
 
 /** `true` = opt-out (disable), `false` = opt-in (enable), `null` = unset/unrecognized (use the default). */
 private fun parseBinAutoRegisterOptOut(value: String?): Boolean? = when (value?.trim()?.lowercase()) {
@@ -53,20 +65,25 @@ private fun parseBinAutoRegisterOptOut(value: String?): Boolean? = when (value?.
  *     at devrig's OWN current install tree and the JDK it is running under — so the launcher self-heals
  *     if it is missing or stale (e.g. after an upgrade repointed the install tree).
  *  2. that launcher is reachable on PATH — POSIX symlinks it into a writable PATH dir under `$HOME`
- *     (pure Java, no subprocess); Windows cannot persist the user PATH from pure Java and must not spawn
- *     a process on the startup path, so it only checks membership and prints a one-time manual hint when
- *     the bin dir is absent (agents launch the wrapper by absolute path, so MCP works regardless).
+ *     (pure Java, no subprocess). Windows registers the bin dir on the user PATH via a marker-gated
+ *     PowerShell call, but only when [registerWindowsPath] is true — callers pass false for the
+ *     `devrig mcp` start so PowerShell never blocks the latency-sensitive MCP serve path (the agent
+ *     launches the wrapper by absolute path anyway); interactive/`install` invocations pass true.
  *
  * The launcher is rewritten ONLY when its content actually changed (normalized comparison), never on
  * every launch — and writes are atomic (temp file + atomic move), so a concurrent agent that is mid-read
- * of the file (the contract: it can change WHILE the binary runs) never sees a torn launcher.
+ * of the file (the contract: it can change WHILE the binary runs) never sees a torn launcher. When the
+ * content already matches, a lost executable bit is still repaired.
+ *
+ * [force] = an explicit `devrig install`: write regardless of the SNAPSHOT/dev passive-start default
+ * (but still honoring an explicit opt-out), so install never registers a wrapper it didn't write.
  *
  * Best-effort: any failure to resolve devrig's root, write the launcher, or touch PATH is logged to
  * stderr and swallowed — it must never prevent `devrig mcp` from serving. All output goes to stderr;
  * stdout is the MCP JSON-RPC channel.
  */
-fun ensureBinLauncher(home: HomePaths) {
-    if (!binAutoRegisterEnabled()) {
+fun ensureBinLauncher(home: HomePaths, force: Boolean = false, registerWindowsPath: Boolean = true) {
+    if (!shouldWriteLauncher(System.getenv(ENV_BIN_NO_AUTO_REGISTER), force)) {
         return
     }
     try {
@@ -77,6 +94,7 @@ fun ensureBinLauncher(home: HomePaths) {
             ownJava = Path.of(System.getProperty("java.home")).toAbsolutePath().normalize(),
             userHome = Path.of(System.getProperty("user.home")).toAbsolutePath().normalize(),
             pathDirs = (System.getenv("PATH") ?: "").split(File.pathSeparatorChar),
+            registerWindowsPath = registerWindowsPath,
         )
     } catch (e: Exception) {
         System.err.println("[mcp-steroid] could not (re)write the devrig launcher: $e")
@@ -100,6 +118,7 @@ internal fun ensureBinLauncher(
     ownJava: Path,
     userHome: Path,
     pathDirs: List<String>,
+    registerWindowsPath: Boolean = true,
 ) {
     val ownBin = ownRoot.resolve("bin").resolve(if (isWin) "devrig.bat" else "devrig").toAbsolutePath().normalize()
     val jdkHome = ownJava.toAbsolutePath().normalize()
@@ -108,7 +127,9 @@ internal fun ensureBinLauncher(
         // needed by the install SCRIPT, not the launcher.
         val cmd = home.binDir.resolve("devrig.cmd")
         writeIfChanged(home.binDir, cmd, renderWindowsCmd(ownBin, jdkHome), executable = false, ownBin = ownBin)
-        ensureWindowsPathEntry(home.binDir)
+        // PATH registration spawns PowerShell, so skip it on the `devrig mcp` hot path (registerWindowsPath
+        // = false) — it would block the first serve until the marker exists. Interactive/install pass true.
+        if (registerWindowsPath) ensureWindowsPathEntry(home.binDir)
     } else {
         val devrig = home.binDir.resolve("devrig")
         writeIfChanged(home.binDir, devrig, renderPosixLauncher(ownBin, jdkHome), executable = true, ownBin = ownBin)
@@ -146,7 +167,15 @@ private fun writeIfChanged(dir: Path, target: Path, desired: String, executable:
         System.err.println("[mcp-steroid] existing launcher $target is unreadable ($e); rewriting it")
         null
     }
-    if (current != null && normalizeLauncher(current) == normalizeLauncher(desired)) return
+    if (current != null && normalizeLauncher(current) == normalizeLauncher(desired)) {
+        // Content already correct — but a launcher that lost its executable bit (e.g. a copy that dropped
+        // perms) must still self-heal, so re-set +x in place without rewriting the bytes.
+        if (executable && !Files.isExecutable(target)) {
+            setExecutable(target)
+            System.err.println("[mcp-steroid] restored the executable bit on $target")
+        }
+        return
+    }
     writeAtomically(dir, target, desired, executable)
     System.err.println("[mcp-steroid] (re)wrote $target -> $ownBin")
 }
@@ -181,8 +210,9 @@ internal fun ensurePosixPathSymlink(binDir: Path, binDevrig: Path, userHome: Pat
         // NotLinkException; a rare IO error bubbles to ensureBinLauncher's best-effort catch (logged).
         if (Files.isSymbolicLink(link)) {
             // Already OUR symlink → nothing to do; return silently so we don't churn the FS or log on
-            // every start (the on-each-start contract means this is the steady-state path).
-            if (Files.readSymbolicLink(link).toAbsolutePath().normalize() == target) return
+            // every start (the on-each-start contract means this is the steady-state path). resolveSibling
+            // handles a RELATIVE link target (resolve against the link's own dir, not the process CWD).
+            if (link.resolveSibling(Files.readSymbolicLink(link)).normalize() == target) return
             continue // foreign symlink — do not clobber
         }
         if (link.exists()) continue // foreign real file — do not clobber

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/BinLauncher.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/BinLauncher.kt
@@ -108,7 +108,7 @@ internal fun ensureBinLauncher(
         // needed by the install SCRIPT, not the launcher.
         val cmd = home.binDir.resolve("devrig.cmd")
         writeIfChanged(home.binDir, cmd, renderWindowsCmd(ownBin, jdkHome), executable = false, ownBin = ownBin)
-        ensureWindowsPathEntry(home.binDir, pathDirs)
+        ensureWindowsPathEntry(home.binDir)
     } else {
         val devrig = home.binDir.resolve("devrig")
         writeIfChanged(home.binDir, devrig, renderPosixLauncher(ownBin, jdkHome), executable = true, ownBin = ownBin)
@@ -202,35 +202,53 @@ internal fun ensurePosixPathSymlink(binDir: Path, binDevrig: Path, userHome: Pat
 }
 
 /**
- * Make `bin/devrig.cmd` discoverable for INTERACTIVE Windows use. We do **NOT** spawn anything from the
- * startup path (no PowerShell, no `setx`) and never touch the registry — the JDK cannot persist the user
- * PATH in pure Java, and spawning a process on every `devrig mcp` start is exactly what we must avoid.
- * Agents launch the wrapper by ABSOLUTE path (see [DevrigUserLauncher.invocation]), so PATH membership is
- * only a human convenience, never a correctness requirement. So this just CHECKS membership against the
- * process PATH (`System.getenv("PATH")` split by [File.pathSeparatorChar], passed in as [pathDirs]) and,
- * if the bin dir is absent, prints a one-time manual hint to stderr (guarded by a marker so it is not
- * repeated on every start). The POSIX side actively symlinks (pure Java, no subprocess); Windows cannot,
- * so it informs instead.
+ * Register `bin/devrig.cmd` on the **user** PATH so `devrig` is runnable directly from a terminal
+ * (the POSIX side does the equivalent with a symlink). The JDK cannot persist the user environment in
+ * pure Java, so we use PowerShell to update `HKCU\Environment\Path` — but **only once per install**: a
+ * marker file gates it so we do NOT spawn PowerShell on every `devrig mcp` / `version` / `install` start
+ * (the bin dir is stable across upgrades, so one registration lasts). The PowerShell **deduplicates**:
+ * it strips every existing entry equal to the bin dir and appends exactly one, so re-runs (or a stale
+ * entry from an earlier install) never accumulate duplicates. No `setx` (it truncates PATH at 1024
+ * chars). stdout is discarded (the MCP JSON-RPC channel); it narrates to stderr. Agents launch the
+ * wrapper by ABSOLUTE path (see [DevrigUserLauncher.invocation]), so MCP works even before a new shell
+ * picks up the updated PATH. Best-effort: a missing marker re-runs it; any failure is logged and ignored.
  */
-internal fun ensureWindowsPathEntry(binDir: Path, pathDirs: List<String>) {
+internal fun ensureWindowsPathEntry(binDir: Path) {
     val binDirNorm = binDir.toAbsolutePath().normalize()
-    if (pathDirs.any { it.isNotBlank() && pathEntryEquals(it, binDirNorm) }) return
-    val marker = binDirNorm.resolve(".path-hint-shown")
+    val marker = binDirNorm.resolve(".user-path-registered")
     if (Files.exists(marker)) return
-    System.err.println(
-        "[mcp-steroid] $binDirNorm is not on your PATH. To run 'devrig' directly from a terminal, add it " +
-            "via System Properties -> Environment Variables (User PATH). Agents use the full path, so MCP " +
-            "works regardless.",
-    )
+    val bin = binDirNorm.toString()
+    // De-dup: drop blanks and any existing == bin entry, then append exactly one bin entry.
+    val script =
+        "\$d = '${bin.replace("'", "''")}'; " +
+            "\$p = [Environment]::GetEnvironmentVariable('Path','User'); if (\$null -eq \$p) { \$p = '' }; " +
+            "\$parts = @(\$p -split ';' | Where-Object { \$_ -ne '' -and \$_ -ne \$d }); " +
+            "\$new = (\$parts + \$d) -join ';'; " +
+            "[Environment]::SetEnvironmentVariable('Path', \$new, 'User'); " +
+            "[Console]::Error.WriteLine('[mcp-steroid] registered ' + \$d + ' on the user PATH (1 entry; open a new terminal to use it)')"
     try {
-        Files.writeString(marker, binDirNorm.toString())
+        val exit = ProcessBuilder("powershell", "-NoProfile", "-NonInteractive", "-Command", script)
+            .redirectErrorStream(false)
+            .redirectOutput(ProcessBuilder.Redirect.DISCARD) // keep the MCP JSON-RPC channel clean
+            .redirectError(ProcessBuilder.Redirect.INHERIT)
+            .start()
+            .waitFor()
+        if (exit == 0) {
+            try {
+                Files.writeString(marker, bin)
+            } catch (e: Exception) {
+                System.err.println("[mcp-steroid] could not write the user-PATH marker $marker: $e")
+            }
+        } else {
+            System.err.println("[mcp-steroid] PowerShell PATH registration exited $exit; will retry next start")
+        }
     } catch (e: Exception) {
-        System.err.println("[mcp-steroid] could not write the PATH-hint marker $marker: $e")
+        System.err.println(
+            "[mcp-steroid] could not register $bin on the user PATH ($e); add it manually via " +
+                "System Properties -> Environment Variables (User PATH), or run devrig by full path",
+        )
     }
 }
-
-private fun pathEntryEquals(entry: String, dir: Path): Boolean =
-    runCatching { Path.of(entry).toAbsolutePath().normalize() }.getOrNull() == dir
 
 private fun writeAtomically(dir: Path, target: Path, content: String, executable: Boolean) {
     Files.createDirectories(dir)

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/BinLauncher.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/BinLauncher.kt
@@ -1,0 +1,274 @@
+/* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
+package com.jonnyzzz.mcpSteroid.devrig
+
+import java.io.File
+import java.nio.file.AtomicMoveNotSupportedException
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.StandardCopyOption
+import java.nio.file.attribute.PosixFilePermission
+import kotlin.io.path.exists
+import kotlin.io.path.readText
+
+internal fun isWindows(): Boolean =
+    System.getProperty("os.name").lowercase().contains("windows")
+
+/**
+ * Undocumented escape hatch governing the on-each-start launcher self-heal ([ensureBinLauncher]).
+ * Intentionally NOT mentioned in `devrig --help` / docs — it exists for tests and for power users who
+ * manage `~/.mcp-steroid/bin/devrig` themselves.
+ */
+internal const val ENV_BIN_NO_AUTO_REGISTER = "DEVRIG_BIN_NO_AUTO_REGISTER"
+
+/**
+ * Whether the binary should own (write + PATH-link) `~/.mcp-steroid/bin/devrig` on this start.
+ *
+ *  - [ENV_BIN_NO_AUTO_REGISTER] = `yes`/`true`/`1`/`on`  → OFF (explicit opt-out).
+ *  - [ENV_BIN_NO_AUTO_REGISTER] = `no`/`false`/`0`/`off` → ON  (explicit opt-in — overrides the default,
+ *    which is how the integration test enables it on a SNAPSHOT build).
+ *  - unset / unrecognized → ON for release builds, OFF for SNAPSHOT/dev builds (and thus for tests,
+ *    whose devrig is always a SNAPSHOT) so a dev build never clobbers the user's real launcher.
+ *
+ * The build version is read straight from the generated [DevrigVersionMetadata]; only the env value is a
+ * parameter, so the env-override branches stay unit-testable without faking the version.
+ */
+internal fun binAutoRegisterEnabled(envValue: String? = System.getenv(ENV_BIN_NO_AUTO_REGISTER)): Boolean {
+    parseBinAutoRegisterOptOut(envValue)?.let { optedOut -> return !optedOut }
+    return !DevrigVersionMetadata.getDevrigVersion().contains("SNAPSHOT", ignoreCase = true)
+}
+
+/** `true` = opt-out (disable), `false` = opt-in (enable), `null` = unset/unrecognized (use the default). */
+private fun parseBinAutoRegisterOptOut(value: String?): Boolean? = when (value?.trim()?.lowercase()) {
+    "yes", "true", "1", "on" -> true
+    "no", "false", "0", "off" -> false
+    else -> null
+}
+
+/**
+ * Self-registration of the user-facing `~/.mcp-steroid/bin` launcher AND its reachability on the user's
+ * PATH. **The devrig binary owns both** — the install script does neither.
+ *
+ * On EVERY devrig start this ensures:
+ *  1. `~/.mcp-steroid/bin/devrig` (POSIX) / `~/.mcp-steroid/bin/devrig.cmd` (Windows) exists and points
+ *     at devrig's OWN current install tree and the JDK it is running under — so the launcher self-heals
+ *     if it is missing or stale (e.g. after an upgrade repointed the install tree).
+ *  2. that launcher is reachable on PATH — POSIX symlinks it into a writable PATH dir under `$HOME`
+ *     (pure Java, no subprocess); Windows cannot persist the user PATH from pure Java and must not spawn
+ *     a process on the startup path, so it only checks membership and prints a one-time manual hint when
+ *     the bin dir is absent (agents launch the wrapper by absolute path, so MCP works regardless).
+ *
+ * The launcher is rewritten ONLY when its content actually changed (normalized comparison), never on
+ * every launch — and writes are atomic (temp file + atomic move), so a concurrent agent that is mid-read
+ * of the file (the contract: it can change WHILE the binary runs) never sees a torn launcher.
+ *
+ * Best-effort: any failure to resolve devrig's root, write the launcher, or touch PATH is logged to
+ * stderr and swallowed — it must never prevent `devrig mcp` from serving. All output goes to stderr;
+ * stdout is the MCP JSON-RPC channel.
+ */
+fun ensureBinLauncher(home: HomePaths) {
+    if (!binAutoRegisterEnabled()) {
+        return
+    }
+    try {
+        ensureBinLauncher(
+            home = home,
+            isWin = isWindows(),
+            ownRoot = DevrigRoot.path,
+            ownJava = Path.of(System.getProperty("java.home")).toAbsolutePath().normalize(),
+            userHome = Path.of(System.getProperty("user.home")).toAbsolutePath().normalize(),
+            pathDirs = (System.getenv("PATH") ?: "").split(File.pathSeparatorChar),
+        )
+    } catch (e: Exception) {
+        System.err.println("[mcp-steroid] could not (re)write the devrig launcher: $e")
+    }
+}
+
+/**
+ * Testable core — every input is explicit (no environment lookups), so the OS branch and path logic are
+ * unit-testable without touching `os.name` / `user.home` / `java.home` / `PATH`.
+ *
+ * There is NO "only when installed under ~/.mcp-steroid" guard: the contract is that the launcher is
+ * (re)written on EVERY start, pointing at wherever this binary currently runs from. The safety against a
+ * dev build clobbering a real launcher is the SNAPSHOT/env gate in [binAutoRegisterEnabled], not a
+ * location check — so the wrapper records ABSOLUTE paths and works from any install location (including
+ * the `/tmp/devrig` the integration test copies the dist to).
+ */
+internal fun ensureBinLauncher(
+    home: HomePaths,
+    isWin: Boolean,
+    ownRoot: Path,
+    ownJava: Path,
+    userHome: Path,
+    pathDirs: List<String>,
+) {
+    val ownBin = ownRoot.resolve("bin").resolve(if (isWin) "devrig.bat" else "devrig").toAbsolutePath().normalize()
+    val jdkHome = ownJava.toAbsolutePath().normalize()
+    if (isWin) {
+        // CMD-only launcher: a single self-contained devrig.cmd. No PowerShell at launch — PS is only
+        // needed by the install SCRIPT, not the launcher.
+        val cmd = home.binDir.resolve("devrig.cmd")
+        writeIfChanged(home.binDir, cmd, renderWindowsCmd(ownBin, jdkHome), executable = false, ownBin = ownBin)
+        ensureWindowsPathEntry(home.binDir, pathDirs)
+    } else {
+        val devrig = home.binDir.resolve("devrig")
+        writeIfChanged(home.binDir, devrig, renderPosixLauncher(ownBin, jdkHome), executable = true, ownBin = ownBin)
+        ensurePosixPathSymlink(home.binDir, devrig, userHome, pathDirs)
+    }
+}
+
+/** The POSIX wrapper: pins the bundled JDK via DEVRIG_JAVA_HOME, then execs the install-tree launcher. */
+internal fun renderPosixLauncher(launcher: Path, jdkHome: Path): String =
+    "#!/bin/sh\n" +
+        "# devrig launcher — managed by the devrig binary. Writes nothing to stdout (MCP stdio channel).\n" +
+        "# Always pins the bundled JDK via DEVRIG_JAVA_HOME (the bundled runtime is the supported one),\n" +
+        "# then hands off to the devrig binary.\n" +
+        "DEVRIG_JAVA_HOME=\"$jdkHome\"; export DEVRIG_JAVA_HOME\n" +
+        "exec \"$launcher\" \"\$@\"\n"
+
+/**
+ * The self-contained Windows launcher: pure batch, NO PowerShell at launch. It ALWAYS pins the bundled
+ * JDK via DEVRIG_JAVA_HOME (the bundled runtime is the supported one), then `call`s the bundled
+ * devrig.bat. STDOUT cleanliness (the MCP JSON-RPC channel): `@echo off` + `set`/`call` emit nothing to
+ * stdout; only the inner devrig.bat → java does. The agent invokes this via `cmd.exe /d /c` — see
+ * [DevrigUserLauncher.invocation].
+ */
+internal fun renderWindowsCmd(launcher: Path, jdkHome: Path): String =
+    "@echo off\r\n" +
+        "set \"DEVRIG_JAVA_HOME=$jdkHome\"\r\n" +
+        "call \"$launcher\" %*\r\n"
+
+private fun writeIfChanged(dir: Path, target: Path, desired: String, executable: Boolean, ownBin: Path) {
+    // An unreadable existing launcher (non-UTF-8 bytes, wrong file type, transient IO) counts as
+    // "changed" so a corrupt launcher self-heals rather than being left in place.
+    val current = if (!target.exists()) null else try {
+        target.readText()
+    } catch (e: Exception) {
+        System.err.println("[mcp-steroid] existing launcher $target is unreadable ($e); rewriting it")
+        null
+    }
+    if (current != null && normalizeLauncher(current) == normalizeLauncher(desired)) return
+    writeAtomically(dir, target, desired, executable)
+    System.err.println("[mcp-steroid] (re)wrote $target -> $ownBin")
+}
+
+/** Tolerant of CRLF↔LF and trailing-newline differences so we rewrite ONLY on a real content change. */
+internal fun normalizeLauncher(s: String): String = s.replace("\r\n", "\n").trimEnd('\n')
+
+/**
+ * Make `bin/devrig` reachable on PATH by symlinking it into the first writable PATH directory under
+ * `$HOME`. Mirrors the install.sh logic that this now replaces: never edits shell profiles, never
+ * touches system dirs, never clobbers a `devrig` that is not already our own symlink, and never
+ * self-links the bin dir. Best-effort — a missing PATH dir is fine; the launcher still works by full path.
+ */
+internal fun ensurePosixPathSymlink(binDir: Path, binDevrig: Path, userHome: Path, pathDirs: List<String>) {
+    val target = binDevrig.toAbsolutePath().normalize()
+    val binDirNorm = binDir.toAbsolutePath().normalize()
+    val homeNorm = userHome.toAbsolutePath().normalize()
+    for (entry in pathDirs) {
+        if (entry.isBlank()) continue
+        val dir = try {
+            Path.of(entry).toAbsolutePath().normalize()
+        } catch (e: Exception) {
+            System.err.println("[mcp-steroid] skipping malformed PATH entry '$entry': $e")
+            continue
+        }
+        if (dir == binDirNorm) continue                 // never self-link
+        if (!dir.startsWith(homeNorm)) continue          // only directories under your home
+        if (!Files.isDirectory(dir) || !Files.isWritable(dir)) continue
+        val link = dir.resolve("devrig")
+        // Never clobber a `devrig` we did not create: a real (non-symlink) file, or a symlink pointing
+        // elsewhere. readSymbolicLink is only called once we know it IS a symlink, so it cannot throw
+        // NotLinkException; a rare IO error bubbles to ensureBinLauncher's best-effort catch (logged).
+        if (Files.isSymbolicLink(link)) {
+            // Already OUR symlink → nothing to do; return silently so we don't churn the FS or log on
+            // every start (the on-each-start contract means this is the steady-state path).
+            if (Files.readSymbolicLink(link).toAbsolutePath().normalize() == target) return
+            continue // foreign symlink — do not clobber
+        }
+        if (link.exists()) continue // foreign real file — do not clobber
+        try {
+            // We only reach here when nothing exists at `link`, so no deleteIfExists is needed.
+            Files.createSymbolicLink(link, target)
+            System.err.println("[mcp-steroid] linked $link -> $target")
+            return
+        } catch (e: Exception) {
+            System.err.println("[mcp-steroid] could not symlink $link -> $target ($e); trying the next PATH dir")
+        }
+    }
+    System.err.println(
+        "[mcp-steroid] devrig is installed at $target but no writable PATH dir under \$HOME was found; " +
+            "add it to PATH manually: export PATH=\"\$HOME/.mcp-steroid/bin:\$PATH\"",
+    )
+}
+
+/**
+ * Make `bin/devrig.cmd` discoverable for INTERACTIVE Windows use. We do **NOT** spawn anything from the
+ * startup path (no PowerShell, no `setx`) and never touch the registry — the JDK cannot persist the user
+ * PATH in pure Java, and spawning a process on every `devrig mcp` start is exactly what we must avoid.
+ * Agents launch the wrapper by ABSOLUTE path (see [DevrigUserLauncher.invocation]), so PATH membership is
+ * only a human convenience, never a correctness requirement. So this just CHECKS membership against the
+ * process PATH (`System.getenv("PATH")` split by [File.pathSeparatorChar], passed in as [pathDirs]) and,
+ * if the bin dir is absent, prints a one-time manual hint to stderr (guarded by a marker so it is not
+ * repeated on every start). The POSIX side actively symlinks (pure Java, no subprocess); Windows cannot,
+ * so it informs instead.
+ */
+internal fun ensureWindowsPathEntry(binDir: Path, pathDirs: List<String>) {
+    val binDirNorm = binDir.toAbsolutePath().normalize()
+    if (pathDirs.any { it.isNotBlank() && pathEntryEquals(it, binDirNorm) }) return
+    val marker = binDirNorm.resolve(".path-hint-shown")
+    if (Files.exists(marker)) return
+    System.err.println(
+        "[mcp-steroid] $binDirNorm is not on your PATH. To run 'devrig' directly from a terminal, add it " +
+            "via System Properties -> Environment Variables (User PATH). Agents use the full path, so MCP " +
+            "works regardless.",
+    )
+    try {
+        Files.writeString(marker, binDirNorm.toString())
+    } catch (e: Exception) {
+        System.err.println("[mcp-steroid] could not write the PATH-hint marker $marker: $e")
+    }
+}
+
+private fun pathEntryEquals(entry: String, dir: Path): Boolean =
+    runCatching { Path.of(entry).toAbsolutePath().normalize() }.getOrNull() == dir
+
+private fun writeAtomically(dir: Path, target: Path, content: String, executable: Boolean) {
+    Files.createDirectories(dir)
+    val tmp = dir.resolve(".tmp.${ProcessHandle.current().pid()}.${target.fileName}")
+    try {
+        Files.writeString(tmp, content)
+        // Set the executable bit on the staging file BEFORE the move, so the final launcher is never
+        // momentarily non-executable (mirrors install.sh: chmod +x then mv).
+        if (executable) setExecutable(tmp)
+        try {
+            Files.move(tmp, target, StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING)
+        } catch (e: AtomicMoveNotSupportedException) {
+            System.err.println("[mcp-steroid] atomic move unsupported (${e.message}); using a plain move")
+            Files.move(tmp, target, StandardCopyOption.REPLACE_EXISTING)
+        }
+    } finally {
+        // On success the move consumed tmp (this is a no-op); on any failure above, sweep the orphan
+        // staging file instead of leaking a `.tmp.<pid>.devrig` into the bin dir.
+        if (Files.exists(tmp)) {
+            try {
+                Files.deleteIfExists(tmp)
+            } catch (e: Exception) {
+                System.err.println("[mcp-steroid] could not remove staging file $tmp: $e")
+            }
+        }
+    }
+}
+
+private fun setExecutable(file: Path) {
+    try {
+        val perms = Files.getPosixFilePermissions(file).toMutableSet()
+        perms += PosixFilePermission.OWNER_EXECUTE
+        perms += PosixFilePermission.GROUP_EXECUTE
+        perms += PosixFilePermission.OTHERS_EXECUTE
+        Files.setPosixFilePermissions(file, perms)
+    } catch (e: UnsupportedOperationException) {
+        // Non-POSIX filesystem (e.g. Windows): fall back to the File API.
+        System.err.println("[mcp-steroid] POSIX permissions unsupported (${e.message}); using File.setExecutable")
+        file.toFile().setExecutable(true, false)
+    }
+}

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/DevrigUserLauncher.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/DevrigUserLauncher.kt
@@ -11,7 +11,7 @@ import java.nio.file.Path
  *
  * The launcher — POSIX `devrig`; Windows `devrig.cmd` (a self-contained batch, no PowerShell) — is the
  * self-healing wrapper that [ensureBinLauncher] writes on every devrig start. It always sets
- * `DEVRIG_JAVA_HOME` to the bundled JDK ITSELF, so **no caller needs to deal with JAVA_HOME**. Pointing
+ * `DEVRIG_JAVA_HOME` to the JDK devrig runs under, so **no caller needs to deal with JAVA_HOME**. Pointing
  * registrations/docs at this stable path (rather than a content-addressed install tree that changes on
  * every upgrade) is what lets the wrapper repoint underneath without re-registering the agent.
  */
@@ -24,7 +24,7 @@ object DevrigUserLauncher {
      * OS-correct command to run the user launcher with [args]. Windows runs the `.cmd` through
      * `cmd.exe /d /c` (a `.cmd` is not directly executable as a process image, and `/d` skips any
      * AutoRun script); POSIX execs the script directly. **No JAVA_HOME** — the launcher exports
-     * `DEVRIG_JAVA_HOME` for the bundled JDK.
+     * `DEVRIG_JAVA_HOME` for the JDK devrig runs under.
      */
     fun invocation(home: HomePaths, args: List<String>, windows: Boolean = isWindows()): StdioMcpCommand {
         val launcher = path(home, windows).toString()

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/DevrigUserLauncher.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/DevrigUserLauncher.kt
@@ -1,0 +1,41 @@
+/* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
+package com.jonnyzzz.mcpSteroid.devrig
+
+import com.jonnyzzz.mcpSteroid.aiAgents.StdioMcpCommand
+import java.nio.file.Path
+
+/**
+ * Single source of truth for the user-facing devrig launcher under `~/.mcp-steroid/bin` and how to
+ * INVOKE it from another process (agent MCP registration, prompts/docs, anywhere a command line is
+ * built).
+ *
+ * The launcher — POSIX `devrig`; Windows `devrig.cmd` (a self-contained batch, no PowerShell) — is the
+ * self-healing wrapper that [ensureBinLauncher] writes on every devrig start. It always sets
+ * `DEVRIG_JAVA_HOME` to the bundled JDK ITSELF, so **no caller needs to deal with JAVA_HOME**. Pointing
+ * registrations/docs at this stable path (rather than a content-addressed install tree that changes on
+ * every upgrade) is what lets the wrapper repoint underneath without re-registering the agent.
+ */
+object DevrigUserLauncher {
+    /** The user-facing launcher file for [windows]: `~/.mcp-steroid/bin/devrig` or `…/devrig.cmd`. */
+    fun path(home: HomePaths, windows: Boolean = isWindows()): Path =
+        home.binDir.resolve(if (windows) "devrig.cmd" else "devrig").toAbsolutePath().normalize()
+
+    /**
+     * OS-correct command to run the user launcher with [args]. Windows runs the `.cmd` through
+     * `cmd.exe /d /c` (a `.cmd` is not directly executable as a process image, and `/d` skips any
+     * AutoRun script); POSIX execs the script directly. **No JAVA_HOME** — the launcher exports
+     * `DEVRIG_JAVA_HOME` for the bundled JDK.
+     */
+    fun invocation(home: HomePaths, args: List<String>, windows: Boolean = isWindows()): StdioMcpCommand {
+        val launcher = path(home, windows).toString()
+        return if (windows) {
+            // cmd.exe parses everything after `/c` as ONE command line, so the launcher path must be
+            // quoted or a `%USERPROFILE%` with a space (e.g. C:\Users\First Last) splits and the server
+            // never starts.
+            val line = (listOf("\"$launcher\"") + args).joinToString(" ")
+            StdioMcpCommand(command = "cmd.exe", args = listOf("/d", "/c", line))
+        } else {
+            StdioMcpCommand(command = launcher, args = args)
+        }
+    }
+}

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/HomePaths.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/HomePaths.kt
@@ -15,6 +15,14 @@ class HomePaths(val home: Path) {
     val executionStorageDir: Path get() = home.resolve("execution-storage")
 
     /**
+     * Directory holding the stable, user-facing devrig launcher (`bin/devrig` on POSIX, `bin/devrig.cmd`
+     * on Windows). The devrig binary OWNS this directory: it (re)writes the launcher on every start (see
+     * [ensureBinLauncher]) and points agent MCP registrations + the user-PATH symlink at `bin/devrig`,
+     * never at the content-addressed install tree (which changes on every upgrade).
+     */
+    val binDir: Path get() = home.resolve("bin")
+
+    /**
      * Directory where the IDE plugin writes per-pid markers and devrig reads them from — always
      * `~/.mcp-steroid/markers`, the same fixed location [home] resolves to. This is the plugin↔devrig
      * contract for marker discovery, so it must never be relocated.
@@ -26,7 +34,7 @@ class HomePaths(val home: Path) {
     fun pidFile(id: String): Path = stateDir.resolve("$id.pid")
 
     fun mkdirsAll() {
-        listOf(logsDir, backendsDir, cachesDir, downloadsDir, stateDir).forEach { Files.createDirectories(it) }
+        listOf(logsDir, backendsDir, cachesDir, downloadsDir, stateDir, binDir).forEach { Files.createDirectories(it) }
     }
 }
 

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/InstallCommand.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/InstallCommand.kt
@@ -9,23 +9,31 @@ import com.jonnyzzz.mcpSteroid.aiAgents.mcpAddStdioInvocation
 import com.jonnyzzz.mcpSteroid.aiAgents.mcpListInvocation
 import com.jonnyzzz.mcpSteroid.aiAgents.mcpRemoveInvocation
 import java.io.PrintStream
-import java.nio.file.Path
-import kotlin.io.path.isRegularFile
 
 private const val DEVRIG_MCP_SERVER_NAME = "mcp-steroid"
 private const val DEVRIG_LEGACY_SERVER_NAME = "devrig"
 
+/**
+ * Registers the **user-facing launcher** (`~/.mcp-steroid/bin/devrig`) as the agent's MCP server. We
+ * register that stable wrapper — never the content-addressed install tree, which changes on every
+ * upgrade — so an upgrade repoints the launcher underneath without re-registering the agent, and we
+ * first call [ensureBinLauncher] so the wrapper definitely exists at the path we are about to register.
+ * The wrapper pins the bundled JDK via `DEVRIG_JAVA_HOME`, so the registered command carries no
+ * `JAVA_HOME`.
+ */
 fun DevrigServices.runInstallCommand(
     command: DevrigCommand.DevrigCommandInstall,
     runner: AiAgentCliRunner = ProcessAiAgentCliRunner(),
-): Int = runInstallCommand(
-    command = command,
-    launcher = resolveDevrigLauncher(),
-    javaHome = Path.of(System.getProperty("java.home")),
-    out = mcpStdout,
-    err = System.err,
-    runner = runner,
-)
+): Int {
+    ensureBinLauncher(homePaths)
+    return runInstallCommand(
+        command = command,
+        mcpCommand = DevrigUserLauncher.invocation(homePaths, listOf("mcp")),
+        out = mcpStdout,
+        err = System.err,
+        runner = runner,
+    )
+}
 
 /**
  * Registers devrig as the `mcp-steroid` stdio MCP server in [command]'s agent, narrating each step so
@@ -44,14 +52,12 @@ fun DevrigServices.runInstallCommand(
  */
 fun runInstallCommand(
     command: DevrigCommand.DevrigCommandInstall,
-    launcher: Path,
-    javaHome: Path,
+    mcpCommand: StdioMcpCommand,
     out: PrintStream,
     err: PrintStream,
     runner: AiAgentCliRunner,
 ): Int {
     val agent = command.agent
-    val mcpCommand = selfMcpCommand(launcher, javaHome)
     val renderedCommand = "${mcpCommand.command} ${mcpCommand.args.joinToString(" ")}"
 
     out.println("Installing devrig as the '$DEVRIG_MCP_SERVER_NAME' MCP server for ${agent.displayName}.")
@@ -63,7 +69,8 @@ fun runInstallCommand(
         "'$DEVRIG_MCP_SERVER_NAME' registration (user scope).")
     out.println("  - ${agent.displayName} will launch this command to start it:")
     out.println("      $renderedCommand")
-    out.println("  - JAVA_HOME recorded for that launch: $javaHome")
+    out.println("  - The launcher pins the bundled JDK itself (via DEVRIG_JAVA_HOME), so the registered")
+    out.println("    command carries no JAVA_HOME and survives devrig upgrades without re-registering.")
     out.println()
     out.println("Re-running install is safe — existing devrig entries are replaced.")
     out.println()
@@ -137,42 +144,3 @@ private fun emitAgentOutput(result: AiAgentCliResult, err: PrintStream) {
     }
 }
 
-fun selfMcpCommand(
-    launcher: Path,
-    javaHome: Path,
-    windows: Boolean = isWindows(),
-): StdioMcpCommand {
-    val normalizedLauncher = launcher.toAbsolutePath().normalize()
-    val normalizedJavaHome = javaHome.toAbsolutePath().normalize()
-    return if (windows) {
-        StdioMcpCommand(
-            command = "cmd.exe",
-            args = listOf("/d", "/c", "set \"JAVA_HOME=$normalizedJavaHome\" && call \"$normalizedLauncher\" mcp"),
-        )
-    } else {
-        StdioMcpCommand(
-            command = "/usr/bin/env",
-            args = listOf("JAVA_HOME=$normalizedJavaHome", normalizedLauncher.toString(), "mcp"),
-        )
-    }
-}
-
-private fun resolveDevrigLauncher(): Path {
-    val name = if (isWindows()) "devrig.bat" else "devrig"
-    val expected = DevrigRoot.path.resolve("bin").resolve(name)
-    if (expected.isRegularFile()) return expected
-
-    // Fat-jar / non-Gradle-distribution layouts don't have `<root>/bin/devrig`.
-    // Fall back to the current process's launcher so `devrig install`
-    // still records a reproducible command line.
-    val processCommand = ProcessHandle.current().info().command().orElse(null)
-    if (processCommand != null) {
-        val launcher = Path.of(processCommand)
-        if (launcher.isRegularFile()) return launcher
-    }
-
-    error("devrig launcher is missing: $expected")
-}
-
-private fun isWindows(): Boolean =
-    System.getProperty("os.name").lowercase().contains("windows")

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/InstallCommand.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/InstallCommand.kt
@@ -9,6 +9,7 @@ import com.jonnyzzz.mcpSteroid.aiAgents.mcpAddStdioInvocation
 import com.jonnyzzz.mcpSteroid.aiAgents.mcpListInvocation
 import com.jonnyzzz.mcpSteroid.aiAgents.mcpRemoveInvocation
 import java.io.PrintStream
+import kotlin.io.path.isRegularFile
 
 private const val DEVRIG_MCP_SERVER_NAME = "mcp-steroid"
 private const val DEVRIG_LEGACY_SERVER_NAME = "devrig"
@@ -16,16 +17,25 @@ private const val DEVRIG_LEGACY_SERVER_NAME = "devrig"
 /**
  * Registers the **user-facing launcher** (`~/.mcp-steroid/bin/devrig`) as the agent's MCP server. We
  * register that stable wrapper — never the content-addressed install tree, which changes on every
- * upgrade — so an upgrade repoints the launcher underneath without re-registering the agent, and we
- * first call [ensureBinLauncher] so the wrapper definitely exists at the path we are about to register.
- * The wrapper pins the bundled JDK via `DEVRIG_JAVA_HOME`, so the registered command carries no
- * `JAVA_HOME`.
+ * upgrade — so an upgrade repoints the launcher underneath without re-registering the agent. `install`
+ * is explicit user intent, so we call [ensureBinLauncher] with `force = true`: the wrapper is written
+ * even on a SNAPSHOT/dev dist (where the passive on-each-start self-heal is off by default), so we never
+ * register a path that does not exist. The wrapper pins the bundled JDK via `DEVRIG_JAVA_HOME`, so the
+ * registered command carries no `JAVA_HOME`. If an explicit opt-out still left the wrapper absent, we
+ * warn loudly rather than silently registering a dead path.
  */
 fun DevrigServices.runInstallCommand(
     command: DevrigCommand.DevrigCommandInstall,
     runner: AiAgentCliRunner = ProcessAiAgentCliRunner(),
 ): Int {
-    ensureBinLauncher(homePaths)
+    ensureBinLauncher(homePaths, force = true, registerWindowsPath = true)
+    val launcher = DevrigUserLauncher.path(homePaths)
+    if (!launcher.isRegularFile()) {
+        System.err.println(
+            "[mcp-steroid] WARNING: the launcher $launcher does not exist (DEVRIG_BIN_NO_AUTO_REGISTER " +
+                "opt-out?). Registering it anyway, but the MCP server will not start until it is created.",
+        )
+    }
     return runInstallCommand(
         command = command,
         mcpCommand = DevrigUserLauncher.invocation(homePaths, listOf("mcp")),

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/InstallCommand.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/InstallCommand.kt
@@ -20,7 +20,7 @@ private const val DEVRIG_LEGACY_SERVER_NAME = "devrig"
  * upgrade — so an upgrade repoints the launcher underneath without re-registering the agent. `install`
  * is explicit user intent, so we call [ensureBinLauncher] with `force = true`: the wrapper is written
  * even on a SNAPSHOT/dev dist (where the passive on-each-start self-heal is off by default), so we never
- * register a path that does not exist. The wrapper pins the bundled JDK via `DEVRIG_JAVA_HOME`, so the
+ * register a path that does not exist. The wrapper pins the JDK devrig runs under via `DEVRIG_JAVA_HOME`, so the
  * registered command carries no `JAVA_HOME`. If an explicit opt-out still left the wrapper absent, we
  * warn loudly rather than silently registering a dead path.
  */
@@ -79,7 +79,7 @@ fun runInstallCommand(
         "'$DEVRIG_MCP_SERVER_NAME' registration (user scope).")
     out.println("  - ${agent.displayName} will launch this command to start it:")
     out.println("      $renderedCommand")
-    out.println("  - The launcher pins the bundled JDK itself (via DEVRIG_JAVA_HOME), so the registered")
+    out.println("  - The launcher pins the JDK devrig runs under (via DEVRIG_JAVA_HOME), so the registered")
     out.println("    command carries no JAVA_HOME and survives devrig upgrades without re-registering.")
     out.println()
     out.println("Re-running install is safe — existing devrig entries are replaced.")

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/Main.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/Main.kt
@@ -85,6 +85,11 @@ suspend fun DevrigServices.mainImpl2(
     command: DevrigCommand,
     headliner: String,
 ): Int = coroutineScope {
+    // The devrig binary owns ~/.mcp-steroid/bin/devrig: (re)create/update it on EVERY start so it
+    // self-heals and always points at this running install + JDK. Best-effort and stderr-only — never
+    // blocks serving. It writes atomically, so an agent mid-read of the launcher never sees a torn file.
+    ensureBinLauncher(homePaths)
+
     // For the MCP command, the running McpServerCore becomes available once the
     // stdio server is built; the update check broadcasts its notice over it (in
     // addition to stderr) as a `notifications/message`. For non-MCP commands the

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/Main.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/Main.kt
@@ -88,7 +88,9 @@ suspend fun DevrigServices.mainImpl2(
     // The devrig binary owns ~/.mcp-steroid/bin/devrig: (re)create/update it on EVERY start so it
     // self-heals and always points at this running install + JDK. Best-effort and stderr-only — never
     // blocks serving. It writes atomically, so an agent mid-read of the launcher never sees a torn file.
-    ensureBinLauncher(homePaths)
+    // For `devrig mcp` we skip the Windows user-PATH registration (it spawns PowerShell and would delay
+    // the first serve); that runs on interactive/`install` invocations instead.
+    ensureBinLauncher(homePaths, registerWindowsPath = command !is DevrigCommand.MCP)
 
     // For the MCP command, the running McpServerCore becomes available once the
     // stdio server is built; the update check broadcasts its notice over it (in

--- a/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/BinLauncherTest.kt
+++ b/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/BinLauncherTest.kt
@@ -1,0 +1,146 @@
+/* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
+package com.jonnyzzz.mcpSteroid.devrig
+
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.condition.DisabledOnOs
+import org.junit.jupiter.api.condition.OS
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.io.path.readText
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class BinLauncherTest {
+
+    // ── env / version gate ──────────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `env opt-out disables auto-registration regardless of build`() {
+        for (v in listOf("yes", "true", "1", "on", "YES", "True", " on ")) {
+            assertFalse(binAutoRegisterEnabled(v), "value '$v' should disable")
+        }
+    }
+
+    @Test
+    fun `env opt-in enables auto-registration even on a SNAPSHOT build`() {
+        // This test JVM runs a SNAPSHOT devrig, so the default (unset) is OFF; the explicit opt-in flips it ON.
+        for (v in listOf("no", "false", "0", "off", "NO", "False")) {
+            assertTrue(binAutoRegisterEnabled(v), "value '$v' should enable")
+        }
+    }
+
+    @Test
+    fun `unset defaults to OFF on this SNAPSHOT test build`() {
+        // The generated DevrigVersionMetadata in any non-release build carries "SNAPSHOT", so the default
+        // (no env override) must be disabled — which is exactly "disabled by default for tests".
+        assertTrue(DevrigVersionMetadata.getDevrigVersion().contains("SNAPSHOT", ignoreCase = true),
+            "test build version should be a SNAPSHOT: ${DevrigVersionMetadata.getDevrigVersion()}")
+        assertFalse(binAutoRegisterEnabled(null))
+        assertFalse(binAutoRegisterEnabled("garbage-unrecognized"))
+    }
+
+    // ── launcher rendering ──────────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `posix launcher pins DEVRIG_JAVA_HOME (absolute) and execs the install-tree launcher`() {
+        val text = renderPosixLauncher(Path.of("/tmp/devrig/bin/devrig"), Path.of("/tmp/jdk-25"))
+        assertTrue(text.startsWith("#!/bin/sh\n"), text)
+        assertTrue(text.contains("DEVRIG_JAVA_HOME=\"/tmp/jdk-25\"; export DEVRIG_JAVA_HOME"), text)
+        assertTrue(text.contains("exec \"/tmp/devrig/bin/devrig\" \"\$@\""), text)
+        assertFalse(text.contains("\r\n"), "POSIX launcher must be LF-only")
+        assertFalse(text.contains("\$HOME"), "wrapper records absolute paths, not \$HOME-relative")
+    }
+
+    @Test
+    fun `windows launcher is pure CRLF batch that pins DEVRIG_JAVA_HOME (absolute)`() {
+        val text = renderWindowsCmd(Path.of("C:\\devrig\\bin\\devrig.bat"), Path.of("C:\\devrig\\jdk-25"))
+        assertTrue(text.startsWith("@echo off\r\n"), text)
+        assertTrue(text.contains("set \"DEVRIG_JAVA_HOME=C:\\devrig\\jdk-25\"\r\n"), text)
+        assertTrue(text.contains("call \"C:\\devrig\\bin\\devrig.bat\" %*\r\n"), text)
+        assertFalse(text.contains("powershell", ignoreCase = true), "windows launcher must not invoke PowerShell")
+    }
+
+    @Test
+    fun `normalizeLauncher is tolerant of CRLF and trailing newlines`() {
+        assertEquals(normalizeLauncher("a\nb\n"), normalizeLauncher("a\r\nb\r\n\n"))
+    }
+
+    // ── core self-heal (POSIX) ──────────────────────────────────────────────────────────────────
+
+    @DisabledOnOs(OS.WINDOWS)
+    @Test
+    fun `writes an executable bin devrig pointing at the running install and JDK`(@TempDir tmp: Path) {
+        val userHome = tmp.resolve("home")
+        val home = HomePaths(userHome.resolve(".mcp-steroid"))
+        val ownRoot = tmp.resolve("opt/devrig") // deliberately OUTSIDE the home — the launcher must still be written
+        val ownJava = tmp.resolve("opt/jdk-25")
+
+        ensureBinLauncher(home, isWin = false, ownRoot = ownRoot, ownJava = ownJava, userHome = userHome, pathDirs = emptyList())
+
+        val launcher = home.binDir.resolve("devrig")
+        assertTrue(Files.isRegularFile(launcher), "launcher should be written")
+        assertTrue(Files.isExecutable(launcher), "launcher should be executable")
+        assertEquals(
+            renderPosixLauncher(ownRoot.resolve("bin/devrig"), ownJava),
+            launcher.readText(),
+        )
+    }
+
+    @DisabledOnOs(OS.WINDOWS)
+    @Test
+    fun `rewriting is idempotent - second start leaves identical bytes`(@TempDir tmp: Path) {
+        val userHome = tmp.resolve("home")
+        val home = HomePaths(userHome.resolve(".mcp-steroid"))
+        val ownRoot = tmp.resolve("opt/devrig")
+        val ownJava = tmp.resolve("opt/jdk-25")
+        fun run() = ensureBinLauncher(home, isWin = false, ownRoot = ownRoot, ownJava = ownJava, userHome = userHome, pathDirs = emptyList())
+
+        run()
+        val first = home.binDir.resolve("devrig").readText()
+        run()
+        assertEquals(first, home.binDir.resolve("devrig").readText())
+    }
+
+    // ── PATH symlink (POSIX) ────────────────────────────────────────────────────────────────────
+
+    @DisabledOnOs(OS.WINDOWS)
+    @Test
+    fun `symlinks bin devrig into a writable PATH dir under the user home`(@TempDir userHome: Path) {
+        val home = HomePaths(userHome.resolve(".mcp-steroid"))
+        val localBin = Files.createDirectories(userHome.resolve(".local/bin"))
+
+        ensureBinLauncher(
+            home, isWin = false,
+            ownRoot = home.home.resolve("binaries/devrig-abc"),
+            ownJava = home.home.resolve("binaries/jdk-abc"),
+            userHome = userHome,
+            pathDirs = listOf("/usr/bin", localBin.toString()), // /usr/bin is outside home → skipped
+        )
+
+        val link = localBin.resolve("devrig")
+        assertTrue(Files.isSymbolicLink(link), "should symlink into the writable PATH dir under home")
+        assertEquals(home.binDir.resolve("devrig").toAbsolutePath().normalize(), Files.readSymbolicLink(link))
+    }
+
+    @DisabledOnOs(OS.WINDOWS)
+    @Test
+    fun `never clobbers a foreign devrig already on PATH`(@TempDir userHome: Path) {
+        val home = HomePaths(userHome.resolve(".mcp-steroid"))
+        val localBin = Files.createDirectories(userHome.resolve(".local/bin"))
+        val foreign = localBin.resolve("devrig")
+        Files.writeString(foreign, "#!/bin/sh\necho a different devrig\n") // a real file, not our symlink
+
+        ensureBinLauncher(
+            home, isWin = false,
+            ownRoot = home.home.resolve("binaries/devrig-abc"),
+            ownJava = home.home.resolve("binaries/jdk-abc"),
+            userHome = userHome,
+            pathDirs = listOf(localBin.toString()),
+        )
+
+        assertFalse(Files.isSymbolicLink(foreign), "a foreign devrig must be left untouched")
+        assertTrue(foreign.readText().contains("a different devrig"))
+    }
+}

--- a/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/BinLauncherTest.kt
+++ b/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/BinLauncherTest.kt
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.condition.OS
 import org.junit.jupiter.api.io.TempDir
 import java.nio.file.Files
 import java.nio.file.Path
+import java.nio.file.attribute.PosixFilePermission
 import kotlin.io.path.readText
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -39,6 +40,21 @@ class BinLauncherTest {
             "test build version should be a SNAPSHOT: ${DevrigVersionMetadata.getDevrigVersion()}")
         assertFalse(binAutoRegisterEnabled(null))
         assertFalse(binAutoRegisterEnabled("garbage-unrecognized"))
+    }
+
+    @Test
+    fun `explicit install (force) writes even on a SNAPSHOT build, but an opt-out still wins`() {
+        // force = explicit `devrig install`: it must write the wrapper despite the SNAPSHOT default-off,
+        // so it never registers a path it didn't create...
+        assertTrue(shouldWriteLauncher(null, force = true))
+        assertTrue(shouldWriteLauncher("garbage", force = true))
+        // ...but a passive start on this SNAPSHOT build still does nothing without an opt-in.
+        assertFalse(shouldWriteLauncher(null, force = false))
+        // ...and an explicit opt-out wins even over force.
+        assertFalse(shouldWriteLauncher("yes", force = true))
+        assertFalse(shouldWriteLauncher("true", force = true))
+        // An explicit opt-in enables both paths.
+        assertTrue(shouldWriteLauncher("no", force = false))
     }
 
     // ── launcher rendering ──────────────────────────────────────────────────────────────────────
@@ -103,6 +119,27 @@ class BinLauncherTest {
         assertEquals(first, home.binDir.resolve("devrig").readText())
     }
 
+    @DisabledOnOs(OS.WINDOWS)
+    @Test
+    fun `restores a lost executable bit even when the content is unchanged`(@TempDir tmp: Path) {
+        val userHome = tmp.resolve("home")
+        val home = HomePaths(userHome.resolve(".mcp-steroid"))
+        val ownRoot = tmp.resolve("opt/devrig")
+        val ownJava = tmp.resolve("opt/jdk-25")
+        fun run() = ensureBinLauncher(home, isWin = false, ownRoot = ownRoot, ownJava = ownJava, userHome = userHome, pathDirs = emptyList())
+
+        run()
+        val launcher = home.binDir.resolve("devrig")
+        // Drop the executable bit (e.g. a copy/restore that lost perms) — content stays identical.
+        val perms = Files.getPosixFilePermissions(launcher).toMutableSet()
+        perms.removeAll(setOf(PosixFilePermission.OWNER_EXECUTE, PosixFilePermission.GROUP_EXECUTE, PosixFilePermission.OTHERS_EXECUTE))
+        Files.setPosixFilePermissions(launcher, perms)
+        assertFalse(Files.isExecutable(launcher), "precondition: +x removed")
+
+        run()
+        assertTrue(Files.isExecutable(launcher), "self-heal must restore +x even when bytes are unchanged")
+    }
+
     // ── PATH symlink (POSIX) ────────────────────────────────────────────────────────────────────
 
     @DisabledOnOs(OS.WINDOWS)
@@ -142,5 +179,28 @@ class BinLauncherTest {
 
         assertFalse(Files.isSymbolicLink(foreign), "a foreign devrig must be left untouched")
         assertTrue(foreign.readText().contains("a different devrig"))
+    }
+
+    @DisabledOnOs(OS.WINDOWS)
+    @Test
+    fun `recognizes a pre-existing RELATIVE symlink that points at our launcher`(@TempDir userHome: Path) {
+        val home = HomePaths(userHome.resolve(".mcp-steroid"))
+        val localBin = Files.createDirectories(userHome.resolve(".local/bin"))
+        // A symlink whose target is RELATIVE (resolved against the link's own dir, not the process CWD)
+        // but points at our launcher — an older install.sh could have created exactly this.
+        val relTarget = Path.of("../../.mcp-steroid/bin/devrig")
+        val link = Files.createSymbolicLink(localBin.resolve("devrig"), relTarget)
+
+        ensureBinLauncher(
+            home, isWin = false,
+            ownRoot = home.home.resolve("binaries/devrig-abc"),
+            ownJava = home.home.resolve("binaries/jdk-abc"),
+            userHome = userHome,
+            pathDirs = listOf(localBin.toString()),
+        )
+
+        // It must be recognized as ours and left exactly as-is (still the relative target), not recreated.
+        assertTrue(Files.isSymbolicLink(link))
+        assertEquals(relTarget, Files.readSymbolicLink(link), "the relative symlink should be left untouched")
     }
 }

--- a/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/HomePathsTest.kt
+++ b/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/HomePathsTest.kt
@@ -47,7 +47,7 @@ class HomePathsTest {
         paths.mkdirsAll()
         paths.mkdirsAll()
 
-        listOf(paths.logsDir, paths.backendsDir, paths.cachesDir, paths.downloadsDir, paths.stateDir).forEach { dir ->
+        listOf(paths.logsDir, paths.backendsDir, paths.cachesDir, paths.downloadsDir, paths.stateDir, paths.binDir).forEach { dir ->
             assertTrue(dir.isDirectory(), "$dir should be a directory")
         }
         assertTrue(!Files.exists(paths.executionStorageDir), "execution-storage is reserved and not created yet")

--- a/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/InstallCommandTest.kt
+++ b/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/InstallCommandTest.kt
@@ -15,8 +15,11 @@ import kotlin.test.assertTrue
 import org.junit.jupiter.api.Test
 
 class InstallCommandTest {
-    private val launcher = Path.of("/opt/devrig/bin/devrig")
-    private val javaHome = Path.of("/opt/jdk-21")
+    // The install command registers the STABLE user-facing wrapper, not the install tree. Fixed home so
+    // the expected launch command is deterministic across platforms (windows = false in tests).
+    private val home = HomePaths(Path.of("/home/user/.mcp-steroid"))
+    private val launcherPath = "/home/user/.mcp-steroid/bin/devrig"
+    private val mcpCommand = DevrigUserLauncher.invocation(home, listOf("mcp"), windows = false)
 
     private val claudeListWithBothNames = """
         Checking MCP server health…
@@ -35,25 +38,6 @@ class InstallCommandTest {
     """.trimIndent()
 
     @Test
-    fun `self mcp command uses current java home on unix`() {
-        val command = selfMcpCommand(launcher, javaHome, windows = false)
-
-        assertEquals("/usr/bin/env", command.command)
-        assertEquals(listOf("JAVA_HOME=/opt/jdk-21", "/opt/devrig/bin/devrig", "mcp"), command.args)
-    }
-
-    @Test
-    fun `self mcp command uses cmd exe for bat launchers on windows`() {
-        val command = selfMcpCommand(Path.of("/opt/devrig/bin/devrig.bat"), Path.of("/opt/jdk-21"), windows = true)
-
-        assertEquals("cmd.exe", command.command)
-        assertEquals(
-            listOf("/d", "/c", "set \"JAVA_HOME=/opt/jdk-21\" && call \"/opt/devrig/bin/devrig.bat\" mcp"),
-            command.args,
-        )
-    }
-
-    @Test
     fun `install reviews the list first, then consolidates, then adds`() {
         // First invocation must be the list (review), last must be the add.
         val result = runInstall(AiAgentCli.CLAUDE, RecordingRunner())
@@ -67,8 +51,7 @@ class InstallCommandTest {
         val result = runInstall(AiAgentCli.CLAUDE, RecordingRunner())
         assertEquals(0, result.exitCode)
         assertEquals(
-            listOf("mcp", "add", "--scope", "user", "mcp-steroid", "--",
-                "/usr/bin/env", "JAVA_HOME=/opt/jdk-21", "/opt/devrig/bin/devrig", "mcp"),
+            listOf("mcp", "add", "--scope", "user", "mcp-steroid", "--", launcherPath, "mcp"),
             result.addInvocation.args,
         )
     }
@@ -77,7 +60,7 @@ class InstallCommandTest {
     fun `install add invocation per agent (codex, gemini)`() {
         val codex = runInstall(AiAgentCli.CODEX, RecordingRunner())
         assertEquals(
-            listOf("mcp", "add", "mcp-steroid", "--", "/usr/bin/env", "JAVA_HOME=/opt/jdk-21", "/opt/devrig/bin/devrig", "mcp"),
+            listOf("mcp", "add", "mcp-steroid", "--", launcherPath, "mcp"),
             codex.addInvocation.args,
         )
 
@@ -85,7 +68,7 @@ class InstallCommandTest {
         assertEquals(
             listOf(
                 "mcp", "add", "--type", "stdio", "--scope", "user", "--trust", "mcp-steroid",
-                "/usr/bin/env", "JAVA_HOME=/opt/jdk-21", "/opt/devrig/bin/devrig", "mcp",
+                launcherPath, "mcp",
             ),
             gemini.addInvocation.args,
         )
@@ -185,8 +168,8 @@ class InstallCommandTest {
         assertContains(out, "Claude")
         assertTrue(out.contains("review", ignoreCase = true), out)
         assertTrue(out.contains("consolidat", ignoreCase = true), out)
-        assertContains(out, "/usr/bin/env JAVA_HOME=/opt/jdk-21 /opt/devrig/bin/devrig mcp")
-        assertContains(out, "/opt/jdk-21")
+        assertContains(out, "$launcherPath mcp")
+        assertTrue(out.contains("DEVRIG_JAVA_HOME", ignoreCase = false), out)
         assertTrue(out.contains("Re-running", ignoreCase = true) || out.contains("safe", ignoreCase = true), out)
         assertContains(out, "claude mcp list")
     }
@@ -209,8 +192,7 @@ class InstallCommandTest {
         val stderr = ByteArrayOutputStream()
         val exitCode = runInstallCommand(
             command = DevrigCommand.DevrigCommandInstall(agent),
-            launcher = launcher,
-            javaHome = javaHome,
+            mcpCommand = mcpCommand,
             out = PrintStream(stdout, true, Charsets.UTF_8),
             err = PrintStream(stderr, true, Charsets.UTF_8),
             runner = runner,


### PR DESCRIPTION
## What

The **devrig binary** now fully owns its user-facing launcher `~/.mcp-steroid/bin/devrig` (POSIX) / `bin/devrig.cmd` (Windows). The install script owns none of it.

1. **Self-heal on every start** — `ensureBinLauncher` runs at the top of `Main.mainImpl2`, atomically (re)writing the launcher (temp + atomic move, rewrite-only-on-change, restores a lost `+x` bit). The wrapper records **absolute** paths and pins the bundled JDK via `DEVRIG_JAVA_HOME` (the install-dist start script honors it), so no caller deals with `JAVA_HOME`. Safe to change while in use.
2. **PATH ownership** — POSIX symlinks `bin/devrig` into a writable `$HOME` PATH dir (pure Java; never self-links, never clobbers a foreign devrig, handles relative pre-existing links). Windows registers the bin dir on the **user** PATH via one PowerShell call, **deduped to exactly one entry**, marker-gated to run once per install — and **never on the `devrig mcp` hot path** (it would delay the first serve; agents launch the wrapper by absolute path anyway).
3. **`devrig install`** registers the **stable wrapper** (not the content-addressed install tree), so upgrades need no re-registration. It force-writes the wrapper (explicit user intent) so it never registers a path that doesn't exist.
4. **Undocumented gate** `DEVRIG_BIN_NO_AUTO_REGISTER` (`yes`/`no`/`true`/`false`): default **ON for release**, **OFF for SNAPSHOT/dev/test** builds (so a dev build never clobbers the real launcher); the env value overrides either way.

## Validation

- `:npx-kt:test` (full) + Docker `:npx-kt:integrationTest` (`CliBinLauncherIntegrationTest`, `CliInstallIntegrationTest`, real dist in Linux containers) green.
- IDE inspections: **0 WARNING+** on all changed files.
- Reviewed by an internal 3-reviewer quorum (**GO**) and an independent 3× `run-agent.sh` peer review (2× claude, 1× codex) — all findings addressed (gated-install dangling wrapper, lost `+x` self-heal, relative-symlink resolution, PowerShell off the `mcp` hot path).
- **Live on Windows 10** (eugene-x220, Corretto 25): `devrig.cmd` written + idempotent; PATH dedup 3→1; concurrent rewrite of `devrig.cmd` while a `devrig mcp` launched through it is still running; `mcp` spawns no PowerShell; `install` force-writes on a SNAPSHOT dist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)