### PR TITLE
SSR youtrackdb: upgrade to with/without-MCP A/B experiment with [ARENA] metrics

### DIFF
--- a/test-experiments/src/test/kotlin/com/jonnyzzz/mcpSteroid/integration/tests/StructuralSearchYoutrackdb261Test.kt
+++ b/test-experiments/src/test/kotlin/com/jonnyzzz/mcpSteroid/integration/tests/StructuralSearchYoutrackdb261Test.kt
@@ -20,13 +20,17 @@ import org.junit.jupiter.api.Timeout
 import java.util.concurrent.TimeUnit
 
 /**
- * Same scenario as [StructuralSearchYoutrackdbTest], pinned via
+ * The MCP-only SSR skill audit on youtrackdb, pinned via
  * [IdeDistribution.FromUrl] to a specific 2026.1.x (build prefix `IU-261.*`)
  * Linux build. The default `IdeChannel.STABLE` resolves to "whatever the
- * current GA is" — once it rolls forward to 2026.2 the existing default test
- * will silently switch IDE generations. This sibling locks the 261 generation
- * in place so any 2026.1-specific SSR / Maven / indexing behavior keeps the
- * same regression coverage. Mirror of [YouTrackDbMaven261Test].
+ * current GA is" — pinning locks the 261 generation in place so any
+ * 2026.1-specific SSR / Maven / indexing behavior keeps the same regression
+ * coverage. Mirror of [YouTrackDbMaven261Test].
+ *
+ * Historical note: [StructuralSearchYoutrackdbTest] used to run this same
+ * audit on the STABLE IDE; it is now the with/without-MCP A/B experiment
+ * (Optional.get() audit), so this pinned sibling is the only remaining
+ * consumer of `runStructuralSearchYoutrackdbAudit`.
  *
  * Update [PINNED_261_URL] to a newer 2026.1.x patch when one ships; do NOT
  * jump it to 2026.2 — that would defeat the purpose of this sibling.

--- a/test-experiments/src/test/kotlin/com/jonnyzzz/mcpSteroid/integration/tests/StructuralSearchYoutrackdbPromptShared.kt
+++ b/test-experiments/src/test/kotlin/com/jonnyzzz/mcpSteroid/integration/tests/StructuralSearchYoutrackdbPromptShared.kt
@@ -17,13 +17,15 @@ import kotlin.io.path.createDirectories
 import kotlin.io.path.writeText
 
 /**
- * Shared helpers used by every `StructuralSearchYoutrackdb*Test` class — kept in
- * one place so the default-IDE and pinned (253/261/...) variants stay in sync.
+ * Shared helpers for the MCP-only SSR *skill audit* on youtrackdb — kept in one
+ * place so pinned-IDE variants (253/261/...) stay in sync. Currently used by
+ * [StructuralSearchYoutrackdb261Test]; the default-IDE [StructuralSearchYoutrackdbTest]
+ * used to run this same audit but is now the with/without-MCP A/B experiment
+ * (Optional.get() audit scored against a pinned-revision ground truth) and does
+ * not use these helpers.
  *
  * Mirror of `YouTrackDbMavenPromptShared.kt` for the SSR scenario.
  */
-
-const val SSR_YOUTRACKDB_LABEL = "ssr-youtrackdb"
 
 /** The single prompt every variant uses. Produces three markers: SSR_PROFILES,
  *  OPTIONAL_GET_MATCHES, JAVA_PREDEFINED_COUNT, plus the IMPROVEMENTS block. */

