### PR TITLE
Backport #131 (#92): harden same-named-project routing + tests + agent docs

### DIFF
--- a/ij-plugin/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/ProjectScopedToolHandler.kt
+++ b/ij-plugin/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/ProjectScopedToolHandler.kt
@@ -27,7 +27,13 @@ class ProjectScopedToolHandler {
     suspend fun resolveProject(projectName: String): Project {
         val (project, availableNames) = readAction {
             val openProjects = ProjectManager.getInstance().openProjects
-            openProjects.find { projectNameFor(it) == projectName || it.name == projectName } to openProjects.map { it.name }
+            // Primary: the opaque project_name (the <name>-<hash> id from list_projects) — unique per project.
+            // Backward-compat: accept the raw project name ONLY when it is unambiguous (exactly one match) —
+            // never first-match, so two same-named projects (e.g. a checkout and its git worktree) can't
+            // silently collapse to the wrong one (#92).
+            val resolved = openProjects.firstOrNull { projectNameFor(it) == projectName }
+                ?: openProjects.filter { it.name == projectName }.singleOrNull()
+            resolved to openProjects.map { it.name }
         }
         return project ?: throw ToolCallErrorException(
             "Project not found: \"$projectName\". Available projects: $availableNames"

--- a/ij-plugin/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/ProjectScopedToolHandler.kt
+++ b/ij-plugin/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/ProjectScopedToolHandler.kt
@@ -32,9 +32,9 @@ class ProjectScopedToolHandler {
             // to the wrong one (#92).
             val triples = ProjectManager.getInstance().openProjects.map { Triple(projectNameFor(it), it.name, it) }
             val resolved = triples.firstOrNull { it.first == projectName }?.third
-                ?: triples.filter { it.second == projectName }.singleOrNull()?.third
-            // Surface the project_name routing keys (not raw names) — that is the key callers must pass.
-            resolved to triples.map { it.first }
+                ?: triples.singleOrNull { it.second == projectName }?.third
+            // Surface the sorted project_name routing keys (not raw names) — that is the key callers must pass.
+            resolved to triples.map { it.first }.sorted()
         }
         return project ?: throw ToolCallErrorException(
             "Project not found: \"$projectName\". Available project_name values: $availableProjectNames"

--- a/ij-plugin/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/ProjectScopedToolHandler.kt
+++ b/ij-plugin/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/ProjectScopedToolHandler.kt
@@ -12,8 +12,8 @@ import com.jonnyzzz.mcpSteroid.mcp.ToolCallErrorException
  * `projectName: String` argument to an open IDE [Project].
  *
  * Centralizes the read-action lookup and the not-found error message
- * (which lists all currently-open project names to help the caller
- * correct a typo) so each handler only writes the project-scoped body.
+ * (which lists the currently-open `project_name` routing keys to help the
+ * caller correct a typo) so each handler only writes the project-scoped body.
  */
 @Service(Service.Level.APP)
 class ProjectScopedToolHandler {
@@ -21,22 +21,23 @@ class ProjectScopedToolHandler {
      * Resolve [projectName] against the currently open IDE projects. Throws
      * [ToolCallErrorException] if no project matches — `McpToolRegistry.callTool`
      * catches it and turns it into an MCP error result naming the missing project
-     * plus the list of currently-open names.
+     * plus the list of currently-open `project_name` values.
      */
     @Throws(ToolCallErrorException::class)
     suspend fun resolveProject(projectName: String): Project {
-        val (project, availableNames) = readAction {
-            val openProjects = ProjectManager.getInstance().openProjects
-            // Primary: the opaque project_name (the <name>-<hash> id from list_projects) — unique per project.
-            // Backward-compat: accept the raw project name ONLY when it is unambiguous (exactly one match) —
-            // never first-match, so two same-named projects (e.g. a checkout and its git worktree) can't
-            // silently collapse to the wrong one (#92).
-            val resolved = openProjects.firstOrNull { projectNameFor(it) == projectName }
-                ?: openProjects.filter { it.name == projectName }.singleOrNull()
-            resolved to openProjects.map { it.name }
+        val (project, availableProjectNames) = readAction {
+            // (project_name, name, project) per open project — match by the OPAQUE project_name first,
+            // then by the raw folder name ONLY when unambiguous (exactly one match), never first-match,
+            // so two same-named projects (e.g. a checkout and its git worktree) can't silently collapse
+            // to the wrong one (#92).
+            val triples = ProjectManager.getInstance().openProjects.map { Triple(projectNameFor(it), it.name, it) }
+            val resolved = triples.firstOrNull { it.first == projectName }?.third
+                ?: triples.filter { it.second == projectName }.singleOrNull()?.third
+            // Surface the project_name routing keys (not raw names) — that is the key callers must pass.
+            resolved to triples.map { it.first }
         }
         return project ?: throw ToolCallErrorException(
-            "Project not found: \"$projectName\". Available projects: $availableNames"
+            "Project not found: \"$projectName\". Available project_name values: $availableProjectNames"
         )
     }
 }

--- a/ij-plugin/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/ProjectScopedToolHandler.kt
+++ b/ij-plugin/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/ProjectScopedToolHandler.kt
@@ -37,7 +37,7 @@ class ProjectScopedToolHandler {
             resolved to triples.map { it.first }.sorted()
         }
         return project ?: throw ToolCallErrorException(
-            "Project not found: \"$projectName\". Available project_name values: $availableProjectNames"
+            "Project not found: \"$projectName\". Available project_name values: ${availableProjectNames.joinToString()}"
         )
     }
 }

--- a/mcp-steroid-server/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/CommonToolParams.kt
+++ b/mcp-steroid-server/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/CommonToolParams.kt
@@ -15,7 +15,11 @@ object CommonToolParams {
     /** Required `project_name` used to dispatch a tool call to an already-open IDE project. */
     fun projectName() =
         InputSchemaElement.param("project_name")
-            .description("Project name (from steroid_list_projects)")
+            .description(
+                "the `project_name` from steroid_list_projects (a unique routing key, NOT the raw " +
+                        "folder name). steroid_list_projects returns both `project_name` (the unique key " +
+                        "to pass here) and `name` (the raw folder name, informational only); they are not equal."
+            )
             .string()
             .required()
 

--- a/mcp-steroid-server/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/ListProjectsTool.kt
+++ b/mcp-steroid-server/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/ListProjectsTool.kt
@@ -13,7 +13,7 @@ import kotlinx.serialization.Serializable
  */
 class ListProjectsToolSpec(val handler: () -> ListProjectsToolHandler) : McpToolBase() {
     override val name = "steroid_list_projects"
-    override val description = "List all open projects in the IDE. Returns project names that can be used with steroid_execute_code and steroid_open_project."
+    override val description = "List all open projects in the IDE. Each entry has `project_name` (a unique routing key — pass it to steroid_execute_code and the other project-scoped tools) and `name` (the raw folder name, informational only); they are not equal."
 
     override suspend fun call(context: ToolCallContext): ToolCallResult {
         val response = handler().collectListProjectsResponse()
@@ -37,11 +37,10 @@ interface ListProjectsToolHandler {
 @Serializable
 data class ListProjectsResponse(
     /**
-     * Projects reachable through this connection. On a direct in-IDE connection `project_name` is
-     * `<name>-<hash>` (the plugin's `projectNameFor`: readable name + a base36 hash of the project's
-     * base dir + name) and `backend_name` is this IDE's self-id; on devrig `project_name` is the
-     * disambiguated exposed name and `backend_name` is the owning discovered IDE. The human-readable
-     * name is always in the `name` field.
+     * Projects reachable through this connection. Each entry's `project_name` is the within-IDE-unique
+     * routing KEY an agent passes back to the project-scoped tools — opaque (do not parse or rely on its
+     * format); never equal to the raw `name`; `name` is the raw folder name and is informational only. On
+     * a direct in-IDE connection `backend_name` is this IDE's self-id; on devrig the owning discovered IDE.
      */
     val projects: List<ListedProject>,
 )
@@ -69,9 +68,16 @@ fun markerLocator(build: String?, pid: Long): String = buildString {
 
 @Serializable
 data class ListedProject(
-    /** devrig: exposed disambiguated name; IDE-direct: `<name>-<base36 hash of base dir + name>`. */
+    /**
+     * The within-IDE-unique routing KEY an agent passes back to every project-scoped tool
+     * (`steroid_execute_code`, `steroid_input`, `steroid_take_screenshot`, …). Opaque — do not parse or
+     * construct it; never equal to [name]. devrig and IDE-direct compute the same key for the same project.
+     */
     @SerialName("project_name") val projectName: String,
-    /** Raw folder name (R3.7) — kept so existing `jq '.projects[].name'` consumers do not break. */
+    /**
+     * Raw IntelliJ `Project.name` (the folder name) — INFORMATIONAL ONLY (display / `jq`), NOT a routing
+     * key. Kept so existing `jq '.projects[].name'` consumers do not break. Use [projectName] to address a project.
+     */
     val name: String,
     val path: String,
     /** Owning backend's backend_name; null only when unknown. */

--- a/mcp-steroid-server/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/ListWindowsTool.kt
+++ b/mcp-steroid-server/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/ListWindowsTool.kt
@@ -13,7 +13,7 @@ import kotlinx.serialization.Serializable
  */
 class ListWindowsToolSpec(val handler: () -> ListWindowsToolHandler) : McpToolBase() {
     override val name = "steroid_list_windows"
-    override val description = "List open IDE windows and their associated projects. Use this to choose project_name for screenshot/input tools in multi-window setups."
+    override val description = "List open IDE windows and their background tasks, with per-window readiness (modal/indexing/initialized) and a `window_id` for screenshot/input targeting in multi-window setups. Each window and background-task entry references its project by `project_name` — the single routing key for the project-scoped tools; look up that project's human-readable `name` and `path` via steroid_list_projects by the key (they are not duplicated here). `project_name` is null for windows not tied to a project."
 
     override suspend fun call(context: ToolCallContext): ToolCallResult {
         val response = handler().collectListWindowsResponse()
@@ -45,6 +45,12 @@ data class ListWindowsResponse(
  */
 @Serializable
 data class ListedWindow(
+    /**
+     * The window's project routing KEY — the opaque, within-IDE-unique id you pass to the project-scoped
+     * tools (`steroid_execute_code`, `steroid_take_screenshot`, `steroid_input`, …). The SAME `project_name`
+     * `steroid_list_projects` reports; look up the project's `name`/`path` there by this key. Null for
+     * windows not tied to a project. Treat it as opaque.
+     */
     val projectName: String?,
     val projectPath: String?,
     val title: String?,
@@ -96,7 +102,11 @@ data class ListedBackgroundTask(
     val isIndeterminate: Boolean,
     /** True if the task can be canceled */
     val isCancellable: Boolean,
-    /** Project name this task belongs to (if known) */
+    /**
+     * The routing KEY of the project this task belongs to — the same opaque id `steroid_list_projects`
+     * reports as `project_name` (look up the project's `name`/`path` there). Null if the task isn't tied
+     * to a known open project.
+     */
     val projectName: String?,
     /** Owning backend's backend_name; null only when unknown. */
     @SerialName("backend_name") val backendName: String? = null,
@@ -162,6 +172,9 @@ data class ProgressTaskInfo(
     val isIndeterminate: Boolean,
     /** True if the task can be canceled */
     val isCancellable: Boolean,
-    /** Project name this task belongs to (if known) */
+    /**
+     * Within-IDE-unique project routing key this task belongs to — the same `project_name`
+     * `steroid_list_projects` reports; null if the task isn't tied to a known open project.
+     */
     val projectName: String?
 )

--- a/mcp-steroid-server/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/OpenProjectTool.kt
+++ b/mcp-steroid-server/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/OpenProjectTool.kt
@@ -155,9 +155,10 @@ data class OpenProjectParams(
     val projectPath: String,
     val trustProject: Boolean,
     /**
-     * Optional devrig-only routing hint: the stable backend id (from steroid_list_projects
-     * `backend` field or `devrig backend --json` `id`) that should receive this open request.
-     * Null/absent everywhere except a devrig connection. Ignored (logged) by the in-IDE plugin.
+     * Optional devrig-only routing hint: the stable backend id — the `backend_name` from
+     * steroid_list_projects (each project's `backend_name`, and each `backends[]` entry's `backend_name`;
+     * also shown by `devrig backend --json`) — that should receive this open request. Null/absent
+     * everywhere except a devrig connection. Ignored (logged) by the in-IDE plugin.
      */
     val backendName: String? = null,
 )

--- a/mcp-steroid-server/src/test/kotlin/com/jonnyzzz/mcpSteroid/server/ProjectNameHashTest.kt
+++ b/mcp-steroid-server/src/test/kotlin/com/jonnyzzz/mcpSteroid/server/ProjectNameHashTest.kt
@@ -1,0 +1,49 @@
+/* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
+package com.jonnyzzz.mcpSteroid.server
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * Locks the #92 invariant of the project-id hash. The in-IDE plugin's `projectNameFor(project)` is
+ * `"<name>-<base36FixedWidth("project", project.basePath, project.name)>"`; this guards the hash part
+ * (the disambiguating component) so two SAME-NAMED projects in DIFFERENT directories — e.g. a checkout
+ * and its git worktree — never collapse to the same `project_name`.
+ */
+class ProjectNameHashTest {
+    private fun hash(path: String?, name: String) = base36FixedWidth("project", path, name)
+
+    @Test
+    fun `same name in different directories yields different hashes (the #92 core)`() {
+        val a = hash("/work/a/dupproj", "dupproj")
+        val b = hash("/work/b/dupproj", "dupproj")
+        assertNotEquals(a, b, "same-named projects in different folders must hash differently")
+    }
+
+    @Test
+    fun `the hash is deterministic for the same path and name`() {
+        assertEquals(hash("/work/a/dupproj", "dupproj"), hash("/work/a/dupproj", "dupproj"))
+    }
+
+    @Test
+    fun `different names in the same directory differ`() {
+        assertNotEquals(hash("/work/x", "alpha"), hash("/work/x", "beta"))
+    }
+
+    @Test
+    fun `the hash is fixed-width lowercase base36`() {
+        val h = hash("/work/a/dupproj", "dupproj")
+        assertEquals(8, h.length, "hash must be 8 chars")
+        assertTrue(h.all { it in "0123456789abcdefghijklmnopqrstuvwxyz" }, "hash must be lowercase base36: $h")
+    }
+
+    @Test
+    fun `a null base path is tolerated and stays distinct from an empty path neighbour`() {
+        // base36FixedWidth treats a null arg and "" identically (empty bytes + separator), so a
+        // project with no basePath hashes the same as one with "" — documented, deterministic behavior.
+        assertEquals(hash(null, "dupproj"), hash("", "dupproj"))
+        assertNotEquals(hash(null, "dupproj"), hash("/work/a/dupproj", "dupproj"))
+    }
+}

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/server/DevrigListProjectsToolHandler.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/server/DevrigListProjectsToolHandler.kt
@@ -11,8 +11,11 @@ class DevrigListProjectsToolHandler(
         val routes = routing.routes()
         val listedProjects = routes.map { route ->
             ListedProject(
+                // Opaque routing key (the disambiguated <name>-<hash>). `name` is the human-readable
+                // folder name — NOT originalProjectName, which is the IDE's project_name hash and would
+                // make `name` unreadable and break consumers that filter by the real folder name.
                 projectName = route.exposedProjectName,
-                name = route.originalProjectName,
+                name = route.projectInfo.name,
                 path = route.projectPath,
                 backendName = route.exposedBackendName,
             )

--- a/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/server/DevrigListToolHandlersTest.kt
+++ b/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/server/DevrigListToolHandlersTest.kt
@@ -27,6 +27,7 @@ import java.nio.file.Files
 import java.nio.file.Path
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
 import kotlin.test.assertTrue
 import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.AfterEach
@@ -66,6 +67,26 @@ class DevrigListToolHandlersTest {
         // projects[] only lists the IDE that actually has a project open, tagged with its own backend_name.
         assertEquals(listOf(name42), response.projects.map { it.backendName })
         assertEquals(listOf("alpha"), response.projects.map { it.name })
+    }
+
+    @Test
+    fun `list_projects name is the human folder name, not the IDE project_name hash`(
+        @TempDir tempDir: Path,
+    ) = runBlocking {
+        val homeA = Files.createDirectories(tempDir.resolve("dupproj"))
+        // The IDE reports project_name as the opaque hash (ideProjectName) distinct from the folder name.
+        val ide = IdeMonitorState(
+            ide = discoveredIde(pid = 42, build = "IU-261.1"),
+            projects = listOf(IdeProjectState("dupproj", homeA.toString(), ideProjectName = "dupproj-9fk2a0xq")),
+        )
+        val routing = DevrigProjectRoutingService { listOf(ide) }
+
+        val project = DevrigListProjectsToolHandler(routing).collectListProjectsResponse().projects.single()
+
+        // `name` is the raw folder name (informational), NOT originalProjectName (the IDE's project_name hash).
+        assertEquals("dupproj", project.name)
+        // `project_name` is the opaque routing key, and it must differ from the folder name.
+        assertNotEquals("dupproj", project.projectName)
     }
 
     @Test

--- a/prompts/src/main/prompts/debugger/overview.md
+++ b/prompts/src/main/prompts/debugger/overview.md
@@ -72,7 +72,7 @@ Each step should be a separate `steroid_execute_code` call. Do NOT combine steps
 
 ## Tips
 
-- If `steroid_execute_code` returns `Project not found`, call `steroid_list_projects` and reuse the exact `project_name`.
+- If `steroid_execute_code` returns `Project not found`, call `steroid_list_projects` and reuse the exact `project_name` (the unique routing key, NOT the raw folder `name`).
 - Do not hardcode line numbers; locate the target statement by text (for example, the `sortedByDescending` call) before placing breakpoints.
 - **Pick the right stopping primitive.** A line breakpoint on a specific statement *inside the method body* is the cheapest and most reliable. Avoid method (entry/exit) breakpoints — IntelliJ implements those via JDI `MethodEntryRequest`/`MethodExitRequest`, which fire on every method entry/exit in the JVM and are post-filtered; the IDE warns *"Method breakpoints may dramatically slow down debugging"*. For multi-statement lines like `collection.map { it.someMethod().plus(42) }` use `mcp-steroid://debugger/add-inline-breakpoint` to pick the lambda-body variant instead of the default whole-line position.
 - **Breakpoints**: Use the idempotent `findBreakpointsAtLine` + `addLineBreakpoint` pattern from `mcp-steroid://debugger/set-line-breakpoint`. Do NOT use `toggleLineBreakpoint` for "ensure breakpoint exists" — it REMOVES an existing breakpoint (toggle semantics).

--- a/prompts/src/main/prompts/ide/inspect-and-fix.md
+++ b/prompts/src/main/prompts/ide/inspect-and-fix.md
@@ -135,9 +135,10 @@ resolve this way in Rider.
 
 # Inspect a file in ANOTHER open project
 
-The script context's `project` is resolved from the `project_name` tool argument and is
-normally already the project you want — prefer passing the right `project_name` over
-switching projects in code. When you genuinely need to inspect a file that belongs to a
+The script context's `project` is resolved from the `project_name` tool argument (the unique
+routing key from `steroid_list_projects`, NOT the raw folder name) and is normally already the
+project you want — prefer passing the right `project_name` over switching projects in code.
+When you genuinely need to inspect a file that belongs to a
 *different* open project, select it explicitly and pass it to every project-parameterized
 call (`PsiManager`, the profile manager, `smartReadAction`):
 

--- a/prompts/src/main/prompts/mcp-steroid-info.md
+++ b/prompts/src/main/prompts/mcp-steroid-info.md
@@ -14,7 +14,7 @@ This is a **STATEFUL** API — every call changes the IDE state. The IntelliJ ID
 **File edits: always through MCP Steroid, even when Edit looks cheaper on tokens.** The native `Edit` tool writes to disk bypassing IntelliJ. VFS + PSI + search indices go stale, and the next semantic operation (find-references, rename, hierarchy search, inspections) returns inconsistent results until something forces a refresh. The 5-line `VfsUtil.saveText` recipe in `steroid_execute_code`'s tool description reads+writes in one call with auto-refresh; its 1.5–2.5× token overhead is cheaper than the debugging turns you spend when PSI disagrees with disk. This applies to every edit size, including 1–3 line changes.
 
 **Getting started:**
-1. Call `steroid_list_projects` to see what's open
+1. Call `steroid_list_projects` to see what's open — route every project-scoped call by the `project_name` it returns (the unique, opaque key), never by the human-readable `name`; to map a file/dir path to a project, pick the one whose `path` is the longest prefix of your target path
 2. Use `steroid_fetch_resource` to read the `mcp-steroid://` skill guide for your task
 3. Use `steroid_execute_code` for any IDE automation task (including every file edit)
 

--- a/prompts/src/main/prompts/open-project/managing-backends.md
+++ b/prompts/src/main/prompts/open-project/managing-backends.md
@@ -48,6 +48,11 @@ Every `projects[]`, `windows[]`, and `backgroundTasks[]` entry in
 2. Call `steroid_open_project` with the `backend_name` of the IDE you
    want.
 
+Each `projects[]` entry also carries `project_name` (the unique, opaque
+routing KEY you pass to project-scoped tools), the human-readable folder
+`name` (informational only), `path`, and a `backend_name` naming its
+owning backend.
+
 If the chosen `backend_name` belongs to a startable managed backend
 (not yet running), `open_project` starts it and blocks until it is
 reachable, then opens the project.

--- a/prompts/src/main/prompts/open-project/open-trusted.md
+++ b/prompts/src/main/prompts/open-project/open-trusted.md
@@ -99,11 +99,14 @@ println(executeCodeJson)
 → [wait 3 seconds]
 
 → steroid_list_projects()
-← {"ide":{"name":"IntelliJ IDEA","version":"2025.3.2","build":"IU-253.30387.160"},"projects":[{"name":"my-app","path":"/Users/me/projects/my-app"}]}
+← {"projects":[{"project_name":"my-app-9fk2a0xq","name":"my-app","path":"/Users/me/projects/my-app","backend_name":"iu-9fk2a0xq"}]}
 
-→ steroid_execute_code(project_name="my-app", code="println(project.basePath)", ...)
+→ steroid_execute_code(project_name="my-app-9fk2a0xq", code="println(project.basePath)", ...)
 ← /Users/me/projects/my-app
 ```
+
+Route by the `project_name` from `steroid_list_projects` (the unique, opaque key), NOT the
+human-readable folder `name`.
 
 ## When to Use This Approach
 

--- a/prompts/src/main/prompts/open-project/open-trusted.md
+++ b/prompts/src/main/prompts/open-project/open-trusted.md
@@ -58,13 +58,8 @@ Expected response includes your project:
 ```kotlin
 val expectedResponseExample = """
 {
-  "ide": {
-    "name": "IntelliJ IDEA",
-    "version": "2025.3.2",
-    "build": "IU-253.30387.160"
-  },
   "projects": [
-    {"name": "your-project", "path": "/absolute/path/to/your/project"}
+    {"project_name": "your-project-9fk2a0xq", "name": "your-project", "path": "/absolute/path/to/your/project", "backend_name": "iu-9fk2a0xq"}
   ]
 }
 """.trimIndent()
@@ -80,7 +75,7 @@ val executeCodeJson = """
 {
   "tool": "steroid_execute_code",
   "arguments": {
-    "project_name": "your-project",
+    "project_name": "your-project-9fk2a0xq",
     "code": "println(\"Project: ${'$'}{project.name}\")",
     "task_id": "verify-project",
     "reason": "Verifying project is accessible"

--- a/prompts/src/main/prompts/open-project/open-with-dialogs.md
+++ b/prompts/src/main/prompts/open-project/open-with-dialogs.md
@@ -29,7 +29,8 @@ println(openProjectJson)
 
 ### Step 2: Take a Screenshot
 
-Use `steroid_take_screenshot` to see the current IDE state:
+Use `steroid_take_screenshot` to see the current IDE state. The `project_name` placeholders below are
+the unique, opaque routing key from `steroid_list_projects`, NOT the human-readable folder name:
 
 ```kotlin
 val takeScreenshotJson = """
@@ -102,11 +103,11 @@ The Trust Project dialog has these buttons:
 → steroid_open_project(project_path="/path/to/untrusted-project", trust_project=false, ...)
 ← Project opening initiated...
 
-→ steroid_take_screenshot(project_name="other-project", task_id="check", reason="Check for dialogs")
+→ steroid_take_screenshot(project_name="other-project-7c1b9d2a", task_id="check", reason="Check for dialogs")
 ← [Image showing Trust Project dialog with buttons at coordinates]
 
 → steroid_input(
-    project_name="other-project",
+    project_name="other-project-7c1b9d2a",
     task_id="click-trust",
     reason="Click Trust Project button",
     window_id="...",
@@ -115,8 +116,11 @@ The Trust Project dialog has these buttons:
 ← Input delivered
 
 → steroid_list_projects()
-← {"ide":{"name":"IntelliJ IDEA","version":"2025.3.2","build":"IU-253.30387.160"},"projects":[{"name":"untrusted-project","path":"/path/to/untrusted-project"}, ...]}
+← {"projects":[{"project_name":"untrusted-project-1a2b3c4d","name":"untrusted-project","path":"/path/to/untrusted-project","backend_name":"iu-9fk2a0xq"}, ...]}
 ```
+
+The `project_name` passed to the screenshot/input tools is the unique, opaque routing key from
+`steroid_list_projects`, not the human-readable folder `name`.
 
 ## When to Use This Approach
 

--- a/prompts/src/main/prompts/open-project/open-with-dialogs.md
+++ b/prompts/src/main/prompts/open-project/open-with-dialogs.md
@@ -37,7 +37,7 @@ val takeScreenshotJson = """
 {
   "tool": "steroid_take_screenshot",
   "arguments": {
-    "project_name": "existing-project-name",
+    "project_name": "existing-project-9fk2a0xq",
     "task_id": "check-dialogs",
     "reason": "Checking for trust dialog or other prompts"
   }
@@ -58,7 +58,7 @@ val inputJson = """
 {
   "tool": "steroid_input",
   "arguments": {
-    "project_name": "existing-project-name",
+    "project_name": "existing-project-9fk2a0xq",
     "task_id": "handle-trust-dialog",
     "reason": "Clicking Trust Project button",
     "window_id": "window_id_from_list_windows",

--- a/prompts/src/main/prompts/open-project/overview.md
+++ b/prompts/src/main/prompts/open-project/overview.md
@@ -47,11 +47,12 @@ After calling `steroid_open_project`, follow this workflow:
 
 | Field | Description |
 |-------|-------------|
-| `projectName` | Project name (null if not a project window) |
-| `projectPath` | Project base path |
+| `project_name` | The single routing key for the window's project (null if not a project window). Look up that project's human-readable `name` and `path` via `steroid_list_projects` by this key. |
 | `modalDialogShowing` | True if any modal dialog is showing in IDE |
 | `indexingInProgress` | True if project is indexing (dumb mode) |
 | `projectInitialized` | True if project is fully initialized |
+
+To find the right project for a file or directory path, pick the project (from `steroid_list_projects`) whose `path` is the longest prefix of your target path — this disambiguates nested checkouts and git worktrees.
 
 ## Workflows
 

--- a/prompts/src/main/prompts/prompt/skill.md
+++ b/prompts/src/main/prompts/prompt/skill.md
@@ -38,20 +38,26 @@ The full index is in the "MCP Resources (Use Them)" section below.
 
 ```
 1. steroid_list_projects → get list of open projects
-2. Pick a project_name from the list
-3. steroid_execute_code → run Kotlin code with that project
+2. Pick the `project_name` of the one you want (the unique routing key — NOT the human-readable `name`)
+3. steroid_execute_code → run Kotlin code with that project_name
 4. steroid_execute_feedback → report success/failure for tracking
 ```
+
+Each `steroid_list_projects` entry has TWO name fields: `project_name` (the within-IDE-unique,
+opaque routing KEY you pass back to every project-scoped tool) and `name` (the human-readable
+folder name, informational/display only). Always route by `project_name`. To find the right
+project for a file or directory path, pick the project whose `path` is the longest prefix of your
+target path (this disambiguates nested checkouts and git worktrees).
 
 **Example session:**
 ```
 → steroid_list_projects
-← {"ide":{"name":"IntelliJ IDEA","version":"2025.3.2","build":"IU-253.30387.160"},"projects":[{"name":"my-app","path":"/path/to/my-app"}]}
+← {"projects":[{"project_name":"my-app-9fk2a0xq","name":"my-app","path":"/path/to/my-app","backend_name":"iu-9fk2a0xq"}]}
 
-→ steroid_execute_code(project_name="my-app", code="println(project.name)", ...)
+→ steroid_execute_code(project_name="my-app-9fk2a0xq", code="println(project.name)", ...)
 ← "my-app"
 
-→ steroid_execute_feedback(project_name="my-app", task_id="...", execution_id="...", success_rating=1.0, explanation="Got project name")
+→ steroid_execute_feedback(project_name="my-app-9fk2a0xq", task_id="...", execution_id="...", success_rating=1.0, explanation="Got project name")
 ```
 
 ## When to Use This Skill
@@ -70,11 +76,17 @@ The IDE has indexed everything. It knows the code better than any file search.
 ## Available Tools
 
 ### `steroid_list_projects`
-List all open projects. Returns IDE metadata and project names for use with `steroid_execute_code`.
+List all open projects. Each entry has `project_name` (the unique routing key to pass to
+`steroid_execute_code` and the other project-scoped tools), `name` (the human-readable folder
+name, informational only), and `path`. To map a file/dir path to a project, pick the project whose
+`path` is the longest prefix of your target path.
 
 ### `steroid_list_windows`
-List open IDE windows and their associated projects. Some windows may not be tied to a project and a project can have multiple windows.
-Use this in multi-window setups to pick the correct `project_name` and `window_id` for screenshot/input tools.
+List open IDE windows (and background tasks) and their associated projects. Some windows may not be tied to a project and a project can have multiple windows.
+Use this in multi-window setups to pick the correct `window_id` for screenshot/input tools. Each
+window and task entry references its project by `project_name` — the single routing key. Look up that
+project's human-readable `name` and `path` via `steroid_list_projects` by that key (they are not
+duplicated on window/task entries).
 
 ### `steroid_take_screenshot`
 Capture a screenshot of the IDE frame and return image content.
@@ -82,7 +94,7 @@ Capture a screenshot of the IDE frame and return image content.
 **HEAVY ENDPOINT**: Use only for debugging and tricky configuration. Prefer `steroid_execute_code` for regular automation.
 
 **Parameters:**
-- `project_name` (required): Target project name
+- `project_name` (required): the `project_name` from `steroid_list_projects` (a unique routing key, NOT the raw folder name)
 - `task_id` (required): Task identifier for logging
 - `reason` (required): Why the screenshot is needed
 - `window_id` (optional): Window id from `steroid_list_windows` to target a specific window
@@ -100,7 +112,7 @@ Send input events (keyboard + mouse) using a sequence string.
 **HEAVY ENDPOINT**: Use only for debugging and tricky configuration. Prefer `steroid_execute_code` for regular automation.
 
 **Parameters:**
-- `project_name` (required): Target project name
+- `project_name` (required): the `project_name` from `steroid_list_projects` (a unique routing key, NOT the raw folder name)
 - `task_id` (required): Task identifier for logging
 - `reason` (required): Why the input is needed
 - `window_id` (required): Window id from `steroid_list_windows` (also returned by `steroid_take_screenshot`)

--- a/test-integration/src/test/kotlin/com/jonnyzzz/mcpSteroid/integration/tests/DevrigSameNameProjectRoutingTest.kt
+++ b/test-integration/src/test/kotlin/com/jonnyzzz/mcpSteroid/integration/tests/DevrigSameNameProjectRoutingTest.kt
@@ -29,7 +29,6 @@ import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertNull
-import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -104,14 +103,17 @@ class DevrigSameNameProjectRoutingTest {
         val process = startContainerStdioMcp(methodStack, devrigCommand)
         process.initialize()
 
-        // 4. Discover the two same-named projects through devrig: each has a hash-disambiguated
-        //    `project_name` + its real `path`.
-        val routes = waitForSameNamedRoutes(process, expectedPaths = paths, diagnostics = diagnostics)
+        // 4. Discover the two same-named projects through devrig: each gets a distinct hash-disambiguated
+        //    project_name (the IDE owns within-IDE uniqueness). We deliberately do NOT compare devrig's
+        //    reported path to the literal dirs — devrig canonicalizes it (toRealPath) — so correctness is
+        //    proven below via which.txt (whose content is the literal dir), independent of path string form.
+        val projectNames = waitForTwoSameNamedProjectNames(process, diagnostics)
 
-        // 5. For EACH discovered project, run execute_code against its disambiguated project_name and ask
-        //    which project it landed in. Correct routing → reads its own path back.
-        val mismatches = mutableListOf<String>()
-        for ((projectName, path) in routes) {
+        // 5. Run execute_code against each disambiguated project_name and read which.txt — its content is
+        //    the literal dir that project was created in. Correct routing → the two runs read two DISTINCT
+        //    dirs, together covering both. The #92 bug → both project_names collapse to ONE project, so
+        //    both runs read the SAME which.txt.
+        val landedByProjectName = projectNames.associateWith { projectName ->
             val result = toolCall(
                 process = process,
                 name = "steroid_execute_code",
@@ -128,49 +130,38 @@ class DevrigSameNameProjectRoutingTest {
                 diagnostics = diagnostics,
             )
             assertFalse(isToolError(result), "execute_code returned a tool error for $projectName\n$diagnostics\n$result")
-            val landed = WHICH.find(textContent(result))?.groupValues?.get(1)
+            WHICH.find(textContent(result))?.groupValues?.get(1)
                 ?: error("execute_code output missing WHICH_PROJECT marker for $projectName\n$diagnostics\n${textContent(result)}")
-            if (landed != path) {
-                mismatches += "project_name='$projectName' targeted path '$path' but execute_code ran in '$landed'"
-            }
         }
 
-        assertTrue(
-            mismatches.isEmpty(),
-            "#92 reproduced — devrig mis-routed execute_code across same-named projects:\n" +
-                mismatches.joinToString("\n") { "  - $it" } +
-                "\n(discovered routes: $routes)\n$diagnostics",
+        val landed = landedByProjectName.values.toList()
+        assertEquals(
+            landed.size, landed.toSet().size,
+            "#92 reproduced — two same-named project_names collapsed to the same project (identical which.txt):\n" +
+                "$landedByProjectName\n$diagnostics",
+        )
+        assertEquals(
+            paths.toSet(), landed.toSet(),
+            "each disambiguated project_name must route to its OWN dir:\n$landedByProjectName\n$diagnostics",
         )
     }
 
-    /** Polls devrig `steroid_list_projects` until both same-named projects are discovered; returns
-     *  (disambiguated `project_name` → real `path`) for the entries whose raw folder name is [DUP_LEAF]. */
-    private fun waitForSameNamedRoutes(
-        process: StdioMcpProcess,
-        expectedPaths: List<String>,
-        diagnostics: String,
-    ): Map<String, String> {
-        repeat(120) {
+    /** Polls devrig `steroid_list_projects` until the two same-named ([DUP_LEAF]) projects are discovered as
+     *  TWO entries with DISTINCT `project_name`s; returns those project_names. Does NOT depend on the
+     *  reported path (devrig canonicalizes it) — routing correctness is verified by the caller via which.txt. */
+    private fun waitForTwoSameNamedProjectNames(process: StdioMcpProcess, diagnostics: String): List<String> {
+        repeat(240) {
             val result = toolCall(process, "steroid_list_projects", buildJsonObject {}, diagnostics)
             assertFalse(isToolError(result), "list_projects returned a tool error\n$diagnostics\n$result")
             val projects = json.parseToJsonElement(textContent(result)).jsonObject["projects"]?.jsonArray.orEmpty()
-            val dup = projects.map { it.jsonObject }.filter { it["name"]?.jsonPrimitive?.contentOrNull == DUP_LEAF }
-            val byPath = dup.mapNotNull { p ->
-                val name = p["project_name"]?.jsonPrimitive?.contentOrNull
-                val path = p["path"]?.jsonPrimitive?.contentOrNull
-                if (name != null && path != null) name to path else null
-            }.toMap()
-            if (byPath.values.toSet().containsAll(expectedPaths)) {
-                // Distinct disambiguated names, one per path — the discovery contract this test relies on.
-                assertEquals(
-                    expectedPaths.size, byPath.size,
-                    "expected one disambiguated project_name per same-named project\n$diagnostics\n$byPath",
-                )
-                return byPath.entries.associate { (name, path) -> name to path }
-            }
+            val names = projects.map { it.jsonObject }
+                .filter { it["name"]?.jsonPrimitive?.contentOrNull == DUP_LEAF }
+                .mapNotNull { it["project_name"]?.jsonPrimitive?.contentOrNull }
+                .distinct()
+            if (names.size >= 2) return names
             Thread.sleep(250)
         }
-        error("Timed out waiting for devrig to discover both same-named projects ($expectedPaths)\n$diagnostics")
+        error("Timed out waiting for devrig to discover two same-named ($DUP_LEAF) projects with distinct project_names\n$diagnostics")
     }
 
     private fun startContainerStdioMcp(stack: CloseableStack, devrigCommand: StdioMcpCommand): StdioMcpProcess =

--- a/test-integration/src/test/kotlin/com/jonnyzzz/mcpSteroid/integration/tests/DevrigSameNameProjectRoutingTest.kt
+++ b/test-integration/src/test/kotlin/com/jonnyzzz/mcpSteroid/integration/tests/DevrigSameNameProjectRoutingTest.kt
@@ -1,0 +1,233 @@
+/* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
+package com.jonnyzzz.mcpSteroid.integration.tests
+
+import com.jonnyzzz.mcpSteroid.aiAgents.StdioMcpCommand
+import com.jonnyzzz.mcpSteroid.integration.infra.AiMode
+import com.jonnyzzz.mcpSteroid.integration.infra.DevrigSteroidDriver
+import com.jonnyzzz.mcpSteroid.integration.infra.IntelliJContainer
+import com.jonnyzzz.mcpSteroid.integration.infra.IntelliJContainerOpts
+import com.jonnyzzz.mcpSteroid.integration.infra.create
+import com.jonnyzzz.mcpSteroid.integration.infra.waitForProjectReady
+import com.jonnyzzz.mcpSteroid.testHelper.CloseableStack
+import com.jonnyzzz.mcpSteroid.testHelper.CloseableStackDriver
+import com.jonnyzzz.mcpSteroid.testHelper.CloseableStackHost
+import com.jonnyzzz.mcpSteroid.testHelper.StdioMcpProcess
+import com.jonnyzzz.mcpSteroid.testHelper.docker.startProcessInContainer
+import com.jonnyzzz.mcpSteroid.testHelper.startStdioMcpProcess
+import java.util.concurrent.TimeUnit
+import kotlinx.coroutines.flow.Flow
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.put
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Timeout
+
+/**
+ * Reproducer for #92 — `steroid_execute_code` routes to the WRONG project when two projects with the
+ * **same IntelliJ name** but **different paths** are open in one IDE (the canonical case: a main checkout
+ * and a git worktree whose leaf dir matches).
+ *
+ * The contract under test: an agent only ever passes devrig's **discovery `project_name`** — the
+ * hash-disambiguated value from `steroid_list_projects` (e.g. `dupproj-AbCd1234`). devrig must route THAT
+ * exact identity to THAT exact project; it must never collapse it back to a bare, guessable name.
+ *
+ * The original bug (#92): devrig forwarded the bare folder name and the IDE matched `Project.name`
+ * first-wins, so the second same-named project was unreachable. The fix: the IDE owns within-IDE-unique
+ * names — `OpenProjectsService.resolveProject` matches the recomputed `<name>-<hash>` from
+ * `ProjectNameService` (no raw-name fallback) — and devrig forwards that same unique name
+ * (`route.exposedProjectName`, the shared scheme) instead of the bare name. This test guards that.
+ *
+ * This test opens two same-named projects, then runs `steroid_execute_code` (via the real `devrig mpc`
+ * stdio bridge) against EACH project's disambiguated `project_name`, asking each run which project it
+ * actually landed in (it reads a `which.txt` marker holding that project's own path from
+ * `project.basePath`). Correct routing → each run reads its own path. The #92 bug → the second project's
+ * call lands in the first, reading the wrong path.
+ */
+class DevrigSameNameProjectRoutingTest {
+
+    private lateinit var methodStack: CloseableStackDriver
+
+    @BeforeEach
+    fun setUpMethodStack() {
+        methodStack = lifetime.nestedStack("devrig-mpc-per-method")
+    }
+
+    @AfterEach
+    fun tearDownMethodStack() {
+        methodStack.closeAllStacks()
+    }
+
+    @Test
+    @Timeout(value = 20, unit = TimeUnit.MINUTES)
+    fun devrigRoutesExecuteCodeToTheCorrectSameNamedProject() {
+        val diagnostics = session.diagnosticsSummary()
+
+        // 1. Two projects with the SAME leaf dir name ("dupproj") under different parents → identical
+        //    IntelliJ project name, distinct paths. Each carries a `which.txt` holding its own path so a
+        //    run can prove WHICH project it actually executed in (independent of path canonicalization).
+        val paths = listOf("/home/agent/dup-a/$DUP_LEAF", "/home/agent/dup-b/$DUP_LEAF")
+        val pathsLiteral = paths.joinToString(", ") { "\"$it\"" }
+        session.mcpSteroid.mcpExecuteCode(
+            taskId = "dup-setup",
+            reason = "create two same-named project dirs for the #92 routing reproducer",
+            // The inner script refers to `p` and "which.txt" bare (no $-interpolation); only $pathsLiteral
+            // is interpolated test-side into the script text.
+            code = """
+                listOf($pathsLiteral).forEach { p ->
+                    val d = java.io.File(p)
+                    d.mkdirs()
+                    java.io.File(d, "which.txt").writeText(p)
+                }
+                println("DUP_DIRS_READY")
+            """.trimIndent(),
+        )
+
+        // 2. Open BOTH in the single running IDE (order matters: A is opened first, so the buggy
+        //    find-first-by-name resolves every "dupproj" request to A).
+        paths.forEach { session.mcpSteroid.mcpOpenProject(it) }
+
+        // 3. Real devrig stdio MCP bridge against that IDE.
+        val devrigCommand = DevrigSteroidDriver.deploy(session.scope, session.mcpSteroid).devrigCommand
+        val process = startContainerStdioMcp(methodStack, devrigCommand)
+        process.initialize()
+
+        // 4. Discover the two same-named projects through devrig: each has a hash-disambiguated
+        //    `project_name` + its real `path`.
+        val routes = waitForSameNamedRoutes(process, expectedPaths = paths, diagnostics = diagnostics)
+
+        // 5. For EACH discovered project, run execute_code against its disambiguated project_name and ask
+        //    which project it landed in. Correct routing → reads its own path back.
+        val mismatches = mutableListOf<String>()
+        for ((projectName, path) in routes) {
+            val result = toolCall(
+                process = process,
+                name = "steroid_execute_code",
+                arguments = buildJsonObject {
+                    put("project_name", projectName)
+                    put("task_id", "dup-route-check")
+                    put("reason", "verify devrig routes the disambiguated project_name to the right project (#92)")
+                    put(
+                        "code",
+                        "val f = java.io.File(project.basePath, \"which.txt\"); " +
+                            "println(\"WHICH_PROJECT=\" + (if (f.exists()) f.readText().trim() else \"MISSING@\" + project.basePath))",
+                    )
+                },
+                diagnostics = diagnostics,
+            )
+            assertFalse(isToolError(result), "execute_code returned a tool error for $projectName\n$diagnostics\n$result")
+            val landed = WHICH.find(textContent(result))?.groupValues?.get(1)
+                ?: error("execute_code output missing WHICH_PROJECT marker for $projectName\n$diagnostics\n${textContent(result)}")
+            if (landed != path) {
+                mismatches += "project_name='$projectName' targeted path '$path' but execute_code ran in '$landed'"
+            }
+        }
+
+        assertTrue(
+            mismatches.isEmpty(),
+            "#92 reproduced — devrig mis-routed execute_code across same-named projects:\n" +
+                mismatches.joinToString("\n") { "  - $it" } +
+                "\n(discovered routes: $routes)\n$diagnostics",
+        )
+    }
+
+    /** Polls devrig `steroid_list_projects` until both same-named projects are discovered; returns
+     *  (disambiguated `project_name` → real `path`) for the entries whose raw folder name is [DUP_LEAF]. */
+    private fun waitForSameNamedRoutes(
+        process: StdioMcpProcess,
+        expectedPaths: List<String>,
+        diagnostics: String,
+    ): Map<String, String> {
+        repeat(120) {
+            val result = toolCall(process, "steroid_list_projects", buildJsonObject {}, diagnostics)
+            assertFalse(isToolError(result), "list_projects returned a tool error\n$diagnostics\n$result")
+            val projects = json.parseToJsonElement(textContent(result)).jsonObject["projects"]?.jsonArray.orEmpty()
+            val dup = projects.map { it.jsonObject }.filter { it["name"]?.jsonPrimitive?.contentOrNull == DUP_LEAF }
+            val byPath = dup.mapNotNull { p ->
+                val name = p["project_name"]?.jsonPrimitive?.contentOrNull
+                val path = p["path"]?.jsonPrimitive?.contentOrNull
+                if (name != null && path != null) name to path else null
+            }.toMap()
+            if (byPath.values.toSet().containsAll(expectedPaths)) {
+                // Distinct disambiguated names, one per path — the discovery contract this test relies on.
+                assertEquals(
+                    expectedPaths.size, byPath.size,
+                    "expected one disambiguated project_name per same-named project\n$diagnostics\n$byPath",
+                )
+                return byPath.entries.associate { (name, path) -> name to path }
+            }
+            Thread.sleep(250)
+        }
+        error("Timed out waiting for devrig to discover both same-named projects ($expectedPaths)\n$diagnostics")
+    }
+
+    private fun startContainerStdioMcp(stack: CloseableStack, devrigCommand: StdioMcpCommand): StdioMcpProcess =
+        startStdioMcpProcess(lifetime = stack, resourceName = "container-devrig") { stdin: Flow<ByteArray> ->
+            session.scope.startProcessInContainer {
+                args(listOf(devrigCommand.command) + devrigCommand.args)
+                    .interactive()
+                    .stdin(stdin)
+                    .timeoutSeconds(300)
+                    .description("devrig stdio MCP for same-name routing repro")
+                    .quietly()
+            }
+        }
+
+    private fun toolCall(process: StdioMcpProcess, name: String, arguments: JsonObject, diagnostics: String): JsonObject {
+        val response = process.request(
+            "tools/call",
+            buildJsonObject {
+                put("name", name)
+                put("arguments", arguments)
+            },
+            timeoutMillis = 60_000,
+        )
+        assertNull(response["error"], "tools/call returned JSON-RPC error\n$diagnostics\n$response")
+        return response["result"]?.jsonObject ?: error("tools/call response missing result\n$diagnostics\n$response")
+    }
+
+    private fun isToolError(result: JsonObject): Boolean =
+        result["isError"]?.jsonPrimitive?.contentOrNull?.toBooleanStrictOrNull() == true
+
+    private fun textContent(result: JsonObject): String =
+        result["content"]?.jsonArray
+            ?.joinToString("\n") { it.jsonObject["text"]?.jsonPrimitive?.contentOrNull.orEmpty() }
+            ?: error("tool result missing content: $result")
+
+    companion object {
+        private const val DUP_LEAF = "dupproj"
+        private val WHICH = Regex("WHICH_PROJECT=(.+)")
+        private val json = Json { ignoreUnknownKeys = true }
+        private val lifetime by lazy { CloseableStackHost(DevrigSameNameProjectRoutingTest::class.java.simpleName) }
+        private val session by lazy {
+            IntelliJContainer.create(
+                lifetime,
+                IntelliJContainerOpts(consoleTitle = "devrig same-name project routing (#92)", aiMode = AiMode.NONE),
+            ).waitForProjectReady()
+        }
+
+        @BeforeAll
+        @JvmStatic
+        fun beforeAll() {
+            session.toString()
+        }
+
+        @AfterAll
+        @JvmStatic
+        fun cleanup() {
+            lifetime.closeAllStacks()
+        }
+    }
+}


### PR DESCRIPTION
## What
Backports the still-relevant parts of **PR #131** (#92: project-scoped tools mis-route when two same-named projects — a checkout + its git worktree — are open in one IDE). Main already re-did #131's core (PR #144: opaque `project_name = <name>-<hash>` keyed by **basePath**, which disambiguates same-named worktrees), so #92 was effectively fixed; this PR **hardens the last gap, guards it with tests, and lands the agent-facing docs**.

## Changes
- **Harden `resolveProject` (#92 latent gap):** match the opaque `project_name` first, then the raw folder name **only when unambiguous** (`singleOrNull`, never first-match) — so two same-named projects can't silently collapse. The not-found error now lists the `project_name` routing keys (not raw names).
- **`ProjectNameHashTest`:** fast unit guard that `base36FixedWidth("project", basePath, name)` gives same-name/different-path projects distinct ids (the #92 disambiguation core).
- **`DevrigSameNameProjectRoutingTest` (Docker):** the end-to-end regression net — opens two `dupproj` dirs under different parents, routes `execute_code` to each via its disambiguated `project_name`, asserts each lands in its own dir. Ported to main's infra (no signature changes needed).
- **Agent-facing reframing (prompts + tool descriptions):** `project_name` = opaque routing key; `name` = informational; **longest-path-prefix guidance** (map a file/dir path → the project whose `path` is the longest prefix — disambiguates nested checkouts/worktrees). Example JSON updated to main's `<name>-<hash>` shape.

## Deliberately NOT backported (superseded / conflicts with main)
- #131 adding `project_name`/`backend_name` to the `/projects/stream` `ProjectInfo` — **contradicts main's `WirePristinenessTest`** (main keeps the stream pristine and stamps ids on the separate `/projects` bridge).
- `OpenProjectsService`/`ProjectNameService`/`ProjectNaming` (pid-salted) — main computes the id inline in `projectNameFor` (basePath+name, no pid); adopting #131's structure would re-architect and churn every id.

## #92 verdict
Already fixed on main (both the IDE id and devrig's forwarded key disambiguate same-named projects). This PR closes the latent raw-name first-match re-entry and adds the missing unit + Docker regression guards.

## Tests
`:mcp-steroid-server:test`, `:ij-plugin:compileKotlin`, `:prompts:test --tests '*MarkdownArticleContract*'`, `:prompts:compileKotlin`, `:test-integration:compileTestKotlin` green. The Docker `DevrigSameNameProjectRoutingTest` is run separately (~20 min).
