### PR TITLE
docs(TASKS): triage cleanup — drop done items, mark partials, track the 0.101 gate

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -14,8 +14,8 @@ Discipline (standing rule): per change — design → implement → 0 WARNING+ I
 
 ## Installer / website epic — remaining
 
-Epic delivered via PRs #117–#125 (PR #113 closed as superseded). See the `installer-epic` memory for the
-full delivered list. Still open:
+Epic delivered via PRs #117–#127 (PR #113 closed as superseded; `install --check` revived in #127). See
+the `installer-epic` memory for the full delivered list. Still open:
 
 1. **Cut a devrig release from `main`.** The LIVE installer is broken on all platforms until then: the
    published `v0.100` binary predates the `install devrig` command (mac/linux: "no such option
@@ -46,53 +46,46 @@ full delivered list. Still open:
    Suspects: `mcp-steroid.kt:664/731/800` (`delay(2_000L)`), `:544` (`delay(500L)`),
    `IdeTestHelpers.kt:152/161` (`Thread.sleep(50)`), `intelliJ-container.kt:307/315/354/384/415` poll loops.
 
-7. **DialogKiller hang on macOS/Docker (in progress).** `VisionService.capture` stalls while a modal
-   `DialogWrapper` is showing (both the killer's pre-close screenshot and `closeDialog` go through
-   `Dispatchers.EDT + ModalityState.any()`, never pumped → modality never resolved → downstream + MCP hang).
-   Goal: the killer must reliably close all dialogs and restore `ModalityState.nonModal()`; the screenshot
-   is secondary and must NEVER block that. Instrumentation in `2e26ec6a` + debug-port in `11bec066`. Next:
-   read the screenshot-vs-close run log, make the screenshot best-effort/off the critical path, and/or fix
-   `VisionService.capture` to not stall under a modal.
-
-8. **devrig binary end-to-end console test (managed-backend self-install).** New console test exercising the
-   whole flow an external user/agent hits — no pre-provisioned IDE: clone Keycloak (cached bare repo) →
-   `devrig install claude` → run the agent with a deterministic find-usages task → devrig fetches + starts
-   the managed IDE → opens the project → asserts the expected usage count. Each step visible in the console.
-   Prereq: managed-backend path health — `DevrigManagedBackendGui` / `DevrigRealIdeBridge` / `DevrigAgent`
-   currently FAIL (see `test-integration/TODO-stability-report.md`); devrig JVM must launch on Java 25.
+> Done (removed 2026-06-19, triage-verified): the **DialogKiller modal hang** (RESOLVED 2026-05-31 —
+> `docs/dialog-killer-modality-hang.md`; screenshot off the close path in `VisionService`/`DialogKiller`,
+> modal-enum redesign) and the **devrig managed-backend e2e console test**
+> (`DevrigManagedBackendAgentE2ETest`, on `main`, commits `cb018b33`/`4f2b7e1a`).
 
 ---
 
 ## Prompts corpus
 
-9. **IMPROVEMENTS.md harness rollout (separate PR).** The two-task prompt + per-agent reflection harness
-   (landed on `FindDuplicatesPromptTest`) is generic; extend it across every `:test-integration` prompt-style
-   test. Audit candidates (`ReferencesSearchPromptTest`, `FilenameIndexPromptTest`, `PsiClassLookupPromptTest`,
-   `MavenRunnerAdoptionTest`, `ResourceReadingTest`, `WhatYouSeeTest.toolPreference`); add Task-2 reflection +
-   snapshot the `<<<IMPROVEMENTS>>>` block; promote `extractImprovementsBlock`/`saveImprovements` to a shared
-   helper; cadence 5×Claude→3×Codex→3×Claude→3×Codex; update CLAUDE.md when done (drop the
-   "currently wired into FindDuplicatesPromptTest" caveat).
+7. **IMPROVEMENTS.md harness rollout (separate PR) — PARTIAL.** The two-task prompt + per-agent reflection
+   harness has spread organically to `PrintCsvPrintToonPromptTest`, `TypeHierarchyPromptTest`,
+   `StructuralSearchPromptTest` (+ `StructuralSearchYoutrackdbPromptShared`). Still open:
+   (a) none of the named audit candidates (`ReferencesSearchPromptTest`, `FilenameIndexPromptTest`,
+   `PsiClassLookupPromptTest`, `MavenRunnerAdoptionTest`, `ResourceReadingTest`,
+   `WhatYouSeeTest.toolPreference`) are wired; (b) `extractImprovementsBlock`/`saveImprovements` are still
+   copy-pasted `private fun` per test — promote to a shared helper; (c) `test-experiments/CLAUDE.md` still
+   carries the "currently wired into FindDuplicatesPromptTest" caveat to drop when done.
 
-10. **Reflection audit follow-up (issue #33).** Replace the two reflection-using `kotlin` recipes with typed
-    APIs (research in `~/Work/intellij` first, then land each as its own KtBlock + in-process tests):
-    - `lsp/hover.md` (lines 88, 93) — `javaClass.methods.find{"getType"}?.invoke(...)`. Typed: Kotlin
-      `KtProperty.typeReference?.text` / `KtParameter.typeReference?.text` / analysis-API
-      `KaSession.getReturnKtType`; Java `PsiVariable.type.canonicalText`.
-    - `lsp/signature-help.md` (lines 82, 88, 96, 112) — same pattern, 4 sites in one snippet wrapped in a
-      failure-hiding `try/catch`. Typed: Kotlin `KtNamedFunction.valueParameters`/`.typeReference`; Java
-      `PsiMethod.parameterList.parameters`/`.returnType`.
+8. **Reflection audit follow-up (issue #33).** Replace the two reflection-using `kotlin` recipes with typed
+   APIs (research in `~/Work/intellij` first, then land each as its own KtBlock + in-process tests):
+   - `lsp/hover.md` (lines 88, 93) — `javaClass.methods.find{"getType"}?.invoke(...)`. Typed: Kotlin
+     `KtProperty.typeReference?.text` / `KtParameter.typeReference?.text` / analysis-API
+     `KaSession.getReturnKtType`; Java `PsiVariable.type.canonicalText`.
+   - `lsp/signature-help.md` (lines 82, 88, 96, 112) — same pattern, 4 sites in one snippet wrapped in a
+     failure-hiding `try/catch`. Typed: Kotlin `KtNamedFunction.valueParameters`/`.typeReference`; Java
+     `PsiMethod.parameterList.parameters`/`.returnType`.
 
 ---
 
 ## Release / cross-cutting
 
-11. **Release independence disclosure.** Every distributed artifact + public surface must state that MCP
-    Steroid and Devrig are independent open-source projects, NOT made by / affiliated with JetBrains:
-    website (footer/about), READMEs, docs, plugin (Marketplace + `plugin.xml` vendor + in-IDE notice), devrig
-    `--version`/`--help` banner + dist `licenses/README` + package metadata, release notes, EULA. Add a
-    release-checklist item + a build-time guard/test so a release can't ship without it. (Backlog; wording TBD.)
+9. **Release independence disclosure — PARTIAL.** PRESENT: website footer + index/about, `plugin.xml`
+   vendor + in-IDE notice + trademark line, `docs/devrig.md`, release notes 0.100. Still MISSING (all
+   required): (1) `README.md` has NO disclosure — and its line-1 badge currently reads as an *official
+   JetBrains incubator* project, directly contradicting the requirement (fix the badge too); (2) the devrig
+   `--version`/`--help` banner (`HelpCommand.kt`); (3) the dist `npx-kt/src/main/dist/licenses/README.md`;
+   (4) a positive independence statement in EULA (it only names JetBrains as a non-party); (5) a
+   release-checklist item; (6) a build-time guard/test asserting the disclosure. (Backlog; wording TBD.)
 
-12. **devrig ↔ plugin protocol forward-compat.** Additive-only wire contract. Done: (1) contract test
+10. **devrig ↔ plugin protocol forward-compat.** Additive-only wire contract. Done: (1) contract test
     `DevrigToolBridgeClientTest`, (3) `ij-plugin/CLAUDE.md` "devrig ↔ plugin wire contract" rule, (4) audit of
     the shared `@Serializable` DTOs. Still open:
     - (2) **cross-version test** — devrig HEAD ↔ an older plugin build (and vice-versa); only meaningful once
@@ -100,3 +93,14 @@ full delivered list. Still open:
     - (5) **devrig-owned DTOs** — give devrig its own copy of the marker + bridge request/result DTOs (today it
       reuses `mcp-steroid-server`'s classes via tolerant decode) so the two evolve independently and only the
       JSON wire shape is shared.
+
+11. **0.101 release gate — reconcile closed-but-not-on-`main` work (tracked in #102).** The 2026-06-19
+    triage found issues marked done/closed whose code was reverted (commit `30236610`, "Revert the 0.101
+    work batch") and never re-landed on `main`:
+    - **#93 / #94 / #69** — `runInspectionsDirectly` on `main` is still a bare `InspectionEngine.inspectEx`
+      (`McpScriptContextImpl.kt`): no per-tool crash isolation, no invalid-PSI tolerance, no `Project`
+      param / structured findings.
+    - **#99 / #100** — `devrig prompt` and `devrig exec-code --file` exist only on `0101-cli-commands`, not
+      `main` (`Cli.kt` has only mcp/backend/project/install/help/version).
+    Before 0.101: either re-land these onto `main` or re-open the issues so their state matches reality.
+    Release gate **#92** (same-named-project routing) is also still open/unverified.


### PR DESCRIPTION
Outcome of the per-task triage (one read-only investigator per open task / issue / epic, 2026-06-19).

## TASKS.md
- **Removed (verified done on `main`):** DialogKiller modal hang (RESOLVED — `docs/dialog-killer-modality-hang.md`) and the devrig managed-backend e2e console test (`DevrigManagedBackendAgentE2ETest`, `cb018b33`/`4f2b7e1a`).
- **Marked PARTIAL:** IMPROVEMENTS.md harness rollout (spread to a few more prompt tests; named candidates + shared helper + CLAUDE.md caveat remain) and release independence disclosure (website/plugin/docs done; README + devrig banner + dist licenses + EULA + checklist + build-guard remain — and the README still carries a contradictory "official JetBrains incubator" badge).
- **Added:** a **0.101 release gate** item — work marked closed/done but reverted by `30236610` and never re-landed on `main`: #93/#94/#69 (`runInspectionsDirectly` still bare `InspectionEngine.inspectEx`) and #99/#100 (`devrig prompt`/`exec-code --file` only on `0101-cli-commands`). Tracked on epic #102.

## GitHub issues (already executed)
- **Closed (verified fixed, evidence comments):** #112 (docs/API now match), #43 (`ExecutionSuggestionService.computeHint` structured threading hints), #73 (two-phase compile-then-run already gates compile errors + `println`/`printJson` helpers exist).
- **Commented (need reporter input):** #58, #79.
- **Epic progress comments:** #102 (8 done / discrepancy flagged), #101 (install --check landed), #91 (all 29 re-verified open).

🤖 Generated with [Claude Code](https://claude.com/claude-code)