--- a/test-experiments/src/test/kotlin/com/jonnyzzz/mcpSteroid/integration/tests/StructuralSearchYoutrackdbTest.kt
+++ b/test-experiments/src/test/kotlin/com/jonnyzzz/mcpSteroid/integration/tests/StructuralSearchYoutrackdbTest.kt
@@ -1,66 +1,203 @@
 /* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
 package com.jonnyzzz.mcpSteroid.integration.tests
 
+import com.jonnyzzz.mcpSteroid.integration.infra.AiMode
 import com.jonnyzzz.mcpSteroid.integration.infra.BuildSystem
 import com.jonnyzzz.mcpSteroid.integration.infra.IntelliJContainer
 import com.jonnyzzz.mcpSteroid.integration.infra.IntelliJContainerOpts
 import com.jonnyzzz.mcpSteroid.integration.infra.IntelliJProject
+import com.jonnyzzz.mcpSteroid.integration.infra.McpConnectionMode
 import com.jonnyzzz.mcpSteroid.integration.infra.create
 import com.jonnyzzz.mcpSteroid.integration.infra.waitForProjectReady
 import com.jonnyzzz.mcpSteroid.testHelper.AiAgentSession
 import com.jonnyzzz.mcpSteroid.testHelper.CloseableStackHost
-import org.junit.jupiter.api.AfterAll
-import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.Timeout
 import java.util.concurrent.TimeUnit
 
 /**
- * Default-IDE variant of the structural-search youtrackdb scenario. Uses the
- * STABLE channel (whatever the current GA is). For pinned IDE-version variants
- * see [StructuralSearchYoutrackdb261Test] — same prompt, same assertions, only
- * the IDE container differs. Shared logic lives in
- * `StructuralSearchYoutrackdbPromptShared.kt`.
+ * MCP-win experiment: **type-exact structural search** on youtrackdb (jonnyzzz/mcp-steroid#169
+ * follow-up). The agent must find EVERY callsite where a no-arg `get()` is invoked on an expression
+ * whose type is `java.util.Optional<T>` — the classic "unsafe Optional.get()" audit.
  *
- * The point of this scenario (vs. [StructuralSearchPromptTest] in
- * `:test-integration:`) is to validate the SSR skill articles against a real-
- * world Maven multi-module Java codebase: https://github.com/JetBrains/youtrackdb
- * — `Matcher` over `GlobalSearchScope.projectScope(project)`, real Java profile,
- * real indexer warm-up.
+ * With MCP the agent runs IntelliJ Structural Search (`Matcher` over
+ * `GlobalSearchScope.projectScope(project)`, apostrophe pattern with an `:[exprtype(...)]`
+ * constraint per the `mcp-steroid://skill/structural-search*` articles) and gets the AST-exact,
+ * type-resolved answer. Without MCP, `grep '.get()'` faces ~940 no-arg `get()` callsites where only
+ * ~36 are Optional — every Atomic, ThreadLocal, Supplier, Future, WeakReference, ByteBuffer,
+ * Netty-attr and gremlin-Traverser `.get()` is an over-match, and chained receivers (`stream.findFirst().get()`,
+ * `reduce(...).get()`, `getDatabase().get()`) require type resolution grep does not have.
+ *
+ * Scored with the pure [scoreSsrOptionalGet] against [GROUND_TRUTH_FILES] — a hand-derived,
+ * type-checked list valid ONLY at the revision [IntelliJProject.YouTrackDbPinnedProject] pins.
+ * Verdict (all files found, none extra) is emitted as an `[ARENA]` block; correctness is a
+ * dashboard metric, not a hard pass gate. A/B per agent; with-MCP legs assert exec_code evidence.
+ *
+ * The MCP-only SSR *skill audit* (profile registry, predefined templates, IMPROVEMENTS reflection)
+ * that used to live here lives on unchanged in [StructuralSearchYoutrackdb261Test] /
+ * `StructuralSearchYoutrackdbPromptShared.kt`.
  */
 class StructuralSearchYoutrackdbTest {
 
-    @Test @Timeout(value = 25, unit = TimeUnit.MINUTES)
-    fun `ssr audit on youtrackdb claude`() = audit(session.aiAgents.claude)
+    @Test @Timeout(value = 50, unit = TimeUnit.MINUTES)
+    fun `claude with mcp`() = run("claude", withMcp = true)
 
-    @Test @Timeout(value = 25, unit = TimeUnit.MINUTES)
-    fun `ssr audit on youtrackdb codex`() = audit(session.aiAgents.codex)
+    @Test @Timeout(value = 50, unit = TimeUnit.MINUTES)
+    fun `claude without mcp`() = run("claude", withMcp = false)
 
-    private fun audit(agent: AiAgentSession) =
-        runStructuralSearchYoutrackdbAudit(session, agent, label = SSR_YOUTRACKDB_LABEL)
+    @Test @Timeout(value = 50, unit = TimeUnit.MINUTES)
+    fun `codex with mcp`() = run("codex", withMcp = true)
 
-    companion object {
+    @Test @Timeout(value = 50, unit = TimeUnit.MINUTES)
+    fun `codex without mcp`() = run("codex", withMcp = false)
 
-        @JvmStatic
-        val lifetime by lazy { CloseableStackHost() }
-
-        val session by lazy {
-            IntelliJContainer.create(lifetime, IntelliJContainerOpts(
-                consoleTitle = "ssr / youtrackdb",
-                project = IntelliJProject.YouTrackDbProject,
+    private fun run(agentName: String, withMcp: Boolean) {
+        val modeLabel = if (withMcp) "mcp" else "none"
+        val lifetime = CloseableStackHost()
+        try {
+            val session = IntelliJContainer.create(lifetime, IntelliJContainerOpts(
+                consoleTitle = "ssr-youtrackdb-$agentName-$modeLabel",
+                project = IntelliJProject.YouTrackDbPinnedProject,
+                aiMode = if (withMcp) AiMode.AI_MCP else AiMode.NONE,
+                mcpConnectionMode = if (withMcp) null else McpConnectionMode.None,
             )).waitForProjectReady(buildSystem = BuildSystem.MAVEN)
-        }
 
-        @JvmStatic
-        @BeforeAll
-        fun beforeAll() {
-            session.toString()
-        }
+            val agent: AiAgentSession = when (agentName) {
+                "claude" -> session.aiAgents.claude
+                "codex" -> session.aiAgents.codex
+                else -> error("Unknown agent: $agentName")
+            }
 
-        @JvmStatic
-        @AfterAll
-        fun tearDown() {
+            val startedAt = System.currentTimeMillis()
+            val result = agent.runPrompt(if (withMcp) withMcpPrompt() else baselinePrompt(), timeoutSeconds = 1800)
+                .awaitForProcessFinish()
+            val agentDurationMs = System.currentTimeMillis() - startedAt
+            val combined = result.stdout + "\n" + result.stderr
+
+            val score = scoreSsrOptionalGet(combined, GROUND_TRUTH_FILES)
+            println("[TEST] ssr optional-get [$agentName+$modeLabel] exact=${score.exact} " +
+                    "found=${score.foundFiles.size}/${GROUND_TRUTH_FILES.size} " +
+                    "missed=${score.missedFiles} falsePos=${score.falsePositiveFiles} " +
+                    "reportedCount=${score.reportedCount} (truth=$GROUND_TRUTH_MATCH_COUNT)")
+
+            recordSemanticRun(
+                scenario = SCENARIO,
+                agentName = agentName,
+                withMcp = withMcp,
+                claimedFix = score.exact,
+                rawOutput = result.rawStdout,
+                exitCode = result.exitCode,
+                agentDurationMs = agentDurationMs,
+                runDir = session.runDirInContainer,
+                summary = "found=${score.foundFiles.size}/${GROUND_TRUTH_FILES.size} files " +
+                        "missed=${score.missedFiles.size} falsePos=${score.falsePositiveFiles.size} " +
+                        "count=${score.reportedCount}/$GROUND_TRUTH_MATCH_COUNT",
+            )
+
+            if (withMcp) assertUsedExecuteCodeEvidence(combined)
+        } finally {
             lifetime.closeAllStacks()
         }
+    }
+
+    /** The task text both legs share — only the tooling instructions differ. */
+    private fun taskText(): String = buildString {
+        appendLine("Task: find EVERY callsite in the project where the no-argument method `get()` is invoked")
+        appendLine("on an expression whose type is `java.util.Optional<T>` — including callsites where the")
+        appendLine("Optional comes from a method-call chain (e.g. `stream().findFirst().get()`,")
+        appendLine("`somethingReturningOptional().get()`), not just from local variables typed `Optional<...>`.")
+        appendLine()
+        appendLine("Scope: main AND test sources of the Maven reactor modules only. The `lucene/` directory is")
+        appendLine("NOT part of the root Maven build — exclude any results under `lucene/`.")
+        appendLine("Do NOT count `get()` calls on other types (Atomic*, ThreadLocal, Supplier, Future,")
+        appendLine("WeakReference, ByteBuffer, ...) or `get(...)` calls that take arguments.")
+        appendLine()
+        appendLine("Output (markers on their own lines):")
+        appendLine("OPTIONAL_GET_MATCHES: <total count of matching callsites>")
+        appendLine("MATCH: <path/relative/to/repo/root/File.java>:<line>   <- one line per callsite")
+    }
+
+    private fun withMcpPrompt(): String = buildString {
+        appendLine("The youtrackdb project is open in IntelliJ IDEA — a multi-module Maven Java project.")
+        appendLine()
+        appendLine("Use IntelliJ Structural Search and Replace (SSR) via `steroid_execute_code`. The recipe")
+        appendLine("lives in these skill articles — fetch them via `steroid_fetch_resource` before writing code:")
+        appendLine()
+        appendLine("- `mcp-steroid://skill/structural-search` — overview")
+        appendLine("- `mcp-steroid://skill/structural-search-api-recipe` — canonical Kotlin recipe")
+        appendLine("- `mcp-steroid://skill/structural-search-syntax` — template language")
+        appendLine()
+        appendLine(taskText())
+        appendLine()
+        appendLine("Hard rules (from `mcp-steroid://skill/structural-search-api-recipe`):")
+        appendLine("- Use the apostrophe form with a `:[exprtype(...)]` constraint on the receiver.")
+        appendLine("- Search over `GlobalSearchScope.projectScope(project)`; drop matches under `lucene/`")
+        appendLine("  from the report afterwards.")
+        appendLine("- Always call `Matcher.validate(project, options)` BEFORE constructing the `Matcher`.")
+        appendLine("- Do NOT wrap `Matcher.findMatches(...)` in an outer `readAction { }`.")
+        appendLine("- Do NOT call `StringToConstraintsTransformer.transformCriteria(...)` twice on the same")
+        appendLine("  `MatchOptions` — it overwrites the search pattern.")
+        appendLine()
+        appendLine("Additional output marker:")
+        appendLine("TOOL_EVIDENCE: <copy the line starting with execution_id: ...>")
+    }
+
+    private fun baselinePrompt(): String = buildString {
+        appendLine("The youtrackdb project is checked out — a multi-module Maven Java project.")
+        appendLine("IntelliJ MCP tools are unavailable in this run — use shell commands only (grep/rg/find/awk).")
+        appendLine()
+        appendLine(taskText())
+        appendLine()
+        appendLine("Beware: many unrelated types also have a no-arg `get()`; a naive text search will both")
+        appendLine("over-match them and miss Optionals produced by method-call chains.")
+    }
+
+    companion object {
+        private const val SCENARIO = "youtrackdb__structural_search"
+
+        /**
+         * Hand-derived ground truth, valid ONLY at the revision
+         * [IntelliJProject.YouTrackDbPinnedProject] pins (tag `0.5.0-20260428.132443-44cf982-SNAPSHOT`
+         * == commit `44cf982894c37a62aba3319b5024f76f6ccae97c`). Every no-arg `get()` whose receiver
+         * expression resolves to `java.util.Optional<T>`, per file (line numbers in the comments;
+         * `lucene/` excluded — it is not a module of the root Maven reactor).
+         *
+         * The derivation swept ALL 942 no-arg `.get()` callsites at that revision: files declaring
+         * `Optional<`, files assigning `var x = Optional.…`, same-line chains `…().get()`,
+         * line-leading `.get()` continuations, and a receiver-token frequency sweep classifying every
+         * remaining name (Atomic*, ThreadLocal, Supplier, Future, WeakReference, ByteBuffer, Netty
+         * Attribute, gremlin Traverser, … = non-Optional).
+         */
+        private val GROUND_TRUTH_FILES: Set<String> = setOf(
+            // 55, 117
+            "core/src/main/java/com/jetbrains/youtrackdb/internal/core/index/engine/v1/VersionedIndexOps.java",
+            // 358
+            "core/src/main/java/com/jetbrains/youtrackdb/internal/core/index/engine/v1/BTreeSingleValueIndexEngine.java",
+            // 29
+            "core/src/main/java/com/jetbrains/youtrackdb/internal/core/tx/FrontendTransactionId.java",
+            // 107
+            "core/src/main/java/com/jetbrains/youtrackdb/internal/core/tx/FrontendTransactionIndexChangesPerKey.java",
+            // 694, 783, 1738, 1889
+            "core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/ridbag/ridbagbtree/SharedLinkBagBTree.java",
+            // 998, 1547, 1579, 2553, 2638
+            "core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/index/sbtree/singlevalue/v3/BTree.java",
+            // 412 — authenticationInfo.getDatabase().get(), Optional via method return
+            "core/src/main/java/com/jetbrains/youtrackdb/internal/core/db/YouTrackDBInternalEmbedded.java",
+            // 30 — traversal.getGraph().get(), Optional via gremlin library API
+            "core/src/main/java/com/jetbrains/youtrackdb/internal/common/profiler/monitoring/YTDBQueryMetricsStrategy.java",
+            // 54 — conf.get(); the chained ).get() on line 55 is Supplier.get()
+            "driver/src/main/java/com/jetbrains/youtrackdb/internal/driver/YTDBDriverRemoteTraversal.java",
+            // 484 (x2), 494, 670, 838, 881, 956
+            "server/src/main/java/com/jetbrains/youtrackdb/internal/server/plugin/gremlin/YTDBAbstractOpProcessor.java",
+            // 226, 228, 240, 241, 243, 244 — `var methodAnnotation = Optional.ofNullable(...)`
+            "gremlin-annotations/src/main/java/com/jetbrains/youtrackdb/internal/annotations/gremlin/dsl/GremlinDslProcessor.java",
+            // 37, 48, 77, 79, 108 — toStream().findFirst().get()
+            "core/src/test/java/com/jetbrains/youtrackdb/internal/core/gremlin/GraphCountStrategyTest.java",
+            // 33 — stream()...reduce(Integer::sum).get()
+            "core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/ResultSetTest.java",
+        )
+
+        /** Total match-site count over [GROUND_TRUTH_FILES] (line 484 of YTDBAbstractOpProcessor has two). */
+        private const val GROUND_TRUTH_MATCH_COUNT = 36
     }
 }

--- a/test-integration/src/main/kotlin/com/jonnyzzz/mcpSteroid/integration/infra/intelliJ-project.kt
+++ b/test-integration/src/main/kotlin/com/jonnyzzz/mcpSteroid/integration/infra/intelliJ-project.kt
@@ -140,6 +140,19 @@ sealed class IntelliJProject{
     object KillBillProject : ProjectFromRemoteGit("https://github.com/killbill/killbill.git")
     object ThingsBoardProject : ProjectFromRemoteGit("https://github.com/thingsboard/thingsboard.git")
     object YouTrackDbProject : ProjectFromRemoteGit("https://github.com/JetBrains/youtrackdb.git")
+
+    /**
+     * [YouTrackDbProject] pinned to a fixed revision (a published snapshot tag). Used by experiments
+     * whose scoring compares the agent's answer against a hand-derived ground truth (e.g. the
+     * structural-search Optional.get() audit in `StructuralSearchYoutrackdbTest`) — the unpinned
+     * default-branch clone would silently invalidate that ground truth on every upstream push.
+     * When bumping this tag, re-derive every dependent ground-truth list at the new revision.
+     */
+    object YouTrackDbPinnedProject : ProjectFromRemoteGit(
+        "https://github.com/JetBrains/youtrackdb.git",
+        // == commit 44cf982894c37a62aba3319b5024f76f6ccae97c
+        gitRef = "0.5.0-20260428.132443-44cf982-SNAPSHOT",
+    )
     object IntelliJPlatformGradlePluginProject : ProjectFromRemoteGit("https://github.com/JetBrains/intellij-platform-gradle-plugin.git")
 
     /** A real Android (Gradle) project, used to exercise Android Studio. Google's official base template. */

--- a/test-integration/src/main/kotlin/com/jonnyzzz/mcpSteroid/integration/tests/SemanticTaskScoring.kt
+++ b/test-integration/src/main/kotlin/com/jonnyzzz/mcpSteroid/integration/tests/SemanticTaskScoring.kt
@@ -114,6 +114,84 @@ fun scoreInspections(output: String, minIssues: Int, targetFile: String): Inspec
     )
 }
 
+data class SsrOptionalGetScore(
+    /** The OPTIONAL_GET_MATCHES total the agent reported (null if it never reported one). */
+    val reportedCount: Int?,
+    /** Normalized (deduplicated) file paths extracted from the agent's `MATCH:` lines. */
+    val reportedFiles: Set<String>,
+    /** Ground-truth files the agent DID report (keyed by the ground-truth spelling). */
+    val foundFiles: Set<String>,
+    /** Ground-truth files the agent FAILED to report — e.g. chained `findFirst().get()` grep can't type. */
+    val missedFiles: Set<String>,
+    /** Reported files with NO true Optional.get() — e.g. ByteBuffer/AtomicLong/Future `.get()` over-matches. */
+    val falsePositiveFiles: Set<String>,
+    /** True when every ground-truth file was reported AND nothing extra was — the SSR-exact answer. */
+    val exact: Boolean,
+)
+
+/**
+ * Score an "audit every `Optional.get()` callsite" answer against a known ground-truth file list
+ * (derived by hand from the audited repo at the revision the experiment pins). SSR with an
+ * `exprtype(java.util.Optional…)` constraint answers this exactly; a text search over `.get()` both
+ * over-matches (dozens of other no-arg `get()` receivers: Atomic*, ThreadLocal, Supplier, Future,
+ * WeakReference, ByteBuffer, …) and under-matches (chained receivers like `stream.findFirst().get()`
+ * whose Optional type only exists after resolution).
+ *
+ * Scored at FILE granularity: line numbers drift with formatting and agents report them
+ * inconsistently, but the file set separates the two failure modes cleanly. Expected markers:
+ *   OPTIONAL_GET_MATCHES: <total count>
+ *   MATCH: <path/relative/to/repo/File.java>:<line>     (one line per callsite)
+ *
+ * Path matching is markdown-normalized and suffix-based, so absolute in-container paths
+ * (`/home/agent/project/core/src/…`) and shorter-but-unambiguous relative spellings both count.
+ */
+fun scoreSsrOptionalGet(output: String, groundTruthFiles: Set<String>): SsrOptionalGetScore {
+    val reportedCount = findMarkerValue(output, "OPTIONAL_GET_MATCHES", "Optional get matches")
+        ?.let { Regex("""\d+""").find(it)?.value?.toIntOrNull() }
+
+    val matchLine = Regex("""(?im)^\s*[*_`>#|:-]*\s*MATCH\s*[*_`]*\s*:\s*(.+)$""")
+    val reportedFiles = matchLine.findAll(output)
+        .map { normalizeReportedPath(it.groupValues[1]) }
+        .filter { it.isNotEmpty() }
+        .toSet()
+
+    val found = groundTruthFiles.filter { truth ->
+        reportedFiles.any { pathsReferToSameFile(it, truth) }
+    }.toSet()
+    val falsePositives = reportedFiles.filterNot { reported ->
+        groundTruthFiles.any { pathsReferToSameFile(reported, it) }
+    }.toSet()
+    val missed = groundTruthFiles - found
+
+    return SsrOptionalGetScore(
+        reportedCount = reportedCount,
+        reportedFiles = reportedFiles,
+        foundFiles = found,
+        missedFiles = missed,
+        falsePositiveFiles = falsePositives,
+        exact = missed.isEmpty() && falsePositives.isEmpty(),
+    )
+}
+
+/** Strip markdown/quoting, unify separators, drop the `:<line>` suffix — keep just the path. */
+private fun normalizeReportedPath(raw: String): String {
+    var p = raw.trim().trim('`', '*', '_', '"', '\'', '|')
+    p = p.replace('\\', '/')
+    // Drop a trailing :<line> or :<line>:<col> suffix (only numeric suffixes are stripped).
+    p = p.replace(Regex("""(:\d+)+\s*$"""), "")
+    p = p.trim().trim('`', '*', '_', '"', '\'')
+    p = p.removePrefix("./")
+    return p.trim('/')
+}
+
+/**
+ * True when one normalized path is a whole-component suffix of the other. Handles the agent
+ * reporting absolute in-container paths (longer than ground truth) or short relative spellings
+ * (shorter than ground truth, e.g. starting below the module root).
+ */
+private fun pathsReferToSameFile(a: String, b: String): Boolean =
+    a == b || a.endsWith("/$b") || b.endsWith("/$a")
+
 data class RootCauseScore(
     val mentionsIgnoredReturn: Boolean,
     val mentionsNewList: Boolean,

--- a/test-integration/src/test/kotlin/com/jonnyzzz/mcpSteroid/integration/tests/SsrOptionalGetScoringTest.kt
+++ b/test-integration/src/test/kotlin/com/jonnyzzz/mcpSteroid/integration/tests/SsrOptionalGetScoringTest.kt
@@ -1,0 +1,134 @@
+/* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
+package com.jonnyzzz.mcpSteroid.integration.tests
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * Pure, local tests for [scoreSsrOptionalGet] — the found/missed/false-positive verdict for the
+ * youtrackdb structural-search A/B. The whole point: SSR with an `exprtype(java.util.Optional…)`
+ * constraint is AST-exact, while `grep '.get()'` over-matches every no-arg get() in the codebase
+ * (AtomicLong, ThreadLocal, Supplier, Future, WeakReference, ByteBuffer, Netty Attribute, gremlin
+ * Traverser, …) and misses chained receivers it cannot type. No IDE/Docker — scored on text only.
+ */
+class SsrOptionalGetScoringTest {
+
+    // A toy ground truth that mirrors the youtrackdb case: three files known to contain
+    // Optional.get() callsites at the pinned revision.
+    private val truth = setOf(
+        "core/src/main/java/com/example/tx/TransactionId.java",
+        "server/src/main/java/com/example/gremlin/OpProcessor.java",
+        "core/src/test/java/com/example/gremlin/CountStrategyTest.java",
+    )
+
+    @Test
+    fun `exact answer scores exact`() {
+        val output = """
+            OPTIONAL_GET_MATCHES: 4
+            MATCH: core/src/main/java/com/example/tx/TransactionId.java:29
+            MATCH: server/src/main/java/com/example/gremlin/OpProcessor.java:484
+            MATCH: server/src/main/java/com/example/gremlin/OpProcessor.java:494
+            MATCH: core/src/test/java/com/example/gremlin/CountStrategyTest.java:37
+        """.trimIndent()
+        val s = scoreSsrOptionalGet(output, truth)
+        assertTrue(s.exact, "missed=${s.missedFiles} falsePos=${s.falsePositiveFiles}")
+        assertEquals(truth, s.foundFiles)
+        assertEquals(emptySet<String>(), s.missedFiles)
+        assertEquals(emptySet<String>(), s.falsePositiveFiles)
+        assertEquals(4, s.reportedCount)
+    }
+
+    @Test
+    fun `grep-style over-match scores false positives`() {
+        // grep '.get()' also flags a ByteBuffer.get() file — a false positive SSR would never produce.
+        val output = """
+            OPTIONAL_GET_MATCHES: 5
+            MATCH: core/src/main/java/com/example/tx/TransactionId.java:29
+            MATCH: server/src/main/java/com/example/gremlin/OpProcessor.java:484
+            MATCH: core/src/test/java/com/example/gremlin/CountStrategyTest.java:37
+            MATCH: core/src/main/java/com/example/wal/DoubleWriteLog.java:390
+        """.trimIndent()
+        val s = scoreSsrOptionalGet(output, truth)
+        assertFalse(s.exact)
+        assertEquals(setOf("core/src/main/java/com/example/wal/DoubleWriteLog.java"), s.falsePositiveFiles)
+        assertEquals(emptySet<String>(), s.missedFiles)
+    }
+
+    @Test
+    fun `grep-style under-match scores missed files`() {
+        // grep misses the chained findFirst().get() in the test file — a classic type-blind miss.
+        val output = """
+            OPTIONAL_GET_MATCHES: 2
+            MATCH: core/src/main/java/com/example/tx/TransactionId.java:29
+            MATCH: server/src/main/java/com/example/gremlin/OpProcessor.java:484
+        """.trimIndent()
+        val s = scoreSsrOptionalGet(output, truth)
+        assertFalse(s.exact)
+        assertEquals(setOf("core/src/test/java/com/example/gremlin/CountStrategyTest.java"), s.missedFiles)
+        assertEquals(emptySet<String>(), s.falsePositiveFiles)
+    }
+
+    @Test
+    fun `absolute container paths and markdown formatting are normalized`() {
+        // Agents report absolute in-container paths, backtick-quote them, and bold the marker.
+        val output = """
+            **MATCH:** `/home/agent/project/core/src/main/java/com/example/tx/TransactionId.java:29`
+            MATCH: `/home/agent/project/server/src/main/java/com/example/gremlin/OpProcessor.java:484`
+            - MATCH: /home/agent/project/core/src/test/java/com/example/gremlin/CountStrategyTest.java:37
+            OPTIONAL_GET_MATCHES: 3
+        """.trimIndent()
+        val s = scoreSsrOptionalGet(output, truth)
+        assertTrue(s.exact, "missed=${s.missedFiles} falsePos=${s.falsePositiveFiles}")
+        assertEquals(3, s.reportedCount)
+    }
+
+    @Test
+    fun `a shorter but unambiguous relative path still counts`() {
+        val output = """
+            MATCH: com/example/tx/TransactionId.java:29
+            MATCH: server/src/main/java/com/example/gremlin/OpProcessor.java:484
+            MATCH: core/src/test/java/com/example/gremlin/CountStrategyTest.java:37
+        """.trimIndent()
+        val s = scoreSsrOptionalGet(output, truth)
+        assertEquals(emptySet<String>(), s.missedFiles)
+        assertEquals(emptySet<String>(), s.falsePositiveFiles)
+    }
+
+    @Test
+    fun `windows-style separators and a missing line number are tolerated`() {
+        val output = """
+            MATCH: core\src\main\java\com\example\tx\TransactionId.java
+            MATCH: server/src/main/java/com/example/gremlin/OpProcessor.java
+            MATCH: core/src/test/java/com/example/gremlin/CountStrategyTest.java:37
+        """.trimIndent()
+        val s = scoreSsrOptionalGet(output, truth)
+        assertEquals(emptySet<String>(), s.missedFiles)
+    }
+
+    @Test
+    fun `duplicate MATCH lines for the same file do not inflate anything`() {
+        val output = """
+            MATCH: core/src/main/java/com/example/tx/TransactionId.java:29
+            MATCH: core/src/main/java/com/example/tx/TransactionId.java:41
+        """.trimIndent()
+        val s = scoreSsrOptionalGet(output, truth)
+        assertEquals(setOf("core/src/main/java/com/example/tx/TransactionId.java"), s.foundFiles)
+        assertEquals(1, s.reportedFiles.size)
+    }
+
+    @Test
+    fun `no MATCH lines at all scores everything missed and no count`() {
+        val s = scoreSsrOptionalGet("I could not find any Optional.get() calls.", truth)
+        assertFalse(s.exact)
+        assertEquals(truth, s.missedFiles)
+        assertEquals(null, s.reportedCount)
+    }
+
+    @Test
+    fun `OPTIONAL_GET_MATCHES count is parsed from decorated lines too`() {
+        val s = scoreSsrOptionalGet("**OPTIONAL_GET_MATCHES**: 36", truth)
+        assertEquals(36, s.reportedCount)
+    }
+}


### PR DESCRIPTION
## TeamCity DSL: method names changed — update build configs in lockstep

`StructuralSearchYoutrackdbTest` methods were **renamed** to the 4-method A/B convention. Any TC build config filtering on the old names will match nothing.

| | method name |
|---|---|
| **OLD** | `ssr audit on youtrackdb claude` |
| **OLD** | `ssr audit on youtrackdb codex` |
| **NEW** | `claude with mcp` |
| **NEW** | `claude without mcp` |
| **NEW** | `codex with mcp` |
| **NEW** | `codex without mcp` |

Gradle filters: `*StructuralSearchYoutrackdbTest.claude with mcp*` etc. Suggested TC-side `executionTimeoutMin`: each method has a 50-min JUnit timeout (read-only task; container start + Maven import + 30-min agent budget).

`StructuralSearchYoutrackdb261Test` method names are **unchanged** (`ssr audit on youtrackdb claude on 261`, `... codex on 261`).

## What changed

The default-IDE SSR youtrackdb test was an MCP-only skill-validation audit — no baseline leg, no `[ARENA]` block, so it never appeared on the A/B dashboard. It is now a proper A/B experiment, scenario id **`youtrackdb__structural_search`**:

**Task (identical for both legs):** find every callsite where a no-arg `get()` is invoked on an expression of type `java.util.Optional<T>`, across main+test sources of the youtrackdb Maven reactor (`lucene/` explicitly excluded — it is not a module of the root pom, so its projectScope/indexing status is ambiguous).

- **with MCP** — keeps the SSR flow: fetch the `mcp-steroid://skill/structural-search*` articles, run `Matcher` over `GlobalSearchScope.projectScope(project)` with an apostrophe `:[exprtype(...)]` pattern, same hard rules as before. Asserts exec_code evidence.
- **without MCP** — grep/shell only. The repo has ~940 no-arg `.get()` callsites of which only **36** are Optional (Atomic, ThreadLocal, Supplier, Future, WeakReference, ByteBuffer, Netty `attr().get()`, gremlin `Traverser.get()` are all bait), and several true matches are chained receivers grep cannot type (`toStream().findFirst().get()`, `reduce(Integer::sum).get()`, `authenticationInfo.getDatabase().get()`, `traversal.getGraph().get()`, `var x = Optional.ofNullable(...)` + `x.get()`).

**Pinned revision.** New `IntelliJProject.YouTrackDbPinnedProject` pins tag `0.5.0-20260428.132443-44cf982-SNAPSHOT` (commit `44cf982`). Ground truth is hand-derived and type-checked at exactly that revision: 36 Optional.get() callsites in 13 files (per-file line numbers documented in the test). Derivation swept **all** 942 no-arg `.get()` sites via five complementary passes (declared `Optional<`, `var = Optional....` assignments, same-line call chains, line-leading `.get()` continuations, receiver-token frequency sweep with manual classification of every ambiguous name). Other youtrackdb tests keep using the unpinned `YouTrackDbProject`.

**Scoring** (`scoreSsrOptionalGet`, pure, in `SemanticTaskScoring.kt`): parses `MATCH: <path>:<line>` lines, normalizes markdown/absolute-path/Windows-separator noise, and produces file-level `found` / `missed` / `falsePositive` sets plus the reported `OPTIONAL_GET_MATCHES` count. Verdict `exact` = all 13 files found and none extra. File granularity (not line) because agents report line numbers inconsistently, while the file set still cleanly separates grep's two failure modes. TDD'd red-first in `SsrOptionalGetScoringTest` (9 unit tests, no IDE/Docker).

**Dashboard:** both legs emit the full `[ARENA]` block via `recordSemanticRun` (verdict, duration, tokens/cost, exec_code vs Read/Edit/Bash/Glob/Grep counters). Correctness is a dashboard metric, not a hard pass gate; only infrastructure problems hard-fail.

**Skill audit preserved:** the MCP-only audit (profile registry, predefined templates, IMPROVEMENTS reflection) still runs unchanged in the pinned-IDE `StructuralSearchYoutrackdb261Test` via the untouched shared helpers.

## Validation

- `:test-experiments:compileTestKotlin` — green
- `:test-integration:test --tests "*SsrOptionalGetScoringTest*"` — 9/9 green (watched fail first)
- No Docker/IDE E2E run locally — CI validates those

🤖 Generated with [Claude Code](https://claude.com/claude-code)