### PR TITLE
execute_code: fix #156 — findProjectFile null class (absolute paths + stale VFS) + empty error diagnostics

### DIFF
--- a/ij-plugin/src/main/kotlin/com/jonnyzzz/mcpSteroid/execution/ExecutionSuggestionService.kt
+++ b/ij-plugin/src/main/kotlin/com/jonnyzzz/mcpSteroid/execution/ExecutionSuggestionService.kt
@@ -6,6 +6,7 @@ import com.intellij.openapi.components.service
 import com.intellij.openapi.project.Project
 import com.jonnyzzz.mcpSteroid.prompts.generated.debugger.OverviewPromptArticle as DebuggerOverview
 import com.jonnyzzz.mcpSteroid.prompts.generated.skill.CodingWithIntelliJThreadingPromptArticle
+import com.jonnyzzz.mcpSteroid.prompts.generated.skill.CodingWithIntelliJVfsPromptArticle
 
 inline val Project.executionSuggestionService: ExecutionSuggestionService get() = service()
 
@@ -116,6 +117,17 @@ class ExecutionSuggestionService(
 
             errorMessage.contains("JavaLineBreakpointProperties", ignoreCase = true) || errorMessage.contains("\"props\" is null") ->
                 "TIP: Use XDebuggerUtil.toggleLineBreakpoint() instead of breakpointManager.addLineBreakpoint() with null properties. See ${DebuggerOverview().uri}"
+
+            // #156: matches ONLY the messageless-exception summary produced by ScriptExecutor
+            // ("NullPointerException (no message)"), so NPEs that carry a real message — which
+            // is its own diagnostic — keep their more specific handling.
+            errorMessage.contains("NullPointerException (no message)") ->
+                "TIP: A bare NullPointerException usually means `!!` on a null lookup. " +
+                    "findProjectFile()/findFile() return null when the file is missing — prefer " +
+                    "`?: error(\"not found: \$path\")` over `!!` so the failure names the path. " +
+                    "Both helpers accept project-relative and absolute paths; outside read/write " +
+                    "actions the lookup always refreshes the file from disk (snapshot-only inside). " +
+                    "For directory refresh and other VFS recipes, fetch ${CodingWithIntelliJVfsPromptArticle().uri}."
 
             errorMessage.contains("breakpoint", ignoreCase = true) || errorMessage.contains("debug", ignoreCase = true) ->
                 "TIP: For debugger help, fetch ${DebuggerOverview().uri} via steroid_fetch_resource"

--- a/ij-plugin/src/main/kotlin/com/jonnyzzz/mcpSteroid/execution/McpScriptContext.kt
+++ b/ij-plugin/src/main/kotlin/com/jonnyzzz/mcpSteroid/execution/McpScriptContext.kt
@@ -426,21 +426,31 @@ interface McpScriptContext {
     // ============================================================
 
     /**
-     * Find a VirtualFile by an absolute path.
-     * Returns null if the file doesn't exist.
+     * Find a VirtualFile by an absolute path (local file system).
+     * Returns null if the file doesn't exist on disk.
+     *
+     * Called outside read/write actions, the lookup ALWAYS refreshes the file from
+     * disk first — externally created, modified, or deleted files are seen correctly
+     * even when the file watcher missed them. Inside a read/write action the helper
+     * is snapshot-only (synchronous refresh there would deadlock), so prefer calling
+     * it at the top level of the script when content freshness matters.
+     * The refresh is per-file and shallow: for a directory it validates the directory
+     * itself, not its unloaded children. After many external writes, batch the writes
+     * and look files up once rather than alternating write → findFile per file.
+     * Files with unsaved in-memory Documents are returned as-is (the unsaved Document
+     * is the newest content; refreshing would trigger the memory-vs-disk conflict).
      *
      * ```kotlin
-     * val vf = findFile("/path/to/file.kt")
-     * if (vf != null) {
-     *     val content = String(vf.contentsToByteArray())
-     * }
+     * val vf = findFile("/path/to/file.kt") ?: error("not found: /path/to/file.kt")
+     * val content = String(vf.contentsToByteArray(), vf.charset)
      * ```
      */
     fun findFile(absolutePath: String): VirtualFile?
 
     /**
      * Find a PsiFile by an absolute path.
-     * Requires a read action context or uses one internally.
+     * Same lookup semantics as [findFile] (always-refresh outside read/write actions),
+     * then PSI resolution inside a read action.
      * Returns null if the file doesn't exist or can't be parsed.
      *
      * ```kotlin
@@ -451,11 +461,15 @@ interface McpScriptContext {
     suspend fun findPsiFile(absolutePath: String): PsiFile?
 
     /**
-     * Find a VirtualFile relative to the project base path.
+     * Find a VirtualFile by a path relative to the project base path.
+     * Absolute paths are also accepted and resolved as-is (like [findFile]).
+     * Same refresh semantics as [findFile]: always refreshes from disk outside
+     * read/write actions; snapshot-only inside.
      * Returns null if the file doesn't exist.
      *
      * ```kotlin
      * val vf = findProjectFile("src/main/kotlin/MyClass.kt")
+     *     ?: error("not found: src/main/kotlin/MyClass.kt")
      * ```
      */
     fun findProjectFile(relativePath: String): VirtualFile?
@@ -468,12 +482,19 @@ interface McpScriptContext {
      * - src/main/starstar-slash-Demo-star.kt for demo classes
      * - star.md for markdown files in root
      *
+     * Iterates the VFS snapshot of the project root — this is NOT a per-path refresh
+     * helper; for externally created files refresh first (or use [findFile] /
+     * [findProjectFile], which refresh their single path).
+     *
      * Returns files sorted by absolute path for deterministic results.
      */
     suspend fun findProjectFiles(globPattern: String): List<VirtualFile>
 
     /**
-     * Find a PsiFile relative to the project base path.
+     * Find a PsiFile by a path relative to the project base path.
+     * Absolute paths are also accepted (delegates to [findProjectFile], inheriting
+     * its always-refresh-outside-actions semantics), then PSI resolution inside a
+     * read action.
      * Returns null if the file doesn't exist or can't be parsed.
      *
      * ```kotlin

--- a/ij-plugin/src/main/kotlin/com/jonnyzzz/mcpSteroid/execution/McpScriptContextImpl.kt
+++ b/ij-plugin/src/main/kotlin/com/jonnyzzz/mcpSteroid/execution/McpScriptContextImpl.kt
@@ -24,7 +24,9 @@ import com.intellij.openapi.project.DumbService
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.project.guessProjectDir
 import com.intellij.openapi.util.Disposer
+import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.vfs.LocalFileSystem
+import com.intellij.openapi.vfs.VfsUtil
 import com.intellij.openapi.vfs.VfsUtilCore
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.psi.PsiFile
@@ -540,8 +542,28 @@ class McpScriptContextImpl(
     // File Access
     // ============================================================
 
-    override fun findFile(absolutePath: String): VirtualFile? =
-        LocalFileSystem.getInstance().findFileByPath(absolutePath)
+    override fun findFile(absolutePath: String): VirtualFile? {
+        val lfs = LocalFileSystem.getInstance()
+        if (ApplicationManager.getApplication().isReadAccessAllowed) {
+            // Synchronous refresh off-EDT under read access deadlocks (the write action
+            // delivering VFS events can never start while our read lock is held —
+            // VirtualFile.refresh / VfsUtil.markDirtyAndRefresh contract). Inside
+            // read/write actions the helper is snapshot-only, same as before #156.
+            return lfs.findFileByPath(absolutePath)?.takeIf { it.isValid }
+        }
+        // #156: ALWAYS refresh. A snapshot hit may still carry stale content — the
+        // refresh-and-find utilities only instantiate path segments missing from the
+        // snapshot and never re-stat an existing file, and in a headless eval IDE the
+        // file watcher cannot be trusted to mark external changes dirty.
+        val vf = lfs.refreshAndFindFileByPath(absolutePath) ?: return null
+        // An UNSAVED in-memory Document + forced refresh would engage the platform's
+        // memory-vs-disk conflict resolver (a dialog in production, IllegalStateException
+        // in tests). The unsaved Document IS the newest content here — keep the snapshot.
+        if (!FileDocumentManager.getInstance().isFileModified(vf)) {
+            VfsUtil.markDirtyAndRefresh(/* async = */ false, /* recursive = */ false, /* reloadChildren = */ false, vf)
+        }
+        return vf.takeIf { it.isValid }
+    }
 
     override suspend fun findPsiFile(absolutePath: String): PsiFile? {
         val vf = findFile(absolutePath) ?: return null
@@ -549,9 +571,15 @@ class McpScriptContextImpl(
     }
 
     override fun findProjectFile(relativePath: String): VirtualFile? {
+        // #156: agents routinely pass absolute paths (every tool result shows them).
+        // Absolute input behaves exactly like findFile(absolutePath).
+        if (isAbsolutePath(relativePath)) return findFile(relativePath)
         val basePath = project.basePath ?: return null
         return findFile("$basePath/$relativePath")
     }
+
+    private fun isAbsolutePath(path: String): Boolean =
+        path.startsWith("/") || runCatching { Path.of(path).isAbsolute }.getOrDefault(false)
 
     override suspend fun findProjectFiles(globPattern: String): List<VirtualFile> {
         if (globPattern.isBlank()) return emptyList()
@@ -590,16 +618,18 @@ class McpScriptContextImpl(
     }
 
     override suspend fun findProjectPsiFile(relativePath: String): PsiFile? {
-        val basePath = project.basePath ?: return null
-        return findPsiFile("$basePath/$relativePath")
+        // Delegate through findProjectFile so absolute-path tolerance and refresh
+        // semantics live in exactly one place (#156).
+        val vf = findProjectFile(relativePath) ?: return null
+        return readAction { PsiManager.getInstance(project).findFile(vf) }
     }
 
     override suspend fun applyPatch(block: ApplyPatchBuilder.() -> Unit): ApplyPatchResult {
         val builder = ApplyPatchBuilder()
         builder.block()
-        // Reuse findFile so apply-patch handles every VFS flavour the rest of the
-        // script context handles (LocalFileSystem in production, temp:// in unit
-        // tests, mock VFS in fixtures) — no hard-coded LocalFileSystem.
+        // Hunk paths resolve through findFile (LocalFileSystem). Note: the resolver
+        // runs inside applyPatch's preflight readAction, where findFile is
+        // snapshot-only (no refresh) — see the findFile read-access guard.
         return executeApplyPatch(project, builder.hunks) { path -> findFile(path) }
     }
 }

--- a/ij-plugin/src/main/kotlin/com/jonnyzzz/mcpSteroid/execution/ScriptExecutor.kt
+++ b/ij-plugin/src/main/kotlin/com/jonnyzzz/mcpSteroid/execution/ScriptExecutor.kt
@@ -254,8 +254,14 @@ class ScriptExecutor(
         } catch (e: CancellationException) {
             throw e
         } catch (t: Throwable) {
-            log.warn("Unexpected error during execution $executionId: ${t.message}", t)
-            val remappedMessage = evalResult.lineMapping.remapStackTrace(t.message ?: "")
+            // #156: never report an empty error. A messageless throwable (e.g. the bare
+            // NullPointerException from `!!`) used to produce "FAILED: Unexpected error
+            // during execution: " — undiagnosable for the agent and invisible to the
+            // hint engine (which matches on errorMessages, not the logged stack trace).
+            val rawMessage = t.message?.takeIf { it.isNotBlank() }
+                ?: "${t.javaClass.simpleName} (no message) — see stack trace above"
+            log.warn("Unexpected error during execution $executionId: $rawMessage", t)
+            val remappedMessage = evalResult.lineMapping.remapStackTrace(rawMessage)
             resultBuilder.logRemappedException("Unexpected error during execution: $remappedMessage", t, evalResult.lineMapping)
             resultBuilder.reportFailed("Unexpected error during execution: $remappedMessage")
         }

--- a/ij-plugin/src/test/kotlin/com/jonnyzzz/mcpSteroid/execution/McpScriptContextTest.kt
+++ b/ij-plugin/src/test/kotlin/com/jonnyzzz/mcpSteroid/execution/McpScriptContextTest.kt
@@ -1,11 +1,15 @@
 /* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
 package com.jonnyzzz.mcpSteroid.execution
 
+import com.intellij.openapi.application.WriteAction
 import com.intellij.openapi.util.Disposer
+import com.intellij.openapi.vfs.VfsUtil
+import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.testFramework.fixtures.BasePlatformTestCase
 import com.intellij.testFramework.common.timeoutRunBlocking
 import com.jonnyzzz.mcpSteroid.TestResultBuilder
 import com.jonnyzzz.mcpSteroid.storage.ExecutionId
+import java.nio.file.Paths
 import kotlinx.serialization.json.buildJsonObject
 import kotlin.time.Duration.Companion.seconds
 
@@ -16,6 +20,11 @@ import kotlin.time.Duration.Companion.seconds
  * since the new API uses ExecutionResultBuilder interface.
  */
 class McpScriptContextTest : BasePlatformTestCase() {
+
+    // Run tests off the EDT: the test EDT holds the IW lock (isReadAccessAllowed == true),
+    // which would force findFile into its snapshot-only guard branch and block the
+    // refresh behavior under test. Same pattern as RunInspectionsDirectlyTest.
+    override fun runInDispatchThread(): Boolean = false
 
     private lateinit var executionId: ExecutionId
 
@@ -147,5 +156,157 @@ class McpScriptContextTest : BasePlatformTestCase() {
         val names = files.map { it.name }.sorted()
 
         assertEquals(listOf("First.kt", "Second.kt"), names)
+    }
+
+    // ============================================================
+    // #156 — findProjectFile / findFile path contract + refresh
+    // ============================================================
+
+    /** Creates a real file under project.basePath through VFS and returns its VirtualFile. */
+    private fun createProjectFile(relativePath: String, content: String): VirtualFile {
+        val basePath = project.basePath ?: error("Project base path is not available")
+        return WriteAction.computeAndWait<VirtualFile, RuntimeException> {
+            val filePath = Paths.get(basePath, relativePath)
+            val parent = VfsUtil.createDirectories(filePath.parent.toString())
+            val name = filePath.fileName.toString()
+            val child = parent.findChild(name) ?: parent.createChildData(this, name)
+            VfsUtil.saveText(child, content)
+            child
+        }
+    }
+
+    fun testFindProjectFileRelativePath() {
+        val (context, _) = createContext()
+        createProjectFile("cfg/app.properties", "key=value")
+
+        val vf = context.findProjectFile("cfg/app.properties")
+        assertNotNull("relative path must resolve", vf)
+        assertEquals("app.properties", vf!!.name)
+    }
+
+    fun testFindProjectFileAbsolutePathUnderRoot() {
+        // The exact eval failure shape from issue #156: an absolute path under the
+        // project root passed to findProjectFile used to double the basePath → null.
+        val (context, _) = createContext()
+        val created = createProjectFile("mod/build.gradle", "plugins {}")
+
+        val vf = context.findProjectFile(created.path)
+        assertNotNull("absolute path under project root must resolve", vf)
+        assertEquals(created.path, vf!!.path)
+    }
+
+    fun testFindProjectFileAbsolutePathOutsideRoot() {
+        val (context, _) = createContext()
+        val outside = java.nio.file.Files.createTempFile("mcp-steroid-156-", ".txt")
+        try {
+            java.nio.file.Files.writeString(outside, "outside")
+            val vf = context.findProjectFile(outside.toString())
+            assertNotNull("absolute path outside project resolves like findFile", vf)
+        } finally {
+            java.nio.file.Files.deleteIfExists(outside)
+        }
+    }
+
+    fun testFindProjectFileBlankResolvesProjectRoot() {
+        // Pins the pre-#156 behavior: "" joins to "$basePath/" → the project root.
+        val (context, _) = createContext()
+        val vf = context.findProjectFile("")
+        assertNotNull("blank path must keep resolving the project root", vf)
+        assertEquals(project.basePath, vf!!.path.trimEnd('/'))
+    }
+
+    fun testFindProjectFileMalformedInputReturnsNull() {
+        val (context, _) = createContext()
+        // NUL is invalid in paths on every supported OS — must return null, never throw
+        // (covers the whole findProjectFile path incl. the isAbsolutePath Path.of guard).
+        assertNull(context.findProjectFile("bad\u0000name"))
+    }
+
+    fun testFindProjectPsiFileAbsolutePathDelegates(): Unit = timeoutRunBlocking(30.seconds) {
+        val (context, _) = createContext()
+        val created = createProjectFile("docs/readme.txt", "hello")
+
+        val psi = context.findProjectPsiFile(created.path)
+        assertNotNull("findProjectPsiFile must accept absolute paths via delegation", psi)
+    }
+
+    /**
+     * Creates a sibling file through VFS and caches the parent directory's children in
+     * the VFS snapshot. Without this, a never-cached directory loads its children
+     * LAZILY from disk on first lookup, and an externally created file would be found
+     * even without any refresh — masking exactly the behavior these tests pin.
+     */
+    private fun cachedExternalDir(dirName: String): java.nio.file.Path {
+        val sibling = createProjectFile("$dirName/sibling.txt", "sibling")
+        sibling.parent.children // cache the children list in the snapshot
+        return sibling.parent.toNioPath()
+    }
+
+    fun testFindFileSeesExternallyCreatedFile() {
+        // Refresh behavior (a): a file created on disk BEHIND the VFS (plain nio write,
+        // no VFS API, parent children already cached) must be visible to a top-level
+        // findFile call via its refresh.
+        val (context, _) = createContext()
+        val dir = cachedExternalDir("ext-created")
+        val nioPath = dir.resolve("new-file.txt")
+        java.nio.file.Files.writeString(nioPath, "created externally")
+
+        val vf = context.findFile(nioPath.toString())
+        assertNotNull("externally created file must be found via refresh", vf)
+        assertEquals("created externally", String(vf!!.contentsToByteArray(), vf.charset))
+    }
+
+    fun testFindFileSeesExternallyModifiedContent() {
+        // Refresh behavior (b) — the always-refresh upgrade: a snapshot HIT whose disk
+        // content changed externally must return the NEW content. Different content
+        // lengths defend against filesystem timestamp granularity.
+        val (context, _) = createContext()
+        val created = createProjectFile("ext-modified/file.txt", "old content")
+        assertEquals("old content", String(created.contentsToByteArray(), created.charset))
+
+        java.nio.file.Files.writeString(created.toNioPath(), "new content, longer than before")
+
+        val vf = context.findFile(created.path)
+        assertNotNull(vf)
+        assertEquals("new content, longer than before", String(vf!!.contentsToByteArray(), vf.charset))
+    }
+
+    fun testFindFileDetectsExternalDeletion() {
+        // Refresh behavior (c): a file deleted on disk behind the VFS must yield null,
+        // not a stale VirtualFile.
+        val (context, _) = createContext()
+        val created = createProjectFile("ext-deleted/file.txt", "doomed")
+        java.nio.file.Files.delete(created.toNioPath())
+
+        assertNull("externally deleted file must not resolve", context.findFile(created.path))
+    }
+
+    fun testFindFileInsideReadActionIsSnapshotOnly(): Unit = timeoutRunBlocking(30.seconds) {
+        // Guard: under a read action the helper must NOT refresh (sync refresh there
+        // deadlocks) — an externally created file stays invisible, and the call returns.
+        val (context, _) = createContext()
+        val dir = cachedExternalDir("ext-read-guarded")
+        val nioPath = dir.resolve("guarded.txt")
+        java.nio.file.Files.writeString(nioPath, "invisible under read lock")
+
+        val underRead = context.readAction { context.findFile(nioPath.toString()) }
+        assertNull("read action must be snapshot-only (no refresh, no deadlock)", underRead)
+
+        // Sanity: the same lookup at top level DOES refresh and finds the file.
+        assertNotNull("top-level lookup must find it via refresh", context.findFile(nioPath.toString()))
+    }
+
+    fun testFindFileInsideWriteActionIsSnapshotOnly() {
+        // Guard: write actions report read access in the current lock model, so the
+        // helper must be snapshot-only there too.
+        val (context, _) = createContext()
+        val dir = cachedExternalDir("ext-write-guarded")
+        val nioPath = dir.resolve("guarded.txt")
+        java.nio.file.Files.writeString(nioPath, "invisible under write lock")
+
+        val underWrite = WriteAction.computeAndWait<VirtualFile?, RuntimeException> {
+            context.findFile(nioPath.toString())
+        }
+        assertNull("write action must be snapshot-only (no refresh)", underWrite)
     }
 }

--- a/ij-plugin/src/test/kotlin/com/jonnyzzz/mcpSteroid/execution/ScriptExecutorTest.kt
+++ b/ij-plugin/src/test/kotlin/com/jonnyzzz/mcpSteroid/execution/ScriptExecutorTest.kt
@@ -205,4 +205,33 @@ class ScriptExecutorTest : BasePlatformTestCase() {
         // Should fail due to timeout (or error if engine not available)
         assertTrue("Should fail", builder.isFailed)
     }
+
+    /**
+     * #156: a messageless throwable (the bare NullPointerException from `!!`) must never
+     * produce an empty "Unexpected error during execution: " FAILED line — the summary
+     * must carry the exception class so the agent (and the hint engine) can react.
+     *
+     * Engine-tolerant per this class's convention: the assertion applies only when the
+     * script actually reached runtime (the failure message carries the runtime prefix);
+     * an environment without the script engine fails earlier with a different message.
+     */
+    fun testMesslessExceptionProducesNonEmptyFailure(): Unit = timeoutRunBlocking(60.seconds) {
+        val code = """
+            val value: String? = null
+            value!!
+        """.trimIndent()
+
+        val builder = TestResultBuilder()
+        executor.executeWithProgress(nextExecutionId(), testExecParams(code), builder)
+
+        assertTrue("Execution of `null!!` must fail", builder.isFailed)
+        val failure = builder.failureMessage ?: ""
+        if (failure.startsWith("Unexpected error during execution:")) {
+            // Runtime was reached: the summary must not be empty after the prefix.
+            assertTrue(
+                "FAILED line must name the exception class for messageless throwables:\n$failure",
+                failure.contains("NullPointerException (no message)")
+            )
+        }
+    }
 }

