### PR TITLE
test(build): add class-file version guard for ij-plugin + npx-kt

### DIFF
--- a/buildSrc/src/main/kotlin/com/jonnyzzz/mcpSteroid/gradle/ClassFileVersionScanner.kt
+++ b/buildSrc/src/main/kotlin/com/jonnyzzz/mcpSteroid/gradle/ClassFileVersionScanner.kt
@@ -1,0 +1,128 @@
+/* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
+package com.jonnyzzz.mcpSteroid.gradle
+
+import java.io.ByteArrayInputStream
+import java.io.File
+import java.io.InputStream
+import java.util.zip.ZipFile
+import java.util.zip.ZipInputStream
+
+/**
+ * Pure, Gradle-independent class-file version scanning used by [VerifyClassFileVersionTask]. Reads the
+ * `.class` header bytes directly — no ASM / bytecode library — so the multi-release-JAR and header-parsing
+ * rules can be unit-tested without building real artifacts.
+ *
+ * The constraint it enforces: every class an artifact ships must fit the *oldest* JBR the artifact targets,
+ * or it throws `UnsupportedClassVersionError` at load time. (Android Studio on platform 261 bundles JBR 21
+ * / class-file major 65; IntelliJ IDEA 2026.1 bundles JBR 25 / major 69.)
+ *
+ * The scan is **fully recursive over every bundled archive at any folder depth** — nested jars *and* nested
+ * zips (e.g. the devrig dist bundles `ij-plugin.zip`, which bundles the kotlinc jars) — not just a `lib/`
+ * directory. Every `.class` found anywhere is subject to the rule.
+ */
+object ClassFileVersionScanner {
+    /** class-file major = Java feature + 44 (Java 1 = 45, so feature N => N + 44; 21 => 65, 25 => 69). */
+    const val CLASS_MAJOR_OFFSET = 44
+
+    private val MR_JAR_ENTRY = Regex("""^META-INF/versions/(\d+)/""")
+
+    data class Violation(val location: String, val major: Int) {
+        val javaFeature: Int get() = major - CLASS_MAJOR_OFFSET
+    }
+
+    /**
+     * @param checked number of `.class` entries whose version was verified (loadable on the floor runtime).
+     * @param violations classes whose major version exceeds the limit.
+     * @param brokenClasses entries named `*.class` that do not parse as a class file (bad magic / truncated)
+     *   — surfaced rather than silently skipped, so a corrupt or mis-shaded artifact is visible.
+     */
+    data class ScanResult(
+        val checked: Int,
+        val violations: List<Violation>,
+        val brokenClasses: List<String>,
+    )
+
+    /** Big-endian u16 major at offset 6 of a `.class` (after the 0xCAFEBABE magic + 2-byte minor). Null if not a class. */
+    fun classFileMajor(bytes: ByteArray): Int? {
+        if (bytes.size < 8) return null
+        if (bytes[0].toInt() and 0xFF != 0xCA || bytes[1].toInt() and 0xFF != 0xFE ||
+            bytes[2].toInt() and 0xFF != 0xBA || bytes[3].toInt() and 0xFF != 0xBE
+        ) {
+            return null
+        }
+        return ((bytes[6].toInt() and 0xFF) shl 8) or (bytes[7].toInt() and 0xFF)
+    }
+
+    /** The multi-release feature version N for an entry under `META-INF/versions/<N>/`, else null (a base entry). */
+    fun multiReleaseFeature(entryName: String): Int? =
+        MR_JAR_ENTRY.find(entryName)?.groupValues?.get(1)?.toIntOrNull()
+
+    /**
+     * Scans [archive] (a `.jar` or `.zip`) and every nested jar/zip it contains, recursively, against
+     * [maxFeature]. The top-level archive is read via random access; nested archives are streamed.
+     */
+    fun scanArchive(archive: File, maxFeature: Int): ScanResult {
+        require(archive.isFile) { "Archive to scan does not exist: $archive" }
+        val acc = Accumulator()
+        ZipFile(archive).use { zip ->
+            val entries = zip.entries()
+            while (entries.hasMoreElements()) {
+                val entry = entries.nextElement()
+                if (entry.isDirectory) continue
+                val name = entry.name
+                when {
+                    name.endsWith(".class") ->
+                        zip.getInputStream(entry).use { checkClass("${archive.name}!$name", it.readBytes(), maxFeature, acc) }
+                    isNestedArchive(name) ->
+                        zip.getInputStream(entry).use { scanStream("${archive.name}!$name", it, maxFeature, acc) }
+                }
+            }
+        }
+        return acc.toResult()
+    }
+
+    /** Streams one nested archive, recursing into the jars/zips it in turn contains. */
+    private fun scanStream(label: String, input: InputStream, maxFeature: Int, acc: Accumulator) {
+        ZipInputStream(input).use { zin ->
+            while (true) {
+                val entry = zin.nextEntry ?: break
+                if (entry.isDirectory) continue
+                val name = entry.name
+                when {
+                    name.endsWith(".class") -> checkClass("$label!$name", zin.readBytes(), maxFeature, acc)
+                    isNestedArchive(name) -> {
+                        val bytes = zin.readBytes()
+                        scanStream("$label!$name", ByteArrayInputStream(bytes), maxFeature, acc)
+                    }
+                }
+            }
+        }
+    }
+
+    private fun isNestedArchive(name: String): Boolean = name.endsWith(".jar") || name.endsWith(".zip")
+
+    private fun checkClass(location: String, bytes: ByteArray, maxFeature: Int, acc: Accumulator) {
+        val entryName = location.substringAfterLast('!')
+        // module-info is a module descriptor, not a classpath-loaded class — skip it.
+        if (entryName == "module-info.class" || entryName.endsWith("/module-info.class")) return
+        // Multi-release overlay for a feature newer than the floor: never loaded on the floor runtime, so a
+        // library may legitimately ship it for newer JDKs — skip rather than flag.
+        val mr = multiReleaseFeature(entryName)
+        if (mr != null && mr > maxFeature) return
+
+        val major = classFileMajor(bytes)
+        if (major == null) {
+            acc.broken += location
+            return
+        }
+        acc.checked++
+        if (major > maxFeature + CLASS_MAJOR_OFFSET) acc.violations += Violation(location, major)
+    }
+
+    private class Accumulator {
+        var checked = 0
+        val violations = mutableListOf<Violation>()
+        val broken = mutableListOf<String>()
+        fun toResult() = ScanResult(checked, violations, broken)
+    }
+}

