### PR TITLE
experiments-report: verdict follows objective build outcome, not claimedFix

### DIFF
--- a/experiments-report/src/main/kotlin/com/jonnyzzz/mcpSteroid/report/Aggregator.kt
+++ b/experiments-report/src/main/kotlin/com/jonnyzzz/mcpSteroid/report/Aggregator.kt
@@ -57,5 +57,17 @@ object Aggregator {
             .sortedWith(compareBy({ it.scenario }, { it.agent }))
 }
 
-/** Best-available "did the agent solve the task" signal, or null when nothing tells us. */
-fun AgentRun.succeeded(): Boolean? = claimedFix ?: buildSuccess ?: testStatus?.let { it.equals("SUCCESS", ignoreCase = true) }
+/**
+ * Best-available "did the agent solve the task" signal, or null when nothing tells us.
+ *
+ * Precedence puts the OBJECTIVE sandbox build/test outcome ahead of the agent's own `claimedFix`:
+ * agents routinely claim success while the build actually failed (observed on Petclinic27 — the
+ * without-MCP run claimed a fix yet produced BUILD FAILURE with only 2 tests). A build counts as
+ * success only if it built AND no tests failed. Falls back to `claimedFix`, then the JUnit status.
+ */
+fun AgentRun.succeeded(): Boolean? = when {
+    buildSuccess != null -> buildSuccess && (testsFail ?: 0) == 0
+    claimedFix != null -> claimedFix
+    testStatus != null -> testStatus.equals("SUCCESS", ignoreCase = true)
+    else -> null
+}

--- a/experiments-report/src/test/kotlin/com/jonnyzzz/mcpSteroid/report/AggregatorTest.kt
+++ b/experiments-report/src/test/kotlin/com/jonnyzzz/mcpSteroid/report/AggregatorTest.kt
@@ -5,10 +5,14 @@ import kotlin.test.assertEquals
 
 class AggregatorTest {
     @Test
-    fun `pairs with-and-without runs per scenario and agent and computes deltas`() {
+    fun `verdict uses the objective build outcome over the agent's self-claim`() {
+        // Real Petclinic27 shape: BOTH agents claim a fix, but only the with-MCP build objectively
+        // succeeded (80 tests, BUILD SUCCESS); without-MCP claimed success yet BUILD FAILURE (2 tests).
+        // The verdict must follow the objective build/test outcome, not the optimistic claimedFix.
         val runs = listOf(
-            AgentRun("petclinic-27", "claude", McpMode.WITH, claimedFix = true, agentDurationMs = 521_000, costUsd = 3.21, buildSuccess = false),
-            AgentRun("petclinic-27", "claude", McpMode.WITHOUT, claimedFix = true, agentDurationMs = 711_000, costUsd = 4.10, buildSuccess = true),
+            AgentRun("petclinic-27", "claude", McpMode.WITH, claimedFix = true, buildSuccess = true, testsFail = 0, agentDurationMs = 436_000, costUsd = 3.21),
+            AgentRun("petclinic-27", "claude", McpMode.WITHOUT, claimedFix = true, buildSuccess = false, testsFail = 0, agentDurationMs = 524_000, costUsd = 4.10),
+            // Fallback case: no build outcome reported → fall back to claimedFix.
             AgentRun("train-ticket-1", "codex", McpMode.WITH, claimedFix = true, agentDurationMs = 100_000),
             AgentRun("train-ticket-1", "codex", McpMode.WITHOUT, claimedFix = false, agentDurationMs = 120_000),
         )
@@ -17,13 +21,31 @@ class AggregatorTest {
         assertEquals(2, comps.size)
 
         val pet = comps.single { it.scenario == "petclinic-27" && it.agent == "claude" }
-        assertEquals(Verdict.NEUTRAL, pet.verdict, "both claimed a fix -> neutral outcome")
-        assertEquals(-190_000L, pet.durationDeltaMs, "mcp run was faster by 190s")
+        assertEquals(Verdict.MCP_HELPED, pet.verdict, "with built, without failed -> MCP helped")
+        assertEquals(-88_000L, pet.durationDeltaMs, "mcp run was faster by 88s")
         assertEquals(-0.89, pet.costDeltaUsd!!, 1e-9)
 
         val tt = comps.single { it.scenario == "train-ticket-1" && it.agent == "codex" }
-        assertEquals(Verdict.MCP_HELPED, tt.verdict, "with-mcp fixed, without did not")
+        assertEquals(Verdict.MCP_HELPED, tt.verdict, "no build outcome -> falls back to claimedFix")
         assertEquals(-20_000L, tt.durationDeltaMs)
+    }
+
+    @Test
+    fun `both builds succeeding is neutral`() {
+        val runs = listOf(
+            AgentRun("x", "claude", McpMode.WITH, buildSuccess = true, testsFail = 0, claimedFix = true),
+            AgentRun("x", "claude", McpMode.WITHOUT, buildSuccess = true, testsFail = 0, claimedFix = true),
+        )
+        assertEquals(Verdict.NEUTRAL, Aggregator.compare(runs).single().verdict)
+    }
+
+    @Test
+    fun `a build that fails its tests is not a success even if claimed`() {
+        val runs = listOf(
+            AgentRun("y", "claude", McpMode.WITH, buildSuccess = true, testsFail = 3, claimedFix = true),
+            AgentRun("y", "claude", McpMode.WITHOUT, buildSuccess = true, testsFail = 0, claimedFix = true),
+        )
+        assertEquals(Verdict.MCP_HURT, Aggregator.compare(runs).single().verdict)
     }
 
     @Test

--- a/experiments-report/src/test/kotlin/com/jonnyzzz/mcpSteroid/report/EndToEndTest.kt
+++ b/experiments-report/src/test/kotlin/com/jonnyzzz/mcpSteroid/report/EndToEndTest.kt
@@ -23,8 +23,12 @@ class EndToEndTest {
         val report = buildReport(dir.toFile(), "Test Dashboard", "2026-06-26T00:00:00Z")
         assertTrue(report.comparisons.isNotEmpty(), "found at least one comparison")
         val pet = report.comparisons.single { it.scenario == "dpaia__spring__petclinic-27" && it.agent == "claude" }
-        // both claimed a fix => neutral, but the MCP run was faster (521s vs 711s)
-        assertTrue(pet.verdict == Verdict.NEUTRAL)
+        // In this fixture the with-MCP run shows BUILD FAILURE (infra noise — 2 unrelated Postgres
+        // docker errors per its summary) while the without-MCP run shows BUILD SUCCESS. The heuristic
+        // follows the OBJECTIVE build outcome, so it reads as MCP_HURT here even though the agent claimed
+        // a fix — exactly the nuance the raw columns + a later RLM pass are there to surface. The MCP run
+        // was still faster (521s vs 711s).
+        assertTrue(pet.verdict == Verdict.MCP_HURT)
         assertTrue(pet.durationDeltaMs == -190_000L)
 
         val html = HtmlRenderer.render(report)


### PR DESCRIPTION
Fresh Petclinic27 data showed agents claim a fix even when the build failed (without-MCP: claimedFix=true but BUILD FAILURE/2 tests; with-MCP: BUILD SUCCESS/80 tests). The verdict now ranks buildSuccess+tests over claimedFix → that reads as MCP_HELPED instead of 'neutral'. TDD-covered. 🤖 Generated with [Claude Code](https://claude.com/claude-code)