### PR TITLE
fix(exec): waitForSmartMode timeout = "indexing in progress, keep polling" (#169)

### DIFF
--- a/ij-plugin/src/main/kotlin/com/jonnyzzz/mcpSteroid/execution/McpScriptContextImpl.kt
+++ b/ij-plugin/src/main/kotlin/com/jonnyzzz/mcpSteroid/execution/McpScriptContextImpl.kt
@@ -201,8 +201,9 @@ class McpScriptContextImpl(
         resultBuilder.logProgress("Waiting for indexing to complete...")
 
         try {
-            // Bounded as a deadlock safety net (indexing that never reaches smart mode) — the tool docs
-            // promise the wait is bounded. Timeout => fail the execution with a clear message.
+            // We only wait this short window per call so the request returns promptly. Reaching it does
+            // NOT mean anything is wrong: dumb mode means indexing is actively running and making
+            // progress. We tell the caller so, and let it poll (call again).
             withTimeout(WAIT_FOR_SMART_MODE_TIMEOUT) {
                 suspendCancellableCoroutine<Unit> { cont ->
                     fun waitForSmart() {
@@ -224,11 +225,15 @@ class McpScriptContextImpl(
                 }
             }
         } catch (_: TimeoutCancellationException) {
-            captureThreadDump("waitForSmartMode-timeout")
-            log.error("[$executionId] waitForSmartMode did not reach smart mode within $WAIT_FOR_SMART_MODE_TIMEOUT")
+            // Not an error and not stuck — indexing is in progress. Tell the caller to keep polling.
+            log.info("[$executionId] still indexing after $WAIT_FOR_SMART_MODE_TIMEOUT — asking caller to poll")
             throw ToolCallErrorException(
-                "waitForSmartMode did not reach smart mode within $WAIT_FOR_SMART_MODE_TIMEOUT — indexing may " +
-                    "be stuck. See the thread dump under execution '${executionId.executionId}'."
+                "INDEXING IN PROGRESS: the IDE is still indexing this project, so it is not ready yet. " +
+                    "This is normal and expected — it is NOT an error and nothing is stuck; indexing always " +
+                    "makes progress and simply needs more time. Indexing a medium-size project can take up " +
+                    "to an hour, and larger projects longer; that wait is acceptable. Just keep polling: " +
+                    "call this tool again to continue waiting (each call waits up to $WAIT_FOR_SMART_MODE_TIMEOUT), " +
+                    "and your request runs automatically once indexing finishes."
             )
         } finally {
             log.info("[$executionId] Waiting for indexing completed")

--- a/test-integration/src/main/kotlin/com/jonnyzzz/mcpSteroid/integration/infra/mcp-steroid.kt
+++ b/test-integration/src/main/kotlin/com/jonnyzzz/mcpSteroid/integration/infra/mcp-steroid.kt
@@ -66,6 +66,19 @@ internal fun ProcessResult.resolveJavaHomeLookup(jdkVersion: String): String {
     error("[COMPILE] JDK $jdkVersion lookup returned no path; stdout=${stdout.take(500)} stderr=${stderr.take(500)}")
 }
 
+/**
+ * Marker the server's `waitForSmartMode` emits when the IDE is still indexing — the signal to keep
+ * polling (call again). Mirrors the message in `McpScriptContextImpl.waitForSmartMode`; the coupling is
+ * the documented tool-result contract.
+ */
+internal const val INDEXING_IN_PROGRESS_MARKER = "INDEXING IN PROGRESS"
+
+/** Overall budget for polling through "still indexing" — large projects can take a long time. */
+private const val INDEXING_POLL_BUDGET_MS = 60 * 60 * 1000L
+
+/** Pure: does this tool-result text say the IDE is still indexing (so we should call again)? */
+internal fun isIndexingInProgress(text: String): Boolean = text.contains(INDEXING_IN_PROGRESS_MARKER)
+
 class McpSteroidDriver(
     val driver: ContainerDriver,
     val ijDriver: IntelliJDriver,
@@ -361,6 +374,10 @@ try {
      * @param timeout Timeout in seconds (default: 600)
      * @param projectName Project name (defaults to the project at guestProjectDir)
      * @return MCP tool result as JSON string
+     *
+     * If the IDE is still indexing, each call waits a short window and returns an "INDEXING IN PROGRESS"
+     * result; we poll exactly as an agent would (call again), since indexing always makes progress and a
+     * large project can legitimately take a long time. Polling is bounded by [INDEXING_POLL_BUDGET_MS].
      */
     fun mcpExecuteCode(
         code: String,
@@ -374,6 +391,25 @@ try {
          * modality choice rather than relying on the server's implicit default.
          */
         modal: ModalMode = ModalMode.DEFAULT,
+    ): ProcessResult {
+        val deadline = System.currentTimeMillis() + INDEXING_POLL_BUDGET_MS
+        var attempt = 0
+        while (true) {
+            attempt++
+            val result = mcpExecuteCodeOnce(code, taskId, reason, timeout, projectName, modal)
+            if (!isIndexingInProgress(result.stdout) || System.currentTimeMillis() >= deadline) return result
+            println("[MCP] $taskId: IDE still indexing (attempt $attempt) — calling again to keep waiting…")
+            Thread.sleep(3_000L)
+        }
+    }
+
+    private fun mcpExecuteCodeOnce(
+        code: String,
+        taskId: String,
+        reason: String,
+        timeout: Int,
+        projectName: String,
+        modal: ModalMode,
     ): ProcessResult {
         // First, initialize MCP session
         val sessionId = mcpInitialize()

--- a/test-integration/src/test/kotlin/com/jonnyzzz/mcpSteroid/integration/infra/IndexingInProgressDetectionTest.kt
+++ b/test-integration/src/test/kotlin/com/jonnyzzz/mcpSteroid/integration/infra/IndexingInProgressDetectionTest.kt
@@ -1,0 +1,35 @@
+/* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
+package com.jonnyzzz.mcpSteroid.integration.infra
+
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * Pure tests for [isIndexingInProgress] — the predicate `mcpExecuteCode` uses to decide whether the IDE
+ * is still indexing (so the harness should call again, exactly as an agent would) versus a real
+ * success/error. See jonnyzzz/mcp-steroid#169.
+ */
+class IndexingInProgressDetectionTest {
+
+    @Test
+    fun `detects the still-indexing message the server emits while indexing`() {
+        val text = """
+            execution_id: eid_x-integration-test
+            [PRE] wait for smart mode
+            ERROR: $INDEXING_IN_PROGRESS_MARKER: the IDE is still indexing this project, so it is not ready
+            yet. This is normal and expected … just keep polling: call this tool again to continue waiting.
+        """.trimIndent()
+        assertTrue(isIndexingInProgress(text))
+    }
+
+    @Test
+    fun `a normal successful result is not still-indexing`() {
+        assertFalse(isIndexingInProgress("execution_id: eid_x\n[RUN] script\nJDKs registered\ndone"))
+    }
+
+    @Test
+    fun `a genuine failure is not still-indexing`() {
+        assertFalse(isIndexingInProgress("execution_id: eid_x\nFAILED: compilation error: unresolved reference"))
+    }
+}


### PR DESCRIPTION
Fixes #169. **Third revision — minimal, per review.** Earlier revisions (raise+configure the timeout via a Registry key; a `RetryableToolCallException`/`isRetryable` mechanism) were both dropped as over-engineered.

## The point

`waitForSmartMode()` (the `[PRE] wait for smart mode` step of every default-modal `steroid_execute_code`) treated its 60s timeout as a hard failure — *"did not reach smart mode within 1m — indexing may be stuck"*, plus a `SEVERE` log and a thread dump. On a large project still doing its first index, that's wrong on every count: nothing is stuck — indexing is just still running and **always making progress**. It broke all four YouTrackDb test-experiments on v101 (~105k files; setup's first call, `mcpRegisterJdks`, died in its PRE sweep before the Maven import even ran). Evidence + thread dump in #169.

Indexing-not-done is never a failure, and the right response is always the same — wait and try again. So **the fix is the message, not machinery.**

## Change (2 files + 1 test)

- **`waitForSmartMode`** keeps the short 60s per-call window, but on timeout returns a clear, friendly result: *"INDEXING IN PROGRESS … this is normal and expected, not an error and nothing is stuck; indexing always makes progress. A medium-size project can take up to an hour, larger ones longer — that wait is acceptable. Keep polling: call this tool again to continue waiting."* Dropped the misleading "may be stuck", the `SEVERE` log, and the per-poll thread dump.
- **Test harness `mcpExecuteCode`** polls on that message — exactly as an agent would — bounded by a generous overall budget, so a slow first index doesn't break setup.

No new exception types, no `isError`/retryable flags, no registry keys, no change to the 60s window.

## Test

`test-integration` `IndexingInProgressDetectionTest` covers the poll predicate (`isIndexingInProgress`): detects the message, ignores success and genuine failures. Plugin compiles; existing execution suites green.

## Reproduction note

The CI failure is environment-bound to slow CI disk: locally a fast SSD finishes indexing under 60s, so the message/poll path never triggers (the local run sails through setup and only fails later for a missing agent API key). The poll path is covered by the unit test and will be exercised by the YouTrackDb builds on CI.
