### PR TITLE
Keycloak call-hierarchy reachability A/B: which endpoints reach BruteForceProtector.failedLogin?

### DIFF
--- a/test-experiments/src/test/kotlin/com/jonnyzzz/mcpSteroid/integration/tests/KeycloakCallHierarchyTest.kt
+++ b/test-experiments/src/test/kotlin/com/jonnyzzz/mcpSteroid/integration/tests/KeycloakCallHierarchyTest.kt
@@ -1,0 +1,171 @@
+/* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
+package com.jonnyzzz.mcpSteroid.integration.tests
+
+import com.jonnyzzz.mcpSteroid.integration.infra.AiMode
+import com.jonnyzzz.mcpSteroid.integration.infra.BuildSystem
+import com.jonnyzzz.mcpSteroid.integration.infra.IntelliJContainer
+import com.jonnyzzz.mcpSteroid.integration.infra.IntelliJContainerOpts
+import com.jonnyzzz.mcpSteroid.integration.infra.IntelliJProject
+import com.jonnyzzz.mcpSteroid.integration.infra.McpConnectionMode
+import com.jonnyzzz.mcpSteroid.integration.infra.create
+import com.jonnyzzz.mcpSteroid.integration.infra.waitForProjectReady
+import com.jonnyzzz.mcpSteroid.testHelper.AiAgentSession
+import com.jonnyzzz.mcpSteroid.testHelper.CloseableStackHost
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Timeout
+import java.util.concurrent.TimeUnit
+
+/**
+ * MCP-win experiment: **inter-procedural CALLER hierarchy on a large codebase** (jonnyzzz/mcp-steroid#169)
+ * — the dual of [KeycloakTypeHierarchyTest]'s subtypes walk. The agent must answer: "which REST/HTTP
+ * endpoints (JAX-RS `@Path`/`@GET`/`@POST` methods) can transitively REACH `BruteForceProtector.failedLogin`?"
+ *
+ * On Keycloak 26.6.4 the only production caller is `AuthenticationProcessor.logFailure`, and every path
+ * from an endpoint down to it crosses links `grep` cannot follow:
+ *  - `AuthenticationFlow.processFlow()/processAction()` — interface dispatch to `DefaultAuthenticationFlow`
+ *    / `FormAuthenticationFlow`, the only classes that call `logFailure`;
+ *  - `TokenEndpoint.processGrantRequest` reaches it only through a DI provider lookup
+ *    (`session.getProvider(OAuth2GrantType.class, grantType)` → `ResourceOwnerPasswordCredentialsGrantType`)
+ *    — `TokenEndpoint.java` never mentions `AuthenticationProcessor` at all;
+ *  - the broker callback endpoint (`AbstractOAuth2IdentityProvider.Endpoint#authResponse`) reaches it only
+ *    through the `AuthenticationCallback` interface (`callback.error(...)` → `IdentityBrokerService`).
+ * The IDE's caller hierarchy (CallerMethodsTreeStructure / ReferencesSearch ascent) follows all of these.
+ *
+ * A/B: each agent runs WITH and WITHOUT MCP, scored purely on completeness ([scoreCallHierarchy]) — did it
+ * report the interface-hop endpoints (and enough total) — identically for both modes. The verdict is
+ * emitted as an `[ARENA]` block; correctness is a dashboard metric, not a hard pass gate, so a legitimate
+ * grep miss is a comparison result, not a red build.
+ */
+class KeycloakCallHierarchyTest {
+
+    // Read-only reachability question — 50 min covers container start + Keycloak import + the walk.
+    @Test @Timeout(value = 50, unit = TimeUnit.MINUTES)
+    fun `claude with mcp`() = run("claude", withMcp = true)
+
+    @Test @Timeout(value = 50, unit = TimeUnit.MINUTES)
+    fun `claude without mcp`() = run("claude", withMcp = false)
+
+    @Test @Timeout(value = 50, unit = TimeUnit.MINUTES)
+    fun `codex with mcp`() = run("codex", withMcp = true)
+
+    @Test @Timeout(value = 50, unit = TimeUnit.MINUTES)
+    fun `codex without mcp`() = run("codex", withMcp = false)
+
+    private fun run(agentName: String, withMcp: Boolean) {
+        val modeLabel = if (withMcp) "mcp" else "none"
+        val lifetime = CloseableStackHost()
+        try {
+            val session = IntelliJContainer.create(lifetime, IntelliJContainerOpts(
+                // mode last in the title so the run-dir zip is mode-tagged (*-mcp / *-none) for the dashboard.
+                consoleTitle = "keycloak-callhierarchy-$agentName-$modeLabel",
+                project = IntelliJProject.KeycloakProject,
+                aiMode = if (withMcp) AiMode.AI_MCP else AiMode.NONE,
+                mcpConnectionMode = if (withMcp) null else McpConnectionMode.None,
+            )).waitForProjectReady(buildSystem = BuildSystem.MAVEN)
+
+            val agent: AiAgentSession = when (agentName) {
+                "claude" -> session.aiAgents.claude
+                "codex" -> session.aiAgents.codex
+                else -> error("Unknown agent: $agentName")
+            }
+
+            val startedAt = System.currentTimeMillis()
+            val result = agent.runPrompt(if (withMcp) withMcpPrompt() else baselinePrompt(), timeoutSeconds = 1800)
+                .awaitForProcessFinish()
+            val agentDurationMs = System.currentTimeMillis() - startedAt
+            val combined = result.stdout + "\n" + result.stderr
+
+            val score = scoreCallHierarchy(combined, REQUIRED_ENDPOINTS, MIN_TOTAL)
+            println("[TEST] keycloak call-hierarchy [$agentName+$modeLabel] complete=${score.complete} " +
+                    "reported=${score.reportedCount} missing=${score.missingRequired}")
+
+            // Emit the full [ARENA] block (verdict + duration + tokens + tool-call counters) for the dashboard.
+            recordSemanticRun(
+                scenario = SCENARIO,
+                agentName = agentName,
+                withMcp = withMcp,
+                claimedFix = score.complete,
+                rawOutput = result.rawStdout,
+                exitCode = result.exitCode,
+                agentDurationMs = agentDurationMs,
+                runDir = session.runDirInContainer,
+                summary = "found ${score.reportedCount} endpoints; missing required ${score.missingRequired}",
+            )
+
+            if (withMcp) {
+                // Prove MCP was actually exercised; completeness itself is the comparison metric, not a gate.
+                assertUsedExecuteCodeEvidence(combined)
+            }
+        } finally {
+            lifetime.closeAllStacks()
+        }
+    }
+
+    private fun withMcpPrompt(): String = buildString {
+        appendLine("The Keycloak project is open in IntelliJ IDEA — a large multi-module Java project.")
+        appendLine()
+        appendLine(taskDescription())
+        appendLine()
+        appendLine("Use IntelliJ's caller hierarchy via `steroid_execute_code`. BEFORE your first attempt,")
+        appendLine("fetch `mcp-steroid://lsp/find-references` for the PSI search recipes. Walk CALLERS upward")
+        appendLine("from the target: `MethodReferencesSearch`/`ReferencesSearch` on each method (an IDE")
+        appendLine("call-hierarchy ascent, like `CallerMethodsTreeStructure`). When a frontier method")
+        appendLine("implements or overrides an interface method, ALSO search references of the super method")
+        appendLine("(`method.findDeepestSuperMethods()`), and follow provider/DI lookups and lambdas")
+        appendLine("(`FunctionalExpressionSearch`) — that is where text search loses the chain.")
+        appendLine("Do not rely on text search.")
+        appendLine()
+        appendLine(outputFormat())
+        appendLine("TOOL_EVIDENCE: <copy the line starting with execution_id: ...>")
+    }
+
+    private fun baselinePrompt(): String = buildString {
+        appendLine("The Keycloak project is checked out (a large multi-module Java project).")
+        appendLine("IntelliJ MCP tools are unavailable in this run — use shell commands only (grep/rg/find).")
+        appendLine()
+        appendLine(taskDescription())
+        appendLine()
+        appendLine(outputFormat())
+    }
+
+    private fun taskDescription(): String = buildString {
+        appendLine("Task: find EVERY REST/HTTP endpoint that can transitively REACH the method")
+        appendLine("`$TARGET_METHOD`")
+        appendLine("i.e. every JAX-RS resource method (annotated `@GET`/`@POST`/... , exposed via `@Path`)")
+        appendLine("from which some call chain leads to that method. Follow calls through interfaces,")
+        append("inherited helper methods, provider lookups, and lambdas. Be exhaustive.")
+    }
+
+    private fun outputFormat(): String = buildString {
+        appendLine("Output (markers on their own lines):")
+        appendLine("ENDPOINTS_FOUND: <total count>")
+        append("ENDPOINT: <fully.qualified.ClassName#methodName>   ← one line per endpoint method")
+    }
+
+    companion object {
+        private const val SCENARIO = "keycloak__call_hierarchy"
+        private const val TARGET_METHOD =
+            "org.keycloak.services.managers.BruteForceProtector#failedLogin(RealmModel, UserModel, ClientConnection, UriInfo, String)"
+
+        // Endpoints whose chain to failedLogin crosses an interface / DI hop grep cannot follow — verified
+        // by hand against the Keycloak 26.6.4 sources (see the class KDoc). Each entry lists acceptable
+        // spellings: agents name a nested JAX-RS resource by the outer class, the nested class, or the
+        // concrete subclass actually served (OIDCIdentityProvider.OIDCEndpoint extends Endpoint).
+        private val REQUIRED_ENDPOINTS = listOf(
+            // token grant: TokenEndpoint → session.getProvider(OAuth2GrantType) → ResourceOwnerPassword…GrantType
+            setOf("org.keycloak.protocol.oidc.endpoints.TokenEndpoint#processGrantRequest"),
+            // broker callback: Endpoint.authResponse → callback.error/cancelled (AuthenticationCallback)
+            // → IdentityBrokerService.browserAuthentication → AuthenticationProcessor.authenticate()
+            setOf(
+                "org.keycloak.broker.oidc.AbstractOAuth2IdentityProvider.Endpoint#authResponse",
+                "org.keycloak.broker.oidc.OIDCIdentityProvider.OIDCEndpoint#authResponse",
+            ),
+        )
+
+        // Beyond the required two there are the greppable browser-flow endpoints (LoginActionsService
+        // authenticate/authenticateForm/reset-credentials/registration/first-broker-login…, Authorization-
+        // Endpoint buildGet/buildPost, SamlService bindings, DeviceEndpoint, DockerEndpoint) — a dozen-plus
+        // total; require a handful so a near-empty answer scores incomplete without punishing naming variance.
+        private const val MIN_TOTAL = 5
+    }
+}