--- a/ij-plugin/src/test/kotlin/com/jonnyzzz/mcpSteroid/server/SkillReferenceHintTest.kt
+++ b/ij-plugin/src/test/kotlin/com/jonnyzzz/mcpSteroid/server/SkillReferenceHintTest.kt
@@ -205,4 +205,47 @@ class SkillReferenceHintTest : BasePlatformTestCase() {
             hint.contains("point-in-time")
         )
     }
+
+    fun testHintForBareNullPointerException() {
+        // #156: the messageless-NPE summary produced by ScriptExecutor must get the
+        // lookup-contract hint (agents' `!!` on a null findProjectFile lookup).
+        val error = "Unexpected error during execution: NullPointerException (no message) — see stack trace above"
+
+        val hint = project.executionSuggestionService.computeHint(error)
+        assertTrue(
+            "Hint should explain the null-lookup / `!!` pattern:\n$hint",
+            hint.contains("null lookup")
+        )
+        assertTrue(
+            "Hint should teach the ?: error(...) idiom naming the path:\n$hint",
+            hint.contains("error(")
+        )
+        assertTrue(
+            "Hint should reference the VFS skill resource:\n$hint",
+            hint.contains("mcp-steroid://skill/coding-with-intellij-vfs")
+        )
+    }
+
+    fun testBreakpointNpeStillWinsOverGenericNpeHint() {
+        // Precedence: the debugger-specific NPE branch must keep matching first.
+        val error = """Cannot invoke "com.intellij.debugger.JavaLineBreakpointProperties.getLambdaOrdinal()" because "props" is null"""
+
+        val hint = project.executionSuggestionService.computeHint(error)
+        assertTrue(
+            "Debugger-specific NPE hint must win over the generic NPE hint:\n$hint",
+            hint.contains("XDebuggerUtil.toggleLineBreakpoint")
+        )
+    }
+
+    fun testNpeWithRealMessageGetsNoLookupHint() {
+        // An NPE that carries its own message is its own diagnostic — the lookup-contract
+        // hint must NOT fire (it matches only the "(no message)" summary shape).
+        val error = """Unexpected error during execution: java.lang.NullPointerException: Cannot read field "foo" because "bar" is null"""
+
+        val hint = project.executionSuggestionService.computeHint(error)
+        assertFalse(
+            "Messaged NPE must not get the lookup-contract hint:\n$hint",
+            hint.contains("null lookup")
+        )
+    }
 }

