### PR TITLE
test(experiments): Keycloak safe-rename A/B (PSI rename vs sed)

### DIFF
--- a/test-experiments/src/test/kotlin/com/jonnyzzz/mcpSteroid/integration/tests/KeycloakRenameTest.kt
+++ b/test-experiments/src/test/kotlin/com/jonnyzzz/mcpSteroid/integration/tests/KeycloakRenameTest.kt
@@ -58,19 +58,27 @@ class KeycloakRenameTest {
                 else -> error("Unknown agent: $agentName")
             }
 
+            val startedAt = System.currentTimeMillis()
             val result = agent.runPrompt(if (withMcp) withMcpPrompt() else baselinePrompt(), timeoutSeconds = 2400)
                 .awaitForProcessFinish()
+            val agentDurationMs = System.currentTimeMillis() - startedAt
             val combined = result.stdout + "\n" + result.stderr
 
             val score = scoreRenameSafety(combined)
             println("[TEST] keycloak rename [$agentName+$modeLabel] safe=${score.safe} " +
                     "renameDone=${score.renameDone} buildGreen=${score.buildGreen}")
 
-            println("[ARENA] $agentName+$modeLabel — $SCENARIO")
-            println("[ARENA]   Claimed fix:    ${score.safe}")
-            println("[ARENA]   Used MCP:       $withMcp")
-            println("[ARENA]   Exit code:      ${result.exitCode ?: -1}")
-            println("[ARENA]   Summary:        renameDone=${score.renameDone} buildGreen=${score.buildGreen}")
+            recordSemanticRun(
+                scenario = SCENARIO,
+                agentName = agentName,
+                withMcp = withMcp,
+                claimedFix = score.safe,
+                rawOutput = result.rawStdout,
+                exitCode = result.exitCode,
+                agentDurationMs = agentDurationMs,
+                runDir = session.runDirInContainer,
+                summary = "renameDone=${score.renameDone} buildGreen=${score.buildGreen}",
+            )
 
             if (withMcp) assertUsedExecuteCodeEvidence(combined)
         } finally {

--- a/test-experiments/src/test/kotlin/com/jonnyzzz/mcpSteroid/integration/tests/KeycloakRenameTest.kt
+++ b/test-experiments/src/test/kotlin/com/jonnyzzz/mcpSteroid/integration/tests/KeycloakRenameTest.kt
@@ -1,0 +1,115 @@
+/* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
+package com.jonnyzzz.mcpSteroid.integration.tests
+
+import com.jonnyzzz.mcpSteroid.integration.infra.AiMode
+import com.jonnyzzz.mcpSteroid.integration.infra.BuildSystem
+import com.jonnyzzz.mcpSteroid.integration.infra.IntelliJContainer
+import com.jonnyzzz.mcpSteroid.integration.infra.IntelliJContainerOpts
+import com.jonnyzzz.mcpSteroid.integration.infra.IntelliJProject
+import com.jonnyzzz.mcpSteroid.integration.infra.McpConnectionMode
+import com.jonnyzzz.mcpSteroid.integration.infra.create
+import com.jonnyzzz.mcpSteroid.integration.infra.waitForProjectReady
+import com.jonnyzzz.mcpSteroid.testHelper.AiAgentSession
+import com.jonnyzzz.mcpSteroid.testHelper.CloseableStackHost
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Timeout
+import java.util.concurrent.TimeUnit
+
+/**
+ * MCP-win experiment: **safe project-wide rename** (jonnyzzz/mcp-steroid#169). The agent renames the
+ * widely-used `org.keycloak.models.UserModel.getEmail()` accessor (referenced across hundreds of files)
+ * to `getEmailAddress()`, then verifies the project still compiles.
+ *
+ * With MCP the agent uses IntelliJ's rename refactoring (`RenameProcessor`) — every reference is updated
+ * by PSI and the build stays green. Without MCP, a sed/text rename over-matches (`EmailValidator`,
+ * `isEmailVerified`, `updateEmail`, …) and/or misses qualified references, breaking compilation.
+ *
+ * Verdict ([scoreRenameSafety]): rename performed AND post-rename build SUCCESS — emitted as an `[ARENA]`
+ * block. A/B per agent; with-MCP asserts exec_code; correctness is a dashboard metric, not a hard gate.
+ */
+class KeycloakRenameTest {
+
+    @Test @Timeout(value = 50, unit = TimeUnit.MINUTES)
+    fun `claude with mcp`() = run("claude", withMcp = true)
+
+    @Test @Timeout(value = 50, unit = TimeUnit.MINUTES)
+    fun `claude without mcp`() = run("claude", withMcp = false)
+
+    @Test @Timeout(value = 50, unit = TimeUnit.MINUTES)
+    fun `codex with mcp`() = run("codex", withMcp = true)
+
+    @Test @Timeout(value = 50, unit = TimeUnit.MINUTES)
+    fun `codex without mcp`() = run("codex", withMcp = false)
+
+    private fun run(agentName: String, withMcp: Boolean) {
+        val modeLabel = if (withMcp) "mcp" else "none"
+        val lifetime = CloseableStackHost()
+        try {
+            val session = IntelliJContainer.create(lifetime, IntelliJContainerOpts(
+                consoleTitle = "keycloak-rename-$agentName-$modeLabel",
+                project = IntelliJProject.KeycloakProject,
+                aiMode = if (withMcp) AiMode.AI_MCP else AiMode.NONE,
+                mcpConnectionMode = if (withMcp) null else McpConnectionMode.None,
+            )).waitForProjectReady(buildSystem = BuildSystem.MAVEN)
+
+            val agent: AiAgentSession = when (agentName) {
+                "claude" -> session.aiAgents.claude
+                "codex" -> session.aiAgents.codex
+                else -> error("Unknown agent: $agentName")
+            }
+
+            val result = agent.runPrompt(if (withMcp) withMcpPrompt() else baselinePrompt(), timeoutSeconds = 2400)
+                .awaitForProcessFinish()
+            val combined = result.stdout + "\n" + result.stderr
+
+            val score = scoreRenameSafety(combined)
+            println("[TEST] keycloak rename [$agentName+$modeLabel] safe=${score.safe} " +
+                    "renameDone=${score.renameDone} buildGreen=${score.buildGreen}")
+
+            println("[ARENA] $agentName+$modeLabel — $SCENARIO")
+            println("[ARENA]   Claimed fix:    ${score.safe}")
+            println("[ARENA]   Used MCP:       $withMcp")
+            println("[ARENA]   Exit code:      ${result.exitCode ?: -1}")
+            println("[ARENA]   Summary:        renameDone=${score.renameDone} buildGreen=${score.buildGreen}")
+
+            if (withMcp) assertUsedExecuteCodeEvidence(combined)
+        } finally {
+            lifetime.closeAllStacks()
+        }
+    }
+
+    private fun withMcpPrompt(): String = buildString {
+        appendLine("The Keycloak project is open in IntelliJ IDEA — a large multi-module Java project.")
+        appendLine()
+        appendLine("Task: rename the method `$SYMBOL` to `getEmailAddress()` PROJECT-WIDE — every reference")
+        appendLine("(callers, overrides, the declaration) must be updated so the project still compiles.")
+        appendLine()
+        appendLine("Use IntelliJ's rename refactoring via `steroid_execute_code` (`com.intellij.refactoring`")
+        appendLine("RenameProcessor / RefactoringFactory) — it updates all references by PSI. Do NOT sed.")
+        appendLine("After renaming, build the affected modules (e.g. server-spi + services) to verify.")
+        appendLine()
+        appendLine("Output (markers on their own lines):")
+        appendLine("RENAME_DONE: yes")
+        appendLine("BUILD_AFTER_RENAME: <SUCCESS or FAILURE>")
+        appendLine("TOOL_EVIDENCE: <copy the line starting with execution_id: ...>")
+    }
+
+    private fun baselinePrompt(): String = buildString {
+        appendLine("The Keycloak project is checked out (a large multi-module Java project).")
+        appendLine("IntelliJ MCP tools are unavailable in this run — use shell commands only.")
+        appendLine()
+        appendLine("Task: rename the method `$SYMBOL` to `getEmailAddress()` PROJECT-WIDE — every reference")
+        appendLine("(callers, overrides, the declaration) must be updated so the project still compiles.")
+        appendLine("Beware: a naive text replace will over-match unrelated identifiers and break the build.")
+        appendLine("After renaming, build the affected modules (e.g. server-spi + services) to verify.")
+        appendLine()
+        appendLine("Output (markers on their own lines):")
+        appendLine("RENAME_DONE: yes")
+        appendLine("BUILD_AFTER_RENAME: <SUCCESS or FAILURE>")
+    }
+
+    companion object {
+        private const val SCENARIO = "keycloak__rename_safety"
+        private const val SYMBOL = "org.keycloak.models.UserModel#getEmail()"
+    }
+}

--- a/test-integration/src/main/kotlin/com/jonnyzzz/mcpSteroid/integration/tests/SemanticTaskScoring.kt
+++ b/test-integration/src/main/kotlin/com/jonnyzzz/mcpSteroid/integration/tests/SemanticTaskScoring.kt
@@ -49,3 +49,33 @@ fun scoreTypeHierarchy(output: String, required: Set<String>, minTotal: Int): Ty
         complete = missing.isEmpty() && reported.size >= minTotal,
     )
 }
