### PR TITLE
Fix exec_code compile-error line mapping drifting with the import count

### DIFF
--- a/kotlin-cli/src/main/kotlin/com/jonnyzzz/mcpSteroid/koltinc/CodeWrapperForCompilation.kt
+++ b/kotlin-cli/src/main/kotlin/com/jonnyzzz/mcpSteroid/koltinc/CodeWrapperForCompilation.kt
@@ -132,41 +132,64 @@ object CodeWrapperForCompilation {
         val importLines = extracted.importLines
         val otherLines = extracted.otherLines
 
-        // Build the wrapped code AND its line mapping in lock-step: record each user
-        // line's wrapped position as it is emitted. This is drift-proof — earlier the
-        // offsets were hardcoded (12 default imports → user code at line 23+N), so growing
-        // [defaultImports] silently shifted every user line and broke remapping (compiler
-        // errors then pointed at the generated line, not the submitted one). Never reintroduce
-        // magic offsets here; the only source of truth is the emission order below.
+        // Build the wrapped code AND its line mapping in lock-step: every line goes through
+        // [WrappedLineEmitter.emit], which appends it and advances the wrapped-line counter
+        // together. This is drift-proof — earlier the offsets were hardcoded (12 default
+        // imports → user code at line 23+N), so growing [defaultImports] silently shifted every
+        // user line and broke remapping (compiler errors then pointed at the generated line,
+        // not the submitted one). Because the counter can only move inside emit(), the mapping
+        // can never drift from the generated layout. Never reintroduce magic offsets here.
         val mapping = mutableMapOf<Int, Int>()
-        var wrappedLine = 0
         val wrappedCode = buildString {
-            defaultImports.forEach { appendLine(it); wrappedLine++ }
-            appendLine(); wrappedLine++
-            appendLine("//imports from the submitted code"); wrappedLine++
+            val out = WrappedLineEmitter(this)
+            defaultImports.forEach { out.emit(it) }
+            out.emit()
+            out.emit("//imports from the submitted code")
             importLines.forEachIndexed { i, line ->
-                appendLine(line); wrappedLine++
-                mapping[wrappedLine] = extracted.importLineNumbers[i]
+                out.emit(line)
+                mapping[out.line] = extracted.importLineNumbers[i]
             }
-            appendLine(); wrappedLine++
-            appendLine("class $clazzName {"); wrappedLine++
-            appendLine("  inline fun $scriptContextFqn.execute(ƒ: $scriptContextFqn.() -> Unit) = ƒ()"); wrappedLine++
-            appendLine("  fun $methodName(builder : $scriptBuilderFqn) { "); wrappedLine++
-            appendLine("    builder.$addBlockName { ${methodName}_code() }"); wrappedLine++
-            appendLine("  }"); wrappedLine++
-            appendLine("  suspend fun $scriptContextFqn.${methodName}_code() {"); wrappedLine++
-            appendLine("    //the rest of submitted code"); wrappedLine++
+            out.emit()
+            out.emit("class $clazzName {")
+            out.emit("  inline fun $scriptContextFqn.execute(ƒ: $scriptContextFqn.() -> Unit) = ƒ()")
+            out.emit("  fun $methodName(builder : $scriptBuilderFqn) { ")
+            out.emit("    builder.$addBlockName { ${methodName}_code() }")
+            out.emit("  }")
+            out.emit("  suspend fun $scriptContextFqn.${methodName}_code() {")
+            out.emit("    //the rest of submitted code")
             otherLines.forEachIndexed { i, line ->
-                append("    ").appendLine(line); wrappedLine++
-                mapping[wrappedLine] = extracted.otherLineNumbers[i]
+                out.emit("    $line")
+                mapping[out.line] = extracted.otherLineNumbers[i]
             }
-            appendLine("  }"); wrappedLine++
-            appendLine("}"); wrappedLine++
+            out.emit("  }")
+            out.emit("}")
             append("\n")
         }
 
         val lineMapping = LineMapping(mapping)
 
         return WrapResult(classFqn = clazzName, methodName = methodName, code = wrappedCode, lineMapping = lineMapping)
+    }
+
+    /**
+     * Single choke point for emitting wrapped-code lines. Appending and advancing the
+     * wrapped-line counter happen together in [emit], so the line mapping built in [wrap]
+     * cannot drift from the generated layout (the bug this design replaced used hardcoded
+     * offsets keyed off the default-import count).
+     *
+     * [emit] rejects any text containing a newline: `appendLine` would then write more than
+     * one physical line while the counter advances by one, silently desyncing every later
+     * mapping entry — exactly the failure mode we are guarding against.
+     */
+    private class WrappedLineEmitter(private val sb: StringBuilder) {
+        /** 1-based number of the last emitted line. */
+        var line: Int = 0
+            private set
+
+        fun emit(text: String = "") {
+            require('\n' !in text) { "emit() writes exactly one line; embedded newline would desync the line counter: <$text>" }
+            sb.appendLine(text)
+            line++
+        }
     }
 }

