### PR TITLE
chore(test-helper): default agents to latest models (Opus 4.8, GPT 5.5)

### DIFF
--- a/test-helper/src/main/kotlin/com/jonnyzzz/mcpSteroid/testHelper/DockerClaudeSession.kt
+++ b/test-helper/src/main/kotlin/com/jonnyzzz/mcpSteroid/testHelper/DockerClaudeSession.kt
@@ -153,7 +153,7 @@ class DockerClaudeSession(
 
     companion object : AIAgentCompanion<DockerClaudeSession>("claude-cli") {
         /** Default Claude model for all test runs. Override via system property `claude.model`. */
-        const val DEFAULT_MODEL = "claude-opus-4-6"
+        const val DEFAULT_MODEL = "claude-opus-4-8"
 
         override val displayName = "Claude Code"
         override val outputFilter get() = ClaudeOutputFilter()

--- a/test-helper/src/main/kotlin/com/jonnyzzz/mcpSteroid/testHelper/DockerCodexSession.kt
+++ b/test-helper/src/main/kotlin/com/jonnyzzz/mcpSteroid/testHelper/DockerCodexSession.kt
@@ -118,7 +118,7 @@ class DockerCodexSession(
 
     companion object : AIAgentCompanion<DockerCodexSession>("codex-cli") {
         /** Default Codex model for all test runs. Override via system property `codex.model`. */
-        const val DEFAULT_MODEL = "gpt-5.4"
+        const val DEFAULT_MODEL = "gpt-5.5"
 
         override val displayName = "Codex"
         override val outputFilter get() = CodexOutputFilter()


### PR DESCRIPTION
Bumps the default test-agent models: Claude `claude-opus-4-6`→`claude-opus-4-8`, Codex `gpt-5.4`→`gpt-5.5`. Still overridable via `-Dclaude.model`/`-Dcodex.model`. Validated locally — a Keycloak run reported `model=claude-opus-4-8`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)