+
+data class RenameSafetyScore(
+    val renameDone: Boolean,
+    /** The post-rename build/compile result the agent reported (null if it never reported one). */
+    val buildGreen: Boolean?,
+    /** A safe rename = it was performed AND the project still compiles afterwards. */
+    val safe: Boolean,
+)
+
+/**
+ * Score a project-wide rename for SAFETY. With MCP the agent uses the IDE's rename refactoring (updates
+ * every reference, build stays green); without MCP a sed/text rename over- or under-matches and breaks
+ * compilation. The verdict is whether the rename was performed AND the project still builds.
+ *
+ * Expected markers (the prompt asks the agent to compile after renaming and report):
+ *   RENAME_DONE: yes
+ *   BUILD_AFTER_RENAME: SUCCESS | FAILURE
+ */
+fun scoreRenameSafety(output: String): RenameSafetyScore {
+    val renameDone = findMarkerValue(output, "RENAME_DONE", "Rename done")?.equals("yes", ignoreCase = true) == true
+    val build = findMarkerValue(output, "BUILD_AFTER_RENAME", "Build after rename")
+    val buildGreen = build?.let {
+        when {
+            it.contains("SUCCESS", ignoreCase = true) || it.equals("pass", ignoreCase = true) || it.equals("green", ignoreCase = true) -> true
+            it.contains("FAIL", ignoreCase = true) || it.contains("error", ignoreCase = true) || it.contains("broke", ignoreCase = true) -> false
+            else -> null
+        }
+    }
+    return RenameSafetyScore(renameDone = renameDone, buildGreen = buildGreen, safe = renameDone && buildGreen == true)
+}

