### PR TITLE
ci: deploy website from a long-lived `website` branch (decouple live site from main)

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -15,14 +15,24 @@
 name: Deploy to GitHub Pages
 
 on:
+  # Deploy from the long-lived `website` branch, NOT `main`. `website` tracks `main`
+  # (advanced by merging main → website, normally often) but can deliberately lag it so
+  # website changes that depend on an UNRELEASED devrig binary — e.g. a new install.sh /
+  # install.ps1 contract — stay off the live site until a matching GitHub release exists.
+  # The release process advances `website` after publishing the release (see
+  # release/release-instructions.md, "Advance the website branch"). A push to `main` no
+  # longer deploys; promoting to `website` does.
   push:
-    branches: [main]
+    branches: [website]
     paths:
       - 'website/**'
       - 'VERSION'
   # Rebuild after a GitHub release is published — the website build queries
   # the release to generate updatePlugins.xml with the correct ZIP download URL.
   # Without this, the push-triggered build fails because the release doesn't exist yet.
+  # NOTE: the deploy job only runs for the `website` branch (GitHub Pages environment
+  # "Deployment branches" rule), so a release-triggered run builds but does not deploy —
+  # the `website`-branch push from the release process is the actual deploy.
   release:
     types: [published]
   workflow_dispatch:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -213,6 +213,14 @@ generate→edit→regenerate→commit workflow. The TC VCS root pulls from `jb`,
 GitHub Pages. Plugin tests are intentionally NOT mirrored — full coverage stays on TC (3–5× faster
 internal agents). Trigger PR builds via `workflow_dispatch` on the PR's head branch.
 
+**Website deploys from the `website` branch, NOT `main`.** GitHub Pages builds on a push to the
+long-lived **`website`** branch (`github-pages.yml`). `website` tracks `main` (advance via
+`git merge main → website`, normally often) but can deliberately lag it so website changes that depend
+on an **unreleased** devrig binary — e.g. a new `install.sh`/`install.ps1` CLI contract — stay off the
+live site until a matching GitHub release exists. The release process advances `website` AFTER
+publishing the release (`release/release-instructions.md` → "Stage 7c"). `website` is **origin-only**
+(never synced to `jb`, which runs TeamCity only). A push to `main` no longer deploys the website.
+
 ## Git Remotes: `origin` vs `jb`
 
 | Remote | URL | Role |

--- a/release/README.md
+++ b/release/README.md
@@ -55,7 +55,13 @@ For a quick release without the full Docker build matrix, use Claude Code agents
 7. **Update website homepage**: In `website/website/hugo.toml`, update `params.version` to the new version and add a `[[params.whatsnew]]` entry at the top. Commit and push in `website/`.
 8. **Update website release page**: Create `website/website/content/releases/<version>.md`, run `cd website/website && make build`. **Note:** `make build` downloads the release ZIP to extract the plugin version, so step 4 must complete first.
 9. **Mark older releases obsolete**: `gh release edit <old-version> --repo jonnyzzz/mcp-steroid --notes-file <updated-body-with-obsolete-banner>`.
-10. **Publish website**: `cd website && git add -A && git commit -m "release: <version> website" && git push`
+10. **Publish website** — advance the `website` deploy branch (this is what GitHub Pages builds from; a push to `main` does NOT deploy):
+    ```bash
+    git checkout website && git merge main --ff-only && git push origin website && git checkout main
+    ```
+    The `website` branch is origin-only (never pushed to `jb`). See `release-instructions.md` →
+    "The `website` deploy branch" + "Stage 7c" for the full rationale (it lets website changes that
+    depend on an unreleased binary stay off the live site until the matching release exists).
 
 Steps 2+3 can run in parallel. Steps 7–10 require step 4 (GitHub release must exist for website build). The `CLAUDECODE` env var must be unset for nested Claude Code invocations via `run-agent.sh`.
 

--- a/release/release-instructions.md
+++ b/release/release-instructions.md
@@ -5,8 +5,27 @@
 There is **one repository**: `jonnyzzz/mcp-steroid` (at `/Users/jonnyzzz/Work/mcp-steroid`).
 It contains both the plugin source and the website source (under `website/`).
 The website is built and deployed automatically by the **GitHub Actions** workflow
