### PR TITLE
Recover Keycloak find-usages / rename / inspections A/B (orphaned by stacked-PR merge)

### DIFF
--- a/test-experiments/src/test/kotlin/com/jonnyzzz/mcpSteroid/integration/tests/KeycloakFindUsagesTest.kt
+++ b/test-experiments/src/test/kotlin/com/jonnyzzz/mcpSteroid/integration/tests/KeycloakFindUsagesTest.kt
@@ -1,0 +1,134 @@
+/* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
+package com.jonnyzzz.mcpSteroid.integration.tests
+
+import com.jonnyzzz.mcpSteroid.integration.infra.AiMode
+import com.jonnyzzz.mcpSteroid.integration.infra.BuildSystem
+import com.jonnyzzz.mcpSteroid.integration.infra.IntelliJContainer
+import com.jonnyzzz.mcpSteroid.integration.infra.IntelliJContainerOpts
+import com.jonnyzzz.mcpSteroid.integration.infra.IntelliJProject
+import com.jonnyzzz.mcpSteroid.integration.infra.McpConnectionMode
+import com.jonnyzzz.mcpSteroid.integration.infra.create
+import com.jonnyzzz.mcpSteroid.integration.infra.waitForProjectReady
+import com.jonnyzzz.mcpSteroid.testHelper.AiAgentSession
+import com.jonnyzzz.mcpSteroid.testHelper.CloseableStackHost
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Timeout
+import java.util.concurrent.TimeUnit
+
+/**
+ * MCP-win experiment: **find all overriders of an interface method via the call/override hierarchy**
+ * (jonnyzzz/mcp-steroid#169). The agent must list every class that overrides
+ * `org.keycloak.credential.CredentialInputValidator.isValid(RealmModel, UserModel, CredentialInput)`.
+ *
+ * With MCP the agent uses PSI override search (`OverridingMethodsSearch` / `ClassInheritorsSearch`) and
+ * gets the exact set of providers that are reached by the runtime polymorphic dispatch. Without MCP,
+ * `grep ".isValid("` both over-counts (unrelated same-named calls all over Keycloak) and can't connect
+ * the single call site to its real implementations — so a faithful answer is hard to produce by text.
+ *
+ * Scored on completeness with the shared [scoreTypeHierarchy] (the verdict is "did the agent report the
+ * real overriding providers"), emitted as an `[ARENA]` block the dashboard reads. A/B per agent; with-MCP
+ * additionally asserts exec_code was used; correctness is a dashboard metric, not a hard pass gate.
+ */
+class KeycloakFindUsagesTest {
+
+    @Test @Timeout(value = 40, unit = TimeUnit.MINUTES)
+    fun `claude with mcp`() = run("claude", withMcp = true)
+
+    @Test @Timeout(value = 40, unit = TimeUnit.MINUTES)
+    fun `claude without mcp`() = run("claude", withMcp = false)
+
+    @Test @Timeout(value = 40, unit = TimeUnit.MINUTES)
+    fun `codex with mcp`() = run("codex", withMcp = true)
+
+    @Test @Timeout(value = 40, unit = TimeUnit.MINUTES)
+    fun `codex without mcp`() = run("codex", withMcp = false)
+
+    private fun run(agentName: String, withMcp: Boolean) {
+        val modeLabel = if (withMcp) "mcp" else "none"
+        val lifetime = CloseableStackHost()
+        try {
+            val session = IntelliJContainer.create(lifetime, IntelliJContainerOpts(
+                consoleTitle = "keycloak-findusages-$agentName-$modeLabel",
+                project = IntelliJProject.KeycloakProject,
+                aiMode = if (withMcp) AiMode.AI_MCP else AiMode.NONE,
+                mcpConnectionMode = if (withMcp) null else McpConnectionMode.None,
+            )).waitForProjectReady(buildSystem = BuildSystem.MAVEN)
+
+            val agent: AiAgentSession = when (agentName) {
+                "claude" -> session.aiAgents.claude
+                "codex" -> session.aiAgents.codex
+                else -> error("Unknown agent: $agentName")
+            }
+
+            val startedAt = System.currentTimeMillis()
+            val result = agent.runPrompt(if (withMcp) withMcpPrompt() else baselinePrompt(), timeoutSeconds = 1500)
+                .awaitForProcessFinish()
+            val agentDurationMs = System.currentTimeMillis() - startedAt
+            val combined = result.stdout + "\n" + result.stderr
+
+            val score = scoreTypeHierarchy(combined, REQUIRED_OVERRIDERS, MIN_TOTAL)
+            println("[TEST] keycloak find-usages [$agentName+$modeLabel] complete=${score.complete} " +
+                    "reported=${score.reportedCount} missing=${score.missingRequired}")
+
+            recordSemanticRun(
+                scenario = SCENARIO,
+                agentName = agentName,
+                withMcp = withMcp,
+                claimedFix = score.complete,
+                rawOutput = result.rawStdout,
+                exitCode = result.exitCode,
+                agentDurationMs = agentDurationMs,
+                runDir = session.runDirInContainer,
+                summary = "found ${score.reportedCount} overriders; missing required ${score.missingRequired}",
+            )
+
+            if (withMcp) assertUsedExecuteCodeEvidence(combined)
+        } finally {
+            lifetime.closeAllStacks()
+        }
+    }
+
+    private fun withMcpPrompt(): String = buildString {
+        appendLine("The Keycloak project is open in IntelliJ IDEA — a large multi-module Java project.")
+        appendLine()
+        appendLine("Task: list EVERY class that OVERRIDES the method")
+        appendLine("`$METHOD` (i.e. every concrete implementation reached when that method is called).")
+        appendLine()
+        appendLine("Use IntelliJ's PSI override/inheritance search via `steroid_execute_code` —")
+        appendLine("find the PsiMethod and use `OverridingMethodsSearch.search(method)` (or")
+        appendLine("`ClassInheritorsSearch` on the interface and resolve the method). Do NOT use text search.")
+        appendLine()
+        appendLine("Output (markers on their own lines):")
+        appendLine("SUBTYPES_FOUND: <count>")
+        appendLine("SUBTYPE: <fully.qualified.ClassName>   ← one line per overriding class")
+        appendLine("TOOL_EVIDENCE: <copy the line starting with execution_id: ...>")
+    }
+
+    private fun baselinePrompt(): String = buildString {
+        appendLine("The Keycloak project is checked out (a large multi-module Java project).")
+        appendLine("IntelliJ MCP tools are unavailable in this run — use shell commands only (grep/rg/find).")
+        appendLine()
+        appendLine("Task: list EVERY class that OVERRIDES the method")
+        appendLine("`$METHOD` (i.e. every concrete implementation reached when that method is called).")
+        appendLine()
+        appendLine("Output (markers on their own lines):")
+        appendLine("SUBTYPES_FOUND: <count>")
+        appendLine("SUBTYPE: <fully.qualified.ClassName>   ← one line per overriding class")
+    }
+
+    companion object {
+        private const val SCENARIO = "keycloak__find_usages"
+        private const val METHOD =
+            "org.keycloak.credential.CredentialInputValidator#isValid(RealmModel, UserModel, CredentialInput)"
+
+        // Real overriding providers reached by the runtime polymorphic dispatch — verified against the
+        // Keycloak source. A textual grep of ".isValid(" cannot reliably connect the call site to these.
+        private val REQUIRED_OVERRIDERS = setOf(
+            "org.keycloak.credential.PasswordCredentialProvider",
+            "org.keycloak.credential.OTPCredentialProvider",
+            "org.keycloak.credential.WebAuthnCredentialProvider",
+            "org.keycloak.credential.RecoveryAuthnCodesCredentialProvider",
+        )
+        private const val MIN_TOTAL = 4
+    }
+}

