### PR TITLE
docs: website-gen module guide + installer-epic (#113) remaining-scope tracker

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,6 +55,7 @@ When changing files across multiple sub-folders, read the guides for each.
 | `test-experiments/` | [test-experiments/CLAUDE.md](test-experiments/CLAUDE.md) | DPAIA arena suite, debugger demos, prompt-quality comparisons, IMPROVEMENTS.md harness |
 | `docs/` | [docs/CLAUDE.md](docs/CLAUDE.md) | Autoresearch / prompt-optimization working notes, DPAIA history |
 | `website/` | [website/CLAUDE.md](website/CLAUDE.md) | Hugo site sources, GitHub Pages deployment |
+| `website-gen/` | [website-gen/CLAUDE.md](website-gen/CLAUDE.md) | Build-tooling generator: version.json + updatePlugins.xml, the computed JDK data model (Corretto/Azul, PGP-verified), the on-disk download cache |
 
 ## MUST DO
 

--- a/TODO-INSTALLER.md
+++ b/TODO-INSTALLER.md
@@ -40,16 +40,34 @@ The **installer-script generator** — everything else from #113 is now supersed
 - `fileName`, `sha256`, `url`, `javaHome` map 1:1 (javaHome is forward-slash, no leading slash — matches
   `JdkCoordinatesMetadataTest`'s assertion).
 
-## Open decisions (resolve before the integration PR)
+## Decisions (resolved 2026-06-18)
 
-- **D1 — home of the installer generator**: extend `:website-gen` (add `InstallerGenerator` + templates +
-  an `installerIntegrationTest` source set) vs. a new `:installer-gen` module depending on `:website-gen`.
-- **D2 — platform coverage**: extend the installer (`ALL_PLATFORMS` + both script templates + the
-  metadata test) to consume the new **alpine (musl) x64/arm64** and **macos-x64** entries (alpine support
-  was the stated goal), vs. ship #113's original 5 platforms first and add alpine in a follow-up.
-- **D3 — `InstallerRealArtifactsTest` source of truth**: have the test download via the `Cache` and
-  re-derive sha/javaHome from the local file (keeps the existing test shape), vs. trust the model's
-  already-PGP-verified computed `sha256`/`javaHome` and assert the model directly (simpler, no re-download).
+- **D1 — module layout**: NEW `:installer-gen` module is the **lower-level** module — it owns **JDK
+  detection** (move `JdkArtifacts`/`JdkModel`/`resolveAllJdks`, `PgpVerifier`, `Cache` + `HttpFetcher`
+  out of `:website-gen`) **and** installer-script generation. **`:website-gen` depends on
+  `:installer-gen`** and reuses its HTTP/cache infra. (Reverses the originally-assumed direction.)
+- **D2 — platform coverage: NO alpine.** IDEs can't run on musl/alpine anyway, so we do NOT ship alpine
+  JDKs. Drop the 2 alpine entries (and macos-x64) from the model → back to the **5** platforms #113 had
+  (`macos-arm64`, `linux-arm64`, `linux-x64`, `windows-x64`, `windows-arm64`). Instead, **install.sh
+  detects musl and fails fast** with a clear "not supported" message.
+- **D3 — `InstallerRealArtifactsTest`: trust the model.** It already PGP-verifies + computes
+  sha256/javaHome, and `InstallerBootstrapTest` does the real-HTTP+sha end-to-end check. Assert the
+  model directly; no re-download.
+
+## Execution plan for the `:installer-gen` PR
+
+1. New `:installer-gen` module (bcpg + commons-compress + ktor + serialization). Move JDK detection
+   (`JdkArtifacts`, `PgpVerifier`, `Cache`/`HttpFetcher`, `JdkModelMain`) + their tests there; package
+   → `com.jonnyzzz.mcpSteroid.installer`. **Trim the model to the 5 platforms** (drop alpine + macos-x64;
+   drop the `ALPINE_LINUX` enum value).
+2. `:website-gen` depends on `:installer-gen`; reuse the shared `KtorHttpFetcher`/`Cache` (drop
+   `WebsiteArtifacts`'s duplicate fetchers). `generateJdkModel` moves to `:installer-gen`.
+3. Port the generator: `InstallerGenerator` + `install.sh.tmpl` / `install.ps1.tmpl`, consuming the
+   `JdkModel` via the adapter (no more `--jdk` args / `LocalJdkArtifact` / `CoordinateResolver`). Add the
+   **musl-detect-and-fail** arm to `install.sh`.
+4. Port + adapt the installer integration tests (`InstallerBootstrapTest` nginx-sidecar real-HTTP;
+   `InstallerRealArtifactsTest` → assert the model; `JdkCoordinatesMetadataTest` → 5 platforms) into an
+   `installerIntegrationTest` source set (NOT in `ciBuildPluginTests`).
 
 ## Minor, non-blocking (from the #122 quorum review)
 

--- a/TODO-INSTALLER.md
+++ b/TODO-INSTALLER.md
@@ -1,0 +1,57 @@
+# TODO — Installer epic (PR #113) status & remaining scope
+
+Running plan for the installer epic. The epic was deliberately peeled into focused PRs off `main`
+instead of merging the big `installer/version-json-driven` branch wholesale. This file tracks what has
+landed and what is **still only on #113**.
+
+## Landed on `main` (extracted from #113, in better form)
+
+- **devrig launcher ownership** — `~/.mcp-steroid/bin/devrig` self-heal + PATH + wrapper registration
+  (#117/#118).
+- **Website generator** — `:website-gen` `WebsiteArtifacts` (version.json + updatePlugins.xml), Kotlin,
+  Ktor (#119); GitHub Action runs it main-only (#120).
+- **Dead-module cleanup** — removed `:jdk-downloader` + `:pgp-verifier` (#121); IDE downloads confirmed
+  SHA-256-based.
+- **JDK data model + cache + PGP** — `:website-gen` `resolveAllJdks` → `JdkModel`, on-disk/in-memory
+  `Cache`, BouncyCastle `PgpVerifier` with **pinned** vendor fingerprints (#122). Validated live (8
+  artifacts). See [website-gen/CLAUDE.md](website-gen/CLAUDE.md).
+
+## Still only on `installer/version-json-driven` (the remaining deliverable)
+
+The **installer-script generator** — everything else from #113 is now superseded by `main`:
+
+| #113 file | Disposition |
+|---|---|
+| `site-gen/.../installer/InstallerGenerator.kt` | **PORT** — generates `install.sh` / `install.ps1` from JDK + devrig coordinates |
+| `site-gen/src/main/resources/templates/install.{sh,ps1}.tmpl` | **PORT** — the script templates (the actual installer logic) |
+| `site-gen/.../installer/CoordinateResolver.kt` (+ `CoordinateResolverTest`) | **REPLACE** with `:website-gen` `resolveAllJdks` `JdkModel` + a thin adapter |
+| `site-gen/.../installer/site/SiteArtifacts.kt` (+ test) | **DROP** — superseded by `main`'s `WebsiteArtifacts` |
+| `site-gen/.../installer/tests/InstallerBootstrapTest.kt` | **PORT** — nginx sidecar, real HTTP, sha256-verify, content-addressed dirs, idempotency |
+| `site-gen/.../installer/tests/InstallerRealArtifactsTest.kt` | **PORT/ADAPT** — re-derives sha/javaHome from a downloaded file (see decision D3) |
+| `site-gen/.../installer/tests/JdkCoordinatesMetadataTest.kt` | **ADAPT** — asserts the platform set (see decision D2) |
+| old `:pgp-verifier`, `:jdk-downloader`, `:site-gen` build wiring | **DROP** — superseded by `:website-gen` |
+
+### The adapter (`JdkModel` → installer-script fields)
+
+`JdkArtifact` is information-complete; the generator needs a thin translation layer:
+- platform key: `JdkOs/JdkArch` enums → `<os>-<cpu>` string with **`AARCH64`→`arm64`** (matches the
+  scripts' `uname -m` normalization);
+- archive: `ArchiveType` → already carries `.extension` (`tar.gz`/`zip`);
+- `fileName`, `sha256`, `url`, `javaHome` map 1:1 (javaHome is forward-slash, no leading slash — matches
+  `JdkCoordinatesMetadataTest`'s assertion).
+
+## Open decisions (resolve before the integration PR)
+
+- **D1 — home of the installer generator**: extend `:website-gen` (add `InstallerGenerator` + templates +
+  an `installerIntegrationTest` source set) vs. a new `:installer-gen` module depending on `:website-gen`.
+- **D2 — platform coverage**: extend the installer (`ALL_PLATFORMS` + both script templates + the
+  metadata test) to consume the new **alpine (musl) x64/arm64** and **macos-x64** entries (alpine support
+  was the stated goal), vs. ship #113's original 5 platforms first and add alpine in a follow-up.
+- **D3 — `InstallerRealArtifactsTest` source of truth**: have the test download via the `Cache` and
+  re-derive sha/javaHome from the local file (keeps the existing test shape), vs. trust the model's
+  already-PGP-verified computed `sha256`/`javaHome` and assert the model directly (simpler, no re-download).
+
+## Minor, non-blocking (from the #122 quorum review)
+
+- Azul `latest` selection: trust `latest=true` + assert a single result, vs. the current sort-and-take.
+- Fold `UrlKey.resolvedUrl` into the cache key (PGP currently backstops the gap).

--- a/website-gen/CLAUDE.md
+++ b/website-gen/CLAUDE.md
@@ -1,0 +1,67 @@
+# website-gen/CLAUDE.md
+
+Guidance for the `:website-gen` module. **Instructions here override the root guide for this folder.**
+Read the [root CLAUDE.md](../CLAUDE.md) too (project-wide rules).
+
+## What this module is
+
+`:website-gen` is **build-tooling**, not plugin runtime — it has **no IntelliJ dependencies** and **no
+`project()` dependencies** (so its Gradle tasks compile only this module, never the whole build). Two
+jobs, both driven from Gradle `JavaExec` tasks:
+
+1. **Website artifacts** (`WebsiteArtifacts.kt`, task `generateWebsite`) — resolves the published GitHub
+   release and writes `version.json` + `updatePlugins.xml` into `website/static`. The task knows all
+   paths (VERSION + release notes from the project layout); CI/Makefile invoke it with no args.
+2. **JDK data model** (`JdkArtifacts.kt`, task `generateJdkModel`) — `resolveAllJdks(cache)` produces a
+   `JdkModel` of every JDK 25 build the installer needs, each field **computed** from the live vendor
+   sources (nothing hand-pinned). Feeds #113's installer-script generation.
+
+## JDK data model — the rules
+
+- **Vendors / platforms**: Amazon Corretto 25 for linux glibc + musl(alpine) x64/aarch64, macOS
+  x64/aarch64, windows-x64; Azul Zulu 25 for windows/aarch64 (resolved via the Azul Metadata API).
+  **Latest 25 is resolved live** for both — no version pin in source.
+- **`JdkArtifact` is self-sufficient for a script generator**: `platform`, `vendor`, `version`
+  (vendor-native, NOT cross-comparable), `featureVersion` (Int, comparable — use this for "is it 25?"),
+  `archive` (+ `ArchiveType.extension`), `url` (version-pinned), `fileName`, `size`, `sha256` (lowercase
+  hex), `javaHome`. **`javaHome` is always archive-relative, forward-slash, no leading/trailing slash**
+  (ZIP/TAR entries are `/`-separated even on Windows — consumers translate separators). It is *computed*
+  by scanning archive entries for the **shallowest** `bin/java[.exe]` (so a nested `jre/bin/java` is not
+  mistaken for `JAVA_HOME`), not hardcoded.
+- **Vendor-natural validation is mandatory and fail-fast**: every download is verified against a detached
+  **OpenPGP signature** (`PgpVerifier`, BouncyCastle) — Corretto's `<file>.sig`, Azul's Metadata-API
+  `signature-binary`. The signing-key **fingerprint is pinned in source** (`CORRETTO_KEY_FINGERPRINT`,
+  `AZUL_KEY_FINGERPRINT`): the public key is fetched live over HTTPS, so verification asserts the key
+  matches the pinned fingerprint before trusting the signature (defeats a compromised key endpoint). PGP
+  runs on **every** resolve, including cache hits. Vendor endpoints/keys are catalogued in the
+  `jdk-feed-vendor-endpoints` memory.
+
+## Caching (`Cache.kt`)
+
+- `Cache.onDisk(root)` (one file per key, atomic temp+move) / `Cache.inMemory()` (ConcurrentHashMap, for
+  tests) behind a static factory. `getOrCompute<T>` uses kotlinx.serialization for `T`.
+- **`downloadWithEtag`** — HEAD `ETag` cache; **fails fast if the host exposes no ETag** (no workaround).
+  Used for Corretto (its CDN exposes a HEAD ETag).
+- **`downloadVerifyingSha256`** — content-addressed by a vendor-published sha256; used for Azul (its CDN
+  exposes no HEAD ETag). Re-hashes on **every** return incl. cache hits, since the cache dir is shared.
+- **The cache root must live OUTSIDE any `build/` folder** (so the ~230 MB archives survive `clean` and
+  are shared across runs/branches) and **its path is passed in from Gradle** (`--cache-dir`), never
+  guessed by the generator. `generateJdkModel` roots it at `gradleUserHome/caches/mcp-steroid/…`.
+
+## Running / testing
+
+- Tests are **hermetic** (synthetic tar.gz/zip via `TestArchives`, real BouncyCastle signing via
+  `TestPgp`, in-memory cache + a fake `HttpFetcher`) — **no network**. Run: `./gradlew :website-gen:test`.
+  Covered by `ciBuildPluginTests` (guarded — see root `build.gradle.kts`).
+- `generateJdkModel` / `generateWebsite` hit the network. The first JDK resolve downloads ~1.5 GB
+  (cached after; re-runs are ~15 s). Don't run them as part of the unit test loop.
+- Deps beyond the repo norm: `org.bouncycastle:bcpg-jdk18on` (PGP), `org.apache.commons:commons-compress`
+  (tar.gz/zip entry scanning). HTTP is Ktor CIO (the repo standard). `KtorHttpFetcher` is `AutoCloseable`
+  — `use {}` it (the generator does).
+
+## Gotchas
+
+- Hold archives as a single `ByteArray` (~230 MB each) to hash + scan; `generateJdkModel` sets
+  `maxHeapSize = "2g"`. Don't introduce a path that holds all 8 in memory at once.
+- The `version` field means different things per vendor (`25.0.3.9.1` vs `25.0.3`). Never compare `version`
+  across vendors — use `featureVersion`.


### PR DESCRIPTION
Documentation-only.

- **website-gen/CLAUDE.md** — module guide for the build-tooling generator: the computed JDK data model (vendor coverage, pinned-fingerprint OpenPGP validation, `javaHome`/version semantics), the ETag vs sha256 cache and the *cache-dir-outside-build* contract, hermetic-test rules, deps (BouncyCastle, commons-compress).
- **CLAUDE.md** — add the `website-gen/` row to the sub-folder guide table.
- **TODO-INSTALLER.md** — installer-epic tracker: what landed on `main` (#117-122) vs the remaining #113 deliverable (the `install.sh`/`install.ps1` generator + templates + installer integration tests), the `JdkModel`→script adapter, and open decisions D1-D3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)