### PR TITLE
docker: host-written bind-mount FILES world-writable (fix MCP plugin not ready on CI)

### DIFF
--- a/test-helper/src/main/kotlin/com/jonnyzzz/mcpSteroid/testHelper/docker/docker-disk.kt
+++ b/test-helper/src/main/kotlin/com/jonnyzzz/mcpSteroid/testHelper/docker/docker-disk.kt
@@ -67,6 +67,12 @@ fun ContainerDriver.copyToContainer(localPath: File, containerPath: String) {
         // Make the parent dir(s) a+rwx so the uid-1000 container can write alongside the host-written file.
         hostPath.parentFile?.mkdirsWorldWritable()
         localPath.copyTo(hostPath, overwrite = true)
+        // The container runs as the image's uid (1000), the host as a different uid — so make the
+        // host-written file group/other-writable too. Otherwise a host-owned 0644 file the IDE needs to
+        // REWRITE on startup (e.g. options/*.xml it loads then persists) fails with EACCES inside the
+        // container, stalling IDE/plugin startup. a+rw matches the run-dir mount contract.
+        hostPath.setReadable(true, /* ownerOnly = */ false)
+        hostPath.setWritable(true, /* ownerOnly = */ false)
         return
     }
     newRunOnHost()

--- a/test-integration/src/main/kotlin/com/jonnyzzz/mcpSteroid/integration/infra/intelliJ.kt
+++ b/test-integration/src/main/kotlin/com/jonnyzzz/mcpSteroid/integration/infra/intelliJ.kt
@@ -198,6 +198,13 @@ class IntelliJDriver(
         //make sure the log file is here
         runCatching { logFile.parentFile.mkdirs() }
         runCatching { logFile.appendText("\n\nStarted MCP Steroid Integration test\n\n") }
+        // The IDE runs as the container's uid (1000), different from the host uid; this log file lives on
+        // the bind-mounted run dir and is created host-owned. Without a+rw the uid-1000 IDE cannot append
+        // to it, so idea.log stays a 4-line stub on Linux CI (no startup diagnostics) — make it writable.
+        runCatching {
+            logFile.setReadable(true, /* ownerOnly = */ false)
+            logFile.setWritable(true, /* ownerOnly = */ false)
+        }
 
         if (!idea.isRunning()) {
             idea.printProcessInfo()


### PR DESCRIPTION
Local repro proved the plugin + :6754 work; the CI failure is the uid-999-host vs uid-1000-container mismatch on host-written bind-mount **files** (0644 host-owned). Sibling to the dir fix (#165): `copyToContainer` and the pre-created `idea.log` now set host-written files a+rw, so the uid-1000 IDE can rewrite its config + append its log (restoring CI startup diagnostics). Validated locally; Linux CI is the final validator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)