--- a/test-experiments/src/test/kotlin/com/jonnyzzz/mcpSteroid/integration/tests/KeycloakInspectionsTest.kt
+++ b/test-experiments/src/test/kotlin/com/jonnyzzz/mcpSteroid/integration/tests/KeycloakInspectionsTest.kt
@@ -1,0 +1,124 @@
+/* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
+package com.jonnyzzz.mcpSteroid.integration.tests
+
+import com.jonnyzzz.mcpSteroid.integration.infra.AiMode
+import com.jonnyzzz.mcpSteroid.integration.infra.BuildSystem
+import com.jonnyzzz.mcpSteroid.integration.infra.IntelliJContainer
+import com.jonnyzzz.mcpSteroid.integration.infra.IntelliJContainerOpts
+import com.jonnyzzz.mcpSteroid.integration.infra.IntelliJProject
+import com.jonnyzzz.mcpSteroid.integration.infra.McpConnectionMode
+import com.jonnyzzz.mcpSteroid.integration.infra.create
+import com.jonnyzzz.mcpSteroid.integration.infra.waitForProjectReady
+import com.jonnyzzz.mcpSteroid.testHelper.AiAgentSession
+import com.jonnyzzz.mcpSteroid.testHelper.CloseableStackHost
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Timeout
+import java.util.concurrent.TimeUnit
+
+/**
+ * MCP-win experiment: **IDE inspections find what grep can't** (jonnyzzz/mcp-steroid#169). The agent must
+ * report the redundant type casts after `instanceof` in Keycloak's
+ * `server-spi/src/main/java/org/keycloak/validate/ValidatorConfig.java`.
+ *
+ * With MCP the agent runs IntelliJ's "Redundant type cast" inspection — semantic type-narrowing finds
+ * each cast that is unnecessary after an `instanceof`. Without MCP, grep sees the cast syntax but cannot
+ * determine whether a cast is redundant (that needs type inference), so it cannot reliably find them.
+ *
+ * Verdict ([scoreInspections]): the agent named the file and reported enough redundant casts — emitted
+ * as an `[ARENA]` block. A/B per agent; with-MCP asserts exec_code; correctness is a dashboard metric.
+ */
+class KeycloakInspectionsTest {
+
+    @Test @Timeout(value = 40, unit = TimeUnit.MINUTES)
+    fun `claude with mcp`() = run("claude", withMcp = true)
+
+    @Test @Timeout(value = 40, unit = TimeUnit.MINUTES)
+    fun `claude without mcp`() = run("claude", withMcp = false)
+
+    @Test @Timeout(value = 40, unit = TimeUnit.MINUTES)
+    fun `codex with mcp`() = run("codex", withMcp = true)
+
+    @Test @Timeout(value = 40, unit = TimeUnit.MINUTES)
+    fun `codex without mcp`() = run("codex", withMcp = false)
+
+    private fun run(agentName: String, withMcp: Boolean) {
+        val modeLabel = if (withMcp) "mcp" else "none"
+        val lifetime = CloseableStackHost()
+        try {
+            val session = IntelliJContainer.create(lifetime, IntelliJContainerOpts(
+                consoleTitle = "keycloak-inspections-$agentName-$modeLabel",
+                project = IntelliJProject.KeycloakProject,
+                aiMode = if (withMcp) AiMode.AI_MCP else AiMode.NONE,
+                mcpConnectionMode = if (withMcp) null else McpConnectionMode.None,
+            )).waitForProjectReady(buildSystem = BuildSystem.MAVEN)
+
+            val agent: AiAgentSession = when (agentName) {
+                "claude" -> session.aiAgents.claude
+                "codex" -> session.aiAgents.codex
+                else -> error("Unknown agent: $agentName")
+            }
+
+            val startedAt = System.currentTimeMillis()
+            val result = agent.runPrompt(if (withMcp) withMcpPrompt() else baselinePrompt(), timeoutSeconds = 1500)
+                .awaitForProcessFinish()
+            val agentDurationMs = System.currentTimeMillis() - startedAt
+            val combined = result.stdout + "\n" + result.stderr
+
+            val score = scoreInspections(combined, MIN_ISSUES, TARGET_FILE)
+            println("[TEST] keycloak inspections [$agentName+$modeLabel] detected=${score.detected} " +
+                    "issuesFound=${score.issuesFound} cast=${score.mentionsRedundantCast} file=${score.mentionsTargetFile}")
+
+            recordSemanticRun(
+                scenario = SCENARIO,
+                agentName = agentName,
+                withMcp = withMcp,
+                claimedFix = score.detected,
+                rawOutput = result.rawStdout,
+                exitCode = result.exitCode,
+                agentDurationMs = agentDurationMs,
+                runDir = session.runDirInContainer,
+                summary = "issuesFound=${score.issuesFound} redundantCast=${score.mentionsRedundantCast}",
+            )
+
+            if (withMcp) assertUsedExecuteCodeEvidence(combined)
+        } finally {
+            lifetime.closeAllStacks()
+        }
+    }
+
+    private fun withMcpPrompt(): String = buildString {
+        appendLine("The Keycloak project is open in IntelliJ IDEA — a large multi-module Java project.")
+        appendLine()
+        appendLine("Task: find every REDUNDANT type cast in `$TARGET_PATH` — casts that are unnecessary")
+        appendLine("because the variable was already narrowed by a preceding `instanceof` check.")
+        appendLine()
+        appendLine("Use IntelliJ's inspections via `steroid_execute_code` — run the \"Redundant type cast\"")
+        appendLine("(RedundantCast) inspection on the file and read its results. Do NOT guess from grep.")
+        appendLine()
+        appendLine("Output (markers on their own lines):")
+        appendLine("ISSUES_FOUND: <count of redundant casts>")
+        appendLine("ISSUE: <file:line — short description>   ← one per redundant cast")
+        appendLine("TOOL_EVIDENCE: <copy the line starting with execution_id: ...>")
+    }
+
+    private fun baselinePrompt(): String = buildString {
+        appendLine("The Keycloak project is checked out (a large multi-module Java project).")
+        appendLine("IntelliJ MCP tools are unavailable in this run — use shell commands only (grep/rg/find).")
+        appendLine()
+        appendLine("Task: find every REDUNDANT type cast in `$TARGET_PATH` — casts that are unnecessary")
+        appendLine("because the variable was already narrowed by a preceding `instanceof` check.")
+        appendLine()
+        appendLine("Output (markers on their own lines):")
+        appendLine("ISSUES_FOUND: <count of redundant casts>")
+        appendLine("ISSUE: <file:line — short description>   ← one per redundant cast")
+    }
+
+    companion object {
+        private const val SCENARIO = "keycloak__inspections"
+        private const val TARGET_FILE = "ValidatorConfig.java"
+        private const val TARGET_PATH = "server-spi/src/main/java/org/keycloak/validate/ValidatorConfig.java"
+
+        // ValidatorConfig.java has ~13 redundant casts after instanceof; require a meaningful fraction.
+        private const val MIN_ISSUES = 5
+    }
+}

