### PR TITLE
test(experiments): Keycloak inspections A/B (IDE inspection vs grep)

### DIFF
--- a/test-experiments/src/test/kotlin/com/jonnyzzz/mcpSteroid/integration/tests/KeycloakInspectionsTest.kt
+++ b/test-experiments/src/test/kotlin/com/jonnyzzz/mcpSteroid/integration/tests/KeycloakInspectionsTest.kt
@@ -58,19 +58,27 @@ class KeycloakInspectionsTest {
                 else -> error("Unknown agent: $agentName")
             }
 
+            val startedAt = System.currentTimeMillis()
             val result = agent.runPrompt(if (withMcp) withMcpPrompt() else baselinePrompt(), timeoutSeconds = 1500)
                 .awaitForProcessFinish()
+            val agentDurationMs = System.currentTimeMillis() - startedAt
             val combined = result.stdout + "\n" + result.stderr
 
             val score = scoreInspections(combined, MIN_ISSUES, TARGET_FILE)
             println("[TEST] keycloak inspections [$agentName+$modeLabel] detected=${score.detected} " +
                     "issuesFound=${score.issuesFound} cast=${score.mentionsRedundantCast} file=${score.mentionsTargetFile}")
 
-            println("[ARENA] $agentName+$modeLabel — $SCENARIO")
-            println("[ARENA]   Claimed fix:    ${score.detected}")
-            println("[ARENA]   Used MCP:       $withMcp")
-            println("[ARENA]   Exit code:      ${result.exitCode ?: -1}")
-            println("[ARENA]   Summary:        issuesFound=${score.issuesFound} redundantCast=${score.mentionsRedundantCast}")
+            recordSemanticRun(
+                scenario = SCENARIO,
+                agentName = agentName,
+                withMcp = withMcp,
+                claimedFix = score.detected,
+                rawOutput = result.rawStdout,
+                exitCode = result.exitCode,
+                agentDurationMs = agentDurationMs,
+                runDir = session.runDirInContainer,
+                summary = "issuesFound=${score.issuesFound} redundantCast=${score.mentionsRedundantCast}",
+            )
 
             if (withMcp) assertUsedExecuteCodeEvidence(combined)
         } finally {

--- a/test-experiments/src/test/kotlin/com/jonnyzzz/mcpSteroid/integration/tests/KeycloakInspectionsTest.kt
+++ b/test-experiments/src/test/kotlin/com/jonnyzzz/mcpSteroid/integration/tests/KeycloakInspectionsTest.kt
@@ -1,0 +1,116 @@
+/* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
+package com.jonnyzzz.mcpSteroid.integration.tests
+
+import com.jonnyzzz.mcpSteroid.integration.infra.AiMode
+import com.jonnyzzz.mcpSteroid.integration.infra.BuildSystem
+import com.jonnyzzz.mcpSteroid.integration.infra.IntelliJContainer
+import com.jonnyzzz.mcpSteroid.integration.infra.IntelliJContainerOpts
+import com.jonnyzzz.mcpSteroid.integration.infra.IntelliJProject
+import com.jonnyzzz.mcpSteroid.integration.infra.McpConnectionMode
+import com.jonnyzzz.mcpSteroid.integration.infra.create
+import com.jonnyzzz.mcpSteroid.integration.infra.waitForProjectReady
+import com.jonnyzzz.mcpSteroid.testHelper.AiAgentSession
+import com.jonnyzzz.mcpSteroid.testHelper.CloseableStackHost
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Timeout
+import java.util.concurrent.TimeUnit
+
+/**
+ * MCP-win experiment: **IDE inspections find what grep can't** (jonnyzzz/mcp-steroid#169). The agent must
+ * report the redundant type casts after `instanceof` in Keycloak's
+ * `server-spi/src/main/java/org/keycloak/validate/ValidatorConfig.java`.
+ *
+ * With MCP the agent runs IntelliJ's "Redundant type cast" inspection — semantic type-narrowing finds
+ * each cast that is unnecessary after an `instanceof`. Without MCP, grep sees the cast syntax but cannot
+ * determine whether a cast is redundant (that needs type inference), so it cannot reliably find them.
+ *
+ * Verdict ([scoreInspections]): the agent named the file and reported enough redundant casts — emitted
+ * as an `[ARENA]` block. A/B per agent; with-MCP asserts exec_code; correctness is a dashboard metric.
+ */
+class KeycloakInspectionsTest {
+
+    @Test @Timeout(value = 40, unit = TimeUnit.MINUTES)
+    fun `claude with mcp`() = run("claude", withMcp = true)
+
+    @Test @Timeout(value = 40, unit = TimeUnit.MINUTES)
+    fun `claude without mcp`() = run("claude", withMcp = false)
+
+    @Test @Timeout(value = 40, unit = TimeUnit.MINUTES)
+    fun `codex with mcp`() = run("codex", withMcp = true)
+
+    @Test @Timeout(value = 40, unit = TimeUnit.MINUTES)
+    fun `codex without mcp`() = run("codex", withMcp = false)
+
+    private fun run(agentName: String, withMcp: Boolean) {
+        val modeLabel = if (withMcp) "mcp" else "none"
+        val lifetime = CloseableStackHost()
+        try {
+            val session = IntelliJContainer.create(lifetime, IntelliJContainerOpts(
+                consoleTitle = "keycloak-inspections-$agentName-$modeLabel",
+                project = IntelliJProject.KeycloakProject,
+                aiMode = if (withMcp) AiMode.AI_MCP else AiMode.NONE,
+                mcpConnectionMode = if (withMcp) null else McpConnectionMode.None,
+            )).waitForProjectReady(buildSystem = BuildSystem.MAVEN)
+
+            val agent: AiAgentSession = when (agentName) {
+                "claude" -> session.aiAgents.claude
+                "codex" -> session.aiAgents.codex
+                else -> error("Unknown agent: $agentName")
+            }
+
+            val result = agent.runPrompt(if (withMcp) withMcpPrompt() else baselinePrompt(), timeoutSeconds = 1500)
+                .awaitForProcessFinish()
+            val combined = result.stdout + "\n" + result.stderr
+
+            val score = scoreInspections(combined, MIN_ISSUES, TARGET_FILE)
+            println("[TEST] keycloak inspections [$agentName+$modeLabel] detected=${score.detected} " +
+                    "issuesFound=${score.issuesFound} cast=${score.mentionsRedundantCast} file=${score.mentionsTargetFile}")
+
+            println("[ARENA] $agentName+$modeLabel — $SCENARIO")
+            println("[ARENA]   Claimed fix:    ${score.detected}")
+            println("[ARENA]   Used MCP:       $withMcp")
+            println("[ARENA]   Exit code:      ${result.exitCode ?: -1}")
+            println("[ARENA]   Summary:        issuesFound=${score.issuesFound} redundantCast=${score.mentionsRedundantCast}")
+
+            if (withMcp) assertUsedExecuteCodeEvidence(combined)
+        } finally {
+            lifetime.closeAllStacks()
+        }
+    }
+
+    private fun withMcpPrompt(): String = buildString {
+        appendLine("The Keycloak project is open in IntelliJ IDEA — a large multi-module Java project.")
+        appendLine()
+        appendLine("Task: find every REDUNDANT type cast in `$TARGET_PATH` — casts that are unnecessary")
+        appendLine("because the variable was already narrowed by a preceding `instanceof` check.")
+        appendLine()
+        appendLine("Use IntelliJ's inspections via `steroid_execute_code` — run the \"Redundant type cast\"")
+        appendLine("(RedundantCast) inspection on the file and read its results. Do NOT guess from grep.")
+        appendLine()
+        appendLine("Output (markers on their own lines):")
+        appendLine("ISSUES_FOUND: <count of redundant casts>")
+        appendLine("ISSUE: <file:line — short description>   ← one per redundant cast")
+        appendLine("TOOL_EVIDENCE: <copy the line starting with execution_id: ...>")
+    }
+
+    private fun baselinePrompt(): String = buildString {
+        appendLine("The Keycloak project is checked out (a large multi-module Java project).")
+        appendLine("IntelliJ MCP tools are unavailable in this run — use shell commands only (grep/rg/find).")
+        appendLine()
+        appendLine("Task: find every REDUNDANT type cast in `$TARGET_PATH` — casts that are unnecessary")
+        appendLine("because the variable was already narrowed by a preceding `instanceof` check.")
+        appendLine()
+        appendLine("Output (markers on their own lines):")
+        appendLine("ISSUES_FOUND: <count of redundant casts>")
+        appendLine("ISSUE: <file:line — short description>   ← one per redundant cast")
+    }
+
+    companion object {
+        private const val SCENARIO = "keycloak__inspections"
+        private const val TARGET_FILE = "ValidatorConfig.java"
+        private const val TARGET_PATH = "server-spi/src/main/java/org/keycloak/validate/ValidatorConfig.java"
+
+        // ValidatorConfig.java has ~13 redundant casts after instanceof; require a meaningful fraction.
+        private const val MIN_ISSUES = 5
+    }
+}

--- a/test-integration/src/main/kotlin/com/jonnyzzz/mcpSteroid/integration/tests/SemanticTaskScoring.kt
+++ b/test-integration/src/main/kotlin/com/jonnyzzz/mcpSteroid/integration/tests/SemanticTaskScoring.kt
@@ -79,3 +79,37 @@ fun scoreRenameSafety(output: String): RenameSafetyScore {
     }
     return RenameSafetyScore(renameDone = renameDone, buildGreen = buildGreen, safe = renameDone && buildGreen == true)
 }
