### PR TITLE
feat(test-helper): route containerized agents through a configurable LLM gateway

### DIFF
--- a/test-helper/src/main/kotlin/com/jonnyzzz/mcpSteroid/testHelper/AgentEndpoint.kt
+++ b/test-helper/src/main/kotlin/com/jonnyzzz/mcpSteroid/testHelper/AgentEndpoint.kt
@@ -1,0 +1,29 @@
+/* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
+package com.jonnyzzz.mcpSteroid.testHelper
+
+import com.jonnyzzz.mcpSteroid.testHelper.docker.DOCKER_HOST_ALIAS
+
+/**
+ * Optional per-vendor API base URL for the containerized agents.
+ *
+ * The agent CLIs (Claude Code, Codex, …) honor the standard `<VENDOR>_BASE_URL` environment variables to
+ * route their LLM traffic through an OpenAI/Anthropic-compatible endpoint instead of the public API. When
+ * the operator sets such a var (e.g. to a local gateway/proxy that holds the credentials), we forward it
+ * into the agent container — but rewrite a loopback host to `host.docker.internal`, because a gateway
+ * listening on `127.0.0.1`/`localhost`/`0.0.0.0` on the host is only reachable from inside the container
+ * through that alias (added via `--add-host=host.docker.internal:host-gateway` by the docker-start helper).
+ *
+ * When no such var is set this returns null and agents talk to the vendor API directly with their key,
+ * exactly as before (e.g. on CI).
+ */
+fun resolveContainerAgentBaseUrl(vararg envNames: String): String? {
+    val raw = envNames.firstNotNullOfOrNull { name -> System.getenv(name)?.takeIf { it.isNotBlank() } } ?: return null
+    return rewriteLoopbackToDockerHost(raw)
+}
+
+/** Replace a loopback host in [url] with the [DOCKER_HOST_ALIAS] (port and path preserved). Pure. */
+internal fun rewriteLoopbackToDockerHost(url: String): String =
+    url
+        .replace("://127.0.0.1", "://$DOCKER_HOST_ALIAS")
+        .replace("://localhost", "://$DOCKER_HOST_ALIAS")
+        .replace("://0.0.0.0", "://$DOCKER_HOST_ALIAS")