--- a/buildSrc/src/main/kotlin/com/jonnyzzz/mcpSteroid/gradle/VerifyClassFileVersionTask.kt
+++ b/buildSrc/src/main/kotlin/com/jonnyzzz/mcpSteroid/gradle/VerifyClassFileVersionTask.kt
@@ -1,0 +1,84 @@
+/* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
+package com.jonnyzzz.mcpSteroid.gradle
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.GradleException
+import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
+import org.gradle.api.tasks.TaskAction
+
+/**
+ * Fails the build if any compiled `.class` shipped in [archives] declares a class-file major version
+ * higher than the one allowed by [maxJavaFeature]. This guards a concrete runtime constraint: a plugin
+ * (or the devrig binary) must load on the *oldest* JBR it targets. Android Studio on the 261 platform
+ * bundles **JBR 21** (class-file major 65), while IntelliJ IDEA 2026.1 bundles JBR 25 (major 69) — so a
+ * class compiled to major 69 throws `UnsupportedClassVersionError` in Android Studio. A JDK-25 toolchain
+ * with no `-jvm-target` / `-Xjdk-release` override silently produces such classes, and nothing else in
+ * the build catches it; this task does.
+ *
+ * Every bundled jar/zip is scanned recursively at any folder depth (see [ClassFileVersionScanner]) — not
+ * just a `lib/` directory. Entries named `*.class` that fail to parse are reported as warnings rather than
+ * silently skipped.
+ */
+abstract class VerifyClassFileVersionTask : DefaultTask() {
+    /** Archives to scan. Each is a `.jar` or `.zip`; nested jars/zips inside are scanned recursively. */
+    @get:InputFiles
+    @get:PathSensitive(PathSensitivity.RELATIVE)
+    abstract val archives: ConfigurableFileCollection
+
+    /**
+     * Maximum Java *feature* release whose class files may appear (e.g. 21 => class-file major 65). This is
+     * the feature version of the oldest JBR the artifact must load on. Keep it derived from a single source
+     * of truth rather than re-hardcoded per call site, so a future JBR bump is a one-line change.
+     */
+    @get:Input
+    abstract val maxJavaFeature: Property<Int>
+
+    @TaskAction
+    fun verify() {
+        val maxFeature = maxJavaFeature.get()
+
+        val results = archives.files.map { ClassFileVersionScanner.scanArchive(it, maxFeature) }
+        val checked = results.sumOf { it.checked }
+        val violations = results.flatMap { it.violations }
+        val brokenClasses = results.flatMap { it.brokenClasses }
+
+        // Surface unparseable .class entries (bad magic / truncated) rather than dropping them silently —
+        // they usually mean a corrupt or mis-shaded artifact worth a look. Non-fatal: warn, don't fail.
+        if (brokenClasses.isNotEmpty()) {
+            logger.warn("Class-file version check: ${brokenClasses.size} entry(ies) named *.class did not parse as a class file and were skipped:")
+            brokenClasses.take(MAX_REPORTED).forEach { logger.warn("  ! $it") }
+            if (brokenClasses.size > MAX_REPORTED) logger.warn("  … and ${brokenClasses.size - MAX_REPORTED} more")
+        }
+
+        require(checked > 0) { "Scanned 0 class files across ${archives.files} — the guard verified nothing." }
+
+        if (violations.isNotEmpty()) {
+            val maxMajor = maxFeature + ClassFileVersionScanner.CLASS_MAJOR_OFFSET
+            throw GradleException(
+                buildString {
+                    appendLine("Class-file version check failed: ${violations.size} class(es) exceed Java $maxFeature (class-file major $maxMajor).")
+                    appendLine("These classes would throw UnsupportedClassVersionError on a JBR $maxFeature runtime (e.g. Android Studio on platform 261).")
+                    appendLine("Compile to the target with `-jvm-target $maxFeature` + `-Xjdk-release=$maxFeature` (Kotlin) / `options.release = $maxFeature` (Java).")
+                    appendLine("Offending classes (showing up to $MAX_REPORTED):")
+                    violations.take(MAX_REPORTED).forEach { appendLine("  - ${it.location} (major ${it.major} / Java ${it.javaFeature})") }
+                    if (violations.size > MAX_REPORTED) appendLine("  … and ${violations.size - MAX_REPORTED} more")
+                },
+            )
+        }
+
+        logger.lifecycle(
+            "Class-file version OK: $checked class file(s) <= Java $maxFeature " +
+                "(major ${maxFeature + ClassFileVersionScanner.CLASS_MAJOR_OFFSET})" +
+                if (brokenClasses.isEmpty()) "." else "; ${brokenClasses.size} unparseable entry(ies) warned.",
+        )
+    }
+
+    companion object {
+        private const val MAX_REPORTED = 50
+    }
+}

