### PR TITLE
devrig: add `install <agent> --check` — read-only registration doctor (issue #86)

### DIFF
--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/Cli.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/Cli.kt
@@ -62,6 +62,8 @@ sealed interface DevrigCommand {
 
     data class DevrigCommandInstall(
         val agent: AiAgentCli,
+        /** Read-only dry-run: report the registration diff + IDE reachability, change nothing. */
+        val check: Boolean = false,
         override val debug: Boolean = false,
         override val json: Boolean = false,
     ) : DevrigCommand
@@ -226,10 +228,16 @@ private class InstallCommand(
     // Only meaningful for `install devrig` (the install scripts pass them); rejected for agents below.
     private val installScript: String? by option("--install-script")
     private val jdkHome: String? by option("--jdk-home")
+    private val checkFlag by option(
+        "--check",
+        help = "read-only dry-run: report the registration diff + IDE reachability, change nothing " +
+            "(exit 1 if install would change anything)",
+    ).flag()
 
     override fun run() {
         val options = options()
         if (agent == "devrig") {
+            if (checkFlag) throw UsageError("--check is only valid for an agent install (claude / codex / gemini)")
             select(DevrigCommand.DevrigCommandInstallDevrig(
                 installScript = installScript, jdkHome = jdkHome, debug = options.debug, json = options.json,
             ))
@@ -240,7 +248,7 @@ private class InstallCommand(
         if (installScript != null || jdkHome != null) {
             throw UsageError("--install-script / --jdk-home are only valid with 'devrig install devrig'")
         }
-        select(DevrigCommand.DevrigCommandInstall(target, debug = options.debug, json = options.json))
+        select(DevrigCommand.DevrigCommandInstall(target, check = checkFlag, debug = options.debug, json = options.json))
     }
 }
 

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/HelpCommand.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/HelpCommand.kt
@@ -24,10 +24,15 @@ fun printHelp(out: PrintStream) : Int {
                                          `--json` emits a single machine-readable
                                          object on stdout; default is human text.
 
-          devrig install claude|codex|gemini
+          devrig install claude|codex|gemini [--check]
                                          register this devrig binary as the
                                          mcp-steroid stdio MCP server in the
-                                         selected coding agent.
+                                         selected coding agent. `--check` is a
+                                         read-only dry-run: it reports the current
+                                         registration, the changes install would
+                                         apply, and how many IDE backends with the
+                                         MCP Steroid plugin are reachable; exits 1
+                                         when install would change anything.
 
           devrig backend download [<id>] [--version <v>] [--json]
                                          no id → list IDEs available for download.

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/InstallCommand.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/InstallCommand.kt
@@ -15,17 +15,9 @@ import kotlin.io.path.isRegularFile
 private const val DEVRIG_MCP_SERVER_NAME = "mcp-steroid"
 private const val DEVRIG_LEGACY_SERVER_NAME = "devrig"
 
-/**
- * Registers the **user-facing launcher** (`~/.mcp-steroid/bin/devrig`) as the agent's MCP server. We
- * register that stable wrapper — never the content-addressed install tree, which changes on every
- * upgrade — so an upgrade repoints the launcher underneath without re-registering the agent. `install`
- * is explicit user intent, so we call [ensureBinLauncher] with `force = true`: the wrapper is written
- * even on a SNAPSHOT/dev dist (where the passive on-each-start self-heal is off by default). We then
- * **verify the launcher file actually exists before registering** and FAIL otherwise — registration must
- * never point at a path that does not exist. The registered command is just the launcher (POSIX
- * `~/.mcp-steroid/bin/devrig`; Windows `cmd.exe /d /c "…\bin\devrig.cmd"`), with no `JAVA_HOME` — the
- * launcher sets up its own runtime.
- */
+/** Exit code of `devrig install <agent> --check` when install would change anything (drift detected). */
+const val INSTALL_CHECK_DRIFT_EXIT_CODE = 1
+
 /**
  * `devrig install devrig` — generate + register devrig's own `~/.mcp-steroid/bin/devrig`(`.cmd`) launcher
  * and put it on PATH. This is devrig's normal launcher self-registration ([ensureBinLauncher], which runs
@@ -60,6 +52,24 @@ fun DevrigServices.runInstallCommand(
     command: DevrigCommand.DevrigCommandInstall,
     runner: AiAgentCliRunner = ProcessAiAgentCliRunner(),
 ): Int {
+    if (command.check) {
+        // `--check` is the read-only dry-run of install: it writes NOTHING — no launcher, no agent
+        // config. The canonical command it compares against is the same stable wrapper install would
+        // register, computed as a pure path (DevrigUserLauncher.invocation never touches disk), so the
+        // diagnosis is correct even before the launcher file exists (install would create it).
+        // Report the launcher itself being absent (install hasn't run yet) as a diagnostic — a read-only
+        // stat, no write. Without it the registered command would point at a path that does not exist.
+        val launcherFile = DevrigUserLauncher.path(homePaths)
+        return runInstallCheckCommand(
+            command = command,
+            mcpCommand = DevrigUserLauncher.invocation(homePaths, listOf("mcp")),
+            missingLauncherPath = launcherFile.takeUnless { it.isRegularFile() },
+            out = mcpStdout,
+            err = System.err,
+            runner = runner,
+            ideReachability = { collectIdeReachability() },
+        )
+    }
     // Create the stable launcher first, then guarantee it exists before we register it.
     ensureBinLauncher(homePaths, force = true, registerWindowsPath = true)
     val launcher = DevrigUserLauncher.path(homePaths)
@@ -140,12 +150,9 @@ fun runInstallCommand(
         }
     }
 
-    // Build the set of names to clear: every detected devrig entry, the canonical name (always, so the
-    // re-add is clean even if the listing missed it), plus the legacy name when we couldn't read the list.
-    val namesToRemove = LinkedHashSet<String>()
-    detected.forEach { namesToRemove += it.name }
-    namesToRemove += DEVRIG_MCP_SERVER_NAME
-    if (listResult.exitCode != 0) namesToRemove += DEVRIG_LEGACY_SERVER_NAME
+    // The shared install plan — `--check` prints exactly this same set (see installRemovalNames), so the
+    // dry-run can never drift from what install actually removes.
+    val namesToRemove = installRemovalNames(detected, listReadable = listResult.exitCode == 0)
 
     // Step 2 — clear them all. Each removal is best-effort: a non-zero exit means "not present", which is
     // expected and not fatal. Underlying agent messages go to stderr; stdout reports confirmed removals.
@@ -188,6 +195,163 @@ private fun emitAgentOutput(result: AiAgentCliResult, err: PrintStream) {
     if (result.output.isNotBlank()) {
         err.print(result.output)
         if (!result.output.endsWith("\n")) err.println()
+    }
+}
+
+/**
+ * The single source of truth for the names `devrig install` clears before re-adding the canonical entry —
+ * shared by install (which EXECUTES the removals) and `--check` (which PRINTS them), so the dry-run can
+ * never drift from what install actually does: every detected devrig-owned entry, the canonical name
+ * (always, so the re-add is clean even if the listing missed it), plus the legacy name when the agent's
+ * list could not be read.
+ */
+internal fun installRemovalNames(detected: List<McpServerRef>, listReadable: Boolean): Set<String> {
+    val names = LinkedHashSet<String>()
+    detected.forEach { names += it.name }
+    names += DEVRIG_MCP_SERVER_NAME
+    if (!listReadable) names += DEVRIG_LEGACY_SERVER_NAME
+    return names
+}
+
+/**
+ * How many marker-discovered IDE backends (IDEs running the MCP Steroid plugin) answered the read-only
+ * snapshot probe, out of how many were discovered. Computed on demand from the same markers + snapshot
+ * scan `devrig backend` performs — nothing is cached or persisted (Tenet 3).
+ */
+data class IdeReachabilityReport(val reachable: Int, val discovered: Int)
+
+/**
+ * One-shot, read-only IDE reachability snapshot for `install --check`: reuses the shared
+ * [collectBackendRows] discovery and counts the marker rows — IDEs that wrote a `~/.mcp-steroid/markers`
+ * marker, i.e. have the MCP Steroid plugin — that answered the snapshot fetch (`projects != null`).
+ *
+ * NOTE: this performs the same LIVE scan `devrig backend` does (a `/projects/stream` fetch per discovered
+ * IDE, bounded per-IDE), so it can block for a few seconds per running IDE. That is intentional for a
+ * diagnostic command — `--check` reports real liveness, not cached state — but it is not instant.
+ */
+fun DevrigServices.collectIdeReachability(): IdeReachabilityReport {
+    val markerRows = collectBackendRows().filterIsInstance<BackendRow.FromMarker>()
+    return IdeReachabilityReport(
+        reachable = markerRows.count { it.projects != null },
+        discovered = markerRows.size,
+    )
+}
+
+/**
+ * Read-only mode of [runInstallCommand] (issue #86): performs the SAME discovery — list the agent's MCP
+ * servers, classify devrig-owned entries, compare against the canonical [mcpCommand] install would
+ * register — but applies NOTHING. `install` is the doctor; `--check` is its dry-run. It prints the
+ * current registration state, the diff install WOULD apply (the shared [installRemovalNames] set + the
+ * canonical add, or "already canonical"), and an IDE-reachability summary so a "Failed to connect" report
+ * gets a one-command diagnosis.
+ *
+ * Returns 0 when the registration is already canonical (re-running install would change nothing) and
+ * [INSTALL_CHECK_DRIFT_EXIT_CODE] when install would change anything — including when the agent's server
+ * list cannot be read, since the state cannot be verified then.
+ *
+ * Stateless by design (Tenet 3): the only agent CLI invocation is the read-only `mcp list`, the IDE probe
+ * reads markers/ports on demand, and the check writes nothing — two concurrent `--check` runs are safe.
+ */
+fun runInstallCheckCommand(
+    command: DevrigCommand.DevrigCommandInstall,
+    mcpCommand: StdioMcpCommand,
+    out: PrintStream,
+    err: PrintStream,
+    runner: AiAgentCliRunner,
+    ideReachability: () -> IdeReachabilityReport,
+    /** Non-null = the devrig launcher does not exist yet at this path (reported as a diagnostic). */
+    missingLauncherPath: Path? = null,
+): Int {
+    val agent = command.agent
+    val renderedCommand = "${mcpCommand.command} ${mcpCommand.args.joinToString(" ")}"
+
+    out.println(
+        "Checking the '$DEVRIG_MCP_SERVER_NAME' MCP registration for ${agent.displayName} " +
+            "(read-only — nothing is changed).",
+    )
+    out.println()
+
+    if (missingLauncherPath != null) {
+        out.println(
+            "Note: the devrig launcher ($missingLauncherPath) does not exist yet — " +
+                "'devrig install ${agent.binary}' will create it before registering.",
+        )
+        out.println()
+    }
+
+    // The SAME review step install performs — and the only agent CLI call --check makes.
+    val listInvocation = mcpListInvocation(agent)
+    val listResult = runner.run(listInvocation)
+    val listReadable = listResult.exitCode == 0
+    val listed = if (listReadable) parseMcpServerList(agent, listResult.output) else emptyList()
+    val detected = listed.filter { it.isDevrigOwned() }
+
+    out.println("Current registration state:")
+    when {
+        !listReadable ->
+            out.println(
+                "  could not read ${agent.displayName}'s MCP server list " +
+                    "('${listInvocation.binary} ${listInvocation.args.joinToString(" ")}' " +
+                    "exited with code ${listResult.exitCode}).",
+            )
+        detected.isEmpty() ->
+            out.println("  no existing devrig / '$DEVRIG_MCP_SERVER_NAME' registration found.")
+        else -> detected.forEach { entry ->
+            out.println("  - '${entry.name}' (matched by ${entry.devrigMatchReason()}): ${entry.commandLine}")
+        }
+    }
+    out.println()
+
+    // Canonical = exactly one devrig-owned entry, under the canonical name, launching the exact command
+    // install would register. Anything else — stale launcher/subcommand, duplicates, a custom name, no
+    // entry, or an unreadable list — is drift.
+    val canonical = listReadable &&
+        detected.singleOrNull()?.let { it.name == DEVRIG_MCP_SERVER_NAME && it.commandLine == renderedCommand } == true
+
+    out.println("What 'devrig install ${agent.binary}' would change:")
+    if (canonical) {
+        out.println("  already canonical — no changes.")
+    } else {
+        // The EXACT removal set install would issue (shared via installRemovalNames) — names install
+        // clears defensively even when not detected are annotated "if present".
+        val detectedNames = detected.map { it.name }.toSet()
+        for (name in installRemovalNames(detected, listReadable)) {
+            out.println("  - remove '$name'" + if (name in detectedNames) "" else ", if present")
+        }
+        out.println("  - add '$DEVRIG_MCP_SERVER_NAME' → $renderedCommand")
+    }
+    out.println()
+
+    reportIdeReachability(out, err, ideReachability)
+    out.println()
+
+    return if (canonical) {
+        out.println("No drift — '$DEVRIG_MCP_SERVER_NAME' is registered canonically for ${agent.displayName}.")
+        0
+    } else {
+        out.println("Drift detected — run 'devrig install ${agent.binary}' to repair.")
+        INSTALL_CHECK_DRIFT_EXIT_CODE
+    }
+}
+
+private fun reportIdeReachability(out: PrintStream, err: PrintStream, probe: () -> IdeReachabilityReport) {
+    val report = try {
+        probe()
+    } catch (e: Exception) {
+        err.println("devrig install --check: IDE discovery failed: ${e.message ?: e::class.simpleName}")
+        null
+    }
+    out.println("IDE backends with the MCP Steroid plugin (read-only discovery, same scan as 'devrig backend'):")
+    when {
+        report == null ->
+            out.println("  discovery failed — see the error above; run 'devrig backend' for details.")
+        report.discovered == 0 ->
+            out.println(
+                "  none discovered — no running IDE has the MCP Steroid plugin. " +
+                    "Start one (or run 'devrig backend' for the full picture).",
+            )
+        else ->
+            out.println("  ${report.reachable} of ${report.discovered} discovered backend(s) reachable.")
     }
 }
 

--- a/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/DevrigCommandTest.kt
+++ b/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/DevrigCommandTest.kt
@@ -105,6 +105,19 @@ class DevrigCommandTest {
         assertIs<DevrigCommand.DevrigCommandParseError>(command("--home", "/tmp/devrig-home"))
     }
 
+    @Test
+    fun `install --check selects the read-only check for an agent and is rejected for devrig`() {
+        // --check sets the read-only flag on an agent install…
+        val checked = assertIs<DevrigCommand.DevrigCommandInstall>(command("install", "claude", "--check"))
+        assertEquals(AiAgentCli.CLAUDE, checked.agent)
+        assertTrue(checked.check)
+        // …and is OFF by default, and works for every agent.
+        assertFalse(assertIs<DevrigCommand.DevrigCommandInstall>(command("install", "codex")).check)
+        assertTrue(assertIs<DevrigCommand.DevrigCommandInstall>(command("install", "gemini", "--check")).check)
+        // 'install devrig' is launcher self-registration, not an agent — --check is rejected there.
+        assertIs<DevrigCommand.DevrigCommandParseError>(command("install", "devrig", "--check"))
+    }
+
     private fun command(vararg args: String): DevrigCommand =
         parseDevrigCommand(args.toList().toTypedArray())
 }

--- a/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/InstallCommandTest.kt
+++ b/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/InstallCommandTest.kt
@@ -37,6 +37,23 @@ class InstallCommandTest {
         ]
     """.trimIndent()
 
+    // A CANONICAL claude listing: exactly one 'mcp-steroid' entry whose command is the stable wrapper
+    // install would register ("$launcherPath mcp"). Re-running install would change nothing.
+    private val claudeCanonicalList = """
+        Checking MCP server health…
+
+        mcp-steroid: $launcherPath mcp - ✓ Connected
+        playwright: npx @playwright/mcp@latest - ✓ Connected
+    """.trimIndent()
+
+    // The codex (--json) analog: command + args reconstruct to the exact canonical "$launcherPath mcp".
+    private val codexCanonicalJson = """
+        [
+          {"name":"mcp-steroid","transport":{"type":"stdio","command":"$launcherPath","args":["mcp"]}},
+          {"name":"playwright","transport":{"type":"stdio","command":"npx","args":["@playwright/mcp@latest"]}}
+        ]
+    """.trimIndent()
+
     @Test
     fun `install reviews the list first, then consolidates, then adds`() {
         // First invocation must be the list (review), last must be the add.
@@ -188,6 +205,177 @@ class InstallCommandTest {
         assertContains(result.stderr, "17")
         assertTrue(result.stderr.contains("fail", ignoreCase = true), result.stderr)
     }
+
+    // ── install --check (read-only dry-run, issue #86) ──
+
+    @Test
+    fun `check reports no drift for a canonical registration and exits 0`() {
+        val r = runCheck(
+            AiAgentCli.CLAUDE,
+            RecordingRunner(listResult = AiAgentCliResult(0, claudeCanonicalList)),
+            reachability = IdeReachabilityReport(reachable = 2, discovered = 3),
+        )
+        assertEquals(0, r.exitCode)
+        assertContains(r.stdout, "already canonical")
+        assertContains(r.stdout, "No drift")
+        assertContains(r.stdout, "2 of 3 discovered backend(s) reachable")
+    }
+
+    @Test
+    fun `check never mutates for ANY agent - only 'mcp list' is ever invoked (canonical and drift)`() {
+        // The no-mutate guarantee is the most safety-critical property of --check, and parseMcpServerList
+        // takes a DIFFERENT code path per agent (codex = JSON, claude/gemini = line) — so assert it for all
+        // three, in both canonical and drift states.
+        val cases = listOf(
+            AiAgentCli.CLAUDE to claudeCanonicalList,
+            AiAgentCli.CLAUDE to "mcp-steroid: /old/path/devrig mcp - ✓ Connected",
+            AiAgentCli.CODEX to codexCanonicalJson,
+            AiAgentCli.CODEX to codexListJson,
+            AiAgentCli.GEMINI to claudeCanonicalList,
+            AiAgentCli.GEMINI to "Checking MCP server health…\n\n",
+        )
+        for ((agent, list) in cases) {
+            val r = runCheck(agent, RecordingRunner(listResult = AiAgentCliResult(0, list)))
+            assertTrue(r.invocations.all { it.args.contains("list") }, "$agent: ${r.invocations}")
+            assertFalse(
+                r.invocations.any { it.args.contains("add") || it.args.contains("remove") },
+                "$agent check must never add/remove: ${r.invocations}",
+            )
+        }
+    }
+
+    @Test
+    fun `check reports no drift for a canonical codex (--json) registration and exits 0`() {
+        val r = runCheck(AiAgentCli.CODEX, RecordingRunner(listResult = AiAgentCliResult(0, codexCanonicalJson)))
+        assertEquals(0, r.exitCode)
+        assertContains(r.stdout, "already canonical")
+    }
+
+    @Test
+    fun `check detects a custom-named devrig entry as drift (by config), exit 1`() {
+        val r = runCheck(
+            AiAgentCli.CLAUDE,
+            RecordingRunner(listResult = AiAgentCliResult(0, "old-steroid: /usr/bin/env /custom/devrig mcp - ✓ Connected")),
+        )
+        assertEquals(INSTALL_CHECK_DRIFT_EXIT_CODE, r.exitCode)
+        // Detected by its command (not name) → removed WITHOUT the "if present" qualifier.
+        assertContains(r.stdout, "remove 'old-steroid'")
+        assertFalse(r.stdout.contains("remove 'old-steroid', if present"), r.stdout)
+        assertContains(r.stdout, "add 'mcp-steroid'")
+    }
+
+    @Test
+    fun `check detects two simultaneous devrig entries as drift, both removed without 'if present'`() {
+        val r = runCheck(AiAgentCli.CLAUDE, RecordingRunner(listResult = AiAgentCliResult(0, claudeListWithBothNames)))
+        assertEquals(INSTALL_CHECK_DRIFT_EXIT_CODE, r.exitCode)
+        assertContains(r.stdout, "remove 'mcp-steroid'")
+        assertContains(r.stdout, "remove 'devrig'")
+        // Both names were detected, so neither carries the defensive "if present" qualifier.
+        assertFalse(r.stdout.contains(", if present"), r.stdout)
+    }
+
+    @Test
+    fun `check reports the launcher is absent when it does not exist yet`() {
+        // Canonical agent registration, but the wrapper file itself is missing — the diagnostic the
+        // feature exists for (issue #86): the registration points at a launcher that is not there yet.
+        val r = runCheck(
+            AiAgentCli.CLAUDE,
+            RecordingRunner(listResult = AiAgentCliResult(0, claudeCanonicalList)),
+            missingLauncherPath = Path.of(launcherPath),
+        )
+        assertContains(r.stdout, "does not exist yet")
+        assertContains(r.stdout, launcherPath)
+    }
+
+    @Test
+    fun `check detects a stale command as drift and prints the repair plan, exit 1`() {
+        val r = runCheck(
+            AiAgentCli.CLAUDE,
+            RecordingRunner(listResult = AiAgentCliResult(0, "mcp-steroid: /old/path/devrig mcp - ✓ Connected")),
+        )
+        assertEquals(INSTALL_CHECK_DRIFT_EXIT_CODE, r.exitCode)
+        assertContains(r.stdout, "Drift detected")
+        assertContains(r.stdout, "remove 'mcp-steroid'")
+        assertContains(r.stdout, "add 'mcp-steroid' → $launcherPath mcp")
+    }
+
+    @Test
+    fun `check treats an empty list as drift (install would add) and exits 1`() {
+        val r = runCheck(
+            AiAgentCli.CLAUDE,
+            RecordingRunner(listResult = AiAgentCliResult(0, "Checking MCP server health…\n\n")),
+        )
+        assertEquals(INSTALL_CHECK_DRIFT_EXIT_CODE, r.exitCode)
+        assertTrue(r.stdout.contains("no existing", ignoreCase = true), r.stdout)
+        assertContains(r.stdout, "add 'mcp-steroid'")
+    }
+
+    @Test
+    fun `check treats an unreadable list as drift (cannot verify) and includes the legacy name, exit 1`() {
+        val r = runCheck(
+            AiAgentCli.CLAUDE,
+            RecordingRunner(listResult = AiAgentCliResult(exitCode = 2, output = "boom: cannot list\n")),
+        )
+        assertEquals(INSTALL_CHECK_DRIFT_EXIT_CODE, r.exitCode)
+        assertTrue(r.stdout.contains("could not read", ignoreCase = true), r.stdout)
+        // Unreadable → install would defensively clear the legacy 'devrig' name too (shared installRemovalNames).
+        assertContains(r.stdout, "remove 'devrig'")
+    }
+
+    @Test
+    fun `check tolerates an IDE-discovery failure (reports it, does not abort the diagnosis)`() {
+        val r = runCheck(
+            AiAgentCli.CLAUDE,
+            RecordingRunner(listResult = AiAgentCliResult(0, "Checking MCP server health…\n\n")),
+            reachabilityThrows = true,
+        )
+        assertEquals(INSTALL_CHECK_DRIFT_EXIT_CODE, r.exitCode)
+        assertContains(r.stderr, "IDE discovery failed")
+        assertContains(r.stdout, "discovery failed")
+    }
+
+    @Test
+    fun `check reports when no IDE backends are discovered`() {
+        val r = runCheck(
+            AiAgentCli.CLAUDE,
+            RecordingRunner(listResult = AiAgentCliResult(0, claudeCanonicalList)),
+            reachability = IdeReachabilityReport(reachable = 0, discovered = 0),
+        )
+        assertContains(r.stdout, "none discovered")
+    }
+
+    private fun runCheck(
+        agent: AiAgentCli,
+        runner: RecordingRunner,
+        reachability: IdeReachabilityReport = IdeReachabilityReport(reachable = 0, discovered = 0),
+        reachabilityThrows: Boolean = false,
+        missingLauncherPath: Path? = null,
+    ): CheckRunResult {
+        val stdout = ByteArrayOutputStream()
+        val stderr = ByteArrayOutputStream()
+        val exitCode = runInstallCheckCommand(
+            command = DevrigCommand.DevrigCommandInstall(agent, check = true),
+            mcpCommand = mcpCommand,
+            out = PrintStream(stdout, true, Charsets.UTF_8),
+            err = PrintStream(stderr, true, Charsets.UTF_8),
+            runner = runner,
+            ideReachability = { if (reachabilityThrows) error("probe boom") else reachability },
+            missingLauncherPath = missingLauncherPath,
+        )
+        return CheckRunResult(
+            exitCode = exitCode,
+            invocations = runner.invocations,
+            stdout = stdout.toString(Charsets.UTF_8),
+            stderr = stderr.toString(Charsets.UTF_8),
+        )
+    }
+
+    private data class CheckRunResult(
+        val exitCode: Int,
+        val invocations: List<AiAgentCliInvocation>,
+        val stdout: String,
+        val stderr: String,
+    )
 
     private fun runInstall(agent: AiAgentCli, runner: RecordingRunner): InstallRunResult {
         val stdout = ByteArrayOutputStream()


### PR DESCRIPTION
## What

Adds **`devrig install <agent> --check`** — a read-only dry-run of `install` that diagnoses MCP-registration drift + IDE reachability without changing anything. Revives the feature designed on the abandoned `0101-installer-docker` branch (issue #86), **reworked** onto current main's install model (the old `selfMcpCommand`/`resolveDevrigLauncher` were dropped by #117/#118).

## Behavior

`--check` performs the SAME discovery as `install` (list the agent's MCP servers → classify devrig-owned entries → compare against the canonical command install would register) but **applies nothing** — no launcher write, no `mcp add`/`remove`; only the read-only `mcp list` + an on-demand marker/port probe. Stateless and concurrency-safe (Tenet 3). It prints:
- the current registration state,
- the diff install **would** apply (shared `installRemovalNames` set + the canonical add, or "already canonical — no changes"),
- whether the devrig launcher itself exists yet,
- how many IDE backends with the MCP Steroid plugin are reachable (diagnoses "Failed to connect").

**Exit 0** = already canonical; **1** = drift / unreadable server list / anything install would change.

`install` and `--check` now share `installRemovalNames(...)`, so the dry-run can't drift from what install actually removes. `--check` is rejected for `install devrig` (launcher self-registration, not an agent).

## Testing
- `:npx-kt:test` green: canonical / drift / unreadable across **claude + codex + gemini**, the no-mutate guarantee for all three agents, custom-name + duplicate-entry drift, the launcher-absent diagnostic, IDE-reachability rendering (incl. probe failure), and CLI parse (`--check` sets the flag; rejected for `install devrig`; off by default).
- IDE inspections **0 WARNING+** on all changed files.
- **3× adversarial quorum**: correctness reviewer found no issues; rework-fidelity + tests reviewers' findings all applied (dead KDoc removed, missing-launcher diagnostic restored, latency KDoc note, +4 test cases + parse case).

A dispatcher-level unit test was deliberately **not** added — it would invoke the live `collectBackendRows` localhost port scan (non-hermetic, violates the repo's hermetic-unit-test rule); the `mcpCommand` wiring it would cover is the same `DevrigUserLauncher.invocation` already exercised by the non-check install tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)