### PR TITLE
devrig: fix Windows PATH-registration hang (#150)

### DIFF
--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/BinLauncher.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/BinLauncher.kt
@@ -7,6 +7,8 @@ import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.StandardCopyOption
 import java.nio.file.attribute.PosixFilePermission
+import java.util.concurrent.TimeUnit
+import org.slf4j.LoggerFactory
 import kotlin.io.path.exists
 import kotlin.io.path.readText
 
@@ -278,6 +280,8 @@ internal fun ensurePosixPathSymlink(binDir: Path, binDevrig: Path, userHome: Pat
     )
 }
 
+private val log = LoggerFactory.getLogger("com.jonnyzzz.mcpSteroid.devrig.BinLauncher")
+
 /**
  * Register `bin/devrig.cmd` on the **user** PATH so `devrig` is runnable directly from a terminal
  * (the POSIX side does the equivalent with a symlink). The JDK cannot persist the user environment in
@@ -303,27 +307,50 @@ internal fun ensureWindowsPathEntry(binDir: Path) {
             "\$new = (\$parts + \$d) -join ';'; " +
             "[Environment]::SetEnvironmentVariable('Path', \$new, 'User'); " +
             "[Console]::Error.WriteLine('[mcp-steroid] registered ' + \$d + ' on the user PATH (1 entry; open a new terminal to use it)')"
+    // Capture BOTH PowerShell streams ourselves — never INHERIT (it would leak onto the console /
+    // risk the JSON-RPC stdout) and never DISCARD. Reading a pipe inline would re-introduce a hang
+    // on a stuck child, so redirect into our own file and read it after the bounded wait.
+    val regLog = Files.createTempFile("mcp-steroid-user-path", ".log")
     try {
-        val exit = ProcessBuilder("powershell", "-NoProfile", "-NonInteractive", "-Command", script)
-            .redirectErrorStream(false)
-            .redirectOutput(ProcessBuilder.Redirect.DISCARD) // keep the MCP JSON-RPC channel clean
-            .redirectError(ProcessBuilder.Redirect.INHERIT)
+        val process = ProcessBuilder("powershell", "-NoProfile", "-NonInteractive", "-Command", script)
+            .redirectErrorStream(true)
+            .redirectOutput(regLog.toFile())
             .start()
-            .waitFor()
-        if (exit == 0) {
-            try {
-                Files.writeString(marker, bin)
-            } catch (e: Exception) {
-                System.err.println("[mcp-steroid] could not write the user-PATH marker $marker: $e")
-            }
-        } else {
-            System.err.println("[mcp-steroid] PowerShell PATH registration exited $exit; will retry next start")
+        // Close the child's stdin (our write end) right away: a left-open stdin pipe can make
+        // PowerShell block, hanging waitFor() indefinitely (#150). Closing it hands an immediate EOF.
+        process.outputStream.close()
+        // Bounded wait — PATH registration is best-effort and must never block devrig startup.
+        val finished = process.waitFor(2, TimeUnit.SECONDS)
+        if (!finished) process.destroyForcibly()
+        val output = Files.readString(regLog).trim()
+        when {
+            !finished ->
+                log.warn("PowerShell PATH registration timed out after 2s; skipping (add {} to PATH manually). {}", bin, output)
+            process.exitValue() != 0 ->
+                log.warn("PowerShell PATH registration exited {}; skipping (add {} to PATH manually). {}", process.exitValue(), bin, output)
+            output.isNotEmpty() ->
+                log.info(output)
         }
     } catch (e: Exception) {
-        System.err.println(
-            "[mcp-steroid] could not register $bin on the user PATH ($e); add it manually via " +
-                "System Properties -> Environment Variables (User PATH), or run devrig by full path",
+        log.warn(
+            "could not register {} on the user PATH; add it manually via System Properties -> " +
+                "Environment Variables (User PATH), or run devrig by full path",
+            bin,
+            e,
         )
+    } finally {
+        try {
+            Files.deleteIfExists(regLog)
+        } catch (e: Exception) {
+            log.debug("could not delete temp file {}", regLog, e)
+        }
+    }
+    // Write the marker regardless of success / failure / timeout: registration is best-effort and
+    // must never re-run (and risk re-hanging) on every subsequent devrig start.
+    try {
+        Files.writeString(marker, bin)
+    } catch (e: Exception) {
+        log.warn("could not write the user-PATH marker {}", marker, e)
     }
 }
 


### PR DESCRIPTION
Minimal, in-place fix for #150 — **no new module**, no `:process-util` extraction.

## Problem
`ensureWindowsPathEntry` (`BinLauncher.kt`) spawned PowerShell with a **left-open stdin pipe** (no `redirectInput`) and an **unbounded `waitFor()`**. On some Windows hosts PowerShell blocks on that open stdin, so `waitFor()` never returns and the caller is pinned (113s+ in the reported thread dump). Output was `DISCARD`/`INHERIT` (leaked to the console, never captured), and the `.user-path-registered` marker was written only on `exit == 0`, so a slow/failing run re-ran (and could re-hang) on every subsequent `devrig` start.

## Fix (ad-hoc, one file: +43/-16)
- **Close the child's stdin immediately** — `process.outputStream.close()` hands PowerShell an EOF right away (the literal "close its stdin"; OS-agnostic, no `NUL` redirect).
- **Capture BOTH streams ourselves** — `redirectErrorStream(true)` + `redirectOutput(<temp file>)`, never `INHERIT`/`DISCARD`; read the file back and emit via the **SLF4J logger** (`info` on success, `warn` on failure/timeout). Reading a pipe inline would re-introduce the hang on a stuck child, so the file is read only after the bounded wait.
- **Bound the wait** — `waitFor(2, TimeUnit.SECONDS)` + `destroyForcibly()` on expiry; PATH registration is best-effort and must never block startup.
- **Write the marker regardless of success / failure / timeout** — so registration never re-runs (and never re-hangs) on the next start.

## Validation
- `:npx-kt:compileKotlin` green.
- The marker-skip guard this relies on was validated on the eugene-x220 Windows host (see #150).

Workaround for users on the released v0.101 is documented in #150 (pre-create the marker file).

Closes #150