+
+data class InspectionScore(
+    val issuesFound: Int?,
+    val mentionsRedundantCast: Boolean,
+    val mentionsTargetFile: Boolean,
+    /** True when the agent detected a meaningful number of the (semantic) redundant-cast issues. */
+    val detected: Boolean,
+)
+
+/**
+ * Score an "run IDE inspections + report issues" answer. The target is the redundant casts after
+ * `instanceof` in Keycloak's `ValidatorConfig.java`. With MCP the agent runs IntelliJ's inspection
+ * (semantic type-narrowing → finds them exactly); grep/shell cannot determine a cast is redundant.
+ *
+ * Expected markers:
+ *   ISSUES_FOUND: <count>
+ *   ISSUE: <description>            (the redundant-cast lines; ideally mentioning the file)
+ *
+ * @param minIssues the lower bound of redundant casts that must be reported to count as detected.
+ */
+fun scoreInspections(output: String, minIssues: Int, targetFile: String): InspectionScore {
+    val count = findMarkerValue(output, "ISSUES_FOUND", "Issues found")
+        ?.let { Regex("""\d+""").find(it)?.value?.toIntOrNull() }
+    val mentionsCast = output.contains("redundant cast", ignoreCase = true) ||
+        output.contains("redundant type cast", ignoreCase = true) ||
+        output.contains("unnecessary cast", ignoreCase = true)
+    val mentionsFile = output.contains(targetFile, ignoreCase = true)
+    return InspectionScore(
+        issuesFound = count,
+        mentionsRedundantCast = mentionsCast,
+        mentionsTargetFile = mentionsFile,
+        detected = mentionsCast && mentionsFile && (count ?: 0) >= minIssues,
+    )
+}