--- a/kotlin-cli/src/main/kotlin/com/jonnyzzz/mcpSteroid/koltinc/CodeWrapperForCompilation.kt
+++ b/kotlin-cli/src/main/kotlin/com/jonnyzzz/mcpSteroid/koltinc/CodeWrapperForCompilation.kt
@@ -132,57 +132,37 @@ object CodeWrapperForCompilation {
         val importLines = extracted.importLines
         val otherLines = extracted.otherLines
 
-        val wrappedCode = buildString {
-            append(defaultImports.joinToString(separator = "\n", postfix = "\n"))
-            appendLine()
-            appendLine("//imports from the submitted code")
-            importLines.forEach { appendLine(it) }
-            appendLine()
-            appendLine("class $clazzName {")
-            appendLine("  inline fun $scriptContextFqn.execute(ƒ: $scriptContextFqn.() -> Unit) = ƒ()")
-            appendLine("  fun $methodName(builder : $scriptBuilderFqn) { ")
-            appendLine("    builder.$addBlockName { ${methodName}_code() }")
-            appendLine("  }")
-            appendLine("  suspend fun $scriptContextFqn.${methodName}_code() {")
-            appendLine("    //the rest of submitted code")
-            otherLines.forEach { append("    ").appendLine(it) }
-            appendLine("  }")
-            appendLine("}")
-            append("\n")
-        }
-
-        // Build the line mapping from wrapped line numbers to original user line numbers.
-        //
-        // The wrapped code layout (1-based line numbers):
-        //   Lines 1..12:          defaultImports (12 lines via joinToString with \n separator + \n postfix)
-        //   Line 13:              empty (appendLine())
-        //   Line 14:              "//imports from the submitted code"
-        //   Lines 15..14+N:       user imports (N = importLines.size)
-        //   Line 15+N:            empty (appendLine())
-        //   Line 16+N:            "class $clazzName {"
-        //   Line 17+N:            "  inline fun ..."
-        //   Line 18+N:            "  fun $methodName..."
-        //   Line 19+N:            "    builder.$addBlockName..."
-        //   Line 20+N:            "  }"
-        //   Line 21+N:            "  suspend fun ..."
-        //   Line 22+N:            "    //the rest of submitted code"
-        //   Lines 23+N..22+N+M:   user code lines (M = otherLines.size)
-        //   Line 23+N+M:          "  }"
-        //   Line 24+N+M:          "}"
-        //   Line 25+N+M:          empty (trailing \n)
-        val n = importLines.size
+        // Build the wrapped code AND its line mapping in lock-step: record each user
+        // line's wrapped position as it is emitted. This is drift-proof — earlier the
+        // offsets were hardcoded (12 default imports → user code at line 23+N), so growing
+        // [defaultImports] silently shifted every user line and broke remapping (compiler
+        // errors then pointed at the generated line, not the submitted one). Never reintroduce
+        // magic offsets here; the only source of truth is the emission order below.
         val mapping = mutableMapOf<Int, Int>()
-
-        // Map user import lines
-        for (i in extracted.importLineNumbers.indices) {
-            val wrappedLine = 15 + i
-            mapping[wrappedLine] = extracted.importLineNumbers[i]
-        }
-
-        // Map user code lines (non-import)
-        for (i in extracted.otherLineNumbers.indices) {
-            val wrappedLine = 23 + n + i
-            mapping[wrappedLine] = extracted.otherLineNumbers[i]
+        var wrappedLine = 0
+        val wrappedCode = buildString {
+            defaultImports.forEach { appendLine(it); wrappedLine++ }
+            appendLine(); wrappedLine++
+            appendLine("//imports from the submitted code"); wrappedLine++
+            importLines.forEachIndexed { i, line ->
+                appendLine(line); wrappedLine++
+                mapping[wrappedLine] = extracted.importLineNumbers[i]
+            }
+            appendLine(); wrappedLine++
+            appendLine("class $clazzName {"); wrappedLine++
+            appendLine("  inline fun $scriptContextFqn.execute(ƒ: $scriptContextFqn.() -> Unit) = ƒ()"); wrappedLine++
+            appendLine("  fun $methodName(builder : $scriptBuilderFqn) { "); wrappedLine++
+            appendLine("    builder.$addBlockName { ${methodName}_code() }"); wrappedLine++
+            appendLine("  }"); wrappedLine++
+            appendLine("  suspend fun $scriptContextFqn.${methodName}_code() {"); wrappedLine++
+            appendLine("    //the rest of submitted code"); wrappedLine++
+            otherLines.forEachIndexed { i, line ->
+                append("    ").appendLine(line); wrappedLine++
+                mapping[wrappedLine] = extracted.otherLineNumbers[i]
+            }
+            appendLine("  }"); wrappedLine++
+            appendLine("}"); wrappedLine++
+            append("\n")
         }
 
         val lineMapping = LineMapping(mapping)

--- a/kotlin-cli/src/test/kotlin/com/jonnyzzz/mcpSteroid/koltinc/CodeWrapperForCompilationTest.kt
+++ b/kotlin-cli/src/test/kotlin/com/jonnyzzz/mcpSteroid/koltinc/CodeWrapperForCompilationTest.kt
@@ -13,10 +13,15 @@ class CodeWrapperForCompilationTest {
      *
      * Deriving the wrapped line from the emitted code — instead of hardcoding an offset like
      * "user code starts at wrapped line 23+N" — is the whole point: those hardcoded offsets
-     * silently drifted when [CodeWrapperForCompilation.defaultImports] grew from 12 to 15 entries,
-     * so real compiler errors (at the true line) were no longer remapped while these tests, which
-     * fed the *stale* line numbers, kept passing. Searching the actual output makes the test track
+     * silently drifted as [CodeWrapperForCompilation.defaultImports] grew over time, so real
+     * compiler errors (at the true line) were no longer remapped while these tests, which fed
+     * the *stale* line numbers, kept passing. Searching the actual output makes the test track
      * reality and catch any future drift.
+     *
+     * [snippet] must match exactly one generated line. If it matched several (a too-short or
+     * boilerplate-colliding snippet), picking the first would let the test measure — and then
+     * "confirm" — the wrong line while still looking meaningful. Demanding a unique match turns
+     * that ambiguity into a loud failure instead of a silent false pass.
      */
     private fun assertRemaps(
         result: CodeWrapperForCompilation.WrapResult,
@@ -24,8 +29,13 @@ class CodeWrapperForCompilationTest {
         originalLine: Int,
         col: Int = 5,
     ) {
-        val wrappedLine = result.code.lines().indexOfFirst { it.contains(snippet) } + 1
-        assertTrue("snippet <$snippet> not found in generated code:\n${result.code}", wrappedLine > 0)
+        val matches = result.code.lines().withIndex().filter { it.value.contains(snippet) }
+        assertEquals(
+            "snippet <$snippet> must match exactly one generated line so the test can't silently " +
+                "measure the wrong one; matched ${matches.size}:\n${result.code}",
+            1, matches.size,
+        )
+        val wrappedLine = matches.single().index + 1
         assertEquals(
             "input.kt:$originalLine:$col: error: boom",
             result.lineMapping.remapCompilerOutput("input.kt:$wrappedLine:$col: error: boom"),
@@ -103,6 +113,41 @@ class CodeWrapperForCompilationTest {
         assertTrue(classLine > 0)
         val input = "input.kt:$classLine:1: error: some weird error"
         assertEquals(input, result.lineMapping.remapCompilerOutput(input))
+    }
+
+    @Test
+    fun `compiler error on a wrapper-added default import passes through unmapped`() {
+        // A default import is boilerplate the wrapper injects, not code the agent wrote, so it
+        // is deliberately absent from the mapping. If kotlinc ever flags one of those lines
+        // (e.g. an import stops resolving), remap has nothing to translate it to and must leave
+        // the reference untouched rather than point at some unrelated user line. This pins that
+        // documented behaviour — see review question "what if the error is in the import line
+        // which we just added". Changing how such errors are reported must update this test.
+        val code = "val x = 1"
+        val result = CodeWrapperForCompilation.wrap("Test", code)
+
+        val firstDefaultImport = CodeWrapperForCompilation.defaultImports.first()
+        val importLine = result.code.lines().indexOfFirst { it == firstDefaultImport } + 1
+        assertTrue("default import <$firstDefaultImport> not found in:\n${result.code}", importLine > 0)
+
+        val input = "input.kt:$importLine:8: error: unresolved reference"
+        assertEquals(input, result.lineMapping.remapCompilerOutput(input))
+    }
+
+    @Test
+    fun `user code line remaps correctly regardless of default-import count`() {
+        // The original bug was drift with the number of preamble lines: offsets computed for 12
+        // default imports broke once the list grew. Prepend a varying number of *user* imports —
+        // which shifts the user code down by exactly that many lines — and assert the error still
+        // remaps to the true source line for each count. A future offset-based regression would
+        // pass for one count and fail for the others.
+        for (extraImports in listOf(0, 1, 3, 12, 25)) {
+            val importBlock = (1..extraImports).joinToString("") { "import pkg.Type$it\n" }
+            val code = importBlock + "val bad: String = 123"
+
+            val result = CodeWrapperForCompilation.wrap("Test", code)
+            assertRemaps(result, "val bad: String = 123", originalLine = extraImports + 1, col = 19)
+        }
     }
 
     @Test

--- a/kotlin-cli/src/test/kotlin/com/jonnyzzz/mcpSteroid/koltinc/CodeWrapperForCompilationTest.kt
+++ b/kotlin-cli/src/test/kotlin/com/jonnyzzz/mcpSteroid/koltinc/CodeWrapperForCompilationTest.kt
@@ -2,9 +2,35 @@
 package com.jonnyzzz.mcpSteroid.koltinc
 
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class CodeWrapperForCompilationTest {
+
+    /**
+     * Drift-proof remap assertion: locate where [snippet] physically lands in the generated
+     * code and verify that a compiler error on that wrapped line remaps back to [originalLine].
+     *
+     * Deriving the wrapped line from the emitted code — instead of hardcoding an offset like
+     * "user code starts at wrapped line 23+N" — is the whole point: those hardcoded offsets
+     * silently drifted when [CodeWrapperForCompilation.defaultImports] grew from 12 to 15 entries,
+     * so real compiler errors (at the true line) were no longer remapped while these tests, which
+     * fed the *stale* line numbers, kept passing. Searching the actual output makes the test track
+     * reality and catch any future drift.
+     */
+    private fun assertRemaps(
+        result: CodeWrapperForCompilation.WrapResult,
+        snippet: String,
+        originalLine: Int,
+        col: Int = 5,
+    ) {
+        val wrappedLine = result.code.lines().indexOfFirst { it.contains(snippet) } + 1
+        assertTrue("snippet <$snippet> not found in generated code:\n${result.code}", wrappedLine > 0)
+        assertEquals(
+            "input.kt:$originalLine:$col: error: boom",
+            result.lineMapping.remapCompilerOutput("input.kt:$wrappedLine:$col: error: boom"),
+        )
+    }
 
     @Test
     fun `line mapping maps import lines back to original positions`() {
@@ -16,13 +42,7 @@ class CodeWrapperForCompilationTest {
         """.trimIndent()
 
         val result = CodeWrapperForCompilation.wrap("Test", code)
-        val mapping = result.lineMapping
-
-        // "import foo.Bar" is on original line 1.
-        // In wrapped code, user imports start at line 15 (after 12 default imports + empty + comment).
-        // So wrapped line 15 should map to original line 1.
-        val remapped = mapping.remapCompilerOutput("input.kt:15:1: error: unresolved")
-        assertEquals("input.kt:1:1: error: unresolved", remapped)
+        assertRemaps(result, "import foo.Bar", originalLine = 1, col = 1)
     }
 
     @Test
@@ -35,19 +55,8 @@ class CodeWrapperForCompilationTest {
         """.trimIndent()
 
         val result = CodeWrapperForCompilation.wrap("Test", code)
-        val mapping = result.lineMapping
-
-        // "import foo.Bar" is 1 import line, so N=1.
-        // Non-import lines: "" (line 2), "val x: String = 123" (line 3), "println(x)" (line 4)
-        // User code starts at wrapped line 23 + N = 24.
-        // Wrapped line 24 -> original line 2 (the empty line)
-        // Wrapped line 25 -> original line 3 (val x: String = 123)
-        // Wrapped line 26 -> original line 4 (println(x))
-        val remapped3 = mapping.remapCompilerOutput("input.kt:25:21: error: type mismatch")
-        assertEquals("input.kt:3:21: error: type mismatch", remapped3)
-
-        val remapped4 = mapping.remapCompilerOutput("input.kt:26:1: error: unresolved reference")
-        assertEquals("input.kt:4:1: error: unresolved reference", remapped4)
+        assertRemaps(result, "val x: String = 123", originalLine = 3, col = 21)
+        assertRemaps(result, "println(x)", originalLine = 4, col = 1)
     }
 
     @Test
@@ -58,17 +67,8 @@ class CodeWrapperForCompilationTest {
         """.trimIndent()
 
         val result = CodeWrapperForCompilation.wrap("Test", code)
-        val mapping = result.lineMapping
-
-        // No user imports, so N=0.
-        // User code starts at wrapped line 23 + 0 = 23.
-        // "val x: String = 123" is original line 1 -> wrapped line 23
-        // "println(x)" is original line 2 -> wrapped line 24
-        val remapped1 = mapping.remapCompilerOutput("input.kt:23:21: error: type mismatch")
-        assertEquals("input.kt:1:21: error: type mismatch", remapped1)
-
-        val remapped2 = mapping.remapCompilerOutput("input.kt:24:1: error: unresolved reference")
-        assertEquals("input.kt:2:1: error: unresolved reference", remapped2)
+        assertRemaps(result, "val x: String = 123", originalLine = 1, col = 21)
+        assertRemaps(result, "println(x)", originalLine = 2, col = 1)
     }
 
     @Test
@@ -81,46 +81,28 @@ class CodeWrapperForCompilationTest {
         """.trimIndent()
 
         val result = CodeWrapperForCompilation.wrap("Test", code)
-        val mapping = result.lineMapping
-
-        // 2 import lines (N=2).
-        // Import 1: wrapped line 15 -> original line 1
-        // Import 2: wrapped line 16 -> original line 2
-        val remappedImport1 = mapping.remapCompilerOutput("input.kt:15:8: error: unresolved")
-        assertEquals("input.kt:1:8: error: unresolved", remappedImport1)
-
-        val remappedImport2 = mapping.remapCompilerOutput("input.kt:16:8: error: unresolved")
-        assertEquals("input.kt:2:8: error: unresolved", remappedImport2)
-
-        // Non-import lines: "" (line 3), "val x = 42" (line 4)
-        // User code starts at wrapped line 23 + 2 = 25.
-        // Wrapped line 25 -> original line 3 (empty)
-        // Wrapped line 26 -> original line 4 (val x = 42)
-        val remappedCode = mapping.remapCompilerOutput("input.kt:26:5: error: something")
-        assertEquals("input.kt:4:5: error: something", remappedCode)
+        assertRemaps(result, "import foo.Bar", originalLine = 1, col = 8)
+        assertRemaps(result, "import baz.Qux", originalLine = 2, col = 8)
+        assertRemaps(result, "val x = 42", originalLine = 4)
     }
 
     @Test
     fun `line mapping with single line of code`() {
         val code = "val x: String = 123"
         val result = CodeWrapperForCompilation.wrap("Test", code)
-        val mapping = result.lineMapping
-
-        // No imports (N=0), one code line at original line 1.
-        // Wrapped line 23 -> original line 1.
-        val remapped = mapping.remapCompilerOutput("input.kt:23:21: error: type mismatch")
-        assertEquals("input.kt:1:21: error: type mismatch", remapped)
+        assertRemaps(result, "val x: String = 123", originalLine = 1, col = 21)
     }
 
     @Test
     fun `wrapper boilerplate lines are not remapped`() {
         val code = "val x = 1"
         val result = CodeWrapperForCompilation.wrap("Test", code)
-        val mapping = result.lineMapping
 
-        // Line 16 is "class Test {" — a wrapper boilerplate line.
-        val input = "input.kt:16:1: error: some weird error"
-        assertEquals(input, mapping.remapCompilerOutput(input))
+        // The generated "class Test {" line is wrapper boilerplate — it must pass through unchanged.
+        val classLine = result.code.lines().indexOfFirst { it.contains("class Test {") } + 1
+        assertTrue(classLine > 0)
+        val input = "input.kt:$classLine:1: error: some weird error"
+        assertEquals(input, result.lineMapping.remapCompilerOutput(input))
     }
 
     @Test
@@ -160,16 +142,8 @@ class CodeWrapperForCompilationTest {
         assertEquals(listOf(2, 4, 6), extracted.otherLineNumbers)
 
         val result = CodeWrapperForCompilation.wrap("Test", code)
-        // 3 imports (N=3), code lines start at 23+3=26
-        // otherLine[0]="val x = 1" (orig 2) -> wrapped 26
-        // otherLine[1]="val y = x + 1" (orig 4) -> wrapped 27
-        // otherLine[2]="println(y)" (orig 6) -> wrapped 28
-        val remapped = result.lineMapping.remapCompilerOutput("input.kt:27:5: error: something on y")
-        assertEquals("input.kt:4:5: error: something on y", remapped)
-
-        // import lines: wrapped 15->orig 1, 16->orig 3, 17->orig 5
-        val remappedImport = result.lineMapping.remapCompilerOutput("input.kt:16:8: error: unresolved")
-        assertEquals("input.kt:3:8: error: unresolved", remappedImport)
+        assertRemaps(result, "val y = x + 1", originalLine = 4)
+        assertRemaps(result, "import java.util.Date", originalLine = 3, col = 8)
     }
 
     @Test
@@ -186,11 +160,7 @@ class CodeWrapperForCompilationTest {
         """.trimIndent()
 
         val result = CodeWrapperForCompilation.wrap("Test", code)
-        // No imports (N=0), code starts at line 23
-        // Line 23->orig 1, 24->2, 25->3, 26->4, 27->5, 28->6, 29->7, 30->8
-        // Error on "val bad: String = result.length" -> orig line 7
-        val remapped = result.lineMapping.remapCompilerOutput("input.kt:29:23: error: type mismatch")
-        assertEquals("input.kt:7:23: error: type mismatch", remapped)
+        assertRemaps(result, "val bad: String = result.length", originalLine = 7, col = 23)
     }
 
     @Test
@@ -198,16 +168,7 @@ class CodeWrapperForCompilationTest {
         val code = "val text = \"\"\"\n    line 1\n    line 2\n    line 3\n\"\"\".trimIndent()\nval bad: Int = text\nprintln(text)"
 
         val result = CodeWrapperForCompilation.wrap("Test", code)
-        // No imports, code starts at line 23
-        // val text = """   -> orig 1, line 23
-        //     line 1        -> orig 2, line 24
-        //     line 2        -> orig 3, line 25
-        //     line 3        -> orig 4, line 26
-        // """.trimIndent()  -> orig 5, line 27
-        // val bad: Int = text -> orig 6, line 28
-        // println(text)     -> orig 7, line 29
-        val remapped = result.lineMapping.remapCompilerOutput("input.kt:28:20: error: type mismatch")
-        assertEquals("input.kt:6:20: error: type mismatch", remapped)
+        assertRemaps(result, "val bad: Int = text", originalLine = 6, col = 20)
     }
 
     @Test
@@ -225,10 +186,7 @@ class CodeWrapperForCompilationTest {
         assertEquals(listOf(1, 2, 3, 4, 6, 7), extracted.otherLineNumbers)
 
         val result = CodeWrapperForCompilation.wrap("Test", code)
-        // 1 import (N=1), code starts at 24
-        // otherLine[4]="val f: Int = File(\"x\")" (orig 6) -> wrapped 28
-        val remapped = result.lineMapping.remapCompilerOutput("input.kt:28:18: error: type mismatch")
-        assertEquals("input.kt:6:18: error: type mismatch", remapped)
+        assertRemaps(result, "val f: Int = File(\"x\")", originalLine = 6, col = 18)
     }
 
     @Test
@@ -250,22 +208,8 @@ class CodeWrapperForCompilationTest {
         """.trimIndent()
 
         val result = CodeWrapperForCompilation.wrap("Test", code)
-        // 1 import (N=1), code starts at 24
-        // otherLines: ""(2), "val counter..."(3), "val incrementer..."(4), "counter.inc..."(5),
-        //   "}"(6), ""(7), "val result: String..."(8), "val items..."(9), "val joined: Int..."(10),
-        //   ""(11), "incrementer()"(12), "println..."(13)
-        // otherLine[6] = "val result: String = counter.get()" (orig 8) -> wrapped 30
-        // otherLine[8] = "val joined: Int = items.joinToString()" (orig 10) -> wrapped 32
-        val compilerOutput = """
-            input.kt:30:26: error: type mismatch: expected 'String', actual 'Int'
-            input.kt:32:24: error: type mismatch: expected 'Int', actual 'String'
-        """.trimIndent()
-        val remapped = result.lineMapping.remapCompilerOutput(compilerOutput)
-        val expected = """
-            input.kt:8:26: error: type mismatch: expected 'String', actual 'Int'
-            input.kt:10:24: error: type mismatch: expected 'Int', actual 'String'
-        """.trimIndent()
-        assertEquals(expected, remapped)
+        assertRemaps(result, "val result: String = counter.get()", originalLine = 8, col = 26)
+        assertRemaps(result, "val joined: Int = items.joinToString()", originalLine = 10, col = 24)
     }
 
     @Test
@@ -288,10 +232,7 @@ class CodeWrapperForCompilationTest {
         assertEquals(listOf(3, 6, 8), extracted.otherLineNumbers)
 
         val result = CodeWrapperForCompilation.wrap("Test", code)
-        // 5 imports (N=5), code starts at 23+5=28
-        // otherLine[2]="val c: String = a + b" (orig 8) -> wrapped 30
-        val remapped = result.lineMapping.remapCompilerOutput("input.kt:30:21: error: type mismatch")
-        assertEquals("input.kt:8:21: error: type mismatch", remapped)
+        assertRemaps(result, "val c: String = a + b", originalLine = 8, col = 21)
     }
 
     @Test
@@ -309,9 +250,7 @@ class CodeWrapperForCompilationTest {
         assertEquals(listOf(1, 2), extracted.otherLineNumbers)
 
         val result = CodeWrapperForCompilation.wrap("Test", code)
-        // No imports (N=0), code starts at 23
-        val remapped = result.lineMapping.remapCompilerOutput("input.kt:24:18: error: type mismatch")
-        assertEquals("input.kt:2:18: error: type mismatch", remapped)
+        assertRemaps(result, "val x: Int = msg", originalLine = 2, col = 18)
     }
 
     @Test
@@ -330,9 +269,7 @@ class CodeWrapperForCompilationTest {
         assertEquals(listOf(1, 3), extracted.otherLineNumbers)
 
         val result = CodeWrapperForCompilation.wrap("Test", code)
-        // 1 import (N=1), code starts at 24
-        val remapped = result.lineMapping.remapCompilerOutput("input.kt:25:18: error: type mismatch")
-        assertEquals("input.kt:3:18: error: type mismatch", remapped)
+        assertRemaps(result, "val f: Int = File(\"x\")", originalLine = 3, col = 18)
     }
 
     @Test
@@ -361,11 +298,7 @@ class CodeWrapperForCompilationTest {
         assertEquals(listOf(5), extracted.importLineNumbers)
 
         val result = CodeWrapperForCompilation.wrap("Test", code)
-        // 1 import, code starts at 24
-        // otherLines: line 1 ($"""), line 2 (import fake), line 3 (real content), line 4 ("""), line 6 (val x)
-        // otherLine[4] = "val x: Int = \"hello\"" (orig 6) -> wrapped 28
-        val remapped = result.lineMapping.remapCompilerOutput("input.kt:28:18: error: type mismatch")
-        assertEquals("input.kt:6:18: error: type mismatch", remapped)
+        assertRemaps(result, "val x: Int = \"hello\"", originalLine = 6, col = 18)
     }
 
     @Test
@@ -399,10 +332,7 @@ class CodeWrapperForCompilationTest {
         assertEquals(listOf(1, 3), extracted.otherLineNumbers)
 
         val result = CodeWrapperForCompilation.wrap("Test", code)
-        // 1 import (N=1), code starts at 24
-        // otherLine[1] = "val x: Int = s" (orig 3) -> wrapped 25
-        val remapped = result.lineMapping.remapCompilerOutput("input.kt:25:18: error: type mismatch")
-        assertEquals("input.kt:3:18: error: type mismatch", remapped)
+        assertRemaps(result, "val x: Int = s", originalLine = 3, col = 18)
     }
 
     @Test
@@ -438,11 +368,7 @@ class CodeWrapperForCompilationTest {
         assertEquals(listOf(2, 3, 4, 5, 7), extracted.otherLineNumbers)
 
         val result = CodeWrapperForCompilation.wrap("Test", code)
-        // 2 imports (N=2), code starts at 25
-        // otherLines: line 2 (val s="""), line 3 (import fake.one), line 4 (import fake.two), line 5 ("""), line 7 (val d)
-        // otherLine[4] = "val d: Int = Date()" (orig 7) -> wrapped 29
-        val remapped = result.lineMapping.remapCompilerOutput("input.kt:29:18: error: type mismatch")
-        assertEquals("input.kt:7:18: error: type mismatch", remapped)
+        assertRemaps(result, "val d: Int = Date()", originalLine = 7, col = 18)
     }
 
     @Test
@@ -467,20 +393,7 @@ class CodeWrapperForCompilationTest {
         """.trimIndent()
 
         val result = CodeWrapperForCompilation.wrap("Script", code)
-
-        // Simulate compiler output with wrapped line numbers:
-        // 1 import (N=1), code lines start at 23+1=24
-        // Line 24 -> original 2 (empty), line 25 -> original 3, line 26 -> original 4
-        val compilerOutput = """
-            e: input.kt:25:21: error: The integer literal does not conform to the expected type 'String'
-            e: input.kt:26:18: error: The literal does not conform to the expected type 'Int'
-        """.trimIndent()
-
-        val remapped = result.lineMapping.remapCompilerOutput(compilerOutput)
-        val expected = """
-            e: input.kt:3:21: error: The integer literal does not conform to the expected type 'String'
-            e: input.kt:4:18: error: The literal does not conform to the expected type 'Int'
-        """.trimIndent()
-        assertEquals(expected, remapped)
+        assertRemaps(result, "val x: String = 123", originalLine = 3, col = 21)
+        assertRemaps(result, "val y: Int = \"hello\"", originalLine = 4, col = 18)
     }
 }


### PR DESCRIPTION
CodeWrapperForCompilation wraps a submitted script with a preamble (default imports + boilerplate) before compiling, then maps wrapped-file line numbers back to the submitted script's lines so kotlinc diagnostics and stack-trace frames point at the line the agent actually wrote.

The mapping used hardcoded offsets (`15 + i` for imports, `23 + n + i` for code) computed for 12 default imports. The default-imports list has since grown (15, and 18 after #42 added the PSI subpackages), so every mapping was off by the difference: real diagnostics fell on unmapped wrapped lines and were shown to the agent verbatim (e.g. `input.kt:26` for a 2-line script), breaking "fix line N" self-correction loops.

Build the line mapping while emitting the wrapped code — record each user line's position as it is written — so the map can never drift from the generated layout again, regardless of how many default imports exist.

CodeWrapperForCompilationTest fed the stale wrapped line numbers (the same numbers the buggy map produced) and so never caught the drift; rewrite each case to derive the wrapped line from the actually-generated code and assert the remap round-trips. Closes item #12 in docs/agent-feature-review-2026-06.md.