--- a/buildSrc/src/test/kotlin/com/jonnyzzz/mcpSteroid/gradle/ClassFileVersionScannerTest.kt
+++ b/buildSrc/src/test/kotlin/com/jonnyzzz/mcpSteroid/gradle/ClassFileVersionScannerTest.kt
@@ -1,0 +1,120 @@
+/* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
+package com.jonnyzzz.mcpSteroid.gradle
+
+import java.io.ByteArrayOutputStream
+import java.io.File
+import java.nio.file.Files
+import java.util.zip.ZipEntry
+import java.util.zip.ZipOutputStream
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class ClassFileVersionScannerTest {
+    // Java 21 => class-file major 65, Java 25 => major 69, Java 17 => major 61.
+    private val major21 = 21 + ClassFileVersionScanner.CLASS_MAJOR_OFFSET
+    private val major25 = 25 + ClassFileVersionScanner.CLASS_MAJOR_OFFSET
+    private val major17 = 17 + ClassFileVersionScanner.CLASS_MAJOR_OFFSET
+
+    /** Minimal valid `.class`: 0xCAFEBABE magic, 2-byte minor (0), 2-byte big-endian [major]. */
+    private fun classBytes(major: Int): ByteArray = byteArrayOf(
+        0xCA.toByte(), 0xFE.toByte(), 0xBA.toByte(), 0xBE.toByte(),
+        0, 0,
+        ((major ushr 8) and 0xFF).toByte(), (major and 0xFF).toByte(),
+    )
+
+    private fun zipBytes(entries: Map<String, ByteArray>): ByteArray {
+        val out = ByteArrayOutputStream()
+        ZipOutputStream(out).use { zip ->
+            entries.forEach { (name, bytes) ->
+                zip.putNextEntry(ZipEntry(name))
+                zip.write(bytes)
+                zip.closeEntry()
+            }
+        }
+        return out.toByteArray()
+    }
+
+    private fun writeArchive(name: String, entries: Map<String, ByteArray>): File {
+        val dir = Files.createTempDirectory("cfv").toFile()
+        val file = File(dir, name)
+        file.writeBytes(zipBytes(entries))
+        return file
+    }
+
+    @Test
+    fun classFileMajorReadsHeaderAndRejectsNonClasses() {
+        assertEquals(major25, ClassFileVersionScanner.classFileMajor(classBytes(major25)))
+        assertEquals(major21, ClassFileVersionScanner.classFileMajor(classBytes(major21)))
+        assertNull(ClassFileVersionScanner.classFileMajor(byteArrayOf(1, 2, 3, 4, 5, 6, 7, 8)), "wrong magic")
+        assertNull(ClassFileVersionScanner.classFileMajor(byteArrayOf(0xCA.toByte(), 0xFE.toByte())), "too short")
+    }
+
+    @Test
+    fun multiReleaseFeatureParsesVersionDirectory() {
+        assertEquals(21, ClassFileVersionScanner.multiReleaseFeature("META-INF/versions/21/com/foo/Bar.class"))
+        assertEquals(9, ClassFileVersionScanner.multiReleaseFeature("META-INF/versions/9/x/Y.class"))
+        assertNull(ClassFileVersionScanner.multiReleaseFeature("com/foo/Bar.class"))
+    }
+
+    @Test
+    fun scanArchiveFlagsOnlyClassesLoadedOnTheFloorRuntimeAndReportsBroken() {
+        val jar = writeArchive(
+            "sample.jar",
+            mapOf(
+                "com/ok/Below.class" to classBytes(major21),       // 65 <= 65  -> OK
+                "com/bad/Above.class" to classBytes(major25),      // 69 > 65   -> VIOLATION
+                "module-info.class" to classBytes(major25),        // module descriptor -> skipped
+                "META-INF/versions/25/com/mr/NewerOverlay.class" to classBytes(major25), // N>floor -> skipped
+                "META-INF/versions/17/com/mr/OlderBad.class" to classBytes(major25),     // N<=floor, 69>65 -> VIOLATION
+                "META-INF/versions/17/com/mr/OlderOk.class" to classBytes(major17),      // 61 <= 65 -> OK
+                "com/x/Corrupt.class" to byteArrayOf(1, 2, 3, 4),  // named .class but not a class -> BROKEN
+                "com/ok/resource.txt" to "hello".toByteArray(),    // not a class -> ignored
+            ),
+        )
+
+        val result = ClassFileVersionScanner.scanArchive(jar, maxFeature = 21)
+
+        // checked = 2 base + 2 applicable overlays (versions/17). NOT module-info, versions/25, broken, .txt
+        assertEquals(4, result.checked)
+        assertEquals(
+            listOf(
+                "sample.jar!META-INF/versions/17/com/mr/OlderBad.class",
+                "sample.jar!com/bad/Above.class",
+            ),
+            result.violations.map { it.location }.sorted(),
+        )
+        assertTrue(result.violations.all { it.major == major25 && it.javaFeature == 25 })
+        assertEquals(listOf("sample.jar!com/x/Corrupt.class"), result.brokenClasses)
+    }
+
+    @Test
+    fun scanArchiveRecursesIntoNestedJarsAndZipsAtAnyFolder() {
+        // A nested jar OUTSIDE any lib/ folder (kotlinc-style) must still be scanned now.
+        val toolJar = zipBytes(mapOf("com/tool/Compiler.class" to classBytes(major25)))
+        // A nested ZIP (devrig dist bundles ij-plugin.zip) whose own nested jar must be reached recursively.
+        val innerPluginJar = zipBytes(mapOf("com/plugin/Service.class" to classBytes(major25)))
+        val nestedPluginZip = zipBytes(mapOf("mcp-steroid/lib/ij-plugin.jar" to innerPluginJar))
+
+        val dist = writeArchive(
+            "dist.zip",
+            mapOf(
+                "dist/kotlinc/lib/tool.jar" to toolJar,   // not under a top-level lib/ — still scanned
+                "dist/ij-plugin.zip" to nestedPluginZip,  // nested zip — recursed
+                "dist/bin/7zz" to byteArrayOf(0, 1, 2),   // binary — ignored
+            ),
+        )
+
+        val result = ClassFileVersionScanner.scanArchive(dist, maxFeature = 21)
+
+        assertEquals(2, result.checked)
+        assertEquals(
+            listOf(
+                "dist.zip!dist/ij-plugin.zip!mcp-steroid/lib/ij-plugin.jar!com/plugin/Service.class",
+                "dist.zip!dist/kotlinc/lib/tool.jar!com/tool/Compiler.class",
+            ),
+            result.violations.map { it.location }.sorted(),
+        )
+    }
+}

