### PR TITLE
test(experiments): add without-MCP baseline to the debugger demo (A/B)

### DIFF
--- a/test-experiments/src/test/kotlin/com/jonnyzzz/mcpSteroid/integration/tests/DebuggerDemoTest.kt
+++ b/test-experiments/src/test/kotlin/com/jonnyzzz/mcpSteroid/integration/tests/DebuggerDemoTest.kt
@@ -2,11 +2,16 @@
 package com.jonnyzzz.mcpSteroid.integration.tests
 
 import com.jonnyzzz.mcpSteroid.integration.infra.AiAgentDriver
+import com.jonnyzzz.mcpSteroid.integration.infra.AiMode
 import com.jonnyzzz.mcpSteroid.integration.infra.ConsoleDriver
+import com.jonnyzzz.mcpSteroid.integration.infra.IdeTestFolders
 import com.jonnyzzz.mcpSteroid.integration.infra.IntelliJContainer
 import com.jonnyzzz.mcpSteroid.integration.infra.IntelliJContainerOpts
+import com.jonnyzzz.mcpSteroid.integration.infra.McpConnectionMode
 import com.jonnyzzz.mcpSteroid.integration.infra.create
 import com.jonnyzzz.mcpSteroid.integration.infra.waitForProjectReady
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
 import com.jonnyzzz.mcpSteroid.testHelper.AiAgentSession
 import com.jonnyzzz.mcpSteroid.testHelper.CloseableStackHost
 import com.jonnyzzz.mcpSteroid.testHelper.process.assertExitCode
