### PR TITLE
experiments-report: add Coverage view

### DIFF
--- a/experiments-report/src/main/kotlin/com/jonnyzzz/mcpSteroid/report/HtmlRenderer.kt
+++ b/experiments-report/src/main/kotlin/com/jonnyzzz/mcpSteroid/report/HtmlRenderer.kt
@@ -29,6 +29,7 @@ object HtmlRenderer {
         renderSummary(sb, report)
         renderComparisons(sb, report)
         renderProblems(sb, report)
+        renderCoverage(sb, report)
 
         sb.append("<footer>MCP Steroid experiments dashboard · heuristic verdicts — see raw columns for nuance</footer>\n")
         sb.append("</body>\n</html>\n")
@@ -139,6 +140,30 @@ object HtmlRenderer {
             sb.append("<tr><td>").append(esc(p.title)).append("</td>")
                 .append("<td class=\"num\">").append(p.count).append("</td>")
                 .append("<td class=\"where\">").append(esc(p.detail)).append("</td></tr>\n")
+        }
+        sb.append("</tbody>\n</table>\n</section>\n")
+    }
+
+    // ── Coverage: which collected builds produced run data ──────────────────────
+    private fun renderCoverage(sb: StringBuilder, report: Report) {
+        if (report.collectedBuilds.isEmpty()) return
+        // Builds whose status is not SUCCESS — their run data may be partial or absent (e.g. the build
+        // failed during IDE preparation, before any [ARENA] block was emitted).
+        val gaps = report.collectedBuilds.filter { it.status != null && !it.status.equals("SUCCESS", true) }
+
+        sb.append("<section><h2>Coverage</h2>\n")
+        sb.append("<p class=\"meta\">").append(report.collectedBuilds.size)
+            .append(" builds collected · ").append(report.allRuns.size).append(" runs parsed · ")
+            .append(gaps.size).append(" build(s) not SUCCESS (data may be partial/absent)</p>\n")
+        sb.append("<table>\n<thead><tr><th>build config</th><th>scenario</th><th>agent</th><th>status</th></tr></thead>\n<tbody>\n")
+        for (m in report.collectedBuilds) {
+            val ok = m.status.equals("SUCCESS", true)
+            val statusCell = if (ok) "<span class=\"ok\">${esc(m.status)}</span>"
+                else "<span class=\"bad\">${esc(m.status ?: "?")}</span>"
+            sb.append("<tr><td class=\"where\">").append(esc(m.buildConfigId)).append("</td>")
+                .append("<td>").append(esc(m.scenario)).append("</td>")
+                .append("<td>").append(esc(m.agent)).append("</td>")
+                .append("<td>").append(statusCell).append("</td></tr>\n")
         }
         sb.append("</tbody>\n</table>\n</section>\n")
     }

--- a/experiments-report/src/main/kotlin/com/jonnyzzz/mcpSteroid/report/InputReader.kt
+++ b/experiments-report/src/main/kotlin/com/jonnyzzz/mcpSteroid/report/InputReader.kt
@@ -39,6 +39,22 @@ object InputReader {
         return mergeRuns(runs)
     }
 