-(`.github/workflows/github-pages.yml`) on every push to `main` that touches `website/**`
-or `VERSION`. There is no separate website repo and no need to commit generated files.
+(`.github/workflows/github-pages.yml`) on every push to the **`website` branch** that touches
+`website/**` or `VERSION`. There is no separate website repo and no need to commit generated files.
+
+### The `website` deploy branch
+
+The live site deploys from a long-lived **`website` branch**, NOT from `main`. `website` tracks
+`main` (advance it by merging `main → website`, normally often) but can deliberately **lag** `main`
+so website changes that depend on an **unreleased** devrig binary — e.g. a new `install.sh` /
+`install.ps1` contract that calls a CLI command only present in the next release — stay OFF the live
+site until a matching GitHub release exists. **A push to `main` no longer deploys the website; you
+advance `website` to publish.** This is done as a release step, AFTER the GitHub release is published
+(see "Stage 7c: Advance the `website` branch"), because the generated `install.sh` / `updatePlugins.xml`
+resolve the just-published release.
+
+The `website` branch is **origin-only** — `jb` runs TeamCity only and carries no GitHub Actions, so
+`website` is never synced to `jb`.
+
+> **One-time GitHub setup:** the GitHub Pages **environment** ("Settings → Environments →
+> github-pages → Deployment branches") must allow the **`website`** branch. If it still lists only
+> `main`, the deploy job is blocked with "… is not allowed to deploy to github-pages due to
+> environment protection rules."
 
 ## Commit-Then-Build Principle
 
@@ -22,13 +41,14 @@ Correct order:
 4. Create tags on both remotes
 5. Create the GitHub release (attaches to existing tag) — plugin zip + devrig zip + EULA
 6. Upload to JetBrains Marketplace
-7. **Explicitly trigger the website build** and verify it's live
+7. **Advance the `website` branch** (merge `main → website`, push `origin website`) — this is what
+   deploys the website; then verify it's live
 
-**Critical:** Steps 1-2 must complete before step 3. The website content (release page,
-`hugo.toml`) must be on `origin/main` before the GitHub release is created, so the
-Pages workflow can find the content when it runs. The push in step 2 will trigger a
-Pages build that fails (release doesn't exist yet) — this is expected. The explicit
-trigger in step 7 is what actually deploys the website.
+**Critical:** Steps 1-2 must complete before step 3. **The push to `main` in step 2 does NOT trigger a
+website deploy** — the Pages workflow only fires on the `website` branch. The website is published in
+step 7 by advancing `website` to `main`, which must happen AFTER the GitHub release exists (step 5) so
+the build can resolve the released ZIP URL + the released devrig binary that the new `install.sh`
+expects.
 
 ## Release Stages
 
@@ -226,11 +246,10 @@ git push origin main
 All release commits (notes, version bump, website page, hugo.toml) must be pushed
 **before** building the plugin and creating the GitHub release.
 
-This push triggers the GitHub Pages workflow on `push:` to `main`. **It will fail by design**
-because the website's `make build` step queries the GitHub release for the plugin ZIP URL,
-and the release does not exist yet (Stage 7b creates it). This failure is harmless and is
-fixed by the explicit `workflow_dispatch` in Stage 9. Do not investigate the failure —
-just confirm Stage 9's run succeeds.
+**This push does NOT trigger a website deploy** — the Pages workflow fires only on the `website`
+branch, not `main`. The website is published later, in Stage 7c, by advancing `website` to `main`
+(after the GitHub release exists). So there is no "expected failing Pages build" on the `main` push
+anymore.
 
 Then sync to the `jb` remote (TeamCity pulls from `jb/main`):
 ```bash
@@ -313,6 +332,27 @@ filename as the asset name — it appears as `EULA` on the release page.
 **Immutable**: Once created, releases cannot have assets added. If a fix is needed,
 delete and recreate the release.
 
+**7c. Advance the `website` branch (this publishes the website):**
+
+The live site deploys from the `website` branch, and the generated `install.sh` / `install.ps1` /
+`updatePlugins.xml` resolve the **just-published** release (Stage 7b) — its plugin ZIP URL and the
+devrig binary whose CLI contract the new install scripts expect. So advance `website` to `main`
+**only now**, after the release exists:
+
+```bash
+git fetch origin
+git checkout website
+git merge main --ff-only        # website normally trails main by exactly the held commits
+git push origin website          # ← this push is what triggers the GitHub Pages deploy
+git checkout main
+```
+
+If `--ff-only` is rejected (website has diverged), use a normal merge:
+`git merge main -m "website: advance to <version> release"`. The push to `origin website` triggers
+the Pages workflow; the deploy + verification happen in Stage 9.
+
+> `website` is **origin-only** — do NOT push it to `jb` (jb has no GitHub Actions).
+
 ### Stage 8: Upload to JetBrains Marketplace
 
 ```bash
@@ -327,32 +367,25 @@ Plugin page: https://plugins.jetbrains.com/plugin/30019-mcp-steroid
 
 The plugin enters the JetBrains review queue and will be listed once approved.
 
-### Stage 9: Trigger Website Build and Verify
+### Stage 9: Verify the Website is Live
 
-The website build (`make build`) queries the GitHub release for the plugin ZIP download
-URL to generate `updatePlugins.xml`. The website content (release page, `hugo.toml`)
-was committed and pushed in Stages 4-5, **before** the release was created.
+The website deploy was triggered by the `git push origin website` in **Stage 7c**. The build
+(`make build`) queries the GitHub release for the plugin ZIP URL + the released devrig binary that
+the generated `install.sh` expects — both exist by now (Stage 7b).
 
-By the time you reach this stage, expect **two prior failed Pages workflow runs** on
-this branch — both are harmless:
+You may see **one harmless prior run**: the `release: published` event from Stage 7b's
+`gh release create` triggers a build from the **tag ref**, whose `deploy` job is blocked by the Pages
+environment ("Deployment branches" allows `website`, not tag refs) — error `Tag "v<version>" is not
+allowed to deploy to github-pages due to environment protection rules.` The `build` job usually
+succeeds; only `deploy` is blocked. Do not weaken the environment rule — the `website`-branch push
+from Stage 7c is what actually deploys.
 
-1. The `push`-triggered run from Stage 5 fails because the GitHub release does not exist
-   yet (`make build` cannot resolve the ZIP URL).
-2. The `release: published`-triggered run from Stage 7b's `gh release create` fails because
-   the GitHub Pages environment is configured to deploy only from `main`, not from tag refs.
-   The error reads `Tag "v<version>" is not allowed to deploy to github-pages due to
-   environment protection rules.` The `build` job on this run usually succeeds; only the
-   `deploy` job is blocked. Do not weaken the environment protection rule — the
-   `workflow_dispatch` from `main` below is what actually deploys.
-
-Explicitly trigger the website build:
+If the Stage 7c push didn't fire a run (e.g. it was a no-op fast-forward with no `website/**` change),
+trigger it explicitly against the **`website`** branch:
 
 ```bash
-gh workflow run "Deploy to GitHub Pages" --repo jonnyzzz/mcp-steroid --ref main
+gh workflow run "Deploy to GitHub Pages" --repo jonnyzzz/mcp-steroid --ref website
 ```
-
-The `release: published` event from Stage 7b may also trigger a run automatically.
-Either way, the explicit trigger ensures the build happens.
 
 **Monitor the deployment:**
 

--- a/website/CLAUDE.md
+++ b/website/CLAUDE.md
@@ -14,6 +14,14 @@ This directory contains the Hugo source for the MCP Steroid website at https://m
 
 The website is built from this directory using Hugo and deployed via GitHub Pages.
 
+**Deploys from the `website` branch, not `main`.** GitHub Pages (`.github/workflows/github-pages.yml`)
+builds on a push to the long-lived **`website`** branch. `website` tracks `main` (advanced via
+`git merge main → website`, normally often) but can deliberately lag it so website changes that depend
+on an **unreleased** devrig binary — e.g. a new `install.sh`/`install.ps1` CLI contract — stay off the
+live site until a matching GitHub release exists. A push to `main` does NOT deploy. The release process
+advances `website` after publishing the release (`release/release-instructions.md` → "Stage 7c").
+`website` is origin-only (never synced to `jb`).
+
 ### What is `mcp-steroid-public/`?
 
 The `mcp-steroid-public/` directory is a **separate clone of the same repository** (`jonnyzzz/mcp-steroid`). This setup allows:


### PR DESCRIPTION
## Problem

The GitHub Pages deploy fires on every push to `main` touching `website/**` or `VERSION`, coupling **what's live** to `main`. Merging a website change that depends on an **unreleased** devrig binary immediately publishes it.

Concretely: #124 added `install.sh`/`install.ps1` that call `devrig install devrig` — a CLI command only in the *next* release. The merge to `main` deployed them, and testing the live one-liner on **mac / linux / windows** confirmed **all three fail** at `devrig install devrig` against the published `v0.100` binary (mac/linux: `no such option`; windows: `input line is too long`). Download + sha-verify worked everywhere; only the binary/script version mismatch broke it.

## Change

Introduce a long-lived **`website` deploy branch**:

- **`github-pages.yml`** now triggers on push to **`website`** (keeps `release: published` + `workflow_dispatch`), not `main`.
- `website` **tracks `main`** (advance via `git merge main → website`, normally often) but can deliberately **lag** it — holding website changes that need an unreleased binary off the live site until a matching GitHub release exists.
- The **release process advances `website` AFTER the release is published** (new **Stage 7c**), since the generated `install.sh`/`updatePlugins.xml` resolve the just-published release + the devrig binary the new scripts expect.
- `website` is **origin-only** (jb runs TeamCity only, carries no GitHub Actions).

## Docs updated
`release/release-instructions.md` ("The `website` deploy branch" + Stage 7c + reworked Stages 5/9), `release/README.md` quick path, root `CLAUDE.md` (CI section), `website/CLAUDE.md`.

## ⚠️ Required operational steps (after merge)
1. Create the `website` branch on origin (initially `= main`).
2. Update the **github-pages environment** "Deployment branches" rule to allow **`website`** (currently `main`), else the deploy job is blocked by environment protection.

The live installer stays broken until the next devrig release is cut from `main` (separate step) and `website` is advanced — this PR sets up the mechanism so it doesn't happen again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)