### PR TITLE
KeycloakChangeSignatureTest: project-wide change-signature A/B (Keycloak 26.6.4)

### DIFF
--- a/test-experiments/src/test/kotlin/com/jonnyzzz/mcpSteroid/integration/tests/KeycloakChangeSignatureTest.kt
+++ b/test-experiments/src/test/kotlin/com/jonnyzzz/mcpSteroid/integration/tests/KeycloakChangeSignatureTest.kt
@@ -1,0 +1,203 @@
+/* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
+package com.jonnyzzz.mcpSteroid.integration.tests
+
+import com.jonnyzzz.mcpSteroid.integration.infra.AiMode
+import com.jonnyzzz.mcpSteroid.integration.infra.BuildSystem
+import com.jonnyzzz.mcpSteroid.integration.infra.IntelliJContainer
+import com.jonnyzzz.mcpSteroid.integration.infra.IntelliJContainerOpts
+import com.jonnyzzz.mcpSteroid.integration.infra.IntelliJProject
+import com.jonnyzzz.mcpSteroid.integration.infra.McpConnectionMode
+import com.jonnyzzz.mcpSteroid.integration.infra.create
+import com.jonnyzzz.mcpSteroid.integration.infra.waitForProjectReady
+import com.jonnyzzz.mcpSteroid.testHelper.AiAgentSession
+import com.jonnyzzz.mcpSteroid.testHelper.CloseableStackHost
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Timeout
+import java.util.concurrent.TimeUnit
+
+/**
+ * MCP-win experiment: **project-wide change signature** (jonnyzzz/mcp-steroid#169) — the sequel to
+ * [KeycloakRenameTest]. The agent adds a trailing `boolean silent` parameter to
+ * `org.keycloak.authentication.Authenticator#authenticate(AuthenticationFlowContext)` — a widely
+ * overridden SPI method — and must ripple the change through EVERY override and call site so the
+ * project still compiles.
+ *
+ * Verified against the pinned Keycloak 26.6.4 tag, the production modules (server-spi-private +
+ * services) contain 29 override declarations beyond the interface itself, including the traps a manual
+ * sweep misses: a `default` method in a sub-interface (`ConditionalAuthenticator`), an abstract base
+ * (`AbstractIdpAuthenticator`), an anonymous class (`SpnegoAuthenticatorFactory.SINGLETON_DISABLED`),
+ * plus `super.authenticate(context)` call sites and javadoc/JS-string mentions of `authenticate(context)`
+ * (`ScriptBasedAuthenticator`) that must NOT be touched.
+ *
+ * With MCP the agent drives IntelliJ's `ChangeSignatureProcessor` via `steroid_execute_code` — PSI
+ * updates the declaration, all overrides and all call sites atomically, with the new argument's default
+ * value inserted at call sites. Without MCP, a shell/editor sweep must find each override by hand.
+ *
+ * Verdict ([scoreChangeSignature]): signature changed AND all ground-truth overrides updated AND the
+ * post-change build reported SUCCESS — emitted as an `[ARENA]` block. A/B per agent; with-MCP asserts
+ * exec_code; correctness is a dashboard metric, not a hard gate.
+ */
+class KeycloakChangeSignatureTest {
+
+    // 80 min, following the KeycloakRenameTest precedent: the without-MCP baseline is edit-heavy — it
+    // legitimately needs ~30 min of agent work for the manual override sweep + rebuild (rename measured
+    // 30.3 min agent time on CI build 991971402, and container start + Keycloak import + verification
+    // pushed the method past 50). The slow baseline IS the experiment's finding — it must complete and
+    // emit its [ARENA] block so the dashboard can show the gap, not die as a timeout with no data.
+    // TC-side executionTimeoutMin=180 fits two 80-min methods.
+
+    @Test @Timeout(value = 80, unit = TimeUnit.MINUTES)
+    fun `claude with mcp`() = run("claude", withMcp = true)
+
+    @Test @Timeout(value = 80, unit = TimeUnit.MINUTES)
+    fun `claude without mcp`() = run("claude", withMcp = false)
+
+    @Test @Timeout(value = 80, unit = TimeUnit.MINUTES)
+    fun `codex with mcp`() = run("codex", withMcp = true)
+
+    @Test @Timeout(value = 80, unit = TimeUnit.MINUTES)
+    fun `codex without mcp`() = run("codex", withMcp = false)
+
+    private fun run(agentName: String, withMcp: Boolean) {
+        val modeLabel = if (withMcp) "mcp" else "none"
+        val lifetime = CloseableStackHost()
+        try {
+            val session = IntelliJContainer.create(lifetime, IntelliJContainerOpts(
+                consoleTitle = "keycloak-changesig-$agentName-$modeLabel",
+                project = IntelliJProject.KeycloakProject,
+                aiMode = if (withMcp) AiMode.AI_MCP else AiMode.NONE,
+                mcpConnectionMode = if (withMcp) null else McpConnectionMode.None,
+            )).waitForProjectReady(buildSystem = BuildSystem.MAVEN)
+
+            val agent: AiAgentSession = when (agentName) {
+                "claude" -> session.aiAgents.claude
+                "codex" -> session.aiAgents.codex
+                else -> error("Unknown agent: $agentName")
+            }
+
+            val startedAt = System.currentTimeMillis()
+            val result = agent.runPrompt(if (withMcp) withMcpPrompt() else baselinePrompt(), timeoutSeconds = 2400)
+                .awaitForProcessFinish()
+            val agentDurationMs = System.currentTimeMillis() - startedAt
+            val combined = result.stdout + "\n" + result.stderr
+
+            val score = scoreChangeSignature(combined, REQUIRED_OVERRIDES)
+            println("[TEST] keycloak change-signature [$agentName+$modeLabel] safe=${score.safe} " +
+                    "signatureChanged=${score.signatureChanged} missing=${score.missingOverrides.size} " +
+                    "buildGreen=${score.buildGreen}")
+            if (score.missingOverrides.isNotEmpty()) {
+                println("[TEST]   missed overrides: ${score.missingOverrides}")
+            }
+
+            recordSemanticRun(
+                scenario = SCENARIO,
+                agentName = agentName,
+                withMcp = withMcp,
+                claimedFix = score.safe,
+                rawOutput = result.rawStdout,
+                exitCode = result.exitCode,
+                agentDurationMs = agentDurationMs,
+                runDir = session.runDirInContainer,
+                summary = "signatureChanged=${score.signatureChanged} " +
+                        "overrides=${score.reportedOverrides.size} missing=${score.missingOverrides.size} " +
+                        "buildGreen=${score.buildGreen}",
+            )
+
+            if (withMcp) assertUsedExecuteCodeEvidence(combined)
+        } finally {
+            lifetime.closeAllStacks()
+        }
+    }
+
+    private fun taskDescription(): String = buildString {
+        appendLine("Task: change the signature of the method `$SYMBOL`")
+        appendLine("by adding a trailing parameter `boolean silent` — the new signature is")
+        appendLine("`void authenticate(AuthenticationFlowContext context, boolean silent)`.")
+        appendLine()
+        appendLine("The change must ripple PROJECT-WIDE so everything still compiles:")
+        appendLine("- the interface declaration itself,")
+        appendLine("- EVERY override — including `default` methods in sub-interfaces, abstract base classes,")
+        appendLine("  and anonymous classes,")
+        appendLine("- EVERY call site — pass `false` as the new argument (including `super.authenticate(...)` calls).")
+        appendLine("Do NOT modify javadoc comments or string literals that merely mention `authenticate(context)`.")
+    }
+
+    private fun withMcpPrompt(): String = buildString {
+        appendLine("The Keycloak project is open in IntelliJ IDEA — a large multi-module Java project.")
+        appendLine()
+        append(taskDescription())
+        appendLine()
+        appendLine("Use IntelliJ's Change Signature refactoring via `steroid_execute_code`:")
+        appendLine("`com.intellij.refactoring.changeSignature.ChangeSignatureProcessor` with the existing")
+        appendLine("parameters plus a new `ParameterInfoImpl` (type `boolean`, default value `false` for call")
+        appendLine("sites) — PSI updates the declaration, all overrides and all call sites atomically. Do NOT sed.")
+        appendLine("After the change, build the affected modules (e.g. server-spi-private + services) to verify.")
+        appendLine()
+        appendLine("Output (markers on their own lines):")
+        appendLine("SIGNATURE_CHANGED: yes")
+        appendLine("OVERRIDES_UPDATED: <total count of updated overriding methods>")
+        appendLine("OVERRIDE_UPDATED: <fully.qualified.ClassName>   ← one line per class whose override was updated")
+        appendLine("BUILD_AFTER_CHANGE: <SUCCESS or FAILURE>")
+        appendLine("TOOL_EVIDENCE: <copy the line starting with execution_id: ...>")
+    }
+
+    private fun baselinePrompt(): String = buildString {
+        appendLine("The Keycloak project is checked out (a large multi-module Java project).")
+        appendLine("IntelliJ MCP tools are unavailable in this run — use shell commands only.")
+        appendLine()
+        append(taskDescription())
+        appendLine()
+        appendLine("Beware: a naive text replace will over-match unrelated `authenticate` methods and miss")
+        appendLine("non-obvious overrides, breaking the build.")
+        appendLine("After the change, build the affected modules (e.g. server-spi-private + services) to verify.")
+        appendLine()
+        appendLine("Output (markers on their own lines):")
+        appendLine("SIGNATURE_CHANGED: yes")
+        appendLine("OVERRIDES_UPDATED: <total count of updated overriding methods>")
+        appendLine("OVERRIDE_UPDATED: <fully.qualified.ClassName>   ← one line per class whose override was updated")
+        appendLine("BUILD_AFTER_CHANGE: <SUCCESS or FAILURE>")
+    }
+
+    companion object {
+        private const val SCENARIO = "keycloak__change_signature"
+        private const val SYMBOL = "org.keycloak.authentication.Authenticator#authenticate(AuthenticationFlowContext)"
+
+        // Ground truth derived from the pinned Keycloak 26.6.4 tag: every class in the production modules
+        // (server-spi-private + services) that declares `void authenticate(AuthenticationFlowContext …)`
+        // as an override. The interface itself is covered by SIGNATURE_CHANGED. The anonymous class inside
+        // SpnegoAuthenticatorFactory (SINGLETON_DISABLED) is deliberately NOT required — agents report
+        // anonymous classes under inconsistent names ($1, .SINGLETON_DISABLED, the factory class) and the
+        // build-green check catches a genuine miss there anyway. Testsuite-module overrides are likewise
+        // excluded so scoring does not depend on whether the testsuite is part of the Maven import.
+        private val REQUIRED_OVERRIDES = setOf(
+            "org.keycloak.authentication.authenticators.AttemptedAuthenticator",
+            "org.keycloak.authentication.authenticators.access.AllowAccessAuthenticator",
+            "org.keycloak.authentication.authenticators.access.DenyAccessAuthenticator",
+            "org.keycloak.authentication.authenticators.broker.AbstractIdpAuthenticator",
+            "org.keycloak.authentication.authenticators.browser.ConditionalOtpFormAuthenticator",
+            "org.keycloak.authentication.authenticators.browser.CookieAuthenticator",
+            "org.keycloak.authentication.authenticators.browser.IdentityProviderAuthenticator",
+            "org.keycloak.authentication.authenticators.browser.OTPFormAuthenticator",
+            "org.keycloak.authentication.authenticators.browser.PasskeysConditionalUIAuthenticator",
+            "org.keycloak.authentication.authenticators.browser.PasswordForm",
+            "org.keycloak.authentication.authenticators.browser.RecoveryAuthnCodesFormAuthenticator",
+            "org.keycloak.authentication.authenticators.browser.ScriptBasedAuthenticator",
+            "org.keycloak.authentication.authenticators.browser.SpnegoAuthenticator",
+            "org.keycloak.authentication.authenticators.browser.UsernameForm",
+            "org.keycloak.authentication.authenticators.browser.UsernamePasswordForm",
+            "org.keycloak.authentication.authenticators.browser.WebAuthnAuthenticator",
+            "org.keycloak.authentication.authenticators.conditional.ConditionalAuthenticator",
+            "org.keycloak.authentication.authenticators.directgrant.ValidateOTP",
+            "org.keycloak.authentication.authenticators.directgrant.ValidatePassword",
+            "org.keycloak.authentication.authenticators.directgrant.ValidateUsername",
+            "org.keycloak.authentication.authenticators.resetcred.ResetCredentialChooseUser",
+            "org.keycloak.authentication.authenticators.resetcred.ResetCredentialEmail",
+            "org.keycloak.authentication.authenticators.resetcred.ResetOTP",
+            "org.keycloak.authentication.authenticators.resetcred.ResetPassword",
+            "org.keycloak.authentication.authenticators.sessionlimits.UserSessionLimitsAuthenticator",
+            "org.keycloak.authentication.authenticators.x509.ValidateX509CertificateUsername",
+            "org.keycloak.authentication.authenticators.x509.X509ClientCertificateAuthenticator",
+            "org.keycloak.organization.authentication.authenticators.browser.OrganizationAuthenticator",
+        )
+    }
+}