--- a/test-experiments/src/test/kotlin/com/jonnyzzz/mcpSteroid/integration/tests/KeycloakRenameTest.kt
+++ b/test-experiments/src/test/kotlin/com/jonnyzzz/mcpSteroid/integration/tests/KeycloakRenameTest.kt
@@ -1,0 +1,123 @@
+/* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
+package com.jonnyzzz.mcpSteroid.integration.tests
+
+import com.jonnyzzz.mcpSteroid.integration.infra.AiMode
+import com.jonnyzzz.mcpSteroid.integration.infra.BuildSystem
+import com.jonnyzzz.mcpSteroid.integration.infra.IntelliJContainer
+import com.jonnyzzz.mcpSteroid.integration.infra.IntelliJContainerOpts
+import com.jonnyzzz.mcpSteroid.integration.infra.IntelliJProject
+import com.jonnyzzz.mcpSteroid.integration.infra.McpConnectionMode
+import com.jonnyzzz.mcpSteroid.integration.infra.create
+import com.jonnyzzz.mcpSteroid.integration.infra.waitForProjectReady
+import com.jonnyzzz.mcpSteroid.testHelper.AiAgentSession
+import com.jonnyzzz.mcpSteroid.testHelper.CloseableStackHost
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Timeout
+import java.util.concurrent.TimeUnit
+
+/**
+ * MCP-win experiment: **safe project-wide rename** (jonnyzzz/mcp-steroid#169). The agent renames the
+ * widely-used `org.keycloak.models.UserModel.getEmail()` accessor (referenced across hundreds of files)
+ * to `getEmailAddress()`, then verifies the project still compiles.
+ *
+ * With MCP the agent uses IntelliJ's rename refactoring (`RenameProcessor`) — every reference is updated
+ * by PSI and the build stays green. Without MCP, a sed/text rename over-matches (`EmailValidator`,
+ * `isEmailVerified`, `updateEmail`, …) and/or misses qualified references, breaking compilation.
+ *
+ * Verdict ([scoreRenameSafety]): rename performed AND post-rename build SUCCESS — emitted as an `[ARENA]`
+ * block. A/B per agent; with-MCP asserts exec_code; correctness is a dashboard metric, not a hard gate.
+ */
+class KeycloakRenameTest {
+
+    @Test @Timeout(value = 50, unit = TimeUnit.MINUTES)
+    fun `claude with mcp`() = run("claude", withMcp = true)
+
+    @Test @Timeout(value = 50, unit = TimeUnit.MINUTES)
+    fun `claude without mcp`() = run("claude", withMcp = false)
+
+    @Test @Timeout(value = 50, unit = TimeUnit.MINUTES)
+    fun `codex with mcp`() = run("codex", withMcp = true)
+
+    @Test @Timeout(value = 50, unit = TimeUnit.MINUTES)
+    fun `codex without mcp`() = run("codex", withMcp = false)
+
+    private fun run(agentName: String, withMcp: Boolean) {
+        val modeLabel = if (withMcp) "mcp" else "none"
+        val lifetime = CloseableStackHost()
+        try {
+            val session = IntelliJContainer.create(lifetime, IntelliJContainerOpts(
+                consoleTitle = "keycloak-rename-$agentName-$modeLabel",
+                project = IntelliJProject.KeycloakProject,
+                aiMode = if (withMcp) AiMode.AI_MCP else AiMode.NONE,
+                mcpConnectionMode = if (withMcp) null else McpConnectionMode.None,
+            )).waitForProjectReady(buildSystem = BuildSystem.MAVEN)
+
+            val agent: AiAgentSession = when (agentName) {
+                "claude" -> session.aiAgents.claude
+                "codex" -> session.aiAgents.codex
+                else -> error("Unknown agent: $agentName")
+            }
+
+            val startedAt = System.currentTimeMillis()
+            val result = agent.runPrompt(if (withMcp) withMcpPrompt() else baselinePrompt(), timeoutSeconds = 2400)
+                .awaitForProcessFinish()
+            val agentDurationMs = System.currentTimeMillis() - startedAt
+            val combined = result.stdout + "\n" + result.stderr
+
+            val score = scoreRenameSafety(combined)
+            println("[TEST] keycloak rename [$agentName+$modeLabel] safe=${score.safe} " +
+                    "renameDone=${score.renameDone} buildGreen=${score.buildGreen}")
+
+            recordSemanticRun(
+                scenario = SCENARIO,
+                agentName = agentName,
+                withMcp = withMcp,
+                claimedFix = score.safe,
+                rawOutput = result.rawStdout,
+                exitCode = result.exitCode,
+                agentDurationMs = agentDurationMs,
+                runDir = session.runDirInContainer,
+                summary = "renameDone=${score.renameDone} buildGreen=${score.buildGreen}",
+            )
+
+            if (withMcp) assertUsedExecuteCodeEvidence(combined)
+        } finally {
+            lifetime.closeAllStacks()
+        }
+    }
+
+    private fun withMcpPrompt(): String = buildString {
+        appendLine("The Keycloak project is open in IntelliJ IDEA — a large multi-module Java project.")
+        appendLine()
+        appendLine("Task: rename the method `$SYMBOL` to `getEmailAddress()` PROJECT-WIDE — every reference")
+        appendLine("(callers, overrides, the declaration) must be updated so the project still compiles.")
+        appendLine()
+        appendLine("Use IntelliJ's rename refactoring via `steroid_execute_code` (`com.intellij.refactoring`")
+        appendLine("RenameProcessor / RefactoringFactory) — it updates all references by PSI. Do NOT sed.")
+        appendLine("After renaming, build the affected modules (e.g. server-spi + services) to verify.")
+        appendLine()
+        appendLine("Output (markers on their own lines):")
+        appendLine("RENAME_DONE: yes")
+        appendLine("BUILD_AFTER_RENAME: <SUCCESS or FAILURE>")
+        appendLine("TOOL_EVIDENCE: <copy the line starting with execution_id: ...>")
+    }
+
+    private fun baselinePrompt(): String = buildString {
+        appendLine("The Keycloak project is checked out (a large multi-module Java project).")
+        appendLine("IntelliJ MCP tools are unavailable in this run — use shell commands only.")
+        appendLine()
+        appendLine("Task: rename the method `$SYMBOL` to `getEmailAddress()` PROJECT-WIDE — every reference")
+        appendLine("(callers, overrides, the declaration) must be updated so the project still compiles.")
+        appendLine("Beware: a naive text replace will over-match unrelated identifiers and break the build.")
+        appendLine("After renaming, build the affected modules (e.g. server-spi + services) to verify.")
+        appendLine()
+        appendLine("Output (markers on their own lines):")
+        appendLine("RENAME_DONE: yes")
+        appendLine("BUILD_AFTER_RENAME: <SUCCESS or FAILURE>")
+    }
+
+    companion object {
+        private const val SCENARIO = "keycloak__rename_safety"
+        private const val SYMBOL = "org.keycloak.models.UserModel#getEmail()"
+    }
+}