--- a/test-helper/src/main/kotlin/com/jonnyzzz/mcpSteroid/testHelper/DockerClaudeSession.kt
+++ b/test-helper/src/main/kotlin/com/jonnyzzz/mcpSteroid/testHelper/DockerClaudeSession.kt
@@ -83,6 +83,8 @@ class DockerClaudeSession(
         }
         val env = buildMap {
             put("ANTHROPIC_API_KEY", apiKey)
+            // Route through a host-side Anthropic-compatible gateway when one is configured (no-op on CI).
+            resolveContainerAgentBaseUrl("ANTHROPIC_BASE_URL")?.let { put("ANTHROPIC_BASE_URL", it) }
             if (debug) {
                 put("CLAUDE_CODE_DEBUG", "1")
                 put("DEBUG", "*")

--- a/test-helper/src/main/kotlin/com/jonnyzzz/mcpSteroid/testHelper/DockerCodexSession.kt
+++ b/test-helper/src/main/kotlin/com/jonnyzzz/mcpSteroid/testHelper/DockerCodexSession.kt
@@ -68,6 +68,11 @@ class DockerCodexSession(
         val extraEnvVars = buildMap {
             put("OPENAI_API_KEY", apiKey)
             put("CODEX_API_KEY", apiKey)
+            // Route through a host-side OpenAI-compatible gateway when one is configured (no-op on CI).
+            resolveContainerAgentBaseUrl("OPENAI_BASE_URL", "OPENAI_API_BASE")?.let {
+                put("OPENAI_BASE_URL", it)
+                put("OPENAI_API_BASE", it)
+            }
 
             if (debug) {
                 put("CODEX_DEBUG", "1")
@@ -106,6 +111,20 @@ class DockerCodexSession(
             add(model)
             add("--dangerously-bypass-approvals-and-sandbox")
             add("--skip-git-repo-check")
+            // Why this isn't just an env var (unlike Claude/Gemini, which honor their *_BASE_URL env
+            // directly): the Codex CLI has NO base-URL environment variable. It reaches the cloud model
+            // ONLY through a configured provider (`model_provider` + `[model_providers.*].base_url`), and
+            // ignores OPENAI_BASE_URL entirely — verified empirically: with only OPENAI_BASE_URL set,
+            // Codex still calls the public API (api.openai.com) and 401s with the gateway key. So when a
+            // gateway URL is configured we point Codex at it via its OWN `-c` config-override flags — no
+            // config file is written — deriving the URL from the same env var the other agents use.
+            // Auth continues to flow through OPENAI_API_KEY (env_key).
+            resolveContainerAgentBaseUrl("OPENAI_BASE_URL", "OPENAI_API_BASE")?.let { url ->
+                addAll(listOf("-c", "model_provider=gateway"))
+                addAll(listOf("-c", "model_providers.gateway.name=gateway"))
+                addAll(listOf("-c", "model_providers.gateway.base_url=$url"))
+                addAll(listOf("-c", "model_providers.gateway.env_key=OPENAI_API_KEY"))
+            }
             add("--json")
             add(prompt)
         }

--- a/test-helper/src/main/kotlin/com/jonnyzzz/mcpSteroid/testHelper/DockerGeminiSession.kt
+++ b/test-helper/src/main/kotlin/com/jonnyzzz/mcpSteroid/testHelper/DockerGeminiSession.kt
@@ -62,6 +62,10 @@ class DockerGeminiSession(
         }
         val env = buildMap {
             put("GEMINI_API_KEY", apiKey)
+            // Route through a host-side Gemini-compatible gateway when one is configured (no-op on CI).
+            resolveContainerAgentBaseUrl("GOOGLE_GEMINI_BASE_URL", "GEMINI_BASE_URL")?.let {
+                put("GOOGLE_GEMINI_BASE_URL", it)
+            }
             // Newer Gemini CLI builds (>= late 2026) demote `--approval-mode yolo`.
             // If the working directory is not trusted, they then refuse to run
             // with exit 55 and a "trusted directory" error.

--- a/test-helper/src/main/kotlin/com/jonnyzzz/mcpSteroid/testHelper/docker/docker-container-start.kt
+++ b/test-helper/src/main/kotlin/com/jonnyzzz/mcpSteroid/testHelper/docker/docker-container-start.kt
@@ -43,6 +43,13 @@ data class StartContainerRequest private constructor(
     fun quietly() = copy(quietly = true)
 }
 
+/**
+ * The hostname a container uses to reach a service on the Docker host. Added as a host alias to every
+ * container via `--add-host` below; reused wherever a host endpoint is rewritten for in-container use
+ * (e.g. the agent LLM-gateway base URL — see AgentEndpoint).
+ */
+const val DOCKER_HOST_ALIAS = "host.docker.internal"
+
 fun startDockerContainerAndForget(
     request: StartContainerRequest,
 ): ContainerDriver {
@@ -55,7 +62,7 @@ fun startDockerContainerAndForget(
         add("-d")
         if (request.autoRemove) add("--rm")
         if (request.init) add("--init")
-        add("--add-host=host.docker.internal:host-gateway")
+        add("--add-host=$DOCKER_HOST_ALIAS:host-gateway")
 
         // NOTE: we deliberately do NOT pass --user $(id -u):$(id -g). Tried
         // that as "standard docker-run hygiene" but the ide-agent image and

--- a/test-helper/src/test/kotlin/com/jonnyzzz/mcpSteroid/testHelper/AgentEndpointTest.kt
+++ b/test-helper/src/test/kotlin/com/jonnyzzz/mcpSteroid/testHelper/AgentEndpointTest.kt
@@ -1,0 +1,44 @@
+/* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
+package com.jonnyzzz.mcpSteroid.testHelper
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+
+/**
+ * Pure tests for the agent base-URL rewrite: a containerized agent reaches a host-side gateway via
+ * `host.docker.internal`, so a loopback base URL must be rewritten (port + path preserved). No real
+ * host or external endpoint is named.
+ */
+class AgentEndpointTest {
+
+    @Test
+    fun `rewrites loopback host to the docker host alias, preserving port and path`() {
+        assertEquals(
+            "http://host.docker.internal:8088/v1/messages",
+            rewriteLoopbackToDockerHost("http://127.0.0.1:8088/v1/messages"),
+        )
+        assertEquals(
+            "https://host.docker.internal:8080/v1",
+            rewriteLoopbackToDockerHost("https://localhost:8080/v1"),
+        )
+        assertEquals(
+            "http://host.docker.internal:9000",
+            rewriteLoopbackToDockerHost("http://0.0.0.0:9000"),
+        )
+    }
+
+    @Test
+    fun `leaves a non-loopback host untouched`() {
+        assertEquals("https://api.anthropic.com", rewriteLoopbackToDockerHost("https://api.anthropic.com"))
+        assertEquals(
+            "https://gw.internal.example:443/v1",
+            rewriteLoopbackToDockerHost("https://gw.internal.example:443/v1"),
+        )
+    }
+
+    @Test
+    fun `resolve returns null when none of the env vars is set`() {
+        assertNull(resolveContainerAgentBaseUrl("MCP_STEROID_DEFINITELY_UNSET_BASE_URL_XYZ"))
+    }
+}


### PR DESCRIPTION
Lets the test agents (Claude, Codex, Gemini) route their LLM traffic through a host-configured OpenAI/Anthropic-compatible **gateway** instead of the public vendor API. No-op on CI (nothing set → agents use their key against the vendor API, as today).

**How**
- When a per-vendor base URL is set on the host, forward it into the agent container, rewriting a loopback host (`127.0.0.1`/`localhost`/`0.0.0.0`) → `host.docker.internal` (the docker-start helper adds that alias). Single source of truth: the shared `DOCKER_HOST_ALIAS` constant.
- **Claude** (`ANTHROPIC_BASE_URL`) and **Gemini** (`GOOGLE_GEMINI_BASE_URL`) honor the env var directly.
- **Codex** ignores `OPENAI_BASE_URL` (verified — it connects to `api.openai.com` regardless), so it only routes via a *configured provider*. When a gateway URL is present we point Codex at it with **`-c model_provider=…` override flags derived from the same env var — no config file written**.

**Validated locally** through a host gateway: `AgentEndpointTest` (rewrite) green; **Claude + Codex both reach the gateway end-to-end** (no `api.openai.com`, no 401). Pure, vendor-neutral — no third-party CLI or proxy named anywhere (squashed to one clean commit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)