+    /** Every collected build's `meta.json` (collector layout only) — for the coverage view. */
+    fun readBuildMetas(root: File): List<BuildMeta> {
+        val buildsDir = File(root, "builds").takeIf { it.isDirectory } ?: return emptyList()
+        return buildsDir.listFiles { f -> f.isDirectory }.orEmpty().mapNotNull { dir ->
+            val meta = File(dir, "meta.json").takeIf { it.isFile } ?: return@mapNotNull null
+            val o = runCatching { json.parseToJsonElement(meta.readText()).jsonObject }.getOrNull() ?: return@mapNotNull null
+            BuildMeta(
+                buildConfigId = o["buildConfigId"]?.jsonPrimitive?.contentOrNull ?: dir.name,
+                buildId = o["buildId"]?.jsonPrimitive?.contentOrNull?.toLongOrNull(),
+                scenario = o["scenario"]?.jsonPrimitive?.contentOrNull ?: "",
+                agent = o["agent"]?.jsonPrimitive?.contentOrNull ?: "",
+                status = o["status"]?.jsonPrimitive?.contentOrNull,
+            )
+        }.sortedBy { it.buildConfigId }
+    }
+
     /** Flat layout: only the self-identifying sources (summary JSON + arena log). */
     private fun readFlat(root: File): List<AgentRun> = buildList {
         root.walkTopDown().filter { it.isFile }.forEach { f ->

--- a/experiments-report/src/main/kotlin/com/jonnyzzz/mcpSteroid/report/Report.kt
+++ b/experiments-report/src/main/kotlin/com/jonnyzzz/mcpSteroid/report/Report.kt
@@ -6,6 +6,17 @@ data class Report(
     val generatedAt: String,
     val comparisons: List<Comparison>,
     val allRuns: List<AgentRun>,
+    /** Every build the collector pulled (incl. ones that produced no parseable run data). Empty for a flat local run. */
+    val collectedBuilds: List<BuildMeta> = emptyList(),
+)
+
+/** One collected build's identity + outcome, from the collector's `meta.json`. Drives the coverage view. */
+data class BuildMeta(
+    val buildConfigId: String,
+    val buildId: Long?,
+    val scenario: String,
+    val agent: String,
+    val status: String?,
 )
 
 /** Per-agent roll-up of the with/without verdicts, shown at the top of the dashboard. */

--- a/experiments-report/src/main/kotlin/com/jonnyzzz/mcpSteroid/report/ReportMain.kt
+++ b/experiments-report/src/main/kotlin/com/jonnyzzz/mcpSteroid/report/ReportMain.kt
@@ -15,6 +15,7 @@ fun buildReport(inputDir: File, title: String, generatedAt: String): Report {
         generatedAt = generatedAt,
         comparisons = Aggregator.compare(runs),
         allRuns = runs,
+        collectedBuilds = InputReader.readBuildMetas(inputDir),
     )
 }
 

--- a/experiments-report/src/test/kotlin/com/jonnyzzz/mcpSteroid/report/CoverageTest.kt
+++ b/experiments-report/src/test/kotlin/com/jonnyzzz/mcpSteroid/report/CoverageTest.kt
@@ -1,0 +1,44 @@
+package com.jonnyzzz.mcpSteroid.report
+
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Path
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class CoverageTest {
+    private fun fixtureText(name: String): String =
+        requireNotNull(javaClass.classLoader.getResourceAsStream("fixtures/$name")) { "missing $name" }
+            .bufferedReader().readText()
+
+    private fun place(dir: Path, rel: String, content: String) {
+        val f = dir.resolve(rel).toFile(); f.parentFile.mkdirs(); f.writeText(content)
+    }
+
+    @Test
+    fun `collects build metas including a failed build that produced no parseable runs`(@TempDir dir: Path) {
+        // a healthy build with a log...
+        place(dir, "builds/petclinic27-claude__1/log.txt", fixtureText("arena-log-petclinic27-claude.txt"))
+        place(dir, "builds/petclinic27-claude__1/meta.json",
+            """{"buildConfigId":"X_Petclinic27_Claude","buildId":1,"scenario":"Petclinic27","agent":"claude","status":"SUCCESS"}""")
+        // ...and a FAILED build that emitted no [ARENA] data (failed during IDE prep)
+        place(dir, "builds/feature125-claude__2/log.txt", "infra exploded before the agent ran")
+        place(dir, "builds/feature125-claude__2/meta.json",
+            """{"buildConfigId":"X_FeatureService125_Claude","buildId":2,"scenario":"FeatureService125","agent":"claude","status":"FAILURE"}""")
+
+        val report = buildReport(dir.toFile(), "Coverage", "2026-06-27T00:00:00Z")
+
+        assertEquals(2, report.collectedBuilds.size, "both builds are reported as collected")
+        val failed = report.collectedBuilds.single { it.status == "FAILURE" }
+        assertEquals("FeatureService125", failed.scenario)
+
+        // the healthy build yields runs; the failed one yields none
+        assertTrue(report.allRuns.any { it.scenario == "dpaia__spring__petclinic-27" })
+        assertTrue(report.allRuns.none { it.scenario == "FeatureService125" })
+
+        // and the rendered dashboard discloses the gap
+        val html = HtmlRenderer.render(report)
+        assertTrue(html.contains("Coverage"))
+        assertTrue(html.contains("FeatureService125"))
+    }
+}


### PR DESCRIPTION
Surfaces every collected build (status from meta.json) so a build that failed before emitting run data shows as a gap rather than silently disappearing — keeps the dashboard aligned with the actual scenarios. TDD-covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)