--- a/test-integration/src/test/kotlin/com/jonnyzzz/mcpSteroid/integration/tests/RenameSafetyScoringTest.kt
+++ b/test-integration/src/test/kotlin/com/jonnyzzz/mcpSteroid/integration/tests/RenameSafetyScoringTest.kt
@@ -1,0 +1,43 @@
+/* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
+package com.jonnyzzz.mcpSteroid.integration.tests
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * Pure, local tests for [scoreRenameSafety] — the verdict for the Keycloak rename A/B: a rename is "safe"
+ * only if it was performed AND the project still compiles. The win shape: MCP (PSI rename) keeps the
+ * build green; a sed rename breaks it. No IDE/Docker/agent needed.
+ */
+class RenameSafetyScoringTest {
+
+    @Test
+    fun `rename done and build green is safe (MCP-style)`() {
+        val s = scoreRenameSafety("RENAME_DONE: yes\nBUILD_AFTER_RENAME: SUCCESS")
+        assertTrue(s.safe)
+        assertEquals(true, s.buildGreen)
+    }
+
+    @Test
+    fun `rename done but build broken is unsafe (sed-style over-match)`() {
+        val s = scoreRenameSafety("RENAME_DONE: yes\nBUILD_AFTER_RENAME: FAILURE — cannot find symbol getEmail")
+        assertFalse(s.safe)
+        assertEquals(false, s.buildGreen)
+    }
+
+    @Test
+    fun `no rename performed is unsafe`() {
+        val s = scoreRenameSafety("I could not complete the rename.\nBUILD_AFTER_RENAME: SUCCESS")
+        assertFalse(s.safe)
+        assertFalse(s.renameDone)
+    }
+
+    @Test
+    fun `missing build report leaves build unknown and unsafe`() {
+        val s = scoreRenameSafety("RENAME_DONE: yes")
+        assertEquals(null, s.buildGreen)
+        assertFalse(s.safe)
+    }
+}


### PR DESCRIPTION
Experiment #4 (#169). **Stacked on #174.** The agent renames `UserModel.getEmail()` (used across hundreds of files) project-wide, then compiles. **With MCP**: `RenameProcessor` updates every reference → build green. **Without MCP**: sed over-matches (`EmailValidator`/`isEmailVerified`) or misses qualified refs → broken build. Verdict (`scoreRenameSafety`, pure + unit-tested 4/4): rename performed AND post-rename build SUCCESS. `[ARENA]` block; with-MCP asserts exec_code. Compiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)