### PR TITLE
test(experiments): Keycloak transitive type-hierarchy A/B (PSI vs grep)

### DIFF
--- a/test-experiments/src/test/kotlin/com/jonnyzzz/mcpSteroid/integration/tests/KeycloakTypeHierarchyTest.kt
+++ b/test-experiments/src/test/kotlin/com/jonnyzzz/mcpSteroid/integration/tests/KeycloakTypeHierarchyTest.kt
@@ -1,0 +1,137 @@
+/* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
+package com.jonnyzzz.mcpSteroid.integration.tests
+
+import com.jonnyzzz.mcpSteroid.integration.infra.AiMode
+import com.jonnyzzz.mcpSteroid.integration.infra.BuildSystem
+import com.jonnyzzz.mcpSteroid.integration.infra.IntelliJContainer
+import com.jonnyzzz.mcpSteroid.integration.infra.IntelliJContainerOpts
+import com.jonnyzzz.mcpSteroid.integration.infra.IntelliJProject
+import com.jonnyzzz.mcpSteroid.integration.infra.McpConnectionMode
+import com.jonnyzzz.mcpSteroid.integration.infra.create
+import com.jonnyzzz.mcpSteroid.integration.infra.waitForProjectReady
+import com.jonnyzzz.mcpSteroid.testHelper.AiAgentSession
+import com.jonnyzzz.mcpSteroid.testHelper.CloseableStackHost
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Timeout
+import java.util.concurrent.TimeUnit
+
+/**
+ * MCP-win experiment: **transitive type hierarchy on a large codebase** (jonnyzzz/mcp-steroid#169).
+ *
+ * The agent must enumerate EVERY implementor of `org.keycloak.authentication.Authenticator`, including
+ * the **transitive** ones (classes that extend an abstract base which implements the interface). On
+ * Keycloak this is where the IDE wins: `ClassInheritorsSearch(..., checkDeep=true)` returns the full
+ * set, whereas `grep "implements Authenticator"` finds only the ~direct implementors and MISSES the
+ * indirect leaves (e.g. `UsernamePasswordForm extends AbstractUsernameFormAuthenticator extends
+ * AbstractFormAuthenticator implements Authenticator`).
+ *
+ * A/B: each agent runs WITH and WITHOUT MCP. Scored purely on completeness ([scoreTypeHierarchy]) — did
+ * the agent report the transitive implementors (and enough total) — identically for both modes, so the
+ * dashboard shows whether the IDE's exact hierarchy walk beats grep. The verdict is emitted as an
+ * `[ARENA]` block (read by the dashboard's ArenaLogParser); correctness is a dashboard metric, not a
+ * hard pass gate, so a legitimate grep miss is a comparison result, not a red build.
+ */
+class KeycloakTypeHierarchyTest {
+
+    @Test @Timeout(value = 40, unit = TimeUnit.MINUTES)
+    fun `claude with mcp`() = run("claude", withMcp = true)
+
+    @Test @Timeout(value = 40, unit = TimeUnit.MINUTES)
+    fun `claude without mcp`() = run("claude", withMcp = false)
+
+    @Test @Timeout(value = 40, unit = TimeUnit.MINUTES)
+    fun `codex with mcp`() = run("codex", withMcp = true)
+
+    @Test @Timeout(value = 40, unit = TimeUnit.MINUTES)
+    fun `codex without mcp`() = run("codex", withMcp = false)
+
+    private fun run(agentName: String, withMcp: Boolean) {
+        val modeLabel = if (withMcp) "mcp" else "none"
+        val lifetime = CloseableStackHost()
+        try {
+            val session = IntelliJContainer.create(lifetime, IntelliJContainerOpts(
+                // mode last in the title so the run-dir zip is mode-tagged (*-mcp / *-none) for the dashboard.
+                consoleTitle = "keycloak-typehierarchy-$agentName-$modeLabel",
+                project = IntelliJProject.KeycloakProject,
+                aiMode = if (withMcp) AiMode.AI_MCP else AiMode.NONE,
+                mcpConnectionMode = if (withMcp) null else McpConnectionMode.None,
+            )).waitForProjectReady(buildSystem = BuildSystem.MAVEN)
+
+            val agent: AiAgentSession = when (agentName) {
+                "claude" -> session.aiAgents.claude
+                "codex" -> session.aiAgents.codex
+                else -> error("Unknown agent: $agentName")
+            }
+
+            val result = agent.runPrompt(if (withMcp) withMcpPrompt() else baselinePrompt(), timeoutSeconds = 1500)
+                .awaitForProcessFinish()
+            val combined = result.stdout + "\n" + result.stderr
+
+            val score = scoreTypeHierarchy(combined, REQUIRED_TRANSITIVE, MIN_TOTAL)
+            println("[TEST] keycloak type-hierarchy [$agentName+$modeLabel] complete=${score.complete} " +
+                    "reported=${score.reportedCount} missing=${score.missingRequired}")
+
+            // [ARENA] block — the dashboard reads the per-mode verdict from here (ArenaLogParser).
+            println("[ARENA] $agentName+$modeLabel — $SCENARIO")
+            println("[ARENA]   Claimed fix:    ${score.complete}")
+            println("[ARENA]   Used MCP:       $withMcp")
+            println("[ARENA]   Exit code:      ${result.exitCode ?: -1}")
+            println("[ARENA]   Summary:        found ${score.reportedCount} subtypes; missing required ${score.missingRequired}")
+
+            if (withMcp) {
+                // Prove MCP was actually exercised; completeness itself is the comparison metric, not a gate.
+                assertUsedExecuteCodeEvidence(combined)
+            }
+        } finally {
+            lifetime.closeAllStacks()
+        }
+    }
+
+    private fun withMcpPrompt(): String = buildString {
+        appendLine("The Keycloak project is open in IntelliJ IDEA — a large multi-module Java project.")
+        appendLine()
+        appendLine("Task: list EVERY class that implements the interface `$INTERFACE_FQN`,")
+        appendLine("INCLUDING transitive/indirect implementors (a class that extends an abstract base which")
+        appendLine("implements the interface still counts). Be exhaustive.")
+        appendLine()
+        appendLine("Use IntelliJ's PSI inheritance search via `steroid_execute_code`. BEFORE your first attempt,")
+        appendLine("fetch `mcp-steroid://lsp/find-references` / the type-hierarchy recipe, then use")
+        appendLine("`ClassInheritorsSearch.search(psiClass, GlobalSearchScope.allScope(project), /*checkDeep=*/ true)`")
+        appendLine("to walk the FULL transitive hierarchy. Do not rely on text search.")
+        appendLine()
+        appendLine("Output (markers on their own lines):")
+        appendLine("SUBTYPES_FOUND: <total count>")
+        appendLine("SUBTYPE: <fully.qualified.ClassName>   ← one line per implementor, including transitive ones")
+        appendLine("TOOL_EVIDENCE: <copy the line starting with execution_id: ...>")
+    }
+
+    private fun baselinePrompt(): String = buildString {
+        appendLine("The Keycloak project is checked out (a large multi-module Java project).")
+        appendLine("IntelliJ MCP tools are unavailable in this run — use shell commands only (grep/rg/find).")
+        appendLine()
+        appendLine("Task: list EVERY class that implements the interface `$INTERFACE_FQN`,")
+        appendLine("INCLUDING transitive/indirect implementors (a class that extends an abstract base which")
+        appendLine("implements the interface still counts). Be exhaustive.")
+        appendLine()
+        appendLine("Output (markers on their own lines):")
+        appendLine("SUBTYPES_FOUND: <total count>")
+        appendLine("SUBTYPE: <fully.qualified.ClassName>   ← one line per implementor, including transitive ones")
+    }
+
+    companion object {
+        private const val SCENARIO = "keycloak__type_hierarchy"
+        private const val INTERFACE_FQN = "org.keycloak.authentication.Authenticator"
+
+        // Transitive (indirect) implementors a naive `grep "implements Authenticator"` MISSES — they
+        // extend an abstract base that implements the interface. Verified against the Keycloak source.
+        private val REQUIRED_TRANSITIVE = setOf(
+            "org.keycloak.authentication.authenticators.browser.UsernamePasswordForm",
+            "org.keycloak.authentication.authenticators.browser.OTPFormAuthenticator",
+            "org.keycloak.authentication.authenticators.broker.IdpConfirmLinkAuthenticator",
+        )
+
+        // Keycloak has ~60 Authenticator implementors; require a healthy fraction so a near-empty
+        // (or only-direct) answer scores incomplete.
+        private const val MIN_TOTAL = 40
+    }
+}

