### PR TITLE
Fix KeycloakInspections false-premise scenario: real ground truth + evidence-based scorer

### DIFF
--- a/test-experiments/src/test/kotlin/com/jonnyzzz/mcpSteroid/integration/tests/KeycloakInspectionsTest.kt
+++ b/test-experiments/src/test/kotlin/com/jonnyzzz/mcpSteroid/integration/tests/KeycloakInspectionsTest.kt
@@ -16,16 +16,30 @@ import org.junit.jupiter.api.Timeout
 import java.util.concurrent.TimeUnit
 
 /**
- * MCP-win experiment: **IDE inspections find what grep can't** (jonnyzzz/mcp-steroid#169). The agent must
- * report the redundant type casts after `instanceof` in Keycloak's
- * `server-spi/src/main/java/org/keycloak/validate/ValidatorConfig.java`.
+ * MCP-win experiment: **IDE inspections find what grep can't** (jonnyzzz/mcp-steroid#169). Among a
+ * fixed list of cast-heavy candidate files, the agent must report which casts are GENUINELY
+ * redundant — removable with no compile error and no semantic change.
  *
- * With MCP the agent runs IntelliJ's "Redundant type cast" inspection — semantic type-narrowing finds
- * each cast that is unnecessary after an `instanceof`. Without MCP, grep sees the cast syntax but cannot
- * determine whether a cast is redundant (that needs type inference), so it cannot reliably find them.
+ * With MCP the agent runs IntelliJ's "Redundant type cast" (RedundantCast) inspection per file —
+ * type inference finds exactly the real ones. Without MCP, grep sees cast syntax everywhere but
+ * cannot determine redundancy: most candidate files are DECOYS full of casts that only LOOK
+ * unnecessary (casts after classic `instanceof` — Java does not narrow there; casts of fluent
+ * builder chains returning a supertype) but are required.
  *
- * Verdict ([scoreInspections]): the agent named the file and reported enough redundant casts — emitted
- * as an `[ARENA]` block. A/B per agent; with-MCP asserts exec_code; correctness is a dashboard metric.
+ * Ground truth ([EXPECTED_ISSUES]) was derived mechanically: `javac -Xlint:cast` over the compiled
+ * `core`/`common`/`server-spi`/`server-spi-private`/`services` modules of the pinned Keycloak
+ * 26.6.4 tag emits exactly 4 `[cast] redundant cast` warnings — those 4 `file:line` pairs. The
+ * decoy files compile with ZERO cast warnings.
+ *
+ * History: the first version of this scenario asked for redundant casts in `ValidatorConfig.java`
+ * — a false premise (its `instanceof`-guarded casts are all REQUIRED; the inspection correctly
+ * reports 0 there). On CI builds 991971406/991971408 both with-MCP legs truthfully answered 0 and
+ * "lost", while the without-MCP legs "won" by hallucinating 15-17 non-issues (codex did so in 17s
+ * with zero tool calls) — the old scorer trusted the self-reported count. The redesigned
+ * [scoreInspections] matches reported `file:line` pairs against ground truth with a spam guard.
+ *
+ * Verdict: at least [MIN_MATCHES] ground-truth pairs hit, without shotgunning — emitted as an
+ * `[ARENA]` block. A/B per agent; with-MCP asserts exec_code; correctness is a dashboard metric.
  */
 class KeycloakInspectionsTest {
 
@@ -64,9 +78,10 @@ class KeycloakInspectionsTest {
             val agentDurationMs = System.currentTimeMillis() - startedAt
             val combined = result.stdout + "\n" + result.stderr
 
-            val score = scoreInspections(combined, MIN_ISSUES, TARGET_FILE)
+            val score = scoreInspections(combined, EXPECTED_ISSUES, MIN_MATCHES)
             println("[TEST] keycloak inspections [$agentName+$modeLabel] detected=${score.detected} " +
-                    "issuesFound=${score.issuesFound} cast=${score.mentionsRedundantCast} file=${score.mentionsTargetFile}")
+                    "matched=${score.matchedCount}/${EXPECTED_ISSUES.values.sumOf { it.size }} " +
+                    "reported=${score.reportedCount} issuesFound=${score.issuesFound}")
 
             recordSemanticRun(
                 scenario = SCENARIO,
@@ -77,7 +92,7 @@ class KeycloakInspectionsTest {
                 exitCode = result.exitCode,
                 agentDurationMs = agentDurationMs,
                 runDir = session.runDirInContainer,
-                summary = "issuesFound=${score.issuesFound} redundantCast=${score.mentionsRedundantCast}",
+                summary = "matched=${score.matchedCount} reported=${score.reportedCount} issuesFound=${score.issuesFound}",
             )
 
             if (withMcp) assertUsedExecuteCodeEvidence(combined)
@@ -86,39 +101,80 @@ class KeycloakInspectionsTest {
         }
     }
 
+    private fun taskDescription(): String = buildString {
+        appendLine("Task: among the candidate files below, find every cast expression that is GENUINELY")
+        appendLine("REDUNDANT — i.e. the cast can be deleted with no compilation error and no change in")
+        appendLine("semantics. Beware: most casts in these files only LOOK unnecessary but are required —")
+        appendLine("e.g. casts after a classic `instanceof` check (Java does not narrow the variable's type")
+        appendLine("there) or casts of fluent builder chains whose setters return a supertype. Report ONLY")
+        appendLine("the casts that are truly redundant.")
+        appendLine()
+        appendLine("Candidate files:")
+        for (file in CANDIDATE_FILES) appendLine("- $file")
+    }
+
+    private fun outputFormat(): String = buildString {
+        appendLine("Output (markers on their own lines):")
+        appendLine("ISSUES_FOUND: <total count of genuinely redundant casts>")
+        appendLine("ISSUE: <path>:<line> — <short description>   ← one per redundant cast, exact line number")
+    }
+
     private fun withMcpPrompt(): String = buildString {
         appendLine("The Keycloak project is open in IntelliJ IDEA — a large multi-module Java project.")
         appendLine()
-        appendLine("Task: find every REDUNDANT type cast in `$TARGET_PATH` — casts that are unnecessary")
-        appendLine("because the variable was already narrowed by a preceding `instanceof` check.")
+        append(taskDescription())
         appendLine()
-        appendLine("Use IntelliJ's inspections via `steroid_execute_code` — run the \"Redundant type cast\"")
-        appendLine("(RedundantCast) inspection on the file and read its results. Do NOT guess from grep.")
+        appendLine("Use IntelliJ's \"Redundant type cast\" (RedundantCast) inspection via `steroid_execute_code`")
+        appendLine("on each candidate file and read its results. Do NOT guess from grep — cast redundancy")
+        appendLine("requires type inference.")
         appendLine()
-        appendLine("Output (markers on their own lines):")
-        appendLine("ISSUES_FOUND: <count of redundant casts>")
-        appendLine("ISSUE: <file:line — short description>   ← one per redundant cast")
+        append(outputFormat())
         appendLine("TOOL_EVIDENCE: <copy the line starting with execution_id: ...>")
     }
 
     private fun baselinePrompt(): String = buildString {
         appendLine("The Keycloak project is checked out (a large multi-module Java project).")
-        appendLine("IntelliJ MCP tools are unavailable in this run — use shell commands only (grep/rg/find).")
+        appendLine("IntelliJ MCP tools are unavailable in this run — use shell commands only (grep/rg/find/cat).")
         appendLine()
-        appendLine("Task: find every REDUNDANT type cast in `$TARGET_PATH` — casts that are unnecessary")
-        appendLine("because the variable was already narrowed by a preceding `instanceof` check.")
+        append(taskDescription())
         appendLine()
-        appendLine("Output (markers on their own lines):")
-        appendLine("ISSUES_FOUND: <count of redundant casts>")
-        appendLine("ISSUE: <file:line — short description>   ← one per redundant cast")
+        append(outputFormat())
     }
 
     companion object {
         private const val SCENARIO = "keycloak__inspections"
-        private const val TARGET_FILE = "ValidatorConfig.java"
-        private const val TARGET_PATH = "server-spi/src/main/java/org/keycloak/validate/ValidatorConfig.java"
 
-        // ValidatorConfig.java has ~13 redundant casts after instanceof; require a meaningful fraction.
-        private const val MIN_ISSUES = 5
+        /**
+         * 4 files with exactly one genuinely redundant cast each + 4 cast-heavy decoys with none
+         * (including `ValidatorConfig.java`, the original false-premise target). Interleaved so
+         * the true positives don't cluster.
+         */
+        private val CANDIDATE_FILES = listOf(
+            "server-spi/src/main/java/org/keycloak/validate/ValidatorConfig.java",
+            "services/src/main/java/org/keycloak/authentication/actiontoken/ActionTokenContext.java",
+            "common/src/main/java/org/keycloak/common/util/reflections/Reflections.java",
+            "services/src/main/java/org/keycloak/services/managers/ResourceAdminManager.java",
+            "services/src/main/java/org/keycloak/protocol/saml/SamlService.java",
+            "services/src/main/java/org/keycloak/authentication/authenticators/browser/SpnegoAuthenticator.java",
+            "services/src/main/java/org/keycloak/services/resources/LoginActionsService.java",
+            "services/src/main/java/org/keycloak/protocol/saml/SamlAbstractMetadataPublicKeyLoader.java",
+        )
+
+        /**
+         * Ground truth from `javac --release 17 -proc:none -Xlint:cast` on Keycloak tag 26.6.4:
+         *  - ActionTokenContext.java:149  `(String) (client == null ? null : client.getClientId())`
+         *  - ResourceAdminManager.java:374  `(LoginProtocol) session.getProvider(LoginProtocol.class, protocol)`
+         *  - SpnegoAuthenticator.java:112  `(String) output.getState().get(KerberosConstants.RESPONSE_TOKEN)`
+         *  - SamlAbstractMetadataPublicKeyLoader.java:107  `(List<XMLStructure>) keyInfo.getContent()`
+         */
+        private val EXPECTED_ISSUES = mapOf(
+            "ActionTokenContext.java" to setOf(149),
+            "ResourceAdminManager.java" to setOf(374),
+            "SpnegoAuthenticator.java" to setOf(112),
+            "SamlAbstractMetadataPublicKeyLoader.java" to setOf(107),
+        )
+
+        /** 3 of 4 true positives — tolerates one inspection/javac disagreement. */
+        private const val MIN_MATCHES = 3
     }
 }