--- a/test-integration/src/test/kotlin/com/jonnyzzz/mcpSteroid/integration/tests/InspectionScoringTest.kt
+++ b/test-integration/src/test/kotlin/com/jonnyzzz/mcpSteroid/integration/tests/InspectionScoringTest.kt
@@ -1,0 +1,50 @@
+/* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
+package com.jonnyzzz.mcpSteroid.integration.tests
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * Pure, local tests for [scoreInspections] — the verdict for the Keycloak inspections A/B. The win
+ * shape: IntelliJ's semantic inspection finds the redundant casts after `instanceof` in
+ * ValidatorConfig.java; grep cannot. No IDE/Docker/agent needed.
+ */
+class InspectionScoringTest {
+
+    private val target = "ValidatorConfig.java"
+
+    @Test
+    fun `an MCP-style answer naming the file and enough redundant casts is detected`() {
+        val out = """
+            I ran the 'Redundant type cast' inspection on ValidatorConfig.java.
+            ISSUES_FOUND: 13
+            ISSUE: redundant cast to String at line 100
+        """.trimIndent()
+        assertTrue(scoreInspections(out, minIssues = 5, targetFile = target).detected)
+    }
+
+    @Test
+    fun `a grep-style answer that cannot tell casts are redundant is not detected`() {
+        val out = """
+            I grepped for '(String)' casts in ValidatorConfig.java but cannot tell which are redundant.
+            ISSUES_FOUND: 0
+        """.trimIndent()
+        assertFalse(scoreInspections(out, minIssues = 5, targetFile = target).detected)
+    }
+
+    @Test
+    fun `too few issues does not count even if redundant cast is mentioned`() {
+        val out = "ValidatorConfig.java\nredundant cast\nISSUES_FOUND: 2"
+        val s = scoreInspections(out, minIssues = 5, targetFile = target)
+        assertEquals(2, s.issuesFound)
+        assertFalse(s.detected)
+    }
+
+    @Test
+    fun `mentioning redundant casts in the wrong file does not count`() {
+        val out = "redundant cast\nISSUES_FOUND: 10\n(in SomeOtherFile.java)"
+        assertFalse(scoreInspections(out, minIssues = 5, targetFile = target).detected)
+    }
+}


### PR DESCRIPTION
Experiment #5 (#169), the last of the four. **Stacked on #175.** The agent reports the redundant casts after `instanceof` in `ValidatorConfig.java`. **With MCP**: IntelliJ's "Redundant type cast" inspection (semantic type-narrowing) finds them exactly. **Without MCP**: grep sees `(String)` but can't tell a cast is redundant. Verdict (`scoreInspections`, pure + unit-tested 4/4): named the file AND reported ≥5 redundant casts. `[ARENA]` block; with-MCP asserts exec_code. Compiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)