--- a/test-experiments/src/test/kotlin/com/jonnyzzz/mcpSteroid/integration/tests/KeycloakTypeHierarchyTest.kt
+++ b/test-experiments/src/test/kotlin/com/jonnyzzz/mcpSteroid/integration/tests/KeycloakTypeHierarchyTest.kt
@@ -63,20 +63,28 @@ class KeycloakTypeHierarchyTest {
                 else -> error("Unknown agent: $agentName")
             }
 
+            val startedAt = System.currentTimeMillis()
             val result = agent.runPrompt(if (withMcp) withMcpPrompt() else baselinePrompt(), timeoutSeconds = 1500)
                 .awaitForProcessFinish()
+            val agentDurationMs = System.currentTimeMillis() - startedAt
             val combined = result.stdout + "\n" + result.stderr
 
             val score = scoreTypeHierarchy(combined, REQUIRED_TRANSITIVE, MIN_TOTAL)
             println("[TEST] keycloak type-hierarchy [$agentName+$modeLabel] complete=${score.complete} " +
                     "reported=${score.reportedCount} missing=${score.missingRequired}")
 
-            // [ARENA] block — the dashboard reads the per-mode verdict from here (ArenaLogParser).
-            println("[ARENA] $agentName+$modeLabel — $SCENARIO")
-            println("[ARENA]   Claimed fix:    ${score.complete}")
-            println("[ARENA]   Used MCP:       $withMcp")
-            println("[ARENA]   Exit code:      ${result.exitCode ?: -1}")
-            println("[ARENA]   Summary:        found ${score.reportedCount} subtypes; missing required ${score.missingRequired}")
+            // Emit the full [ARENA] block (verdict + duration + tokens + tool-call counters) for the dashboard.
+            recordSemanticRun(
+                scenario = SCENARIO,
+                agentName = agentName,
+                withMcp = withMcp,
+                claimedFix = score.complete,
+                rawOutput = result.rawStdout,
+                exitCode = result.exitCode,
+                agentDurationMs = agentDurationMs,
+                runDir = session.runDirInContainer,
+                summary = "found ${score.reportedCount} subtypes; missing required ${score.missingRequired}",
+            )
 
             if (withMcp) {
                 // Prove MCP was actually exercised; completeness itself is the comparison metric, not a gate.

--- a/test-experiments/src/test/kotlin/com/jonnyzzz/mcpSteroid/integration/tests/SemanticRunRecorder.kt
+++ b/test-experiments/src/test/kotlin/com/jonnyzzz/mcpSteroid/integration/tests/SemanticRunRecorder.kt
@@ -1,0 +1,59 @@
+/* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
+package com.jonnyzzz.mcpSteroid.integration.tests
+
+import com.jonnyzzz.mcpSteroid.integration.arena.extractDecodedLogMetrics
+import com.jonnyzzz.mcpSteroid.integration.arena.extractTokenUsage
+import com.jonnyzzz.mcpSteroid.integration.arena.findDecodedLogFile
+import java.io.File
+
+/**
+ * Emit a full `[ARENA]` block for one agent run of a semantic A/B experiment (type-hierarchy,
+ * find-usages, rename, inspections, debugger). The dashboard's ArenaLogParser reads these lines, so the
+ * with/without-MCP comparison shows not just the correctness verdict but the **efficiency** signals —
+ * agent duration, tokens/cost, and the **tool-call counters** (which tools each mode used:
+ * steroid_execute_code vs Read/Edit/Write/Bash/Glob/Grep). This is what surfaces the MCP win when both
+ * modes are equally *correct* but differ in effort. Format mirrors DpaiaScenarioBaseTest exactly.
+ *
+ * @param claimedFix the experiment's correctness verdict for this run.
+ * @param rawOutput  the agent's raw stdout (NDJSON) — token/cost/turns are parsed from it.
+ * @param runDir     the run dir holding the decoded agent log — tool-call counts are parsed from it.
+ */
+fun recordSemanticRun(
+    scenario: String,
+    agentName: String,
+    withMcp: Boolean,
+    claimedFix: Boolean,
+    rawOutput: String,
+    exitCode: Int?,
+    agentDurationMs: Long,
+    runDir: File?,
+    summary: String,
+) {
+    val mode = if (withMcp) "mcp" else "none"
+    val tokens = extractTokenUsage(rawOutput)
+    val decodedLogName = when (agentName) {
+        "claude" -> "claude-code"
+        else -> agentName
+    }
+    val decoded = runDir
+        ?.let { findDecodedLogFile(it, agentName = decodedLogName) }
+        ?.let { runCatching { extractDecodedLogMetrics(it.readText()) }.getOrNull() }
+
+    println("[ARENA] $agentName+$mode — $scenario")
+    println("[ARENA]   Claimed fix:    $claimedFix")
+    println("[ARENA]   Used MCP:       $withMcp")
+    println("[ARENA]   Exit code:      ${exitCode ?: -1}")
+    println("[ARENA]   Agent time:     ${agentDurationMs / 1000}s")
+    if (tokens != null) {
+        println("[ARENA]   Tokens in/out:  ${tokens.inputTokens}/${tokens.outputTokens}")
+        tokens.costUsd?.let { println("[ARENA]   Cost:           $$it") }
+        tokens.numTurns?.let { println("[ARENA]   Turns:          $it") }
+    }
+    if (decoded != null) {
+        // Tool-call counters — "which tools were executed" in each mode.
+        println("[ARENA]   exec_code:      ${decoded.execCodeCalls}")
+        println("[ARENA]   Read/Edit/Write: ${decoded.readCalls}/${decoded.editCalls}/${decoded.writeCalls}")
+        println("[ARENA]   Glob/Grep/Bash: ${decoded.globCalls}/${decoded.grepCalls}/${decoded.bashCalls}")
+    }
+    println("[ARENA]   Summary:        ${summary.replace('\n', ' ').take(120)}")
+}

--- a/test-integration/src/main/kotlin/com/jonnyzzz/mcpSteroid/integration/tests/SemanticTaskScoring.kt
+++ b/test-integration/src/main/kotlin/com/jonnyzzz/mcpSteroid/integration/tests/SemanticTaskScoring.kt
@@ -1,0 +1,51 @@
+/* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
+package com.jonnyzzz.mcpSteroid.integration.tests
+
+/**
+ * Pure scorers for the "MCP wins on whole-project semantic queries" experiments (jonnyzzz/mcp-steroid#169
+ * follow-up). Each takes the agent's textual answer and a known ground truth and returns a structured,
+ * mode-independent verdict — so a with-MCP run and a without-MCP (grep/shell) run are scored identically
+ * and the dashboard can show whether MCP's exact PSI answer beats grep's incomplete one. No IDE / Docker /
+ * agent needed → unit-tested directly.
+ */
+
+/** A fully-qualified type name extractor: matches `com.foo.Bar`, nested `com.foo.Bar.Baz`, `Outer$Inner`. */
+private val FQN = Regex("""\b([a-z][\w]*(?:\.[a-z][\w]*)*\.[A-Z][\w$]*)\b""")
+
+data class TypeHierarchyScore(
+    /** FQNs the agent reported as subtypes (from `SUBTYPE:` markers, else any FQN in the answer). */
+    val reported: Set<String>,
+    /** Required subtypes the agent FAILED to report — the transitive / cross-module ones grep misses. */
+    val missingRequired: Set<String>,
+    val reportedCount: Int,
+    /** True when every required subtype was reported AND at least [minTotal] subtypes were listed. */
+    val complete: Boolean,
+)
+
+/**
+ * Score a transitive type-hierarchy answer for completeness.
+ *
+ * @param output       the agent's answer text
+ * @param required     FQNs that MUST appear — pick the transitive (indirect) / cross-module implementors
+ *                     a naive `grep "implements X"` would miss; finding them proves a real hierarchy walk.
+ * @param minTotal     minimum number of distinct subtypes expected (guards against a near-empty answer).
+ */
+fun scoreTypeHierarchy(output: String, required: Set<String>, minTotal: Int): TypeHierarchyScore {
+    // Prefer explicit `SUBTYPE: <fqn>` markers; if the agent used a different layout, fall back to every
+    // FQN that appears in the answer body.
+    val marked = Regex("""(?im)^\s*[*_`>#-]*\s*SUBTYPE\s*[*_`>#-]*\s*:\s*([\w.$]+)""")
+        .findAll(output).map { it.groupValues[1].trim().trim('.') }.toSet()
+    val reported = marked.ifEmpty { FQN.findAll(output).map { it.groupValues[1] }.toSet() }
+
+    // A required subtype counts as found if it (or its simple name as a distinct token) was reported.
+    val missing = required.filterNot { req ->
+        req in reported || reported.any { it.endsWith(".${req.substringAfterLast('.')}") }
+    }.toSet()
+
+    return TypeHierarchyScore(
+        reported = reported,
+        missingRequired = missing,
+        reportedCount = reported.size,
+        complete = missing.isEmpty() && reported.size >= minTotal,
+    )
+}

--- a/test-integration/src/test/kotlin/com/jonnyzzz/mcpSteroid/integration/tests/TypeHierarchyScoringTest.kt
+++ b/test-integration/src/test/kotlin/com/jonnyzzz/mcpSteroid/integration/tests/TypeHierarchyScoringTest.kt
@@ -1,0 +1,59 @@
+/* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
+package com.jonnyzzz.mcpSteroid.integration.tests
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * Pure, local tests for [scoreTypeHierarchy] — the completeness verdict for the Keycloak type-hierarchy
+ * A/B. The whole point: a `grep "implements X"` answer misses the **transitive** subtype, so it scores
+ * incomplete, while the PSI (ClassInheritorsSearch) answer lists it and scores complete. No IDE/Docker.
+ */
+class TypeHierarchyScoringTest {
+
+    // A toy hierarchy that mirrors the Keycloak case: B implements X directly; C extends B (transitive).
+    private val required = setOf("org.kc.B", "org.kc.C")
+
+    @Test
+    fun `MCP-style complete answer (lists the transitive subtype) scores complete`() {
+        val mcp = """
+            I walked the hierarchy with ClassInheritorsSearch.
+            SUBTYPES_FOUND: 3
+            SUBTYPE: org.kc.A
+            SUBTYPE: org.kc.B
+            SUBTYPE: org.kc.C
+        """.trimIndent()
+        val s = scoreTypeHierarchy(mcp, required, minTotal = 3)
+        assertTrue(s.complete, "missing=${s.missingRequired} count=${s.reportedCount}")
+        assertEquals(emptySet<String>(), s.missingRequired)
+    }
+
+    @Test
+    fun `grep-style answer that misses the transitive subtype scores incomplete`() {
+        // `grep "implements X"` finds A and B (direct) but NOT C (C extends B) — the classic miss.
+        val grep = """
+            I grepped for 'implements X'.
+            SUBTYPE: org.kc.A
+            SUBTYPE: org.kc.B
+        """.trimIndent()
+        val s = scoreTypeHierarchy(grep, required, minTotal = 3)
+        assertFalse(s.complete)
+        assertTrue(s.missingRequired.contains("org.kc.C"), "should flag the missed transitive subtype")
+    }
+
+    @Test
+    fun `a reported FQN with the same simple name still counts (slightly different package)`() {
+        // Agents sometimes report a subtype under a marginally different package; credit by simple name.
+        val s = scoreTypeHierarchy("SUBTYPE: org.kc.B\nSUBTYPE: org.kc.impl.C", required, minTotal = 2)
+        assertEquals(emptySet<String>(), s.missingRequired)
+    }
+
+    @Test
+    fun `a too-short answer fails the minimum-count guard even if required are present`() {
+        val s = scoreTypeHierarchy("SUBTYPE: org.kc.B\nSUBTYPE: org.kc.C", required, minTotal = 5)
+        assertFalse(s.complete, "only 2 reported, minTotal=5")
+        assertEquals(emptySet<String>(), s.missingRequired)
+    }
+}


### PR DESCRIPTION
Experiment #2 of the MCP-win set (#169 follow-up). The clearest semantic win: on a large codebase, enumerate **every** implementor of `org.keycloak.authentication.Authenticator` *including transitive ones*.

- **With MCP**: `ClassInheritorsSearch(…, checkDeep=true)` → the full set (~60).
- **Without MCP**: `grep "implements Authenticator"` finds the ~direct implementors but **misses** the indirect leaves — e.g. `UsernamePasswordForm extends AbstractUsernameFormAuthenticator extends AbstractFormAuthenticator implements Authenticator`.

**Scoring** (`scoreTypeHierarchy`, pure + unit-tested 4/4 incl. the grep-miss case): completeness — credits a transitive subtype only when actually reported; requires the 3 known transitive leaves + ≥40 total. Scored identically for both modes; verdict emitted as an `[ARENA]` block the dashboard reads. Correctness is a dashboard metric, not a hard gate; with-MCP additionally asserts exec_code was used.

Ground truth (interface, transitive implementors, count) verified against the Keycloak source via a research pass. Compiles; scorer locally green. The live agent runs validate on CI after promotion to `jb` (Keycloak is huge — the `waitForSmartMode` poll fix from #169 is the prerequisite that makes setup survive indexing).

DSL build configs land separately in the teamcity repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)