--- a/test-integration/src/main/kotlin/com/jonnyzzz/mcpSteroid/integration/tests/SemanticTaskScoring.kt
+++ b/test-integration/src/main/kotlin/com/jonnyzzz/mcpSteroid/integration/tests/SemanticTaskScoring.kt
@@ -81,36 +81,80 @@ fun scoreRenameSafety(output: String): RenameSafetyScore {
 }
 
 data class InspectionScore(
+    /** The agent's self-reported `ISSUES_FOUND:` count (informational only — never trusted for the verdict). */
     val issuesFound: Int?,
-    val mentionsRedundantCast: Boolean,
-    val mentionsTargetFile: Boolean,
-    /** True when the agent detected a meaningful number of the (semantic) redundant-cast issues. */
+    /** `file simple name → line numbers` parsed from the agent's `ISSUE: <path>:<line>` markers. */
+    val reportedLines: Map<String, Set<Int>>,
+    /** Total number of reported `file:line` pairs. */
+    val reportedCount: Int,
+    /** Ground-truth `file:line` pairs the agent actually hit (±1 line tolerance, each consumed once). */
+    val matchedLines: Map<String, Set<Int>>,
+    val matchedCount: Int,
+    /** True when enough ground-truth pairs were hit AND the answer is not a shotgun spam of cast lines. */
     val detected: Boolean,
 )
 
 /**
- * Score an "run IDE inspections + report issues" answer. The target is the redundant casts after
- * `instanceof` in Keycloak's `ValidatorConfig.java`. With MCP the agent runs IntelliJ's inspection
- * (semantic type-narrowing → finds them exactly); grep/shell cannot determine a cast is redundant.
+ * Score a "run IDE inspections + report issues" answer against a known ground truth of `file:line`
+ * pairs (for the Keycloak scenario: the genuinely redundant casts found by `javac -Xlint:cast` on
+ * the pinned 26.6.4 tag). With MCP the agent runs IntelliJ's RedundantCast inspection (type
+ * inference → exact findings); grep sees cast syntax but cannot determine redundancy.
+ *
+ * The verdict is evidence-based, NOT self-report-based: CI builds 991971406/991971408 showed the
+ * old count-only scorer rewarding a hallucinated "ISSUES_FOUND: 17" (produced with zero tool calls)
+ * and rejecting a truthful "ISSUES_FOUND: 0". Now:
+ *  - each reported `ISSUE: <path>:<line>` is matched against [expected] by file simple name and
+ *    line (±1 tolerance for multi-line expressions; each expected line consumes at most one
+ *    reported line and vice versa);
+ *  - `detected` requires at least [minMatches] true positives AND at most `3 × |expected|` total
+ *    reported pairs — listing every cast in every candidate file cannot win by luck.
  *
  * Expected markers:
  *   ISSUES_FOUND: <count>
- *   ISSUE: <description>            (the redundant-cast lines; ideally mentioning the file)
+ *   ISSUE: <path>:<line> — <description>
  *
- * @param minIssues the lower bound of redundant casts that must be reported to count as detected.
+ * @param expected ground truth: file simple name → the line numbers of the real issues.
+ * @param minMatches how many ground-truth pairs must be hit to count as detected.
  */