--- a/ij-plugin/build.gradle.kts
+++ b/ij-plugin/build.gradle.kts
@@ -633,8 +633,22 @@ val verifyBundledLibraries by tasks.registering {
     }
 }
 
+// Class-file version guard: every class the plugin bundles must fit the OLDEST JBR the plugin targets, or
+// it throws UnsupportedClassVersionError at load time. Android Studio on platform 261 bundles JBR 21
+// (class-file major 65) where IntelliJ IDEA 2026.1 bundles JBR 25 (major 69) — so a JDK-25 toolchain that
+// emits major-69 classes loads in IDEA but NOT in Android Studio. Scans every bundled jar/zip recursively
+// at any folder (including kotlinc / ocr-tesseract). `maxJavaFeature` is the single knob the JDK-target
+// change lowers to 21.
+val verifyClassFileVersions by tasks.registering(VerifyClassFileVersionTask::class) {
+    group = "verification"
+    description = "Verify bundled plugin class files load on the oldest supported JBR (class-file version guard)"
+    archives.from(tasks.buildPlugin)
+    maxJavaFeature.set(25)
+}
+
 tasks.test {
     dependsOn(verifyBundledLibraries)
+    dependsOn(verifyClassFileVersions)
 }
 
 // Wire the kotlinx runtime probe into :check so local `./gradlew :ij-plugin:check`
