### PR TITLE
Fix the 2 remaining experiment-gate failures: markdown-blind ROOT_CAUSE scorer + rename baseline timeout

### DIFF
--- a/test-experiments/src/test/kotlin/com/jonnyzzz/mcpSteroid/integration/tests/DebuggerDemoTest.kt
+++ b/test-experiments/src/test/kotlin/com/jonnyzzz/mcpSteroid/integration/tests/DebuggerDemoTest.kt
@@ -431,20 +431,13 @@ class DebuggerDemoTest {
             "Agent did not output required marker 'ROOT_CAUSE:' (or equivalent).\nOutput:\n$combined"
         }
 
-        val ignoredReturnPatterns = listOf(
-            "ignor", "unused", "discard", "return value", "not assigned", "not assigned back",
-            "not used", "isn't assigned", "not stored", "not captured", "thrown away", "result is lost",
-        )
-        val returnsNewListPatterns = listOf(
-            "new list", "returns new", "does not modify", "doesn't modify",
-            "not in place", "immutable", "original list", "new sorted list", "sorted copy",
-        )
-        val mentionsIgnoredReturn = ignoredReturnPatterns.any { rootCause.contains(it, ignoreCase = true) }
-        val mentionsNewList = returnsNewListPatterns.any { rootCause.contains(it, ignoreCase = true) }
-        check(mentionsIgnoredReturn && mentionsNewList) {
+        // Pattern-matching lives in scoreSortedByDescendingRootCause (markdown-normalized — raw substring
+        // matching rejected two semantically perfect CI answers because of backticks around identifiers).
+        val rootCauseScore = scoreSortedByDescendingRootCause(rootCause)
+        check(rootCauseScore.pass) {
             "ROOT_CAUSE must explain that sortedByDescending returns a new list and its return value is ignored.\n" +
-                    "Expected ignored-return patterns: $ignoredReturnPatterns\n" +
-                    "Expected new-list patterns: $returnsNewListPatterns\n" +
+                    "mentionsIgnoredReturn=${rootCauseScore.mentionsIgnoredReturn} " +
+                    "mentionsNewList=${rootCauseScore.mentionsNewList}\n" +
                     "Actual ROOT_CAUSE: $rootCause\nOutput:\n$combined"
         }
         console.writeSuccess("ROOT_CAUSE quality validated")

--- a/test-experiments/src/test/kotlin/com/jonnyzzz/mcpSteroid/integration/tests/KeycloakRenameTest.kt
+++ b/test-experiments/src/test/kotlin/com/jonnyzzz/mcpSteroid/integration/tests/KeycloakRenameTest.kt
@@ -29,16 +29,23 @@ import java.util.concurrent.TimeUnit
  */
 class KeycloakRenameTest {
 
-    @Test @Timeout(value = 50, unit = TimeUnit.MINUTES)
+    // 80 min, not the 50 the other Keycloak scenarios use: the without-MCP baseline legitimately needs
+    // ~30 min of agent work for the manual rename sweep + rebuild (measured on CI build 991971402, where
+    // the agent finished successfully at 30.3 min but container start + Keycloak import + verification
+    // pushed the method past 50). The slow baseline IS the experiment's finding — it must complete and
+    // emit its [ARENA] block so the dashboard can show the gap, not die as a timeout with no data.
+    // TC-side executionTimeoutMin=180 fits two 80-min methods.
+
+    @Test @Timeout(value = 80, unit = TimeUnit.MINUTES)
     fun `claude with mcp`() = run("claude", withMcp = true)
 
-    @Test @Timeout(value = 50, unit = TimeUnit.MINUTES)
+    @Test @Timeout(value = 80, unit = TimeUnit.MINUTES)
     fun `claude without mcp`() = run("claude", withMcp = false)
 
-    @Test @Timeout(value = 50, unit = TimeUnit.MINUTES)
+    @Test @Timeout(value = 80, unit = TimeUnit.MINUTES)
     fun `codex with mcp`() = run("codex", withMcp = true)
 
-    @Test @Timeout(value = 50, unit = TimeUnit.MINUTES)
+    @Test @Timeout(value = 80, unit = TimeUnit.MINUTES)
     fun `codex without mcp`() = run("codex", withMcp = false)
 
     private fun run(agentName: String, withMcp: Boolean) {

--- a/test-integration/src/main/kotlin/com/jonnyzzz/mcpSteroid/integration/tests/SemanticTaskScoring.kt
+++ b/test-integration/src/main/kotlin/com/jonnyzzz/mcpSteroid/integration/tests/SemanticTaskScoring.kt
@@ -113,3 +113,41 @@ fun scoreInspections(output: String, minIssues: Int, targetFile: String): Inspec
         detected = mentionsCast && mentionsFile && (count ?: 0) >= minIssues,
     )
 }
+
+data class RootCauseScore(
+    val mentionsIgnoredReturn: Boolean,
+    val mentionsNewList: Boolean,
+) {
+    val pass: Boolean get() = mentionsIgnoredReturn && mentionsNewList
+}
+
+/**
+ * Score the ROOT_CAUSE explanation for the sortedByDescending debugger scenario: the agent must state
+ * BOTH that `sortedByDescending` produces a new list (does not mutate) AND that its return value is
+ * ignored / never assigned back.
+ *
+ * Matching runs on a markdown-normalized copy of the text — backticks/asterisks stripped, punctuation
+ * collapsed to spaces — because agents format code identifiers ("returns a NEW sorted `List`", "the
+ * original `players` list"), which broke raw substring patterns on two real CI runs (988635686,
+ * 991971410) despite semantically perfect answers.
+ */
+fun scoreSortedByDescendingRootCause(rootCause: String): RootCauseScore {
+    // Normalize: lowercase, drop markdown emphasis/code marks and punctuation, collapse whitespace.
+    val text = rootCause.lowercase()
+        .replace(Regex("[`*_,;:()\\[\\]{}\"']"), " ")
+        .replace(Regex("\\s+"), " ")
+
+    val ignoredReturnPatterns = listOf(
+        "ignor", "unused", "discard", "return value", "not assigned", "never assigned",
+        "not used", "isn't assigned", "not stored", "not captured", "thrown away", "result is lost",
+    )
+    val returnsNewListPatterns = listOf(
+        "new list", "returns new", "returns a new", "does not modify", "doesn't modify",
+        "not in place", "non-mutating", "non mutating", "immutable", "original list",
+        "new sorted list", "a new sorted", "sorted copy", "leaves the original", "leaves the receiver",
+    )
+    return RootCauseScore(
+        mentionsIgnoredReturn = ignoredReturnPatterns.any { text.contains(it) },
+        mentionsNewList = returnsNewListPatterns.any { text.contains(it) },
+    )
+}

--- a/test-integration/src/test/kotlin/com/jonnyzzz/mcpSteroid/integration/tests/SortedByDescendingRootCauseTest.kt
+++ b/test-integration/src/test/kotlin/com/jonnyzzz/mcpSteroid/integration/tests/SortedByDescendingRootCauseTest.kt
@@ -1,0 +1,79 @@
+/* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
+package com.jonnyzzz.mcpSteroid.integration.tests
+
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * Pure tests for [scoreSortedByDescendingRootCause] — the DebuggerDemoTest gate for the "unit test via
+ * debugger" scenario. The two REGRESSION cases are the verbatim ROOT_CAUSE texts Claude (Opus 4.8)
+ * produced on CI builds 988635686 (2026-06-30) and 991971410 (2026-07-02): both semantically perfect
+ * (the second even carries debugger identity evidence and the exact fix) yet rejected by the old raw
+ * substring patterns — markdown backticks broke `new sorted list` ("NEW sorted `List`") and inserted
+ * words broke `original list` ("the original `players` list"). Scoring must normalize markdown before
+ * matching.
+ */
+class SortedByDescendingRootCauseTest {
+
+    // Verbatim from CI build 991971410 (2026-07-02).
+    private val ci20260702 =
+        "sortedByDescending` is a non-mutating extension that returns a NEW sorted `List` and leaves " +
+            "the original `players` list untouched. On line 9 the return value of " +
+            "`players.sortedByDescending { it.score }` is ignored — it is never assigned back to " +
+            "`players` (nor is `sortByDescending`, the in-place variant, used). So line 10 " +
+            "`return players` returns the original, still-unsorted list."
+
+    // Verbatim from CI build 988635686 (2026-06-30).
+    private val ci20260630 =
+        "sortedByDescending` is a non-mutating Kotlin extension that returns a NEW sorted `List` and " +
+            "leaves the receiver untouched (debugger confirmed `sortedByDescending(...) === players` is " +
+            "`false`). On line 9 the return value is ignored / never assigned back to `players`, so " +
+            "line 10 `return players` returns the original unsorted list."
+
+    @Test
+    fun `accepts the real CI answers that the raw substring patterns rejected`() {
+        for (rootCause in listOf(ci20260702, ci20260630)) {
+            val score = scoreSortedByDescendingRootCause(rootCause)
+            assertTrue(score.mentionsIgnoredReturn, "ignored-return should match:\n$rootCause")
+            assertTrue(score.mentionsNewList, "new-list should match:\n$rootCause")
+            assertTrue(score.pass, "must pass:\n$rootCause")
+        }
+    }
+
+    @Test
+    fun `accepts a plain unformatted correct explanation`() {
+        val score = scoreSortedByDescendingRootCause(
+            "sortedByDescending returns a new list; the return value is ignored and never assigned back."
+        )
+        assertTrue(score.pass)
+    }
+
+    @Test
+    fun `rejects an explanation that misses the new-list half`() {
+        val score = scoreSortedByDescendingRootCause(
+            "The return value on line 9 is ignored, so the list stays unsorted."
+        )
+        assertTrue(score.mentionsIgnoredReturn)
+        assertFalse(score.mentionsNewList)
+        assertFalse(score.pass)
+    }
+
+    @Test
+    fun `rejects an explanation that misses the ignored-return half`() {
+        val score = scoreSortedByDescendingRootCause(
+            "sortedByDescending creates a new sorted list instead of sorting in place."
+        )
+        assertTrue(score.mentionsNewList)
+        assertFalse(score.mentionsIgnoredReturn)
+        assertFalse(score.pass)
+    }
+
+    @Test
+    fun `rejects a wrong root cause entirely`() {
+        val score = scoreSortedByDescendingRootCause(
+            "The comparator is inverted: it.score should be negated for descending order."
+        )
+        assertFalse(score.pass)
+    }
+}


### PR DESCRIPTION
The 2026-07-02 re-run of the experiment matrix on the redesigned import infra came back **7/9 green** — the Keycloak import stabilization works. This PR fixes the two remaining reds; **neither is an infra or agent bug**:

## 1. DebuggerDemo_UnitTest_Claude — scorer false negative (2nd occurrence)
Claude's ROOT_CAUSE was semantically perfect both times (builds 988635686, 991971410) — it even included the exact fix, and the second run carried debugger identity evidence (`sortedByDescending(...) === players` is `false`). The raw substring patterns rejected it purely over markdown:
- `returns a NEW sorted \`List\`` — backtick breaks `new sorted list`
- `the original \`players\` list` — inserted word breaks `original list`

**Fix:** extracted pure `scoreSortedByDescendingRootCause` (in `SemanticTaskScoring`): normalize markdown (strip code/emphasis marks + punctuation, collapse whitespace), broaden patterns (`non-mutating`, `never assigned`, `leaves the original/receiver`, …). Unit-tested with the **two verbatim CI answers as regression cases**, plus wrong/half answers still rejected (`SortedByDescendingRootCauseTest`, 5 cases, TDD).

## 2. KeycloakRename_Claude — baseline needs more than 50 min
The without-MCP baseline agent **finished successfully at 30.3 min** of agent work (255 tool calls: 161 Read / 59 Bash / 24 Edit — the manual sweep + rebuild), but setup + verification pushed the method past the 50-min `@Timeout`, killing the run **with no `[ARENA]` block**. The slow baseline is exactly the finding — it must complete and record data so the dashboard shows the gap (the with-MCP run passed comfortably).

**Fix:** `@Timeout` 50 → 80 min for `KeycloakRenameTest` only (rationale in a code comment; TC-side `executionTimeoutMin=180` fits 2×80).

## Verification
- `SortedByDescendingRootCauseTest` 5/5; `:test-experiments:compileTestKotlin` green.
- After merge: re-run `KeycloakRename_Claude` + `DebuggerDemo_UnitTest_Claude` on CI → expect 9/9 → re-render dashboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)