--- a/prompts/src/main/prompts/skill/coding-with-intellij-context-api.md
+++ b/prompts/src/main/prompts/skill/coding-with-intellij-context-api.md
@@ -193,11 +193,12 @@ println("Project scope: $projScope")
 ### File Access Helpers
 
 ```kotlin
-// File access helpers — call from the script body or another suspend fun, NEVER inside readAction { }:
+// File access helpers — call from the script body or another suspend fun, NEVER inside readAction { }
+// (inside readAction they are snapshot-only; at top level they ALWAYS refresh the file from disk):
 val vf = findFile("/tmp/test.txt")                   // VirtualFile by absolute path
 val psi = findPsiFile("/tmp/test.txt")                // PsiFile by absolute path — SUSPEND
-val projFile = findProjectFile("build.gradle.kts")    // VirtualFile relative to project
-val projPsi = findProjectPsiFile("build.gradle.kts")  // PsiFile relative to project — SUSPEND
+val projFile = findProjectFile("build.gradle.kts")    // VirtualFile relative to project (absolute also accepted)
+val projPsi = findProjectPsiFile("build.gradle.kts")  // PsiFile relative to project (absolute also accepted) — SUSPEND
 println("file=$vf, psi=$psi, projFile=$projFile, projPsi=$projPsi")
 //
 // DON'T:
@@ -210,7 +211,7 @@ println("file=$vf, psi=$psi, projFile=$projFile, projPsi=$projPsi")
 //   readAction { /* now operate on `psi` here */ }  // wrap only the PSI/VFS reads, not the resolver call
 ```
 
