### PR TITLE
Finding A: re-provision the current plugin on every managed start

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -111,20 +111,13 @@ PR #139 delivered: marker `ideHome` identity, `pluginPath` marker field, the fou
 taxonomy, dedup, running-managed exclusion, and `open_project` auto-start. Design + contract:
 `docs/startable-backends-design.md`. Remaining:
 
-12. **Finding A — re-provision the current plugin on managed start ("update plugin before run").**
-    `BackendManager.start` must install/refresh the *current* mcp-steroid plugin into the managed
-    backend before launch, so a started managed IDE boots compatible (writes `ideHome`) instead of
-    the stale bundled plugin. Until this lands, `open_project` on a pre-existing managed backend
-    (old plugin, no `ideHome`) times out at 120 s. The `McpSteroidServerInfo.pluginPath` marker
-    field (shipped in #139) is the hook — nothing reads it yet. Consumer side reads `pluginPath`,
-    compares to the deploying devrig's plugin version, redeploys if stale.
-
-13. **Live-prove running-managed exclusion from startable.** #139 covers it with unit tests at
+12. **Live-prove running-managed exclusion from startable.** #139 covers it with unit tests at
     `startableBackends()`, `DevrigBackendService.candidates()`, and CLI render levels, but it was
-    not live-verified by actually starting a managed IDE (avoided the finding-A 120 s timeout +
-    modal-dialog risk). Re-verify live once Finding A removes the timeout.
+    not live-verified by actually starting a managed IDE. Re-verify live now that Finding A has
+    removed the 120 s timeout (start re-provisions vmoptions + the current plugin on every
+    not-already-running start, so a managed IDE boots reachable).
 
-14. **Group 4 (downloadable) — real catalog flow.** Today group 4 is advertise-only: the footer
+13. **Group 4 (downloadable) — real catalog flow.** Today group 4 is advertise-only: the footer
     points at the full-cycle install command `devrig backend download <product>`. Decide whether
     `open_project` / `devrig backend` should ever enumerate concrete downloadable IDEs (catalog),
     or keep it advertise-only.

--- a/docs/startable-backends-design.md
+++ b/docs/startable-backends-design.md
@@ -77,12 +77,13 @@ Group-specific contracts:
 - **Group 2** is display-only — devrig cannot drive or start these. The group exists to *advertise
   the `devrig backend` subcommands* (download/start) so the user can move an incompatible/plugin-less
   IDE toward a usable state. Never an `open_project` candidate.
-- **Group 3** backends are started fresh by devrig. Today `BackendManager.start` re-provisions
-  **vmoptions** before launch; the mcp-steroid **plugin** is provisioned at `download` time (so a
-  freshly-downloaded backend boots with the current plugin). Re-provisioning the *current* plugin on
-  every `start` ("update plugin before run") is **Finding A — deferred** (see `TASKS.md` item 12); the
-  `McpSteroidServerInfo.pluginPath` marker field is the hook for it. Excluded from startable while a
-  live managed pid exists (Finding B).
+- **Group 3** backends are started fresh by devrig. `BackendManager.start` re-provisions both
+  **vmoptions** and the **current bundled mcp-steroid plugin** on every not-already-running start
+  (Finding A implemented). This ensures a backend downloaded by an older devrig boots with the
+  current plugin and writes `ideHome` in its marker, making it reachable. Concurrency is safe: the
+  marker/port wait in `DevrigBackendService.ensureBackendRunning` plus IntelliJ's own single-instance
+  lock (a duplicate spawn exits cleanly) handle races — no lock file needed. Excluded from startable
+  while a live managed pid exists (Finding B).
 - **Group 4** is never enumerated in the listing — the command only surfaces the install entry point.
   The promotion footer picks the **full-cycle install command** `devrig backend download <product>`,
   which *downloads and installs* the managed backend (per its `--help`); the IDE then appears as a
@@ -261,9 +262,14 @@ BackendManager scans pid files to determine liveness. A managed IDE that is runn
 written a marker (e.g. still booting) is therefore correctly excluded from startable before its
 marker appears.
 
-### A — plugin path (deferred)
+### A — plugin path
+
+**Finding A is implemented.** `BackendManager.start` now re-provisions vmoptions AND the current
+bundled mcp-steroid plugin on every not-already-running start (see `ManagedBackend.kt`,
+`startLocked`). A backend downloaded by an older devrig boots with the current plugin, writes
+`ideHome` in its marker, and becomes reachable without a 120 s timeout.
 
 `McpSteroidServerInfo.pluginPath` carries the absolute path of the deployed mcp-steroid plugin
-folder inside the IDE's plugin directory. This field is plumbing for a future
-"update plugin before run" step (Finding A): when devrig detects an outdated plugin version at
-`pluginPath`, it can redeploy before starting. No logic reads this field yet.
+folder inside the IDE's plugin directory. It remains the hook for a future *already-running*
+staleness hint: when a running IDE's plugin is outdated, devrig could surface a nudge via
+`pluginPath`. No logic reads this field for that purpose yet.

--- a/docs/startable-backends-design.md
+++ b/docs/startable-backends-design.md
@@ -1,6 +1,6 @@
 # Startable backends + backend-listing simplification
 
-**Status:** design approved 2026-06-22; implementation plan pending.
+**Status:** core shipped in PR #139; Finding A (re-provision the current plugin on managed start) shipped in PR #143.
 
 ## Goal
 
@@ -151,7 +151,7 @@ sources — no `BackendRow`:
 2. **Other IDEs (incompatible or no MCP Steroid)** (S1 `ideHome == null` + S2) — *detected; cannot
    be driven; use the `devrig backend` subcommands to make one usable.*
 3. **Installed, not running (startable)** (S3) — *startable; a fresh start re-provisions vmoptions +
-   plugins.*
+   the mcp-steroid plugin.*
 4. **footer** — how to download/install more (`devrig backend download …`); group 4 is advertised
    here, never enumerated.
 

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/ManagedBackend.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/ManagedBackend.kt
@@ -450,6 +450,11 @@ class BackendManager(
         require(Files.isExecutable(launcher)) { "Launcher is not executable: $launcher" }
 
         writeBackendVmOptions(homePaths, resolved.id, descriptor.bundleDirName)
+        // Re-provision the current bundled plugin before launch so a backend downloaded by an older
+        // devrig boots with THIS devrig's plugin (writes ideHome → becomes reachable). Only reached when
+        // the backend is not already running (the pid-file checks above early-return otherwise), so the
+        // plugin dir is never rewritten under a live IDE.
+        deployMcpSteroidPlugin(resolved.id)
         val cacheDir = homePaths.cacheDir(resolved.id)
         val logDir = cacheDir.resolve("logs")
         listOf("config", "system", "logs", "plugins").forEach { Files.createDirectories(cacheDir.resolve(it)) }

--- a/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/BackendManagerStartStopTest.kt
+++ b/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/BackendManagerStartStopTest.kt
@@ -308,7 +308,8 @@ class BackendManagerStartStopTest {
             ideUserHome = tempDir.resolve("user-home"),
         )
 
-        manager.start(parseBackendId("idea-community-2025.3.3"))
+        val started = manager.start(parseBackendId("idea-community-2025.3.3"))
+        assertTrue(started.pid > 0)
         try {
             assertEquals(
                 "current",
@@ -318,6 +319,41 @@ class BackendManagerStartStopTest {
             assertFalse(pluginDir.resolve("stale.txt").exists(), "start must remove stale plugin files before redeploying")
         } finally {
             manager.stop(parseBackendId("idea-community-2025.3.3"))
+        }
+    }
+
+    @Test
+    fun `start on an already-running backend does not re-provision the plugin`(
+        @TempDir tempDir: Path,
+    ) = kotlinx.coroutines.runBlocking {
+        val homePaths = HomePaths(tempDir.resolve("home"))
+        installStubBackend(homePaths, launcherBody = gracefulLauncher())
+        val firstManager = BackendManager(
+            homePaths = homePaths,
+            downloader = StaticDownloader,
+            bundledPluginResolver = FixedBundledPluginResolver(bundledPluginZipFixture(tempDir.resolve("dist/ij-plugin.zip"), "v1")),
+            ideUserHome = tempDir.resolve("user-home"),
+        )
+
+        val firstStart = firstManager.start(parseBackendId("idea-community-2025.3.3"))
+        assertTrue(firstStart.pid > 0)
+        assertFalse(firstStart.alreadyRunning)
+        try {
+            // Build a second manager with a resolver that must NOT be called:
+            // if deployMcpSteroidPlugin runs for an already-running backend the test will fail.
+            val secondManager = BackendManager(
+                homePaths = homePaths,
+                downloader = StaticDownloader,
+                bundledPluginResolver = ThrowingBundledPluginResolver,
+                ideUserHome = tempDir.resolve("user-home"),
+            )
+
+            val secondStart = secondManager.start(parseBackendId("idea-community-2025.3.3"))
+
+            assertTrue(secondStart.alreadyRunning, "second start must report alreadyRunning=true")
+            assertEquals(firstStart.pid, secondStart.pid, "pid must be the same running process")
+        } finally {
+            firstManager.stop(parseBackendId("idea-community-2025.3.3"))
         }
     }
 
@@ -411,5 +447,10 @@ class BackendManagerStartStopTest {
             resolution: BackendDownloadResolution,
             targetDir: Path,
         ): BackendDownloadArtifact = error("downloadAndUnpack should not be called by start/stop tests")
+    }
+
+    private object ThrowingBundledPluginResolver : BundledPluginResolver {
+        override fun resolveBundledPluginZip(): Path =
+            error("re-provision must not run for an already-running backend")
     }
 }

--- a/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/BackendManagerStartStopTest.kt
+++ b/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/BackendManagerStartStopTest.kt
@@ -31,6 +31,7 @@ class BackendManagerStartStopTest {
         val manager = BackendManager(
             homePaths = homePaths,
             downloader = StaticDownloader,
+            bundledPluginResolver = FixedBundledPluginResolver(bundledPluginZipFixture(tempDir.resolve("dist/ij-plugin.zip"), "test")),
             ideUserHome = tempDir.resolve("user-home"),
         )
 
@@ -61,6 +62,7 @@ class BackendManagerStartStopTest {
         val manager = BackendManager(
             homePaths = homePaths,
             downloader = StaticDownloader,
+            bundledPluginResolver = FixedBundledPluginResolver(bundledPluginZipFixture(tempDir.resolve("dist/ij-plugin.zip"), "test")),
             ideUserHome = tempDir.resolve("user-home"),
             stopGracePeriodMillis = 0L,
         )
@@ -78,7 +80,11 @@ class BackendManagerStartStopTest {
     fun `stop treats a missing pid file as successful not running`(
         @TempDir tempDir: Path,
     ) = kotlinx.coroutines.runBlocking {
-        val manager = BackendManager(HomePaths(tempDir.resolve("home")), downloader = StaticDownloader)
+        val manager = BackendManager(
+            homePaths = HomePaths(tempDir.resolve("home")),
+            downloader = StaticDownloader,
+            bundledPluginResolver = FixedBundledPluginResolver(bundledPluginZipFixture(tempDir.resolve("dist/ij-plugin.zip"), "test")),
+        )
 
         val stopped = manager.stop(parseBackendId("idea-community-2025.3.3"))
 
@@ -98,6 +104,7 @@ class BackendManagerStartStopTest {
             val manager = BackendManager(
                 homePaths = homePaths,
                 downloader = StaticDownloader,
+                bundledPluginResolver = FixedBundledPluginResolver(bundledPluginZipFixture(tempDir.resolve("dist/ij-plugin.zip"), "test")),
                 ideUserHome = tempDir.resolve("user-home"),
             )
 
@@ -148,6 +155,7 @@ class BackendManagerStartStopTest {
             val manager = BackendManager(
                 homePaths = homePaths,
                 downloader = StaticDownloader,
+                bundledPluginResolver = FixedBundledPluginResolver(bundledPluginZipFixture(tempDir.resolve("dist/ij-plugin.zip"), "test")),
                 ideUserHome = userHome,
             )
 
@@ -171,6 +179,7 @@ class BackendManagerStartStopTest {
         val manager = BackendManager(
             homePaths = homePaths,
             downloader = ThrowingDownloader,
+            bundledPluginResolver = FixedBundledPluginResolver(bundledPluginZipFixture(tempDir.resolve("dist/ij-plugin.zip"), "test")),
             ideUserHome = tempDir.resolve("user-home"),
         )
 
@@ -193,6 +202,7 @@ class BackendManagerStartStopTest {
         val manager = BackendManager(
             homePaths = homePaths,
             downloader = ThrowingDownloader,
+            bundledPluginResolver = FixedBundledPluginResolver(bundledPluginZipFixture(tempDir.resolve("dist/ij-plugin.zip"), "test")),
             ideUserHome = tempDir.resolve("user-home"),
         )
         val started = manager.start(parseBackendId("idea-community-2025.2.6.2"))
@@ -214,6 +224,7 @@ class BackendManagerStartStopTest {
         val manager = BackendManager(
             homePaths = homePaths,
             downloader = StaticDownloader,
+            bundledPluginResolver = FixedBundledPluginResolver(bundledPluginZipFixture(tempDir.resolve("dist/ij-plugin.zip"), "test")),
             ideUserHome = tempDir.resolve("user-home"),
         )
 
@@ -244,6 +255,7 @@ class BackendManagerStartStopTest {
         val manager = BackendManager(
             homePaths = homePaths,
             downloader = StaticDownloader,
+            bundledPluginResolver = FixedBundledPluginResolver(bundledPluginZipFixture(tempDir.resolve("dist/ij-plugin.zip"), "test")),
             ideUserHome = userHome,
         )
 
@@ -274,6 +286,39 @@ class BackendManagerStartStopTest {
             manager.stop(parseBackendId("idea-community-2025.3.3"))
         }
         assertFalse(ProcessHandle.of(started.pid).map { it.isAlive }.orElse(false))
+    }
+
+    @Test
+    fun `start re-provisions the current bundled plugin before launching`(
+        @TempDir tempDir: Path,
+    ) = kotlinx.coroutines.runBlocking {
+        val homePaths = HomePaths(tempDir.resolve("home"))
+        installStubBackend(homePaths, launcherBody = gracefulLauncher())
+
+        // Seed a stale old plugin to verify that start replaces it with the current one.
+        val pluginDir = homePaths.cacheDir("idea-community-2025.3.3").resolve("plugins/mcp-steroid")
+        Files.createDirectories(pluginDir.resolve("lib"))
+        Files.writeString(pluginDir.resolve("lib/plugin.txt"), "old")
+        Files.writeString(pluginDir.resolve("stale.txt"), "stale")
+
+        val manager = BackendManager(
+            homePaths = homePaths,
+            downloader = StaticDownloader,
+            bundledPluginResolver = FixedBundledPluginResolver(bundledPluginZipFixture(tempDir.resolve("dist/ij-plugin.zip"), "current")),
+            ideUserHome = tempDir.resolve("user-home"),
+        )
+
+        manager.start(parseBackendId("idea-community-2025.3.3"))
+        try {
+            assertEquals(
+                "current",
+                Files.readString(pluginDir.resolve("lib/plugin.txt")),
+                "start must re-deploy the current bundled plugin, overwriting the stale one",
+            )
+            assertFalse(pluginDir.resolve("stale.txt").exists(), "start must remove stale plugin files before redeploying")
+        } finally {
+            manager.stop(parseBackendId("idea-community-2025.3.3"))
+        }
     }
 
     private fun installStubBackend(

--- a/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/BundledPluginTestFixtures.kt
+++ b/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/BundledPluginTestFixtures.kt
@@ -1,0 +1,39 @@
+/* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
+package com.jonnyzzz.mcpSteroid.devrig
+
+import org.apache.commons.compress.archivers.zip.ZipArchiveEntry
+import org.apache.commons.compress.archivers.zip.ZipArchiveOutputStream
+import java.nio.file.Files
+import java.nio.file.Path
+
+/**
+ * Writes a minimal bundled-plugin zip with entries:
+ *  - `mcp-steroid/lib/plugin.txt` = [version]
+ *  - `mcp-steroid/kotlinc/bin/kotlinc` (executable)
+ *
+ * Returns [zip] for chaining.
+ */
+internal fun bundledPluginZipFixture(zip: Path, version: String): Path {
+    Files.createDirectories(zip.parent)
+    ZipArchiveOutputStream(Files.newOutputStream(zip)).use { out ->
+        out.addZipFile("mcp-steroid/lib/plugin.txt", version)
+        out.addZipFile("mcp-steroid/kotlinc/bin/kotlinc", "#!/usr/bin/env sh\n", mode = 0b111_101_101)
+    }
+    return zip
+}
+
+private fun ZipArchiveOutputStream.addZipFile(name: String, text: String, mode: Int = 0b110_100_100) {
+    val bytes = text.toByteArray(Charsets.UTF_8)
+    val entry = ZipArchiveEntry(name).apply {
+        size = bytes.size.toLong()
+        unixMode = mode
+    }
+    putArchiveEntry(entry)
+    write(bytes)
+    closeArchiveEntry()
+}
+
+/** A [BundledPluginResolver] that always returns the given [zip]. */
+internal class FixedBundledPluginResolver(private val zip: Path) : BundledPluginResolver {
+    override fun resolveBundledPluginZip(): Path = zip
+}

--- a/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/PluginDeployTest.kt
+++ b/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/PluginDeployTest.kt
@@ -3,8 +3,6 @@ package com.jonnyzzz.mcpSteroid.devrig
 
 import com.jonnyzzz.mcpSteroid.ideDownloader.IdeProduct
 import kotlinx.coroutines.runBlocking
-import org.apache.commons.compress.archivers.zip.ZipArchiveEntry
-import org.apache.commons.compress.archivers.zip.ZipArchiveOutputStream
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
 import java.nio.file.Files
@@ -21,7 +19,7 @@ class PluginDeployTest {
         @TempDir tempDir: Path,
     ) {
         val homePaths = HomePaths(tempDir.resolve("home"))
-        val source = pluginZipFixture(tempDir.resolve("dist/ij-plugin.zip"), version = "one")
+        val source = bundledPluginZipFixture(tempDir.resolve("dist/ij-plugin.zip"), version = "one")
         val stale = homePaths.cacheDir("idea-community-2025.3.3")
             .resolve("plugins/mcp-steroid/stale/old.txt")
         Files.createDirectories(stale.parent)
@@ -30,7 +28,7 @@ class PluginDeployTest {
         val manager = BackendManager(
             homePaths = homePaths,
             downloader = StaticDownloader,
-            bundledPluginResolver = FixedPluginResolver(source),
+            bundledPluginResolver = FixedBundledPluginResolver(source),
         )
 
         val deployed = manager.deployMcpSteroidPlugin("idea-community-2025.3.3")
@@ -47,7 +45,7 @@ class PluginDeployTest {
         @TempDir tempDir: Path,
     ) = runBlocking {
         val homePaths = HomePaths(tempDir.resolve("home"))
-        val resolver = MutablePluginResolver(pluginZipFixture(tempDir.resolve("dist-v1/ij-plugin.zip"), version = "one"))
+        val resolver = MutablePluginResolver(bundledPluginZipFixture(tempDir.resolve("dist-v1/ij-plugin.zip"), version = "one"))
         val downloader = InstallingDownloader()
         val manager = BackendManager(
             homePaths = homePaths,
@@ -61,7 +59,7 @@ class PluginDeployTest {
         assertEquals("one", Files.readString(deployedFile))
         assertEquals(1, downloader.unpackCount)
 
-        resolver.zip = pluginZipFixture(tempDir.resolve("dist-v2/ij-plugin.zip"), version = "two")
+        resolver.zip = bundledPluginZipFixture(tempDir.resolve("dist-v2/ij-plugin.zip"), version = "two")
         val stale = homePaths.cacheDir("idea-community-2025.3.3")
             .resolve("plugins/mcp-steroid/stale.txt")
         Files.writeString(stale, "stale")
@@ -71,30 +69,6 @@ class PluginDeployTest {
         assertEquals("two", Files.readString(deployedFile))
         assertFalse(stale.exists(), "re-download must remove stale plugin files before redeploy")
         assertEquals(1, downloader.unpackCount, "existing IDE archive should be reused on the second download")
-    }
-
-    private fun pluginZipFixture(zip: Path, version: String): Path {
-        Files.createDirectories(zip.parent)
-        ZipArchiveOutputStream(Files.newOutputStream(zip)).use { out ->
-            out.addFile("mcp-steroid/lib/plugin.txt", version)
-            out.addFile("mcp-steroid/kotlinc/bin/kotlinc", "#!/usr/bin/env sh\n", mode = 0b111_101_101)
-        }
-        return zip
-    }
-
-    private fun ZipArchiveOutputStream.addFile(name: String, text: String, mode: Int = 0b110_100_100) {
-        val bytes = text.toByteArray(Charsets.UTF_8)
-        val entry = ZipArchiveEntry(name).apply {
-            size = bytes.size.toLong()
-            unixMode = mode
-        }
-        putArchiveEntry(entry)
-        write(bytes)
-        closeArchiveEntry()
-    }
-
-    private class FixedPluginResolver(private val zip: Path) : BundledPluginResolver {
-        override fun resolveBundledPluginZip(): Path = zip
     }
 
     private class MutablePluginResolver(var zip: Path) : BundledPluginResolver {

--- a/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/SingleInstanceLockTest.kt
+++ b/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/SingleInstanceLockTest.kt
@@ -96,6 +96,7 @@ class SingleInstanceLockTest {
         val manager = BackendManager(
             homePaths = homePaths,
             downloader = StaticDownloader,
+            bundledPluginResolver = FixedBundledPluginResolver(bundledPluginZipFixture(tempDir.resolve("dist/ij-plugin.zip"), "test")),
             ideUserHome = tempDir.resolve("user-home"),
         )
         val started = manager.start(parseBackendId("idea-community-2025.3.3"))
@@ -121,6 +122,7 @@ class SingleInstanceLockTest {
         val manager = BackendManager(
             homePaths = homePaths,
             downloader = StaticDownloader,
+            bundledPluginResolver = FixedBundledPluginResolver(bundledPluginZipFixture(tempDir.resolve("dist/ij-plugin.zip"), "test")),
             ideUserHome = tempDir.resolve("user-home"),
             processInspector = FakeProcessInspector(
                 snapshots = listOf(ProcessSnapshot(pid = 4242L, command = orphanCommand)),
@@ -151,12 +153,14 @@ class SingleInstanceLockTest {
         val firstManager = BackendManager(
             homePaths = homePaths,
             downloader = StaticDownloader,
+            bundledPluginResolver = FixedBundledPluginResolver(bundledPluginZipFixture(tempDir.resolve("dist/ij-plugin.zip"), "test")),
             ideUserHome = tempDir.resolve("user-home"),
             processInspector = processInspector,
         )
         val secondManager = BackendManager(
             homePaths = homePaths,
             downloader = StaticDownloader,
+            bundledPluginResolver = FixedBundledPluginResolver(bundledPluginZipFixture(tempDir.resolve("dist/ij-plugin.zip"), "test")),
             ideUserHome = tempDir.resolve("user-home"),
             processInspector = processInspector,
         )


### PR DESCRIPTION
## What

Implements **Finding A** (deferred from PR #139): a devrig-managed IDE now **re-provisions the current bundled plugin on every (not-already-running) start**, so a backend downloaded by an *older* devrig boots with *this* devrig's plugin — writes the marker's `ideHome`, becomes a compatible backend, and `steroid_open_project` no longer times out waiting for a marker that never comes.

## Change
- `ManagedBackend.startLocked`: after the existing `writeBackendVmOptions(...)`, call `deployMcpSteroidPlugin(resolved.id)`. Re-provision = vmoptions (already there) + plugin (new) — nothing else.
- Only reached when **not already running** (the pid-file checks early-return for the running case), so the plugin dir is never rewritten under a live IDE.

## Why no lock file / no ij-plugin change
Concurrency is already covered: `ensureBackendRunning` starts → waits for the pid marker / IDE port (5-min timeout), and IntelliJ's own single-instance lock makes any duplicate spawn exit cleanly. The pid file remains the "is it running" signal. So no separate lock file, no new vmoption, no plugin-side code.

## Tests
`:npx-kt:test` — 1326 tests, 0 failures. New: `start re-provisions the current bundled plugin before launching` (seeds a stale plugin in the cache, starts, asserts the current plugin replaced it). Existing `start`-path tests inject a fake `BundledPluginResolver` (new shared `BundledPluginTestFixtures.kt`).

## Docs
`docs/startable-backends-design.md` (Finding A → implemented; group-3 contract updated) and `TASKS.md` (item 12 removed as done).