@@ -645,12 +659,14 @@ tasks.check {
 
 tasks.buildPlugin {
     finalizedBy(verifyBundledLibraries)
+    finalizedBy(verifyClassFileVersions)
 }
 
 tasks.verifyPlugin {
     dependsOn(verifyBundledKotlinCompatibility)
     dependsOn(verifyBundledKotlinxRuntime)
     dependsOn(verifyBundledLibraries)
+    dependsOn(verifyClassFileVersions)
 }
 
 // Deploy plugin to running IDEs with hot-reload support

--- a/npx-kt/build.gradle.kts
+++ b/npx-kt/build.gradle.kts
@@ -1,4 +1,5 @@
 import com.jonnyzzz.mcpSteroid.gradle.GenerateMetadataTask
+import com.jonnyzzz.mcpSteroid.gradle.VerifyClassFileVersionTask
 import com.jonnyzzz.mcpSteroid.gradle.configurePathingJarClasspath
 import org.gradle.api.attributes.Usage
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
@@ -587,14 +588,29 @@ val verifyBundledLibraries by tasks.registering {
     }
 }
 
+// Class-file version guard (mirrors :ij-plugin's). devrig is shipped to end users and launched on a
+// Java 25 runtime today, but the build target is held at the same floor as the plugin so the two stay
+// uniform — and so a future "run devrig on the IDE's JBR" path can't regress. Scans the whole dist
+// recursively at any folder — devrig's own jars AND the bundled ij-plugin.zip (kotlinc included). The
+// 7-Zip binaries aren't .class/.jar/.zip and are ignored. `maxJavaFeature` is the single knob the
+// JDK-target change lowers to 21.
+val verifyClassFileVersions by tasks.registering(VerifyClassFileVersionTask::class) {
+    group = "verification"
+    description = "Verify devrig class files load on the oldest supported JBR (class-file version guard)"
+    archives.from(tasks.distZip)
+    maxJavaFeature.set(25)
+}
+
 tasks.test {
     dependsOn(verifyBundledLibraries)
 }
 
 tasks.distZip {
     finalizedBy(verifyBundledLibraries)
+    finalizedBy(verifyClassFileVersions)
 }
 
 tasks.named("check") {
     dependsOn(verifyBundledLibraries)
+    dependsOn(verifyClassFileVersions)
 }