--- a/test-integration/src/main/kotlin/com/jonnyzzz/mcpSteroid/integration/tests/SemanticTaskScoring.kt
+++ b/test-integration/src/main/kotlin/com/jonnyzzz/mcpSteroid/integration/tests/SemanticTaskScoring.kt
@@ -50,6 +50,84 @@ fun scoreTypeHierarchy(output: String, required: Set<String>, minTotal: Int): Ty
     )
 }
 
+data class CallHierarchyScore(
+    /** Endpoints the agent reported (normalized `pkg.Class.method` strings from `ENDPOINT:` markers). */
+    val reported: Set<String>,
+    /** Required endpoints the agent FAILED to report — the interface-dispatch / DI-lookup ones grep misses. */
+    val missingRequired: Set<String>,
+    val reportedCount: Int,
+    /** True when every required endpoint was reported AND at least [minTotal] endpoints were listed. */
+    val complete: Boolean,
+)
+
+/**
+ * Score a caller-hierarchy (endpoint reachability) answer for completeness — the CALLERS dual of
+ * [scoreTypeHierarchy]. The question is "which REST endpoints can transitively reach method X?"; the
+ * required endpoints are the ones whose call chain crosses an interface dispatch, a lambda, or a DI
+ * provider lookup — links `grep` cannot follow but the IDE's caller hierarchy walks exactly.
+ *
+ * @param output   the agent's answer text (markdown tolerated — backticks/emphasis are stripped first,
+ *                 and `#`, `.`, `$`, `::` are all accepted as class/method separators).
+ * @param required each entry is one required endpoint given as a set of ACCEPTABLE SPELLINGS
+ *                 (`pkg.Class#method`) — agents legitimately name a nested JAX-RS resource by its outer
+ *                 class, the nested class, or an inheriting subclass. An endpoint counts as found when
+ *                 any spelling's simple class name appears ADJACENT to its method name (separators only
+ *                 in between); a class mentioned in prose without its method does not count.
+ * @param minTotal minimum number of distinct endpoints expected (guards against a near-empty answer).
+ */
+fun scoreCallHierarchy(output: String, required: List<Set<String>>, minTotal: Int): CallHierarchyScore {
+    // Strip markdown emphasis/code marks so `Class.method()` and **Class#method** match plain patterns.
+    val text = output.replace(Regex("[`*_]"), "")
+
+    // Reported endpoints: prefer explicit `ENDPOINT: <class-and-method>` markers; if the agent used a
+    // different layout, fall back to every `Class.method` / `Class#method`-shaped token in the answer.
+    val marked = Regex("""(?im)^\s*[>#\-]*\s*ENDPOINT\s*:\s*(\S.*)$""")
+        .findAll(text).map { normalizeEndpointSpec(it.groupValues[1]) }.filter { it.isNotEmpty() }.toSet()
+    val reported = marked.ifEmpty {
+        Regex("""\b[A-Z]\w*(?:\s*[.#$]\s*|\s*::\s*)[a-z]\w*\b""")
+            .findAll(text).map { normalizeEndpointSpec(it.value) }.toSet()
+    }
+
+    val missing = required
+        .filter { alternatives -> alternatives.none { spec -> endpointMentioned(text, spec) } }
+        .map { it.first() }
+        .toSet()
+
+    return CallHierarchyScore(
+        reported = reported,
+        missingRequired = missing,
+        reportedCount = reported.size,
+        complete = missing.isEmpty() && reported.size >= minTotal,
+    )
+}
+
+/** Canonicalize one endpoint mention: unify separators to `.`, drop `()`/whitespace, lowercase. */
+private fun normalizeEndpointSpec(raw: String): String = raw
+    .replace("::", ".").replace('#', '.').replace('$', '.')
+    .replace(Regex("""\(\s*\)"""), "")
+    .replace(Regex("""\s+"""), "")
+    .trim('.', ',', ';', ':', '-')
+    .lowercase()
+
+/**
+ * True when [spec] (`pkg.Outer.Inner#method`) is mentioned in [text]: any of its simple class names must
+ * appear with the method name adjacent to it — only `.`/`#`/`$`/`::` separators (possibly through further
+ * nested-class identifiers) in between. Prose like "looked at TokenEndpoint but found nothing" does NOT
+ * match because there is no separator chain between the class and the method name.
+ */
+private fun endpointMentioned(text: String, spec: String): Boolean {
+    val method = spec.substringAfterLast('#').trim()
+    val classNames = spec.substringBeforeLast('#')
+        .split('.', '$').filter { it.firstOrNull()?.isUpperCase() == true }
+    if (method.isEmpty() || classNames.isEmpty()) return false
+    return classNames.any { cls ->
+        Regex(
+            """\b${Regex.escape(cls)}(?:\s*(?:[.#$]|::)\s*[A-Za-z_]\w*)*\s*(?:[.#$]|::)\s*${Regex.escape(method)}\b""",
+            RegexOption.IGNORE_CASE,
+        ).containsMatchIn(text)
+    }
+}
+
 data class RenameSafetyScore(
     val renameDone: Boolean,
     /** The post-rename build/compile result the agent reported (null if it never reported one). */

--- a/test-integration/src/test/kotlin/com/jonnyzzz/mcpSteroid/integration/tests/CallHierarchyScoringTest.kt
+++ b/test-integration/src/test/kotlin/com/jonnyzzz/mcpSteroid/integration/tests/CallHierarchyScoringTest.kt
@@ -1,0 +1,119 @@
+/* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
+package com.jonnyzzz.mcpSteroid.integration.tests
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * Pure, local tests for [scoreCallHierarchy] — the completeness verdict for the Keycloak call-hierarchy
+ * (endpoint reachability) A/B. The point mirrors the type-hierarchy scorer: a grep walk cannot follow a
+ * call chain through an interface dispatch or a DI provider lookup, so it misses the REQUIRED endpoints;
+ * the IDE's caller hierarchy finds them. No IDE/Docker needed.
+ */
+class CallHierarchyScoringTest {
+
+    // Mirrors the Keycloak ground truth shape: each required endpoint is a group of acceptable spellings
+    // (agents name a nested JAX-RS resource by its outer class, the subclass, or the base class).
+    private val required = listOf(
+        setOf("org.kc.TokenEndpoint#processGrantRequest"),
+        setOf(
+            "org.kc.AbstractBrokerProvider.Endpoint#authResponse",
+            "org.kc.OidcBrokerProvider.OidcEndpoint#authResponse",
+        ),
+    )
+
+    @Test
+    fun `MCP-style complete answer (marker lines with hash separator) scores complete`() {
+        val mcp = """
+            I walked the caller hierarchy from the target method.
+            ENDPOINTS_FOUND: 3
+            ENDPOINT: org.kc.TokenEndpoint#processGrantRequest
+            ENDPOINT: org.kc.AbstractBrokerProvider.Endpoint#authResponse
+            ENDPOINT: org.kc.LoginActionsService#authenticate
+        """.trimIndent()
+        val s = scoreCallHierarchy(mcp, required, minTotal = 3)
+        assertTrue(s.complete, "missing=${s.missingRequired} count=${s.reportedCount}")
+        assertEquals(emptySet<String>(), s.missingRequired)
+        assertEquals(3, s.reportedCount)
+    }
+
+    @Test
+    fun `grep-style answer that misses the interface-dispatch endpoints scores incomplete`() {
+        // grep from the target upward finds the direct textual callers but cannot cross the DI provider
+        // lookup (TokenEndpoint) or the callback interface (broker endpoint) — the classic miss.
+        val grep = """
+            I grepped for callers.
+            ENDPOINTS_FOUND: 3
+            ENDPOINT: org.kc.LoginActionsService#authenticate
+            ENDPOINT: org.kc.LoginActionsService#authenticateForm
+            ENDPOINT: org.kc.AuthorizationEndpoint#buildGet
+        """.trimIndent()
+        val s = scoreCallHierarchy(grep, required, minTotal = 3)
+        assertFalse(s.complete)
+        assertEquals(2, s.missingRequired.size, "both interface-hop endpoints should be flagged missing")
+    }
+
+    @Test
+    fun `alternative spelling of a nested resource class still counts`() {
+        val out = """
+            ENDPOINT: org.kc.TokenEndpoint#processGrantRequest
+            ENDPOINT: org.kc.OidcBrokerProvider.OidcEndpoint#authResponse
+            ENDPOINT: org.kc.LoginActionsService#authenticate
+        """.trimIndent()
+        val s = scoreCallHierarchy(out, required, minTotal = 3)
+        assertEquals(emptySet<String>(), s.missingRequired)
+        assertTrue(s.complete)
+    }
+
+    @Test
+    fun `markdown formatting and dot or dollar separators are tolerated`() {
+        // Agents love backticks and `Class.method()` / `Outer${'$'}Inner.method` layouts.
+        val out = """
+            ENDPOINTS_FOUND: 3
+            ENDPOINT: `org.kc.TokenEndpoint.processGrantRequest()`
+            ENDPOINT: **org.kc.AbstractBrokerProvider${'$'}Endpoint.authResponse**
+            ENDPOINT: org.kc.LoginActionsService::authenticate
+        """.trimIndent()
+        val s = scoreCallHierarchy(out, required, minTotal = 3)
+        assertEquals(emptySet<String>(), s.missingRequired, "markdown/separator variants must be normalized")
+        assertEquals(3, s.reportedCount)
+        assertTrue(s.complete)
+    }
+
+    @Test
+    fun `answer without ENDPOINT markers falls back to free-text class-and-method matching`() {
+        val out = """
+            The following REST endpoints reach the target:
+            1. TokenEndpoint.processGrantRequest (the token grant POST)
+            2. AbstractBrokerProvider.Endpoint.authResponse (broker callback GET)
+            3. LoginActionsService.authenticate
+        """.trimIndent()
+        val s = scoreCallHierarchy(out, required, minTotal = 1)
+        assertEquals(emptySet<String>(), s.missingRequired)
+    }
+
+    @Test
+    fun `mentioning the class without the method does not count as found`() {
+        val out = """
+            ENDPOINT: org.kc.LoginActionsService#authenticate
+            I also looked at TokenEndpoint but found no path from it.
+        """.trimIndent()
+        // "TokenEndpoint" appears in prose, but never adjacent to processGrantRequest → still missing.
+        val s = scoreCallHierarchy(out, required, minTotal = 1)
+        assertTrue(s.missingRequired.any { it.contains("TokenEndpoint") },
+            "class mentioned without its endpoint method must not count; missing=${s.missingRequired}")
+    }
+
+    @Test
+    fun `a too-short answer fails the minimum-count guard even if required are present`() {
+        val out = """
+            ENDPOINT: org.kc.TokenEndpoint#processGrantRequest
+            ENDPOINT: org.kc.AbstractBrokerProvider.Endpoint#authResponse
+        """.trimIndent()
+        val s = scoreCallHierarchy(out, required, minTotal = 5)
+        assertFalse(s.complete, "only 2 reported, minTotal=5")
+        assertEquals(emptySet<String>(), s.missingRequired)
+    }
+}


### PR DESCRIPTION
## What

A new MCP-win A/B experiment — the **CALLERS dual** of the type-hierarchy subtypes walk (#169 follow-up). Question posed to the agent: *"which REST/HTTP endpoints can transitively REACH `org.keycloak.services.managers.BruteForceProtector#failedLogin(RealmModel, UserModel, ClientConnection, UriInfo, String)`?"* — an inter-procedural caller walk. grep cannot follow calls through interfaces, DI provider lookups, and lambdas; the IDE's caller hierarchy (CallerMethodsTreeStructure / ReferencesSearch ascent) can.

- `KeycloakCallHierarchyTest` (test-experiments): 4 legs `claude|codex` × `with|without mcp`, scenario `keycloak__call_hierarchy`, full `[ARENA]` block per leg via `recordSemanticRun`. Completeness is a **dashboard metric, not a pass gate**; only the with-MCP legs assert `exec_code` evidence. 50-min `@Timeout` (read-only task).
- `scoreCallHierarchy` (test-integration main): pure scorer — required endpoints as **alternative-spelling groups** (agents legitimately name a nested JAX-RS resource by outer class, nested class, or the concrete subclass), markdown-normalized, and **adjacency-matched** (class simple name + separators + method) so "I looked at TokenEndpoint but found no path" does not count as a find.
- `CallHierarchyScoringTest` (test-integration test): 7 TDD unit cases — written first, watched fail, then implemented.

## Ground truth (hand-traced on the pinned tag 26.6.4, commit `dc1bfc5`)

`BruteForceProtector.failedLogin` has exactly **one** production caller: `AuthenticationProcessor.logFailure` (AuthenticationProcessor.java:771). `logFailure` is invoked from `DefaultAuthenticationFlow` (:519, :535), `FormAuthenticationFlow` (:231) — both implementations of the `AuthenticationFlow` **interface** — and from `AuthenticationProcessor.authenticationAction` (:1065). `AuthenticationProcessor` reaches the flows only through the interface calls `authenticationFlow.processFlow()` / `processAction(...)` (:965, :1078, :1118) from its entry points `authenticate()` / `authenticateOnly()` / `authenticationAction()`.

### REQUIRED endpoints (the interface/DI hops grep misses)

1. **`org.keycloak.protocol.oidc.endpoints.TokenEndpoint#processGrantRequest`** (`@POST` on `…/protocol/openid-connect/token`)
   Trace: `processGrantRequest` → `grant = session.getProvider(OAuth2GrantType.class, grantType)` (TokenEndpoint.java:213) → `grant.process(context)` (:162) → **DI/provider hop** → `ResourceOwnerPasswordCredentialsGrantType.process` (implements `OAuth2GrantType` via `OAuth2GrantTypeBase`) → `new AuthenticationProcessor()` + `processor.authenticateOnly()` → `AuthenticationFlow.processFlow()` **interface hop** → `DefaultAuthenticationFlow` → `processor.logFailure` → `failedLogin`.
   *Why grep misses it:* `TokenEndpoint.java` contains **zero** mentions of `AuthenticationProcessor` or `ResourceOwnerPasswordCredentialsGrantType` — the link exists only through the provider registry.

2. **`org.keycloak.broker.oidc.AbstractOAuth2IdentityProvider.Endpoint#authResponse`** (`@GET` on `…/broker/{alias}/endpoint`; alternative spelling `OIDCIdentityProvider.OIDCEndpoint#authResponse` — the concrete subclass actually served)
   Trace: `authResponse` → `callback.cancelled(...)` / `callback.error(...)` (AbstractOAuth2IdentityProvider.java:745/:747/:751) — **`AuthenticationCallback` interface hop** → `IdentityBrokerService.cancelled` (:1088→:1098) / `.error` (:1102→:1117) → `browserAuthentication` (:1466) → `new AuthenticationProcessor()` (:1470) + `processor.authenticate()` (:1485) → `AuthenticationFlow.processFlow()` **interface hop** → `logFailure` → `failedLogin`.
   *Why grep misses it:* `AbstractOAuth2IdentityProvider.java` never names `IdentityBrokerService` (only the callback interface), and `IdentityBrokerService.java` never names the broker endpoint class.

   Both required chains cross **3+ interface hops** counting the target itself: `BruteForceProtector` (SPI interface; impl `DefaultBruteForceProtector`) ← `AuthenticationFlow` dispatch ← `OAuth2GrantType` DI / `AuthenticationCallback`.

### Additional true endpoints (count toward MIN_TOTAL = 5, greppable with effort)

- `LoginActionsService#authenticate` (@GET) / `#authenticateForm` (@POST) — LoginActionsService.java:322/:401 → `processFlow` (:354) → `processor.authenticate()` (:382); likewise reset-credentials (:412/:438), registration (:777/:796), first-broker-login (:842/:853), post-broker-login (:864/:875) — all funnel into the same `processFlow` helper.
- `AuthorizationEndpoint#buildGet`/`#buildPost` (@GET/@POST :117/:110) → inherited `AuthorizationEndpointBase.handleBrowserAuthenticationRequest` (:107) → `processor.authenticateOnly()`/`authenticate()` (:117/:149).
- `SamlService` redirect/post bindings (@GET :932 / @POST :942 → `newBrowserAuthentication` :913 → `handleBrowserAuthenticationRequest` :919).
- `DeviceEndpoint` verification (DeviceEndpoint.java:355) and `DockerEndpoint#get` (DockerEndpoint.java:74) — same inherited base-class path.

The scorer only rewards extra finds (never punishes them), so static-analysis over-approximation on other `handleBrowserAuthenticationRequest` / client-auth paths is harmless.

## Scoring

`scoreCallHierarchy(output, required, minTotal=5)` — `complete` ⇔ both required groups found AND ≥5 distinct endpoints reported. `ENDPOINT:` markers preferred, free-text `Class#method`/`Class.method(` fallback; `#`, `.`, `$`, `::` separators and markdown all normalized.

## TeamCity

To be registered in the TC DSL repo as `IntegrationTests_KeycloakCallHierarchy_Claude` / `IntegrationTests_KeycloakCallHierarchy_Codex` (Gradle filter `*KeycloakCallHierarchyTest.claude*` / `*KeycloakCallHierarchyTest.codex*`), same shape as the existing `IntegrationTests_KeycloakTypeHierarchy_*` configs; `executionTimeoutMin` fitting two 50-min methods per agent.

## Validation

- `:test-integration:test --tests "*CallHierarchyScoringTest*"` — 7/7 green (watched the red state first, TDD).
- `:test-experiments:compileTestKotlin` — green. Docker/IDE E2E left to CI by convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)