--- a/test-integration/src/main/kotlin/com/jonnyzzz/mcpSteroid/integration/tests/SemanticTaskScoring.kt
+++ b/test-integration/src/main/kotlin/com/jonnyzzz/mcpSteroid/integration/tests/SemanticTaskScoring.kt
@@ -49,3 +49,67 @@ fun scoreTypeHierarchy(output: String, required: Set<String>, minTotal: Int): Ty
         complete = missing.isEmpty() && reported.size >= minTotal,
     )
 }
+
+data class RenameSafetyScore(
+    val renameDone: Boolean,
+    /** The post-rename build/compile result the agent reported (null if it never reported one). */
+    val buildGreen: Boolean?,
+    /** A safe rename = it was performed AND the project still compiles afterwards. */
+    val safe: Boolean,
+)
+
+/**
+ * Score a project-wide rename for SAFETY. With MCP the agent uses the IDE's rename refactoring (updates
+ * every reference, build stays green); without MCP a sed/text rename over- or under-matches and breaks
+ * compilation. The verdict is whether the rename was performed AND the project still builds.
+ *
+ * Expected markers (the prompt asks the agent to compile after renaming and report):
+ *   RENAME_DONE: yes
+ *   BUILD_AFTER_RENAME: SUCCESS | FAILURE
+ */
+fun scoreRenameSafety(output: String): RenameSafetyScore {
+    val renameDone = findMarkerValue(output, "RENAME_DONE", "Rename done")?.equals("yes", ignoreCase = true) == true
+    val build = findMarkerValue(output, "BUILD_AFTER_RENAME", "Build after rename")
+    val buildGreen = build?.let {
+        when {
+            it.contains("SUCCESS", ignoreCase = true) || it.equals("pass", ignoreCase = true) || it.equals("green", ignoreCase = true) -> true
+            it.contains("FAIL", ignoreCase = true) || it.contains("error", ignoreCase = true) || it.contains("broke", ignoreCase = true) -> false
+            else -> null
+        }
+    }
+    return RenameSafetyScore(renameDone = renameDone, buildGreen = buildGreen, safe = renameDone && buildGreen == true)
+}
+
+data class InspectionScore(
+    val issuesFound: Int?,
+    val mentionsRedundantCast: Boolean,
+    val mentionsTargetFile: Boolean,
+    /** True when the agent detected a meaningful number of the (semantic) redundant-cast issues. */
+    val detected: Boolean,
+)
+
+/**
+ * Score an "run IDE inspections + report issues" answer. The target is the redundant casts after
+ * `instanceof` in Keycloak's `ValidatorConfig.java`. With MCP the agent runs IntelliJ's inspection
+ * (semantic type-narrowing → finds them exactly); grep/shell cannot determine a cast is redundant.
+ *
+ * Expected markers:
+ *   ISSUES_FOUND: <count>
+ *   ISSUE: <description>            (the redundant-cast lines; ideally mentioning the file)
+ *
+ * @param minIssues the lower bound of redundant casts that must be reported to count as detected.
+ */
+fun scoreInspections(output: String, minIssues: Int, targetFile: String): InspectionScore {
+    val count = findMarkerValue(output, "ISSUES_FOUND", "Issues found")
+        ?.let { Regex("""\d+""").find(it)?.value?.toIntOrNull() }
+    val mentionsCast = output.contains("redundant cast", ignoreCase = true) ||
+        output.contains("redundant type cast", ignoreCase = true) ||
+        output.contains("unnecessary cast", ignoreCase = true)
+    val mentionsFile = output.contains(targetFile, ignoreCase = true)
+    return InspectionScore(
+        issuesFound = count,
+        mentionsRedundantCast = mentionsCast,
+        mentionsTargetFile = mentionsFile,
+        detected = mentionsCast && mentionsFile && (count ?: 0) >= minIssues,
+    )
+}