### PR DESCRIPTION
## Why

The plugin and devrig are compiled with a JDK 25 toolchain, emitting **class-file major 69**. They load in IntelliJ IDEA 2026.1 (bundled **JBR 25**) but **not** in Android Studio on the same 261 platform, which bundles **JBR 21** (class-file major 65) and throws `UnsupportedClassVersionError`. Nothing in the build caught this.

## What

`VerifyClassFileVersionTask` (buildSrc) reads each `.class` header directly (no ASM) and fails the build if any class an artifact ships exceeds the maximum Java feature the **oldest supported JBR** allows.

- **Recursive over every bundled jar *and* zip at any folder depth** — the plugin's `kotlinc/` and `ocr-tesseract/` trees, and the `ij-plugin.zip` that the devrig dist bundles — not just a `lib/` directory.
- **Multi-release-JAR aware** — `META-INF/versions/<N>/` overlays for `N` newer than the floor are skipped (they never load on that runtime); base + at/below-floor overlays are checked.
- Skips `module-info.class` (a module descriptor, not a classpath-loaded class).
- Entries named `*.class` that don't parse (bad magic / truncated) are reported as **warnings** instead of being silently dropped.
- Pure scan logic in `ClassFileVersionScanner`, covered by buildSrc unit tests (header parsing incl. bad-magic/short, MRJAR floor rule, module-info skip, broken-class reporting, recursive nested jar/zip descent).
- Wired into **`:ij-plugin`** (plugin zip) and **`:npx-kt`** (devrig dist) via the same lifecycle hooks as `verifyBundledLibraries` (`test` / `buildPlugin`+`distZip` finalizer / `verifyPlugin` / `check`).

`maxJavaFeature` is **25** here, locking the current state. It is the single knob a follow-up lowers to **21** alongside the JDK-target change.

## Verification (local)

- buildSrc unit tests: `tests=4, failures=0`.
- Recursive guard scans real artifacts green, no broken-class warnings: `:ij-plugin` **62,577** classes, `:npx-kt` **82,367** classes ≤ major 69.

First of a 3-part series: (1) **this guard**, (2) JDK 21 target (`-jvm-target 21` + `-Xjdk-release=21`) + lower the knob to 21, (3) Android Studio integration test.