### PR TITLE
test-integration: fail fast when the IDE dies during the MCP-startup wait

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -35,7 +35,7 @@
   thrown), but the signal is noise for Kotlin projects. Found validating #200's settle on
   GradleCompileTest (2026-07-02).
 
-- [ ] **`waitForMcpReady` should fail fast on a dead container (quorum follow-up to PR #187, the typed-retry
+- [x] **`waitForMcpReady` should fail fast on a dead container (quorum follow-up to PR #187, the typed-retry
   rework)**: the 300s startup health-check treats a *dead/missing* container the same as "server still
   starting" — `docker exec … curl` **exits non-zero (125)** rather than throwing, so it is retried to the
   300s deadline instead of surfacing at once as a terminal `McpRequestFailedError`. Pre-existing (not a

--- a/test-integration/src/main/kotlin/com/jonnyzzz/mcpSteroid/integration/infra/intelliJ-factory.kt
+++ b/test-integration/src/main/kotlin/com/jonnyzzz/mcpSteroid/integration/infra/intelliJ-factory.kt
@@ -151,7 +151,7 @@ fun IntelliJContainer.Companion.create(lifetime: CloseableStack, opts: IntelliJC
     require(ijProcess.isRunning()) { "${ideProduct.displayName} process finished" }
 
     // Wait for MCP server readiness
-    val mcpSteroidDriver = McpSteroidDriver(container, ijDriver)
+    val mcpSteroidDriver = McpSteroidDriver(container, ijDriver, ijProcess)
     console.writeInfo("Waiting for MCP Steroid server...")
     mcpSteroidDriver.waitForMcpReady()
 

--- a/test-integration/src/main/kotlin/com/jonnyzzz/mcpSteroid/integration/infra/mcp-steroid.kt
+++ b/test-integration/src/main/kotlin/com/jonnyzzz/mcpSteroid/integration/infra/mcp-steroid.kt
@@ -3,6 +3,7 @@ package com.jonnyzzz.mcpSteroid.integration.infra
 
 import com.jonnyzzz.mcpSteroid.testHelper.docker.ContainerDriver
 import com.jonnyzzz.mcpSteroid.testHelper.docker.ContainerPort
+import com.jonnyzzz.mcpSteroid.testHelper.docker.RunningContainerProcess
 import com.jonnyzzz.mcpSteroid.testHelper.docker.mapGuestPortToHostPort
 import com.jonnyzzz.mcpSteroid.testHelper.docker.startProcessInContainer
 import com.jonnyzzz.mcpSteroid.testHelper.docker.writeFileInContainer
@@ -166,6 +167,13 @@ fun parseMcpToolResultIsError(response: String): Boolean =
 class McpSteroidDriver(
     val driver: ContainerDriver,
     val ijDriver: IntelliJDriver,
+    /**
+     * The IDE process this MCP server lives in — the liveness signal for [waitForMcpReady]. Passed in
+     * from [IntelliJDriver.startIde]'s return value (the driver stays stateless — it can start multiple
+     * container processes and holds no mutable process field); kept private so the process-level surface
+     * does not leak past this driver.
+     */
+    private val ideProcess: RunningContainerProcess,
 ) {
     companion object {
         val MCP_STEROID_PORT = ContainerPort(6754)
@@ -179,6 +187,17 @@ class McpSteroidDriver(
 
     fun waitForMcpReady() {
         waitFor(300_000, "MCP Steroid server ready") {
+            // Dead-IDE/dead-container fail-fast: a dead IDE process can never serve MCP, but its symptoms —
+            // `docker exec` exiting non-zero (125 on a dead container) or curl connection-refused — are
+            // indistinguishable from "server still starting", so they alone must keep retrying. The process
+            // liveness (`kill -0` via docker exec; also false when the whole container is gone) is the real
+            // signal: when it drops, log the process details and stop the 300s poll at once instead of
+            // burning it to the deadline (quorum follow-up to the typed-retry rework).
+            if (!ideProcess.isRunning()) {
+                ideProcess.printProcessInfo() // exit code + output tails, logged by the process itself
+                throw McpRequestFailedError("IDE died while waiting for the MCP Steroid server")
+            }
+
             // The container interactions here are terminal-by-default: reading the IDE log and running the
             // health-check curl both go through `docker exec`, which THROWS if the container has died — a
             // terminal infrastructure failure, so we map it to McpRequestFailedError (an Error) and the wait


### PR DESCRIPTION
Closes the known gap from the typed-retry rework (tracked in TODO.md, found by the adversarial quorum's round 7 on #187): during the 300 s MCP-startup poll, a dead IDE process / dead container was indistinguishable from "server still starting" (`docker exec … curl` exits non-zero without throwing), so the poll burned the full 300 s before a generic timeout.

## What
- **The handle enters once, at construction:** the factory passes `startIde()`'s return value into `McpSteroidDriver(driver, ijDriver, ideProcess)`, held as a `private val`. `startIde` stays **pure** — `IntelliJDriver` can start multiple container processes and keeps **no mutable process field** (`intelliJ.kt` is untouched). `waitForMcpReady()` keeps its no-arg signature; the process-level surface leaks nowhere.
- Every poll round starts with the liveness check (`kill -0` via `docker exec`; false for a dead process AND a dead container). On death the process **logs its own details** (`printProcessInfo`: exit code, output tails) and the poll throws a terminal `McpRequestFailedError` with an abstract message. Healthy slow starts are unaffected. TODO entry ticked.

## Gates
- **Local:** `:test-integration` unit tests green; **GradleCompileTest E2E green on this exact shape** (server-ready through the liveness-gated poll, 2 m 10 s).
- **Quorum:** claude + codex **APPROVE** (re-run on each of the three design iterations).
- **Inspections:** clean on the changed lines.