### PR TITLE
build: target JVM 21 bytecode while keeping the JDK 25 toolchain

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -117,6 +117,24 @@ extra["releaseNotesText"] = releaseNotesText
 subprojects {
     group = rootProject.group
     version = rootProject.version
+
+    // Bytecode target floor: compile every module to JVM 21 (class-file major 65) even though the
+    // toolchain and Gradle daemon stay on JDK 25. The shipped plugin and devrig must load on the OLDEST
+    // JBR they target — Android Studio on platform 261 bundles JBR 21 (major 65), while IntelliJ IDEA
+    // 2026.1 bundles JBR 25 (major 69), so a JDK-25-targeted class throws UnsupportedClassVersionError in
+    // Android Studio. `jvmTarget = 21` sets the emitted bytecode version; `-Xjdk-release=21` additionally
+    // clamps the visible JDK API to 21 so a 22..25-only method can't slip in and NoSuchMethodError at
+    // runtime on JBR 21. `configureEach` runs after the per-module `jvmToolchain(25)`, so it reliably
+    // overrides the toolchain's default target. Enforced on the artifacts by `verifyClassFileVersions`.
+    tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
+        compilerOptions {
+            jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_21)
+            freeCompilerArgs.add("-Xjdk-release=21")
+        }
+    }
+    tasks.withType<JavaCompile>().configureEach {
+        options.release.set(21)
+    }
 }
 
 allprojects {

--- a/ij-plugin/build.gradle.kts
+++ b/ij-plugin/build.gradle.kts
@@ -643,7 +643,7 @@ val verifyClassFileVersions by tasks.registering(VerifyClassFileVersionTask::cla
     group = "verification"
     description = "Verify bundled plugin class files load on the oldest supported JBR (class-file version guard)"
     archives.from(tasks.buildPlugin)
-    maxJavaFeature.set(25)
+    maxJavaFeature.set(21)
 }
 
 tasks.test {

--- a/npx-kt/build.gradle.kts
+++ b/npx-kt/build.gradle.kts
@@ -598,7 +598,7 @@ val verifyClassFileVersions by tasks.registering(VerifyClassFileVersionTask::cla
     group = "verification"
     description = "Verify devrig class files load on the oldest supported JBR (class-file version guard)"
     archives.from(tasks.distZip)
-    maxJavaFeature.set(25)
+    maxJavaFeature.set(21)
 }
 
 tasks.test {

--- a/test-integration/src/main/kotlin/com/jonnyzzz/mcpSteroid/integration/infra/intelliJ-factory.kt
+++ b/test-integration/src/main/kotlin/com/jonnyzzz/mcpSteroid/integration/infra/intelliJ-factory.kt
@@ -7,7 +7,6 @@ import com.jonnyzzz.mcpSteroid.testHelper.docker.ContainerVolume
 import com.jonnyzzz.mcpSteroid.testHelper.docker.StartContainerRequest
 import com.jonnyzzz.mcpSteroid.testHelper.docker.mapGuestPortToHostPort
 import com.jonnyzzz.mcpSteroid.testHelper.docker.startDockerContainerAndDispose
-import com.sun.tools.javac.tree.TreeInfo.args
 import java.io.File
 
 fun IntelliJContainer.Companion.create(lifetime: CloseableStack, opts: IntelliJContainerOpts): IntelliJContainer = opts.run {


### PR DESCRIPTION
## Why

The plugin and devrig must load on the **oldest JBR they target**. Android Studio on platform 261 bundles **JBR 21** (class-file major 65); IntelliJ IDEA 2026.1 bundles **JBR 25** (major 69). Compiling with a JDK 25 toolchain emitted major-69 classes that load in IDEA but throw `UnsupportedClassVersionError` in Android Studio.

Builds on #181 (the `verifyClassFileVersions` guard).

## What

Keep the **JDK 25 toolchain and Gradle daemon** (the build still runs on 25), but pin the **emitted bytecode to JVM 21** for every module via a root `subprojects {}` convention:

- **Kotlin**: `jvmTarget = JVM_21` + `-Xjdk-release=21`. The release flag clamps the visible JDK API to 21 so a 22–25-only method can't compile through and then `NoSuchMethodError` on JBR 21 at runtime. `configureEach` overrides the per-module `jvmToolchain(25)` default target without ordering pitfalls.
- **Java**: `options.release = 21`.

Lower the `verifyClassFileVersions` guard from 25 → **21** in `:ij-plugin` and `:npx-kt`; it now enforces major ≤ 65 on the shipped artifacts.

Also removes a stray `com.sun.tools.javac.tree.TreeInfo.args` import in `intelliJ-factory.kt` — unused, and only resolvable with full JDK module access, which `-Xjdk-release=21` (correctly) forbids. (Surfaced by the convention.)

## Verification (local)

- **Guard fails on the pre-change v69 build** — `8074 class(es) exceed Java 21 (class-file major 65) … would throw UnsupportedClassVersionError on a JBR 21 runtime`, listing our classes (proves the guard detects the regression).
- After the target change: `compileAllClasses` green across **all** modules under `-Xjdk-release=21` (nothing uses a 22–25-only API), no jvm-target inconsistency warnings.
- Both guards green at 21: `:ij-plugin` **62,577**, `:npx-kt` **82,367** classes ≤ major 65.

Part 2 of 3: (1) ✅ bytecode guard (#181), (2) **this — JDK 21 target**, (3) Android Studio integration test.