-> **⚠️ `findProjectFile()` pitfall for resource files**: This function requires the **full relative path** from the project root (e.g., `"src/main/resources/application.properties"`). Calling it with just a filename (`findProjectFile("application.properties")`) **always returns null** — causing NPE on `!!`. For files under `src/main/resources/`, use `FilenameIndex.getVirtualFilesByName()` which searches by filename without requiring the full path:
+> **⚠️ `findProjectFile()` pitfall for resource files**: This function requires the **full relative path** from the project root (e.g., `"src/main/resources/application.properties"`). Calling it with just a filename (`findProjectFile("application.properties")`) **always returns null** (prefer `?: error("not found: ...")` over `!!` so the failure names the path). For files under `src/main/resources/`, use `FilenameIndex.getVirtualFilesByName()` which searches by filename without requiring the full path:
 ```kotlin
 import com.intellij.psi.search.FilenameIndex
 import com.intellij.psi.search.GlobalSearchScope

--- a/prompts/src/main/prompts/skill/coding-with-intellij-threading.md
+++ b/prompts/src/main/prompts/skill/coding-with-intellij-threading.md
@@ -49,7 +49,7 @@ If you are about to write any of these in a `steroid_execute_code` script, you o
 | `PsiDocumentManager.getInstance(project).commitAllDocuments()` | `writeAction { }` |
 | Refactoring processor `.run()` (Rename / Move / SafeDelete / Inline / ChangeSignature / Extract*) | `writeIntentReadAction { }` (NOT `writeAction` — deadlocks) |
 
-**Safe outside any wrap:** `LocalFileSystem.getInstance().findFileByPath(path)` (resolution only), `findProjectFile(relPath)` helper, `vf.path` / `vf.name` / `vf.isDirectory` (cached metadata), and plain `java.io.File` / `Files.*` / `Path.*` operations. The wrap becomes mandatory the moment you read the file's *structure* or hand it to a PSI API.
+**Safe outside any wrap:** `LocalFileSystem.getInstance().findFileByPath(path)` (resolution only), `findProjectFile(relPath)` helper, `vf.path` / `vf.name` / `vf.isDirectory` (cached metadata), and plain `java.io.File` / `Files.*` / `Path.*` operations. The wrap becomes mandatory the moment you read the file's *structure* or hand it to a PSI API. Do NOT call `findFile` / `findProjectFile` *inside* `readAction { }` "to be safe" — under a read action they silently skip their disk refresh and can return stale content; resolve at the top level, then wrap only the PSI/structure reads.
 
 **Symptom of skipping the wrap:** the runtime emits `SEVERE` `ThreadingAssertions` log lines and — in stricter modes — throws `RuntimeExceptionWithAttachments: Read access is allowed from inside read-action only`. Even when assertions only log, the IDE may produce stale or partial results, so wrap eagerly.
 

--- a/prompts/src/main/prompts/skill/coding-with-intellij-vfs.md
+++ b/prompts/src/main/prompts/skill/coding-with-intellij-vfs.md
@@ -134,9 +134,16 @@ action cannot start while your read action is held, so the call **deadlocks**. I
 (outside `readAction { }` / `smartReadAction { }`), then do the PSI/document work in a
 separate read action afterwards.
 
-Note: the script context's `findProjectFile()` / `findFile()` do a **plain lookup without
-refresh** — for externally created files they return `null` until you have run one of the
-refresh-then-find calls above (or a directory refresh like the post-Bash recipe below).
+Note: the script context's `findProjectFile()` / `findFile()` **always refresh the single
+file from disk** when called outside `readAction { }` / `writeAction { }` — externally
+created, modified, or deleted files are seen correctly without a manual refresh-then-find.
+Inside a read/write action they are snapshot-only (a synchronous refresh there would
+deadlock), so call them at the script top level when content freshness matters. Their
+refresh is per-file and shallow: for **directory contents** (new children created by an
+external process) you still need the explicit refresh-then-find calls above or the
+recursive post-Bash recipe below. After MANY external writes, batch the writes and look
+files up once — or run one recursive `markDirtyAndRefresh` — rather than alternating
+write → `findFile` per file.
 
 ### List Directory Contents
 ```kotlin