### PR DESCRIPTION
## Problem

PRs #174 (find-usages), #175 (rename), #176 (inspections) were a **stacked PR chain** whose bases pointed at each other's feature branches instead of `main`:

| PR | scenario | base branch |
|----|----------|-------------|
| #173 | type-hierarchy | `main` ✅ |
| #174 | find-usages | `feat/keycloak-type-hierarchy-ab` |
| #175 | rename | `feat/keycloak-find-usages-ab` |
| #176 | inspections | `feat/keycloak-rename-ab` |

All three merged within ~1 minute (09:38–09:39 UTC) of #173 landing on `main`, **before GitHub retargeted them**. So they merged into the now-stale intermediate branches and their content **never reached `main`** — even though GitHub reports all three MERGED.

### Symptom
The TeamCity experiment builds for these three scenarios fail at the Gradle step:
```
No tests found for given includes: [*KeycloakFindUsagesTest.claude*](filter.includeTestsMatching)
```
because the test classes are simply absent from `main`. Only `KeycloakTypeHierarchyTest` (from #173) is present.

## Fix
Restores the three orphaned test classes + the extra scoring helpers (`scoreRenameSafety`, `scoreInspections`) from the tip of the stack (`feat/keycloak-rename-ab`, the #176 merge commit), rebased onto current `main`.

- Method names (`claude with mcp` / `codex with mcp`) match the DSL test filters.
- find-usages reuses `scoreTypeHierarchy` (both are PSI-completeness checks).
- `:test-integration:compileKotlin :test-experiments:compileTestKotlin` is green.

After merge + promotion to `jb/main`, the 6 currently-failing Keycloak builds will find their tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)