@@ -55,6 +60,16 @@ class DebuggerDemoTest {
     @Timeout(value = 20, unit = TimeUnit.MINUTES)
     fun `gemini finds sortedByDescending bug via debugger`() = runDebuggerDemo(AiAgentDriver::gemini)
 
+    // ── Baselines: same task, no MCP / no debugger (Claude + Codex). Scored on correctness only,
+    //    so the dashboard can show whether the live debugger actually helps. ──
+    @Test
+    @Timeout(value = 20, unit = TimeUnit.MINUTES)
+    fun `claude finds sortedByDescending bug without mcp`() = runDebuggerDemo(AiAgentDriver::claude, withMcp = false)
+
+    @Test
+    @Timeout(value = 20, unit = TimeUnit.MINUTES)
+    fun `codex finds sortedByDescending bug without mcp`() = runDebuggerDemo(AiAgentDriver::codex, withMcp = false)
+
     @Test
     @Timeout(value = 20, unit = TimeUnit.MINUTES)
     fun `test debugger finds null-default bug with Claude`() = runNullDefaultDemo(AiAgentDriver::claude)
@@ -83,18 +98,23 @@ class DebuggerDemoTest {
     @Timeout(value = 20, unit = TimeUnit.MINUTES)
     fun `codex debugs JonnyzzzDebugTest via debugger`() = runJonnyzzzDebugDemo(AiAgentDriver::codex)
 
-    private fun runDebuggerDemo(agentName: KProperty1<AiAgentDriver, AiAgentSession>) {
+    private fun runDebuggerDemo(agentName: KProperty1<AiAgentDriver, AiAgentSession>, withMcp: Boolean = true) {
+        val modeLabel = if (withMcp) "mcp" else "none"
         val session = IntelliJContainer.create(
             lifetime, IntelliJContainerOpts(
-                consoleTitle = "Debugger with ${agentName.name.titleCase()}",
+                // The mode goes in the console title so the published run-dir zip is mode-tagged
+                // (fetch.sh maps *-mcp* -> with, *-none* -> without) and the dashboard pairs the two.
+                consoleTitle = "Debugger-$modeLabel-${agentName.name.titleCase()}",
+                aiMode = if (withMcp) AiMode.AI_MCP else AiMode.NONE,
+                mcpConnectionMode = if (withMcp) null else McpConnectionMode.None,
             )
         ).waitForProjectReady()
         val console = session.console
 
         val agent = session.aiAgents.run { agentName(this) }
-        console.writeStep("Building prompt for $agentName")
+        console.writeStep("Building prompt for $agentName (withMcp=$withMcp)")
 
-        val prompt = buildString {
+        val prompt = if (withMcp) buildString {
             appendLine("# Task: Debug DemoByJonnyzzz.kt to find the bug")
             appendLine()
             appendLine("You MUST use the IntelliJ debugger to investigate the bug.")
@@ -126,6 +146,29 @@ class DebuggerDemoTest {
             appendLine("- You MUST use the debugger (set breakpoints, evaluate variables, step through code)")
             appendLine("- Do NOT use screenshots or UI input tools")
             appendLine("- Read MCP debugger resources for API patterns -- do not invent API calls")
+        } else buildString {
+            // BASELINE (no MCP / no IDE): the agent has only the shell. It cannot use the IntelliJ
+            // debugger — so it must find the bug by reading the code and reasoning (and may add
+            // temporary logging / run the program via the build tool). Scored ONLY on whether it
+            // correctly identifies the bug — the same correctness check as the MCP run.
+            appendLine("# Task: Find the bug in DemoByJonnyzzz.kt")
+            appendLine()
+            appendLine("IntelliJ MCP tools are unavailable in this run. Use shell commands only")
+            appendLine("(`bash`, `cat`, `find`, `grep`, and the project's build tool). Do NOT call `steroid_*` tools.")
+            appendLine()
+            appendLine("## Instructions")
+            appendLine()
+            appendLine("1. Find `DemoByJonnyzzz.kt` in the project and read it.")
+            appendLine("2. Determine the bug by reasoning about the code. You may add temporary logging and run")
+            appendLine("   the program to confirm, but there is no interactive debugger available.")
+            appendLine("3. Identify the bug and its root cause.")
+            appendLine()
+            appendLine("## Required Output")
+            appendLine()
+            appendLine("Print these markers on separate lines:")
+            appendLine("BUG_FOUND: yes")
+            appendLine("BUG_LINE: <the exact buggy source line>")
+            appendLine("ROOT_CAUSE: <must explain what the bug is and why, mentioning both that sortedByDescending returns a new list AND that the return value is ignored/unused>")
         }
 
         console.writeStep("Running agent prompt")
@@ -136,98 +179,77 @@ class DebuggerDemoTest {
         // execution IDs in NDJSON tool_result events, not in the final extracted text.
         val combined = result.stdout + "\n" + result.stderr
 
-        console.writeStep( "Validating agent output")
-
-        // If CLI timed out but the agent already emitted required markers, keep validating the output.
-        val hasFinalMarkers = hasAnyMarkerLine(output, "BUG_FOUND", "Bug found") &&
-                hasAnyMarkerLine(output, "ROOT_CAUSE", "Root cause")
-        if (result.exitCode != 0 && !hasFinalMarkers) {
-            console.writeError("Agent exited with code ${result.exitCode}")
-            result.assertExitCode(0, message = "debugger demo")
-        }
+        console.writeStep("Validating agent output (withMcp=$withMcp)")
         console.writeInfo("Agent exited with code ${result.exitCode ?: "?"}")
 
-        // Agent must show evidence of MCP Steroid execute_code usage
-        console.writeInfo("Checking: steroid_execute_code usage evidence")
-        assertUsedExecuteCodeEvidence(combined)
-        console.writeSuccess("execute_code evidence found")
+        // Correctness — the fair, mode-independent verdict scored identically for both modes
+        // (did the agent actually identify the bug, however it got there?). See scoreSortedByDescendingBug.
+        val score = scoreSortedByDescendingBug(output)
+        console.writeInfo("Bug identified: ${score.bugFound}${if (score.reasons.isEmpty()) "" else " — misses: ${score.reasons}"}")
 
-        console.writeInfo("Checking: BUG_LINE marker")
-        val bugLine = findMarkerValue(output, "BUG_LINE", "Buggy line", "Bug line")
-        check(bugLine != null) {
-            "Agent did not output required marker 'BUG_LINE:' (or equivalent).\nOutput:\n$combined"
-        }
-        check(bugLine.contains("sortedByDescending", ignoreCase = true)) {
-            "BUG_LINE must mention sortedByDescending.\nOutput:\n$combined"
-        }
-        val hasExactBugStatement = bugLine.contains("players.sortedByDescending", ignoreCase = true) &&
-                bugLine.contains("it.score", ignoreCase = true)
-        val hasSortedLineEvidence = Regex("""(?im)sortedByDescending line\s*\(1-based\)\s*:\s*7""")
-            .containsMatchIn(combined)
-        check(hasExactBugStatement || hasSortedLineEvidence) {
-            "BUG_LINE must identify the exact buggy statement, or execution logs must show line-number evidence " +
-                    "for the sortedByDescending line.\nOutput:\n$combined"
-        }
-        console.writeSuccess("BUG_LINE: $bugLine")
-
-        // Agent must mention sortedByDescending in its analysis
-        result.assertOutputContains("sortedByDescending", message = "agent must mention sortedByDescending")
-
-        // Agent must identify the root cause: sortedByDescending returns a new list
-        // but the return value is ignored
-        console.writeInfo("Checking: ROOT_CAUSE marker")
-        val rootCause = findMarkerValue(output, "ROOT_CAUSE", "Root cause")
-        check(rootCause != null) {
-            "Agent did not output required marker 'ROOT_CAUSE:' (or equivalent).\nOutput:\n$combined"
-        }
-        console.writeSuccess("ROOT_CAUSE: $rootCause")
-
-        console.writeInfo("Checking: BUG_FOUND marker")
-        val bugFound = findMarkerValue(output, "BUG_FOUND", "Bug found")
-        val hasExplicitYes = bugFound?.equals("yes", ignoreCase = true) == true
-        val inferredYes = bugFound == null && bugLine.isNotBlank() && rootCause.isNotBlank()
-        check(hasExplicitYes || inferredYes) {
-            "Agent did not confirm bug detection with 'BUG_FOUND: yes' and no valid fallback markers were found.\nOutput:\n$combined"
-        }
-        console.writeSuccess("BUG_FOUND: ${bugFound ?: "(inferred)"}")
-
-        console.writeInfo("Checking: ROOT_CAUSE quality")
-        val ignoredReturnPatterns = listOf(
-            "ignor", "unused", "discard", "return value", "not assigned", "not assigned back", "not used",
-            "isn't assigned", "ignored/not assigned", "not stored", "not captured", "thrown away", "result is lost",
-        )
-        val returnsNewListPatterns = listOf(
-            "new list", "returns new", "does not modify", "doesn't modify",
-            "not in place", "immutable", "original list", "original unsorted list",
-            "new sorted list", "sorted copy",
+        // Record a per-mode run summary so the dashboard pairs with-MCP vs without-MCP and shows
+        // helped/hurt/neutral. `agent_claimed_fix` carries the correctness verdict.
+        writeDebuggerRunSummary(
+            scenario = "debugger__sortedByDescending",
+            agentName = agentName.name,
+            modeLabel = modeLabel,
+            withMcp = withMcp,
+            exitCode = result.exitCode,
+            bugFound = score.bugFound,
+            summaryText = score.rootCause ?: score.reasons.joinToString("; "),
         )
 
-        val mentionsIgnoredReturn = ignoredReturnPatterns.any { pattern ->
-            rootCause.contains(pattern, ignoreCase = true)
+        if (withMcp) {
+            // With MCP we additionally require proof the IDE debugger was actually used — otherwise the
+            // "with mcp" run isn't exercising MCP. Correctness itself is a dashboard metric, NOT a hard
+            // gate, so a legitimate miss surfaces as a comparison result rather than a red build.
+            console.writeInfo("Checking: steroid_execute_code usage evidence")
+            assertUsedExecuteCodeEvidence(combined)
+            console.writeInfo("Checking: debugger evidence (suspension + evaluation)")
+            assertDebuggerEvidence(combined, console)
+            console.writeSuccess("MCP debugger evidence validated")
+        } else {
+            // Baseline: only require the agent actually ran to completion (exited cleanly or emitted its
+            // final markers). Whether it FOUND the bug is the comparison data point, not a pass gate.
+            val hasFinalMarkers = hasAnyMarkerLine(output, "BUG_FOUND", "Bug found") &&
+                    hasAnyMarkerLine(output, "ROOT_CAUSE", "Root cause")
+            check(result.exitCode == 0 || hasFinalMarkers) {
+                "Baseline agent neither exited cleanly nor produced final markers.\nOutput:\n$combined"
+            }
         }
-        val mentionsNewListBehavior = returnsNewListPatterns.any { pattern ->
-            rootCause.contains(pattern, ignoreCase = true)
-        }
-        check(mentionsIgnoredReturn && mentionsNewListBehavior) {
-            "ROOT_CAUSE must explain that sortedByDescending returns a new list and its return value is ignored.\n" +
-                    "Expected ignored patterns: $ignoredReturnPatterns\n" +
-                    "Expected new-list patterns: $returnsNewListPatterns\nOutput:\n$combined"
-        }
-        check(!rootCause.contains("it.first", ignoreCase = true)) {
-            "ROOT_CAUSE should not claim a selector bug (`it.first` vs `it.score`).\nOutput:\n$combined"
-        }
-        console.writeSuccess("ROOT_CAUSE quality validated")
 
-        // Validate debugger evidence: the agent must have actually used the debugger,
-        // not just read source code and guessed the answer.
-        console.writeInfo("Checking: debugger evidence (suspension + evaluation)")
-        assertDebuggerEvidence(combined, console)
-        console.writeSuccess("Debugger evidence validated")
+        console.writeHeader(if (score.bugFound) "BUG IDENTIFIED" else "BUG NOT IDENTIFIED")
+        println("[TEST] Debugger demo [$agentName+$modeLabel] bugFound=${score.bugFound}")
+    }
 
-        console.writeSuccess("Agent '$agentName' identified the sortedByDescending bug")
-        console.writeHeader("PASSED")
-
-        println("[TEST] Agent '$agentName' successfully identified the sortedByDescending bug")
+    /**
+     * Write a per-mode run summary (`dpaia-arena-run-<scenario>-<agent>-<mode>.json`) so the experiments
+     * dashboard pairs the with-MCP and without-MCP runs and computes helped/hurt/neutral. The verdict
+     * field is `agent_claimed_fix` = whether the agent correctly identified the bug.
+     */
+    private fun writeDebuggerRunSummary(
+        scenario: String,
+        agentName: String,
+        modeLabel: String,
+        withMcp: Boolean,
+        exitCode: Int?,
+        bugFound: Boolean,
+        summaryText: String,
+    ) {
+        val json = buildJsonObject {
+            put("instance_id", scenario)
+            put("agent", agentName)
+            put("mode", modeLabel)
+            put("exit_code", exitCode ?: -1)
+            put("agent_claimed_fix", bugFound)
+            put("used_mcp_steroid", withMcp)
+            put("agent_summary", summaryText)
+            put("timestamp", java.time.Instant.now().toString())
+        }
+        val out = IdeTestFolders.testOutputDir.resolve("dpaia-arena-run-$scenario-$agentName-$modeLabel.json")
+        out.parentFile.mkdirs()
+        out.writeText(json.toString())
+        println("[TEST] Run summary written: ${out.absolutePath}")
     }
 
     /**

--- a/test-integration/src/main/kotlin/com/jonnyzzz/mcpSteroid/integration/tests/DebuggerTestHelpers.kt
+++ b/test-integration/src/main/kotlin/com/jonnyzzz/mcpSteroid/integration/tests/DebuggerTestHelpers.kt
@@ -39,6 +39,57 @@ fun findMarkerValue(output: String, vararg markers: String): String? {
     }
 }
 
+/**
+ * Outcome of scoring an agent's answer for the `sortedByDescending` demo bug — the bug is that
+ * `players.sortedByDescending { it.score }` returns a NEW sorted list whose return value is ignored,
+ * so the original unsorted list is used. [bugFound] is true only when the agent both pinpointed the
+ * line AND explained the root cause correctly (ignored/unused return + non-mutating "new list"),
+ * without claiming the wrong selector (`it.first`).
+ */
+data class BugIdentificationScore(
+    val bugFound: Boolean,
+    val bugLine: String?,
+    val rootCause: String?,
+    val reasons: List<String>,
+)
+
+/**
+ * PURE correctness score for the `sortedByDescending` demo — the fair, mode-independent verdict for
+ * the debugger A/B (with-MCP vs without-MCP): did the agent *correctly identify the bug*, regardless of
+ * how (live debugger vs reading code)? No IDE/Docker/agent needed, so it is unit-tested directly.
+ */
+fun scoreSortedByDescendingBug(output: String): BugIdentificationScore {
+    val bugLine = findMarkerValue(output, "BUG_LINE", "Buggy line", "Bug line")
+    val rootCause = findMarkerValue(output, "ROOT_CAUSE", "Root cause")
+    val reasons = mutableListOf<String>()
+
+    val bugLineNamesCall = bugLine?.contains("sortedByDescending", ignoreCase = true) == true
+    if (!bugLineNamesCall) reasons += "BUG_LINE missing or does not name sortedByDescending"
+
+    val ignoredReturnPatterns = listOf(
+        "ignor", "unused", "discard", "return value", "not assigned", "not assigned back", "not used",
+        "isn't assigned", "ignored/not assigned", "not stored", "not captured", "thrown away", "result is lost",
+    )
+    val newListPatterns = listOf(
+        "new list", "returns new", "does not modify", "doesn't modify",
+        "not in place", "immutable", "original list", "original unsorted list",
+        "new sorted list", "sorted copy",
+    )
+    val rc = rootCause ?: ""
+    val mentionsIgnoredReturn = ignoredReturnPatterns.any { rc.contains(it, ignoreCase = true) }
+    val mentionsNewListBehavior = newListPatterns.any { rc.contains(it, ignoreCase = true) }
+    val notWrongSelector = !rc.contains("it.first", ignoreCase = true)
+
+    if (rootCause == null) reasons += "ROOT_CAUSE missing"
+    if (!mentionsIgnoredReturn) reasons += "ROOT_CAUSE does not explain the ignored/unused return value"
+    if (!mentionsNewListBehavior) reasons += "ROOT_CAUSE does not explain the new-list / non-mutating behavior"
+    if (!notWrongSelector) reasons += "ROOT_CAUSE wrongly claims a selector bug (it.first)"
+
+    val bugFound = bugLineNamesCall && rootCause != null &&
+        mentionsIgnoredReturn && mentionsNewListBehavior && notWrongSelector
+    return BugIdentificationScore(bugFound, bugLine, rootCause, reasons)
+}
+
 fun assertUsedExecuteCodeEvidence(combined: String) {
     val executionIdPattern = Regex("""\b(?:Execution ID|execution_id):\s*eid_[A-Za-z0-9_-]+""")
     val hasToolEvidence = executionIdPattern.containsMatchIn(combined)

--- a/test-integration/src/test/kotlin/com/jonnyzzz/mcpSteroid/integration/tests/DebuggerBugScoringTest.kt
+++ b/test-integration/src/test/kotlin/com/jonnyzzz/mcpSteroid/integration/tests/DebuggerBugScoringTest.kt
@@ -1,0 +1,69 @@
+/* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
+package com.jonnyzzz.mcpSteroid.integration.tests
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * Pure, local tests for [scoreSortedByDescendingBug] — the mode-independent correctness verdict used
+ * by the debugger A/B (with-MCP vs without-MCP). This is the "did the agent actually identify the bug"
+ * score that feeds the dashboard's `agent_claimed_fix`, scored identically for both modes so the
+ * comparison is fair. No IDE / Docker / agent key required.
+ */
+class DebuggerBugScoringTest {
+
+    @Test
+    fun `a correct answer scores bugFound = true`() {
+        val output = """
+            Some analysis...
+            BUG_FOUND: yes
+            BUG_LINE: val sorted = players.sortedByDescending { it.score }
+            ROOT_CAUSE: sortedByDescending returns a new sorted list but the return value is ignored,
+                        so the original unsorted list is used.
+        """.trimIndent()
+        val score = scoreSortedByDescendingBug(output)
+        assertTrue(score.bugFound, "expected bugFound; reasons=${score.reasons}")
+        assertEquals(emptyList<String>(), score.reasons)
+    }
+
+    @Test
+    fun `a without-MCP agent that reasons it out (no debugger) still scores when correct`() {
+        // The whole point of the baseline: a no-debugger agent can still be scored on correctness.
+        val output = """
+            I read the code and reasoned about it without running the debugger.
+            BUG_LINE: players.sortedByDescending { it.score }
+            ROOT_CAUSE: the call returns a new sorted copy and that result is not stored, so the
+                        list is never actually reordered (sortedByDescending does not modify in place).
+        """.trimIndent()
+        assertTrue(scoreSortedByDescendingBug(output).bugFound)
+    }
+
+    @Test
+    fun `an incomplete root cause does not score`() {
+        val output = """
+            BUG_LINE: players.sortedByDescending { it.score }
+            ROOT_CAUSE: the list is sorted in the wrong order.
+        """.trimIndent()
+        val score = scoreSortedByDescendingBug(output)
+        assertFalse(score.bugFound)
+        assertTrue(score.reasons.any { it.contains("ignored", ignoreCase = true) })
+    }
+
+    @Test
+    fun `the wrong-selector misdiagnosis does not score`() {
+        val output = """
+            BUG_LINE: players.sortedByDescending { it.score }
+            ROOT_CAUSE: it uses it.first instead of it.score, and the new list return value is ignored.
+        """.trimIndent()
+        val score = scoreSortedByDescendingBug(output)
+        assertFalse(score.bugFound, "wrong-selector claim must not pass")
+        assertTrue(score.reasons.any { it.contains("it.first") })
+    }
+
+    @Test
+    fun `missing markers do not score`() {
+        assertFalse(scoreSortedByDescendingBug("I could not find the bug.").bugFound)
+    }
+}


### PR DESCRIPTION
First of the "find more examples where MCP wins" experiments (#169 follow-up). Makes the **debugger demo** a scored **with/without-MCP A/B** instead of MCP-only, so it stops showing as "incomplete" and actually measures the live debugger's value.

## Why the debugger is a clean MCP-win case
Without MCP the agent has **no debugger at all** — it must find the bug by reading code and reasoning. With MCP it sets a breakpoint and reads runtime state. We score **only correctness** (did it identify the bug), identically for both modes, so the dashboard shows whether the debugger actually helps.

## What's here
- **`scoreSortedByDescendingBug(output)`** (pure, in `DebuggerTestHelpers`): the mode-independent correctness verdict — BUG_LINE names `sortedByDescending` **and** ROOT_CAUSE explains the ignored/unused return + non-mutating "new list", without the `it.first` misdiagnosis. Unit-tested directly in **`DebuggerBugScoringTest`** (5 cases) — no IDE/Docker/agent key needed (ran locally: 5/5 green).
- **`runDebuggerDemo(agent, withMcp)`**: toggles `aiMode`/`mcpConnectionMode`, branches the prompt (with-MCP uses the debugger; baseline is shell-only, no debugger), scores both modes, and writes a per-mode `dpaia-arena-run-debugger__sortedByDescending-<agent>-<mode>.json` (`agent_claimed_fix` = correctness) so the dashboard pairs them — same mechanism as the arena tests. The debugger/exec_code evidence checks are asserted **only** with MCP; correctness is a dashboard metric, not a hard gate, so a legitimate miss is a comparison result, not a red build.
- Paired `claude`/`codex … without mcp` methods (Claude + Codex, no Gemini).

## Scope notes
- **No new TC build configs needed** — the existing filter `*DebuggerDemoTest.claude*sortedByDescending*` already matches both the `via debugger` and `without mcp` methods, so one build runs the A/B. (A companion 1-line DSL bump in `mcp-steroid-teamcity` raises that build's timeout to 90 min for two back-to-back agent runs.)
- Only the `sortedByDescending` scenario gets a baseline in this PR (canonical demo); the other debugger scenarios can follow the same pattern once this validates on CI.

## Validation
Compiles (`:test-integration`, `:test-experiments`); the pure scorer is unit-tested locally. The live agent run + dashboard pairing are validated on CI (local can't run the agent — no API key), after promotion to `jb`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