@@ -269,7 +276,7 @@ java.io.File("${project.basePath}/src/main/java/com/example/model/Product.java")
 LocalFileSystem.getInstance().refreshAndFindFileByPath("${project.basePath}/src/main/java/com/example/model/Product.java")
 println("Created Product.java")
 // Verify the write succeeded:
-val vf = findProjectFile("src/main/java/com/example/model/Product.java")!!
+val vf = findProjectFile("src/main/java/com/example/model/Product.java") ?: error("Product.java not found")
 check(String(vf.contentsToByteArray(), vf.charset).contains("class Product")) { "Write failed or file is empty" }
 println("Verified: Product.java written correctly")
 ```
@@ -322,12 +329,25 @@ println("File created and VFS refreshed")
 ## Read a Project File via findProjectFile
 
 ```kotlin
-val vf = findProjectFile("src/main/resources/application.properties")!!
+val path = "src/main/resources/application.properties"
+val vf = findProjectFile(path) ?: error("not found: $path")
 val text = String(vf.contentsToByteArray(), vf.charset)
 println(text)
 ```
 
-**⚠️ `findProjectFile()` pitfall for resource files**: requires the **FULL relative path** from the project root (e.g., `"src/main/resources/application.properties"`). Calling it with just a filename **always returns null** — causing NPE on `!!`. For files under `src/main/resources/`, use `FilenameIndex.getVirtualFilesByName()` which searches by filename:
+**Path contract for the script-context file helpers:**
+
+| Helper | Path argument | Refresh behavior |
+|---|---|---|
+| `findFile(p)` / `findPsiFile(p)` | absolute | always refreshes the file from disk outside read/write actions; snapshot-only inside |
+| `findProjectFile(p)` / `findProjectPsiFile(p)` | relative to project root — **absolute also accepted** | same as `findFile` |
+| `findProjectFiles(glob)` | glob relative to project root | iterates the VFS snapshot; NOT a per-path refresh |
+| `applyPatch { hunk(path, …) }` | absolute | resolves during a preflight read action → snapshot-only |
+
+Prefer `?: error("not found: $path")` over `!!` on every lookup — a bare `!!` NPE carries no
+message, while `error(...)` names the exact path that failed.
+
+**⚠️ `findProjectFile()` pitfall for resource files**: requires the **FULL relative path** from the project root (e.g., `"src/main/resources/application.properties"`). Calling it with just a filename **always returns null** (use `?: error(...)` so the failure names the path). For files under `src/main/resources/`, use `FilenameIndex.getVirtualFilesByName()` which searches by filename:
 ```kotlin
 import com.intellij.psi.search.FilenameIndex
 import com.intellij.psi.search.GlobalSearchScope