--- a/test-integration/src/main/kotlin/com/jonnyzzz/mcpSteroid/integration/tests/SemanticTaskScoring.kt
+++ b/test-integration/src/main/kotlin/com/jonnyzzz/mcpSteroid/integration/tests/SemanticTaskScoring.kt
@@ -80,6 +80,70 @@ fun scoreRenameSafety(output: String): RenameSafetyScore {
     return RenameSafetyScore(renameDone = renameDone, buildGreen = buildGreen, safe = renameDone && buildGreen == true)
 }
 
+data class ChangeSignatureScore(
+    /** The agent reported the interface method's signature itself was changed. */
+    val signatureChanged: Boolean,
+    /** FQNs the agent reported as updated overrides (from `OVERRIDE_UPDATED:` markers, else any FQN). */
+    val reportedOverrides: Set<String>,
+    /** Ground-truth overrides the agent did NOT report updating — the manual-sweep misses. */
+    val missingOverrides: Set<String>,
+    /** The post-change build result the agent reported (null if it never reported one). */
+    val buildGreen: Boolean?,
+    /** Signature changed AND every ground-truth override was reported updated. */
+    val complete: Boolean,
+    /** A safe change-signature = complete AND the project still compiles afterwards. */
+    val safe: Boolean,
+)
+
+/**
+ * Score a project-wide CHANGE SIGNATURE for completeness + safety. With MCP the agent drives IntelliJ's
+ * `ChangeSignatureProcessor` (PSI): the interface method, every override — abstract bases, `default`
+ * methods in sub-interfaces, anonymous classes — and every call site are updated atomically. Without MCP
+ * a shell/editor sweep typically misses the non-obvious overrides or breaks call sites. Scored
+ * identically for both modes.
+ *
+ * Expected markers (the prompt asks the agent to compile after the change and report):
+ *   SIGNATURE_CHANGED: yes
+ *   OVERRIDE_UPDATED: <fully.qualified.ClassName>   (one line per updated override)
+ *   BUILD_AFTER_CHANGE: SUCCESS | FAILURE
+ *
+ * @param requiredOverrides ground-truth override FQNs derived from the project source — every one must
+ *                          be reported (exact FQN, or same simple name under a nearby package).
+ */
+fun scoreChangeSignature(output: String, requiredOverrides: Set<String>): ChangeSignatureScore {
+    val signatureChanged = findMarkerValue(output, "SIGNATURE_CHANGED", "Signature changed")
+        ?.contains("yes", ignoreCase = true) == true
+
+    // Prefer explicit `OVERRIDE_UPDATED: <fqn>` markers (tolerating markdown wrapping and backticked
+    // FQNs); if the agent used a different layout, fall back to every FQN in the answer body.
+    val marked = Regex("""(?im)^\s*[*_`>#-]*\s*OVERRIDE_UPDATED\s*[*_`>#-]*\s*:\s*[*_`]*([\w.$]+)""")
+        .findAll(output).map { it.groupValues[1].trim().trim('.') }.toSet()
+    val reported = marked.ifEmpty { FQN.findAll(output).map { it.groupValues[1] }.toSet() }
+
+    val missing = requiredOverrides.filterNot { req ->
+        req in reported || reported.any { it.endsWith(".${req.substringAfterLast('.')}") }
+    }.toSet()
+
+    val build = findMarkerValue(output, "BUILD_AFTER_CHANGE", "Build after change")
+    val buildGreen = build?.let {
+        when {
+            it.contains("SUCCESS", ignoreCase = true) || it.equals("pass", ignoreCase = true) || it.equals("green", ignoreCase = true) -> true
+            it.contains("FAIL", ignoreCase = true) || it.contains("error", ignoreCase = true) || it.contains("broke", ignoreCase = true) -> false
+            else -> null
+        }
+    }
+
+    val complete = signatureChanged && missing.isEmpty()
+    return ChangeSignatureScore(
+        signatureChanged = signatureChanged,
+        reportedOverrides = reported,
+        missingOverrides = missing,
+        buildGreen = buildGreen,
+        complete = complete,
+        safe = complete && buildGreen == true,
+    )
+}
+
 data class InspectionScore(
     val issuesFound: Int?,
     val mentionsRedundantCast: Boolean,

--- a/test-integration/src/test/kotlin/com/jonnyzzz/mcpSteroid/integration/tests/ChangeSignatureScoringTest.kt
+++ b/test-integration/src/test/kotlin/com/jonnyzzz/mcpSteroid/integration/tests/ChangeSignatureScoringTest.kt
@@ -1,0 +1,147 @@
+/* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
+package com.jonnyzzz.mcpSteroid.integration.tests
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * Pure, local tests for [scoreChangeSignature] — the verdict for the Keycloak change-signature A/B.
+ * The point of the experiment: IntelliJ's ChangeSignatureProcessor updates the interface method, EVERY
+ * override (abstract bases, default methods, anonymous classes) and every call site atomically, while a
+ * shell/editor sweep misses overrides or breaks call sites. The scorer checks three things from the
+ * agent's marker output: the signature was changed, ALL ground-truth overrides were updated, and the
+ * post-change build was reported green. No IDE/Docker needed.
+ */
+class ChangeSignatureScoringTest {
+
+    // A toy ground truth mirroring the Keycloak shape: a concrete override, an abstract-base override,
+    // and a default-method override in a sub-interface.
+    private val required = setOf(
+        "org.kc.auth.FooAuthenticator",
+        "org.kc.auth.AbstractBarAuthenticator",
+        "org.kc.auth.ConditionalBaz",
+    )
+
+    @Test
+    fun `MCP-style answer with all overrides and green build scores safe`() {
+        val mcp = """
+            Used ChangeSignatureProcessor via steroid_execute_code.
+            SIGNATURE_CHANGED: yes
+            OVERRIDES_UPDATED: 3
+            OVERRIDE_UPDATED: org.kc.auth.FooAuthenticator
+            OVERRIDE_UPDATED: org.kc.auth.AbstractBarAuthenticator
+            OVERRIDE_UPDATED: org.kc.auth.ConditionalBaz
+            BUILD_AFTER_CHANGE: SUCCESS
+        """.trimIndent()
+        val s = scoreChangeSignature(mcp, required)
+        assertTrue(s.signatureChanged)
+        assertEquals(emptySet<String>(), s.missingOverrides)
+        assertEquals(true, s.buildGreen)
+        assertTrue(s.complete)
+        assertTrue(s.safe)
+    }
+
+    @Test
+    fun `sweep that misses the default-method override scores incomplete`() {
+        // The classic manual-sweep miss: the `default void authenticate(...)` in a sub-interface.
+        val sweep = """
+            SIGNATURE_CHANGED: yes
+            OVERRIDE_UPDATED: org.kc.auth.FooAuthenticator
+            OVERRIDE_UPDATED: org.kc.auth.AbstractBarAuthenticator
+            BUILD_AFTER_CHANGE: FAILURE
+        """.trimIndent()
+        val s = scoreChangeSignature(sweep, required)
+        assertTrue(s.signatureChanged)
+        assertTrue(s.missingOverrides.contains("org.kc.auth.ConditionalBaz"))
+        assertEquals(false, s.buildGreen)
+        assertFalse(s.complete)
+        assertFalse(s.safe)
+    }
+
+    @Test
+    fun `complete override list but red build is complete yet not safe`() {
+        val out = """
+            SIGNATURE_CHANGED: yes
+            OVERRIDE_UPDATED: org.kc.auth.FooAuthenticator
+            OVERRIDE_UPDATED: org.kc.auth.AbstractBarAuthenticator
+            OVERRIDE_UPDATED: org.kc.auth.ConditionalBaz
+            BUILD_AFTER_CHANGE: FAILURE — 12 call sites do not compile
+        """.trimIndent()
+        val s = scoreChangeSignature(out, required)
+        assertTrue(s.complete)
+        assertEquals(false, s.buildGreen)
+        assertFalse(s.safe)
+    }
+
+    @Test
+    fun `markdown-formatted markers and backticked FQNs still parse`() {
+        // Agents love markdown; markers may carry emphasis and FQNs may be backticked (the exact failure
+        // mode that broke raw substring scoring before — see scoreSortedByDescendingRootCause).
+        val md = """
+            **SIGNATURE_CHANGED**: yes
+            - OVERRIDE_UPDATED: `org.kc.auth.FooAuthenticator`
+            - OVERRIDE_UPDATED: `org.kc.auth.AbstractBarAuthenticator`
+            - OVERRIDE_UPDATED: `org.kc.auth.ConditionalBaz`
+            **BUILD_AFTER_CHANGE**: SUCCESS
+        """.trimIndent()
+        val s = scoreChangeSignature(md, required)
+        assertTrue(s.signatureChanged, "markdown-wrapped SIGNATURE_CHANGED must parse")
+        assertEquals(emptySet<String>(), s.missingOverrides, "backticked FQNs must parse")
+        assertTrue(s.safe)
+    }
+
+    @Test
+    fun `no OVERRIDE_UPDATED markers falls back to FQNs anywhere in the answer`() {
+        val prose = """
+            SIGNATURE_CHANGED: yes
+            I updated org.kc.auth.FooAuthenticator, org.kc.auth.AbstractBarAuthenticator and
+            org.kc.auth.ConditionalBaz to the new signature.
+            BUILD_AFTER_CHANGE: SUCCESS
+        """.trimIndent()
+        val s = scoreChangeSignature(prose, required)
+        assertEquals(emptySet<String>(), s.missingOverrides)
+        assertTrue(s.safe)
+    }
+
+    @Test
+    fun `same simple name under a slightly different package still counts`() {
+        val out = """
+            SIGNATURE_CHANGED: yes
+            OVERRIDE_UPDATED: org.kc.auth.FooAuthenticator
+            OVERRIDE_UPDATED: org.kc.auth.AbstractBarAuthenticator
+            OVERRIDE_UPDATED: org.kc.auth.impl.ConditionalBaz
+            BUILD_AFTER_CHANGE: SUCCESS
+        """.trimIndent()
+        val s = scoreChangeSignature(out, required)
+        assertEquals(emptySet<String>(), s.missingOverrides)
+    }
+
+    @Test
+    fun `signature not changed at all scores unsafe regardless of build`() {
+        val out = """
+            SIGNATURE_CHANGED: no
+            BUILD_AFTER_CHANGE: SUCCESS
+        """.trimIndent()
+        val s = scoreChangeSignature(out, required)
+        assertFalse(s.signatureChanged)
+        assertFalse(s.complete)
+        assertFalse(s.safe)
+    }
+
+    @Test
+    fun `missing build marker yields null buildGreen and unsafe`() {
+        val out = """
+            SIGNATURE_CHANGED: yes
+            OVERRIDE_UPDATED: org.kc.auth.FooAuthenticator
+            OVERRIDE_UPDATED: org.kc.auth.AbstractBarAuthenticator
+            OVERRIDE_UPDATED: org.kc.auth.ConditionalBaz
+        """.trimIndent()
+        val s = scoreChangeSignature(out, required)
+        assertNull(s.buildGreen)
+        assertTrue(s.complete)
+        assertFalse(s.safe)
+    }
+}


### PR DESCRIPTION
## What

The sequel to the rename win (#169 follow-up): a new A/B experiment where the agent must **change the signature** of the widely-overridden SPI method

```
org.keycloak.authentication.Authenticator#authenticate(AuthenticationFlowContext)
  →  void authenticate(AuthenticationFlowContext context, boolean silent)
```

and ripple the change through every override and call site so the project still compiles (call sites pass `false`).

- **with MCP**: steered to IntelliJ's `ChangeSignatureProcessor` (+ `ParameterInfoImpl`, default value `false`) via `steroid_execute_code` — PSI updates declaration, all overrides and all call sites atomically.
- **without MCP**: same task, shell/editor only — the manual sweep must find each override by hand.

Both legs emit `[ARENA]` blocks (scenario `keycloak__change_signature`); correctness is a dashboard metric, not a hard gate; with-MCP legs assert exec_code evidence. 80-min `@Timeout` per the `KeycloakRenameTest` precedent (edit-heavy baseline).

## Scoring (TDD)

New pure scorer `scoreChangeSignature` in `SemanticTaskScoring.kt`, unit-tested first in `ChangeSignatureScoringTest` (8 cases, incl. markdown-wrapped markers and backticked FQNs — the normalization pitfall that bit earlier scorers). Verdict: `SIGNATURE_CHANGED: yes` AND all ground-truth overrides reported (`OVERRIDE_UPDATED:` markers, FQN fallback, simple-name credit) AND `BUILD_AFTER_CHANGE: SUCCESS`.

## Ground-truth override list (Keycloak 26.6.4, production modules)

Derived from a fresh `--depth 1 --branch 26.6.4` clone: 29 override declarations beyond the interface in `server-spi-private` + `services`. 28 are REQUIRED (below); the anonymous class `SpnegoAuthenticatorFactory.SINGLETON_DISABLED` is excluded from the required list (agents report anonymous classes under inconsistent names; the build-green check catches a real miss), and testsuite-module overrides are excluded so scoring doesn't depend on Maven import scope. Traps a manual sweep hits: `default` method in `ConditionalAuthenticator`, abstract base `AbstractIdpAuthenticator`, the anonymous class, `super.authenticate(context)` call sites, and javadoc/JS-string mentions in `ScriptBasedAuthenticator(Factory)` that must NOT be edited.

```
org.keycloak.authentication.authenticators.AttemptedAuthenticator
org.keycloak.authentication.authenticators.access.AllowAccessAuthenticator
org.keycloak.authentication.authenticators.access.DenyAccessAuthenticator
org.keycloak.authentication.authenticators.broker.AbstractIdpAuthenticator
org.keycloak.authentication.authenticators.browser.ConditionalOtpFormAuthenticator
org.keycloak.authentication.authenticators.browser.CookieAuthenticator
org.keycloak.authentication.authenticators.browser.IdentityProviderAuthenticator
org.keycloak.authentication.authenticators.browser.OTPFormAuthenticator
org.keycloak.authentication.authenticators.browser.PasskeysConditionalUIAuthenticator
org.keycloak.authentication.authenticators.browser.PasswordForm
org.keycloak.authentication.authenticators.browser.RecoveryAuthnCodesFormAuthenticator
org.keycloak.authentication.authenticators.browser.ScriptBasedAuthenticator
org.keycloak.authentication.authenticators.browser.SpnegoAuthenticator
org.keycloak.authentication.authenticators.browser.UsernameForm
org.keycloak.authentication.authenticators.browser.UsernamePasswordForm
org.keycloak.authentication.authenticators.browser.WebAuthnAuthenticator
org.keycloak.authentication.authenticators.conditional.ConditionalAuthenticator
org.keycloak.authentication.authenticators.directgrant.ValidateOTP
org.keycloak.authentication.authenticators.directgrant.ValidatePassword
org.keycloak.authentication.authenticators.directgrant.ValidateUsername
org.keycloak.authentication.authenticators.resetcred.ResetCredentialChooseUser
org.keycloak.authentication.authenticators.resetcred.ResetCredentialEmail
org.keycloak.authentication.authenticators.resetcred.ResetOTP
org.keycloak.authentication.authenticators.resetcred.ResetPassword
org.keycloak.authentication.authenticators.sessionlimits.UserSessionLimitsAuthenticator
org.keycloak.authentication.authenticators.x509.ValidateX509CertificateUsername
org.keycloak.authentication.authenticators.x509.X509ClientCertificateAuthenticator
org.keycloak.organization.authentication.authenticators.browser.OrganizationAuthenticator
```

## TeamCity registration (follow-up in the internal DSL repo)

Two configs, Gradle filter `*KeycloakChangeSignatureTest.<agent>*`, `executionTimeoutMin=180` (two 80-min methods each):

- `IntegrationTests_KeycloakChangeSignature_Claude`
- `IntegrationTests_KeycloakChangeSignature_Codex`

## Validation

- `./gradlew :test-integration:test --tests "*ChangeSignatureScoringTest"` — 8/8 green (written failing-first).
- `./gradlew :test-experiments:compileTestKotlin` — green.
- Docker/IDE E2E left to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)