### PR TITLE
docker mkdirs: create bind-mounted dirs host-side first (fix trusted-paths.xml in test-experiments)

### DIFF
--- a/test-helper/src/main/kotlin/com/jonnyzzz/mcpSteroid/testHelper/docker/docker-disk.kt
+++ b/test-helper/src/main/kotlin/com/jonnyzzz/mcpSteroid/testHelper/docker/docker-disk.kt
@@ -7,6 +7,13 @@ import com.jonnyzzz.mcpSteroid.testHelper.process.startProcess
 import java.io.File
 
 fun ContainerDriver.mkdirs(guestPath: String): ProcessResult {
+    // If the path is under a bind mount, create it on the HOST first so the directory is host-owned.
+    // Creating it only via in-container `mkdir` makes it container-owned, after which the host JVM
+    // cannot add subdirectories under it — which broke writeTrustedPaths with a FileNotFoundException
+    // on `ide-config/options/trusted-paths.xml` (the host-mapped copyToContainer write could not create
+    // the `options/` dir inside the container-owned `ide-config`). The in-container `mkdir -p` below then
+    // no-ops on the now-existing directory, leaving ownership with the host.
+    mapGuestPathToHostPathOrNull(guestPath)?.mkdirs()
     return startProcessInContainer {
         this
             .args("mkdir", "-p", guestPath)


### PR DESCRIPTION
## Problem
Every `:test-experiments` arena run currently fails in IDE setup:
```
java.io.FileNotFoundException: …/run-…/intellij/ide-config/options/trusted-paths.xml (No such file or directory)
  at writeTrustedPaths(intelliJ.kt:366) → copyToContainer(docker-disk.kt:40) → startIde(intelliJ.kt:154)
```

## Cause
`startIde` creates `ide-config` via in-container `mkdir` (so it's **container-owned**), but that dir lives
under the **host-mounted** run dir. `writeTrustedPaths` then writes `ide-config/options/trusted-paths.xml`
through the host-mapped `copyToContainer` path — and the host JVM can't create `options/` inside the
container-owned `ide-config`, so `parentFile.mkdirs()` silently returns false and the write throws.

## Fix
In `ContainerDriver.mkdirs`, when the guest path is under a bind mount, create it on the **host** first
(host-owned) so later host-mapped writes can add subdirectories; the in-container `mkdir -p` then no-ops
on the existing dir. One line, at the right layer (fixes all host-mapped config writes, not just trusted-paths).

## Validation
Compiles (`:test-helper:compileKotlin`). The container/IDE behavior is validated by re-running a
`:test-experiments` build — I can't reproduce the Docker+IDE container locally. Paired with the already-merged
`devrig.package.zip` fix, this should let arena runs reach the agent phase and emit `[ARENA]` data again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)