--- a/prompts/src/main/prompts/skill/execute-code-tool-description.md
+++ b/prompts/src/main/prompts/skill/execute-code-tool-description.md
@@ -27,11 +27,11 @@ Keep `old_string` to the shortest unique signature (30–60 chars usually — no
 | Task shape | One-line IDE call |
 |---|---|
 | **Two or more literal-text edits, same or different files** | `steroid_execute_code` with the `applyPatch { }` DSL — atomic undo, pre-flight validation, PSI commit, VFS refreshed after the script. See `mcp-steroid://ide/apply-patch`. |
-| **One literal-text edit, single file** | `val vf = findProjectFile(p)!!; writeAction { VfsUtil.saveText(vf, String(vf.contentsToByteArray(), vf.charset).replace(OLD, NEW)) }` |
+| **One literal-text edit, single file** | `val vf = findProjectFile(p) ?: error("not found: $p"); writeAction { VfsUtil.saveText(vf, String(vf.contentsToByteArray(), vf.charset).replace(OLD, NEW)) }` |
 | **Find files by extension** | `readAction { FilenameIndex.getAllFilesByExt(project, "java", projectScope()) }` — not `Bash find … -name "*.java"` |
 | **Find files by exact name** | `readAction { FilenameIndex.getVirtualFilesByName("UserService.java", projectScope()) }` |
 | **Find all references to a symbol** | `readAction { ReferencesSearch.search(psiElement, projectScope()).findAll() }` — type-aware; Grep over source text is a fallback |
-| **Read file content (any size)** | `String(findProjectFile(p)!!.contentsToByteArray(), charset)` — stays inside the IDE; the next semantic query sees what you read |
+| **Read file content (any size)** | `String((findProjectFile(p) ?: error("not found: $p")).contentsToByteArray(), charset)` — accepts relative or absolute paths, always re-reads from disk when called at the script top level; the next semantic query sees what you read |
 | **Grep content inside project files** | `readAction { FilenameIndex.getAllFilesByExt(project, ext, scope).flatMap { vf -> Regex(pat).findAll(String(vf.contentsToByteArray(), vf.charset)) … } }` in ONE call |
 | **Run Maven / Gradle tests** | IDE runner — see `mcp-steroid://skill/execute-code-maven` and `mcp-steroid://skill/execute-code-gradle`; Bash is only for shell-level final verification or IDE-runner fallback |
 | **IDE build aborted (`errors=false, aborted=true`)** | Fetch `mcp-steroid://skill/execute-code-gradle` or `mcp-steroid://skill/execute-code-maven` and run the matching sync pattern before Bash fallback. |
@@ -197,11 +197,12 @@ For deeper patterns (SMTRunner listeners that block until tests finish + emit st
 - `Read access is allowed from inside read-action only` → wrap in `readAction { }`
 
 **File discovery**: `readAction { FilenameIndex.getAllFilesByExt(project, ext, projectScope()) }` or `readAction { FilenameIndex.getVirtualFilesByName(name, projectScope()) }` inside `steroid_execute_code` — O(1) indexed lookup over the same VFS your next write will touch. The `readAction { }` wrap is mandatory; without it the call throws `Read access is allowed from inside read-action only` and the script aborts.
-**File reading**: `String(findProjectFile(relPath)!!.contentsToByteArray(), charset)` inside `steroid_execute_code` — single call, stays inside the IDE so PSI is consistent if you read the same file again later. The native `Read` tool is a valid alternative but imposes the Read-before-Edit contract only it tracks; staying inside `steroid_execute_code` avoids that coupling entirely.
+**File reading**: `String((findProjectFile(path) ?: error("not found: $path")).contentsToByteArray(), charset)` inside `steroid_execute_code` — `findProjectFile` accepts project-relative AND absolute paths, and (outside `readAction`/`writeAction`) always refreshes the file from disk before returning, so externally created or modified files are seen correctly. Prefer `?: error(...)` over `!!` so a missing file fails with the path in the message. Single call, stays inside the IDE so PSI is consistent if you read the same file again later. The native `Read` tool is a valid alternative but imposes the Read-before-Edit contract only it tracks; staying inside `steroid_execute_code` avoids that coupling entirely.
 **In-place file editing (ANY size, 1–1000+ lines)**: use steroid_execute_code — do NOT use the native `Edit` tool. The native `Edit` writes to disk bypassing IntelliJ, leaving VFS + PSI stale; every following semantic query sees the old content until you force a refresh. The IDE-side recipe below is ~5 lines of real code, same payload shape as `Edit(old, new)`, reads+writes inside one call, and the VFS auto-refreshes so PSI stays consistent:
 
 ```kotlin
-val vf = findProjectFile("src/main/java/com/example/MyClass.java")!!
+val path = "src/main/java/com/example/MyClass.java"   // relative or absolute both work
+val vf = findProjectFile(path) ?: error("not found: $path")
 val content = String(vf.contentsToByteArray(), vf.charset)  // read
 val updated = content.replace("OLD_STRING", "NEW_STRING")
 check(updated != content) { "no match for OLD_STRING — verify with Grep first" }


### PR DESCRIPTION
Fixes #156.

## Problem

At full-eval scale (2026-06-26 run, 141 tasks), `findProjectFile(absolutePath)!!` was the **#1 `execute_code` failure class**: 52/147 failures (35%), hitting 49/138 tasks (36%). Agents naturally pass absolute paths (every tool result shows them); the helper unconditionally prepended `basePath` → doubled path → `null` → bare NPE from `!!` → the agent received a **completely empty** `FAILED: Unexpected error during execution: ` line plus an unrelated generic HINT. 44 tasks recovered by trial-and-error round-trips; 5 abandoned the IDE entirely for the task.

A second null/staleness source feeds the same failure: a snapshot lookup can return **stale content** — the platform's refresh-and-find utilities only instantiate path segments missing from the snapshot and never re-stat an existing file, and headless eval IDEs cannot trust the file watcher (team decision: always refresh; verified against `intellij/community` sources — `VirtualDirectoryImpl.findChild(doRefresh=true)` refreshes only on kind change; `VfsUtil.markDirtyAndRefresh` javadoc names itself the reliable watcher-bypassing API).

## Changes

**1. `findFile` — always refresh (guarded):**
- Outside read/write actions: `refreshAndFindFileByPath` (makes missing files visible) + `markDirtyAndRefresh(sync, single-file, shallow)` (re-stats content; detects external modification AND deletion).
- Inside read/write actions: snapshot-only, exactly the pre-fix behavior — a sync refresh under read access off-EDT deadlocks (`VirtualFile.refresh` contract; write actions report read access in the current lock model).
- Skips the forced refresh when the file has an unsaved in-memory `Document` (refreshing would engage the memory-vs-disk conflict resolver; the unsaved Document IS the newest content).

**2. `findProjectFile` — absolute paths accepted** (delegate to `findFile`; exception-safe detection; relative behavior incl. blank-path root resolution unchanged). `findProjectPsiFile` delegates through `findProjectFile` so the tolerance lives in one place.

**3. `ScriptExecutor` — never-empty error summary:** messageless throwables now report `<Class> (no message) — see stack trace above` instead of an empty string, in the FAILED line, the log line, and (crucially) `errorMessages`, which is what the hint engine matches on.

**4. Targeted hint** (`ExecutionSuggestionService`): matches only the new `NullPointerException (no message)` summary shape — teaches the `?: error("not found: $path")` idiom over `!!` and the path/refresh contract; references the VFS skill via the generated article class. Debugger-NPE precedence preserved; NPEs with real messages unaffected.

**5. Prompt corpus:** `execute-code-tool-description.md` examples drop `findProjectFile(p)!!` for `?: error(...)` (this tool description taught the exact failing idiom); VFS skill gains the helper path/refresh contract table and updated pitfall notes; context-api quick-lookup and threading skill updated (don't call lookup helpers inside `readAction` "to be safe" — that silently disables the refresh).

## Tests

- `McpScriptContextTest` (off-EDT now, same pattern as `RunInspectionsDirectlyTest`): path matrix (relative / absolute-under-root — the exact eval failure shape / absolute-outside / blank → project root / NUL → null not throw / PSI delegation), refresh behaviors (externally created / modified / deleted files — with parent-children pre-caching so lazy child loading can't mask the assertions), and both guard tests (read action + write action stay snapshot-only, no deadlock).
- `SkillReferenceHintTest`: new hint fires on the summary shape; breakpoint-NPE branch still wins; messaged NPEs get no false hint.
- `ScriptExecutorTest`: `null!!` produces a non-empty FAILED line naming the class (engine-tolerant per class convention).

## Design & validation

Full design doc + three adversarial codex review rounds (incl. verification against the IntelliJ platform sources for the lock-model/refresh semantics) live in the private eval-logs repo (`2026-06-29/design-156.md`, `codex-design-review{,2,3}.md`). Known accepted limitations, documented in code/KDoc: `applyPatch` hunk resolution runs inside its preflight `readAction` (snapshot-only); sync refresh after a real external change waits on write-action/EDT availability (the #177 wedged-EDT class is a separate fix); `findFile(directoryPath)` validates the directory itself, not unloaded children.

Eval acceptance for the next run: the 52-failure class → ~0, empty FAILED lines extinct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