-fun scoreInspections(output: String, minIssues: Int, targetFile: String): InspectionScore {
-    val count = findMarkerValue(output, "ISSUES_FOUND", "Issues found")
+fun scoreInspections(output: String, expected: Map<String, Set<Int>>, minMatches: Int): InspectionScore {
+    // Strip markdown code/bold marks so `path.java:112` and **path.java:112** parse the same.
+    // Underscores are NOT stripped — they are significant in marker names (ISSUES_FOUND) and paths.
+    val text = output.replace(Regex("[`*]"), "")
+    val count = findMarkerValue(text, "ISSUES_FOUND", "Issues found")
         ?.let { Regex("""\d+""").find(it)?.value?.toIntOrNull() }
-    val mentionsCast = output.contains("redundant cast", ignoreCase = true) ||
-        output.contains("redundant type cast", ignoreCase = true) ||
-        output.contains("unnecessary cast", ignoreCase = true)
-    val mentionsFile = output.contains(targetFile, ignoreCase = true)
+
+    // Every `ISSUE:` marker line contributes one (file simple name, line) pair. The file-name
+    // pattern has no `/`, so it naturally captures the last path segment.
+    val reported = mutableMapOf<String, MutableList<Int>>()
+    Regex("""(?im)^\s*[-•>#\s]*ISSUE\s*:\s*(.+)$""").findAll(text).forEach { issue ->
+        val m = Regex("""([\w$.-]+\.java)\s*:\s*(\d+)""").find(issue.groupValues[1]) ?: return@forEach
+        reported.getOrPut(m.groupValues[1]) { mutableListOf() }.add(m.groupValues[2].toInt())
+    }
+    val reportedCount = reported.values.sumOf { it.size }
+
+    // Greedy bipartite match per file: exact line first, then ±1; each reported line consumed once.
+    val matched = mutableMapOf<String, MutableSet<Int>>()
+    for ((file, expectedLines) in expected) {
+        val available = reported[file]?.toMutableList() ?: continue
+        for (tolerance in 0..1) {
+            for (expectedLine in expectedLines.sorted()) {
+                if (expectedLine in (matched[file] ?: emptySet<Int>())) continue
+                val hit = available.firstOrNull { kotlin.math.abs(it - expectedLine) <= tolerance } ?: continue
+                available.remove(hit)
+                matched.getOrPut(file) { mutableSetOf() }.add(expectedLine)
+            }
+        }
+    }
+    val matchedCount = matched.values.sumOf { it.size }
+    val expectedCount = expected.values.sumOf { it.size }
+
     return InspectionScore(
         issuesFound = count,
-        mentionsRedundantCast = mentionsCast,
-        mentionsTargetFile = mentionsFile,
-        detected = mentionsCast && mentionsFile && (count ?: 0) >= minIssues,
+        reportedLines = reported.mapValues { it.value.toSet() },
+        reportedCount = reportedCount,
+        matchedLines = matched,
+        matchedCount = matchedCount,
+        detected = matchedCount >= minMatches && reportedCount <= 3 * expectedCount,
     )
 }
 

--- a/test-integration/src/test/kotlin/com/jonnyzzz/mcpSteroid/integration/tests/InspectionScoringTest.kt
+++ b/test-integration/src/test/kotlin/com/jonnyzzz/mcpSteroid/integration/tests/InspectionScoringTest.kt
@@ -1,0 +1,183 @@
+/* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
+package com.jonnyzzz.mcpSteroid.integration.tests
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * TDD unit tests for [scoreInspections] — the redesigned ground-truth-line scorer for the Keycloak
+ * inspections A/B (jonnyzzz/mcp-steroid#169).
+ *
+ * Why the redesign: on CI builds 991971406/991971408 the OLD scorer graded `detected` from the
+ * self-reported `ISSUES_FOUND` count alone. Both with-MCP legs ran IntelliJ's RedundantCast
+ * inspection correctly and truthfully reported `ISSUES_FOUND: 0` (the old target file had none —
+ * classic `instanceof` does not narrow types in Java, so its casts are REQUIRED) and scored
+ * `detected=false`; meanwhile the codex without-MCP leg reported "ISSUES_FOUND: 17" with ZERO tool
+ * calls — a pure hallucination — and scored `detected=true`. The scorer now checks the REPORTED
+ * `file:line` pairs against known ground truth (derived via `javac -Xlint:cast` on the pinned
+ * Keycloak 26.6.4 tag), with a spam guard, so a made-up or shotgunned answer cannot win.
+ */
+class InspectionScoringTest {
+
+    /** The real ground truth of the scenario: `javac -Xlint:cast` on Keycloak 26.6.4. */
+    private val expected = mapOf(
+        "ActionTokenContext.java" to setOf(149),
+        "ResourceAdminManager.java" to setOf(374),
+        "SpnegoAuthenticator.java" to setOf(112),
+        "SamlAbstractMetadataPublicKeyLoader.java" to setOf(107),
+    )
+
+    @Test
+    fun `correct answer with matching file-line pairs is detected`() {
+        val output = """
+            I ran the RedundantCast inspection on every candidate file.
+            ISSUES_FOUND: 4
+            ISSUE: services/src/main/java/org/keycloak/authentication/actiontoken/ActionTokenContext.java:149 — Casting to 'String' is redundant
+            ISSUE: services/src/main/java/org/keycloak/services/managers/ResourceAdminManager.java:374 — Casting to 'LoginProtocol' is redundant
+            ISSUE: services/src/main/java/org/keycloak/authentication/authenticators/browser/SpnegoAuthenticator.java:112 — Casting to 'String' is redundant
+            ISSUE: services/src/main/java/org/keycloak/protocol/saml/SamlAbstractMetadataPublicKeyLoader.java:107 — Casting to 'List<XMLStructure>' is redundant
+            TOOL_EVIDENCE: execution_id: eid_x
+        """.trimIndent()
+        val score = scoreInspections(output, expected, minMatches = 3)
+        assertEquals(4, score.issuesFound)
+        assertEquals(4, score.matchedCount)
+        assertEquals(4, score.reportedCount)
+        assertTrue(score.detected)
+    }
+
+    @Test
+    fun `hallucinated lines are NOT detected even with a big ISSUES_FOUND count`() {
+        // Real failure shape: codex+none on CI build 991971408 reported 17 issues in 17s with zero
+        // tool calls — lines it never looked at cannot match ground truth.
+        val output = buildString {
+            appendLine("ISSUES_FOUND: 17")
+            for (line in listOf(100, 113, 117, 133, 137, 153, 157, 173, 177, 193, 197, 213, 217, 233, 237, 253, 257)) {
+                appendLine("ISSUE: server-spi/src/main/java/org/keycloak/validate/ValidatorConfig.java:$line — redundant cast after instanceof")
+            }
+        }
+        val score = scoreInspections(output, expected, minMatches = 3)
+        assertEquals(17, score.issuesFound)
+        assertEquals(0, score.matchedCount)
+        assertFalse(score.detected)
+    }
+
+    @Test
+    fun `off-by-one line numbers still match (multi-line expressions)`() {
+        val output = """
+            ISSUES_FOUND: 4
+            ISSUE: ActionTokenContext.java:150 — redundant cast
+            ISSUE: ResourceAdminManager.java:373 — redundant cast
+            ISSUE: SpnegoAuthenticator.java:112 — redundant cast
+            ISSUE: SamlAbstractMetadataPublicKeyLoader.java:108 — redundant cast
+        """.trimIndent()
+        val score = scoreInspections(output, expected, minMatches = 3)
+        assertEquals(4, score.matchedCount)
+        assertTrue(score.detected)
+    }
+
+    @Test
+    fun `markdown-formatted issue lines are parsed (backticks, bold, bullets)`() {
+        // Agents love wrapping paths in backticks — raw substring matching broke scorers before
+        // (see scoreSortedByDescendingRootCause). Normalize before parsing.
+        val output = """
+            **ISSUES_FOUND:** 3
+            - ISSUE: `services/src/main/java/org/keycloak/authentication/actiontoken/ActionTokenContext.java:149` — *redundant* cast
+            - **ISSUE**: **ResourceAdminManager.java:374** — redundant cast
+            - ISSUE: `SpnegoAuthenticator.java:112`
+        """.trimIndent()
+        val score = scoreInspections(output, expected, minMatches = 3)
+        assertEquals(3, score.issuesFound)
+        assertEquals(3, score.matchedCount)
+        assertTrue(score.detected)
+    }
+
+    @Test
+    fun `too few matches is not detected`() {
+        val output = """
+            ISSUES_FOUND: 2
+            ISSUE: ActionTokenContext.java:149 — redundant cast
+            ISSUE: ResourceAdminManager.java:374 — redundant cast
+        """.trimIndent()
+        val score = scoreInspections(output, expected, minMatches = 3)
+        assertEquals(2, score.matchedCount)
+        assertFalse(score.detected)
+    }
+
+    @Test
+    fun `truthful zero-issue answer is not detected but parses cleanly`() {
+        val output = """
+            The inspection ran successfully and reported zero redundant casts.
+            ISSUES_FOUND: 0
+            TOOL_EVIDENCE: execution_id: eid_y
+        """.trimIndent()
+        val score = scoreInspections(output, expected, minMatches = 3)
+        assertEquals(0, score.issuesFound)
+        assertEquals(0, score.reportedCount)
+        assertFalse(score.detected)
+    }
+
+    @Test
+    fun `right line in the wrong file does not count`() {
+        val output = """
+            ISSUES_FOUND: 4
+            ISSUE: SamlService.java:149 — redundant cast
+            ISSUE: ValidatorConfig.java:374 — redundant cast
+            ISSUE: LoginActionsService.java:112 — redundant cast
+            ISSUE: SpnegoAuthenticator.java:112 — redundant cast
+        """.trimIndent()
+        val score = scoreInspections(output, expected, minMatches = 3)
+        assertEquals(1, score.matchedCount)
+        assertFalse(score.detected)
+    }
+
+    @Test
+    fun `spamming every cast line in every candidate file is not detected`() {
+        // A shotgun answer that lists dozens of cast lines (including, by luck, the true ones) must
+        // not win: the guard rejects answers reporting more than 3x the ground-truth count.
+        val output = buildString {
+            appendLine("ISSUES_FOUND: 40")
+            appendLine("ISSUE: ActionTokenContext.java:149 — cast")
+            appendLine("ISSUE: ResourceAdminManager.java:374 — cast")
+            appendLine("ISSUE: SpnegoAuthenticator.java:112 — cast")
+            appendLine("ISSUE: SamlAbstractMetadataPublicKeyLoader.java:107 — cast")
+            for (line in 1..36) appendLine("ISSUE: ValidatorConfig.java:${line * 7} — cast")
+        }
+        val score = scoreInspections(output, expected, minMatches = 3)
+        assertEquals(4, score.matchedCount)
+        assertEquals(40, score.reportedCount)
+        assertFalse(score.detected)
+    }
+
+    @Test
+    fun `a few extra findings beyond ground truth are tolerated`() {
+        // IntelliJ's RedundantCast can legitimately find slightly more than javac -Xlint:cast; a
+        // superset answer within the spam cap still counts.
+        val output = """
+            ISSUES_FOUND: 6
+            ISSUE: ActionTokenContext.java:149 — redundant cast
+            ISSUE: ResourceAdminManager.java:374 — redundant cast
+            ISSUE: SpnegoAuthenticator.java:112 — redundant cast
+            ISSUE: SamlAbstractMetadataPublicKeyLoader.java:107 — redundant cast
+            ISSUE: SamlService.java:210 — redundant cast
+            ISSUE: Reflections.java:88 — redundant cast
+        """.trimIndent()
+        val score = scoreInspections(output, expected, minMatches = 3)
+        assertEquals(4, score.matchedCount)
+        assertEquals(6, score.reportedCount)
+        assertTrue(score.detected)
+    }
+
+    @Test
+    fun `each reported line is consumed by at most one expected line`() {
+        // 113 may satisfy expected 112 OR 114, never both.
+        val output = """
+            ISSUES_FOUND: 1
+            ISSUE: F.java:113 — redundant cast
+        """.trimIndent()
+        val score = scoreInspections(output, mapOf("F.java" to setOf(112, 114)), minMatches = 2)
+        assertEquals(1, score.matchedCount)
+        assertFalse(score.detected)
+    }
+}


### PR DESCRIPTION
## Diagnosis: the scenario itself was broken, on both axes

The KeycloakInspections A/B read **"MCP hurt" on BOTH agents**. Pulling the real CI evidence (builds [991971406](https://buildserver.labs.intellij.net/buildConfiguration/mcp_steroid_IntegrationTests_KeycloakInspections_Claude/991971406) Claude, [991971408](https://buildserver.labs.intellij.net/buildConfiguration/mcp_steroid_IntegrationTests_KeycloakInspections_Codex/991971408) Codex) shows the with-MCP legs were **right** and the scorer punished them:

**The task premise was false.** The old target, `ValidatorConfig.java`, has ZERO redundant casts: classic `instanceof` does not narrow a variable's static type in Java, so every `(Integer) value` after `if (value instanceof Integer)` is *required*. Claude+MCP ran the inspection and explained exactly that:

> "The inspection ran successfully and reported **zero** redundant casts. This is the correct result, and worth explaining why it contradicts the task's premise. … Classic `instanceof` does **not** narrow a variable's static type — `value` keeps its declared type `Object`, so the explicit cast is genuinely required. … ISSUES_FOUND: 0"

Codex+MCP wrote a clean `InspectionEngine.inspectEx(... RedundantCastInspection ...)` script; the IDE returned:

> `execution_id: eid_20260702T173727-validator-config-redundant-casts` … `ISSUES_FOUND: 0`

Both were scored `detected=false`. Meanwhile the without-MCP legs "won" by hallucinating:

> `[ARENA] codex+none — keycloak__inspections … Agent time: 17s … exec_code: 0 … Read/Edit/Write: 0/0/0 … Glob/Grep/Bash: 0/0/0 … Summary: issuesFound=17`

**17 "issues" in 17 seconds with zero tool calls** — the old scorer graded `detected` from the self-reported `ISSUES_FOUND` count plus two substring checks, so a made-up count beat a truthful zero.

## Fix

### 1. Real ground truth (mechanically derived)

`javac --release 17 -proc:none -Xlint:cast` over the compiled `core`/`common`/`server-spi`/`server-spi-private`/`services` modules of the pinned Keycloak **26.6.4** tag emits exactly **4** `[cast] redundant cast` warnings:

| file:line | cast |
|---|---|
| `ActionTokenContext.java:149` | `(String) (client == null ? null : client.getClientId())` — ternary is already `String` |
| `ResourceAdminManager.java:374` | `(LoginProtocol) session.getProvider(LoginProtocol.class, protocol)` — generic return is already `LoginProtocol` |
| `SpnegoAuthenticator.java:112` | `(String) output.getState().get(...)` — `getState()` is `Map<String, String>` |
| `SamlAbstractMetadataPublicKeyLoader.java:107` | `(List<XMLStructure>) keyInfo.getContent()` — declared return type |

The scenario now lists **8 candidate files**: these 4 plus 4 cast-heavy decoys that compile with zero cast warnings (including `ValidatorConfig.java`, the original false-premise target, and `SamlService.java`, `LoginActionsService.java`, `Reflections.java`). Every decoy is full of casts that only LOOK unnecessary — determining redundancy requires type inference, which is exactly the semantic gap grep cannot cross. The with-MCP flow (per-file `RedundantCast` via `InspectionEngine`) is the same one both agents already executed successfully in the failing builds, so no MCP-side change is needed.

### 2. Evidence-based scorer (TDD: `InspectionScoringTest`, 10 cases written first)

`scoreInspections` now matches the agent's `ISSUE: <path>:<line>` markers against the ground-truth `file:line` pairs (file simple name, ±1 line tolerance for multi-line expressions, each line consumed at most once, markdown-normalized) and requires:

- `matchedCount >= 3` of the 4 true positives (tolerates one javac/IntelliJ disagreement), and
- `reportedCount <= 3 × |ground truth|` — a shotgun answer listing every cast line cannot win by luck, while a with-MCP superset (IntelliJ legitimately finding a bit more than javac) still passes.

The hallucinated codex answer above scores `matchedCount=0, detected=false` under the new scorer (covered by a dedicated unit test reproducing its shape), and a truthful honest-zero answer no longer gets *rewarded* for the wrong reason either — with the corrected premise the right answer is to find the 4 real casts.

Class name, test method names (`claude with mcp` / …), and the `keycloak__inspections` scenario id are unchanged, so the TeamCity Gradle filters and dashboard history still match.

## Validation

- `:test-integration:test --tests "*InspectionScoringTest*"` — 10/10 green (watched them fail first).
- `:test-experiments:compileTestKotlin` + existing `*ScoringTest*`/`SortedByDescendingRootCauseTest` — green.
- Ground truth cross-checked against the 26.6.4 sources (e.g. `CredentialValidationOutput.getState()` is `Map<String, String>`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)