### PR TITLE
experiments-report: scenario buckets — IDE-power experiments lead, DPAIA gets its own heading

### DIFF
--- a/experiments-report/src/main/kotlin/com/jonnyzzz/mcpSteroid/report/HtmlRenderer.kt
+++ b/experiments-report/src/main/kotlin/com/jonnyzzz/mcpSteroid/report/HtmlRenderer.kt
@@ -87,7 +87,7 @@ object HtmlRenderer {
         sb.append("</section>\n")
     }
 
-    // ── Primary: per-agent with/without tables ──────────────────────────────────
+    // ── Primary: per-agent with/without tables, grouped into scenario buckets ───
     private fun renderComparisons(sb: StringBuilder, report: Report) {
         val byAgent = report.comparisons.groupBy { it.agent }.toSortedMap()
         for ((agent, comps) in byAgent) {
@@ -95,23 +95,30 @@ object HtmlRenderer {
             sb.append("<table>\n<thead><tr>")
             sb.append("<th>task</th><th>verdict</th><th>with MCP</th><th>without MCP</th><th>Δ agent time</th><th>Δ cost</th>")
             sb.append("</tr></thead>\n<tbody>\n")
-            for (c in comps) {
-                sb.append("<tr>")
-                sb.append("<td class=\"task\">").append(esc(c.scenario)).append("</td>")
-                sb.append("<td>").append(verdictBadge(c.verdict)).append("</td>")
-                sb.append("<td>").append(runCell(c.withMcp)).append("</td>")
-                sb.append("<td>").append(runCell(c.without)).append("</td>")
-                sb.append("<td class=\"num\">").append(durationDelta(c.durationDeltaMs)).append("</td>")
-                sb.append("<td class=\"num\">").append(costDelta(c.costDeltaUsd)).append("</td>")
-                sb.append("</tr>\n")
-                val toolDiff = renderToolDiff(c.withMcp, c.without)
-                if (toolDiff.isNotEmpty()) {
-                    sb.append("<tr class=\"detail\"><td colspan=\"6\">").append(toolDiff).append("</td></tr>\n")
-                }
-                val summary = c.withMcp?.summary ?: c.without?.summary
-                if (!summary.isNullOrBlank()) {
-                    sb.append("<tr class=\"detail\"><td colspan=\"6\"><span class=\"detail-label\">summary:</span> ")
-                        .append(esc(summary)).append("</td></tr>\n")
+            // Scenario buckets in display order (IDE power leads, DPAIA gets its dedicated heading);
+            // a bucket with no rows renders no heading.
+            val byBucket = comps.groupBy { scenarioBucket(it.scenario) }
+            for (bucket in ScenarioBucket.entries) {
+                val rows = byBucket[bucket] ?: continue
+                sb.append("<tr class=\"bucket\"><td colspan=\"6\">").append(esc(bucket.title)).append("</td></tr>\n")
+                for (c in rows) {
+                    sb.append("<tr>")
+                    sb.append("<td class=\"task\">").append(esc(c.scenario)).append("</td>")
+                    sb.append("<td>").append(verdictBadge(c.verdict)).append("</td>")
+                    sb.append("<td>").append(runCell(c.withMcp)).append("</td>")
+                    sb.append("<td>").append(runCell(c.without)).append("</td>")
+                    sb.append("<td class=\"num\">").append(durationDelta(c.durationDeltaMs)).append("</td>")
+                    sb.append("<td class=\"num\">").append(costDelta(c.costDeltaUsd)).append("</td>")
+                    sb.append("</tr>\n")
+                    val toolDiff = renderToolDiff(c.withMcp, c.without)
+                    if (toolDiff.isNotEmpty()) {
+                        sb.append("<tr class=\"detail\"><td colspan=\"6\">").append(toolDiff).append("</td></tr>\n")
+                    }
+                    val summary = c.withMcp?.summary ?: c.without?.summary
+                    if (!summary.isNullOrBlank()) {
+                        sb.append("<tr class=\"detail\"><td colspan=\"6\"><span class=\"detail-label\">summary:</span> ")
+                            .append(esc(summary)).append("</td></tr>\n")
+                    }
                 }
             }
             sb.append("</tbody>\n</table>\n</section>\n")
@@ -288,6 +295,7 @@ object HtmlRenderer {
         .seg.helped { fill:#2f9e44; } .seg.hurt { fill:#e03131; }
         .seg.neutral { fill:#5c636e; } .seg.incomplete { fill:#e8950c; }
         .missing { color:var(--grey); font-style:italic; }
+        tr.bucket td { background:var(--bg2, #f3f4f6); font-weight:600; text-transform:uppercase; font-size:11px; letter-spacing:.06em; color:var(--grey); padding-top:14px; }
         .empty { color:var(--mut); }
         footer { padding:16px 28px; color:var(--mut); font-size:12px; }
     """.trimIndent()

--- a/experiments-report/src/main/kotlin/com/jonnyzzz/mcpSteroid/report/ScenarioBucket.kt
+++ b/experiments-report/src/main/kotlin/com/jonnyzzz/mcpSteroid/report/ScenarioBucket.kt
@@ -1,0 +1,22 @@
+package com.jonnyzzz.mcpSteroid.report
+
+/**
+ * Dashboard grouping for scenarios, in DISPLAY ORDER: the IDE-power experiments lead (they are the
+ * dashboard's headline — semantic tasks where the IDE's PSI answer is exact while grep's is
+ * incomplete), the debugger demos follow, and the DPAIA fix-the-build arena sits under its own
+ * dedicated heading instead of interleaving with everything else.
+ */
+enum class ScenarioBucket(val title: String) {
+    IDE_SEMANTIC("IDE semantic power — PSI vs grep"),
+    DEBUGGER("Debugger"),
+    DPAIA("DPAIA arena — fix the build"),
+    OTHER("Other experiments"),
+}
+
+/** Bucket for one scenario id, by its stable prefix (`keycloak__…`, `dpaia__…`, `debugger__…`). */
+fun scenarioBucket(scenario: String): ScenarioBucket = when {
+    scenario.startsWith("keycloak__") || scenario.startsWith("youtrackdb__") -> ScenarioBucket.IDE_SEMANTIC
+    scenario.startsWith("debugger__") -> ScenarioBucket.DEBUGGER
+    scenario.startsWith("dpaia__") -> ScenarioBucket.DPAIA
+    else -> ScenarioBucket.OTHER
+}

--- a/experiments-report/src/test/kotlin/com/jonnyzzz/mcpSteroid/report/ScenarioBucketTest.kt
+++ b/experiments-report/src/test/kotlin/com/jonnyzzz/mcpSteroid/report/ScenarioBucketTest.kt
@@ -1,0 +1,63 @@
+package com.jonnyzzz.mcpSteroid.report
+
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Pure tests for [scenarioBucket] + the bucketed rendering: the dashboard groups scenarios into
+ * dedicated buckets so the IDE-power experiments (Keycloak semantic tasks, SSR) are highlighted and
+ * the DPAIA fix-the-build arena sits under its own heading instead of interleaving with everything.
+ */
+class ScenarioBucketTest {
+
+    @Test
+    fun `scenario ids map to their buckets by prefix`() {
+        assertEquals(ScenarioBucket.IDE_SEMANTIC, scenarioBucket("keycloak__rename_safety"))
+        assertEquals(ScenarioBucket.IDE_SEMANTIC, scenarioBucket("keycloak__change_signature"))
+        assertEquals(ScenarioBucket.IDE_SEMANTIC, scenarioBucket("keycloak__call_hierarchy"))
+        assertEquals(ScenarioBucket.IDE_SEMANTIC, scenarioBucket("youtrackdb__structural_search"))
+        assertEquals(ScenarioBucket.DEBUGGER, scenarioBucket("debugger__sortedByDescending"))
+        assertEquals(ScenarioBucket.DPAIA, scenarioBucket("dpaia__spring__petclinic-27"))
+        assertEquals(ScenarioBucket.OTHER, scenarioBucket("something__new"))
+    }
+
+    @Test
+    fun `buckets render as section headers in priority order with rows under the right one`() {
+        val runs = listOf(
+            AgentRun("dpaia__spring__petclinic-27", "claude", McpMode.WITH, claimedFix = true),
+            AgentRun("dpaia__spring__petclinic-27", "claude", McpMode.WITHOUT, claimedFix = true),
+            AgentRun("keycloak__rename_safety", "claude", McpMode.WITH, claimedFix = true),
+            AgentRun("keycloak__rename_safety", "claude", McpMode.WITHOUT, claimedFix = false),
+            AgentRun("debugger__sortedByDescending", "claude", McpMode.WITH, claimedFix = true),
+            AgentRun("debugger__sortedByDescending", "claude", McpMode.WITHOUT, claimedFix = true),
+        )
+        val html = HtmlRenderer.render(
+            Report(title = "t", generatedAt = "now", comparisons = Aggregator.compare(runs), allRuns = runs)
+        )
+
+        // All three bucket headings present…
+        val ide = html.indexOf(ScenarioBucket.IDE_SEMANTIC.title)
+        val dbg = html.indexOf(ScenarioBucket.DEBUGGER.title)
+        val dpaia = html.indexOf(ScenarioBucket.DPAIA.title)
+        assertTrue(ide >= 0 && dbg >= 0 && dpaia >= 0, "all bucket headings rendered")
+        // …in priority order: IDE power first, debugger next, DPAIA in its dedicated bucket after.
+        assertTrue(ide < dbg && dbg < dpaia, "bucket order: IDE < debugger < DPAIA")
+        // Rows land under their own bucket heading.
+        assertTrue(html.indexOf("keycloak__rename_safety") in ide..dbg, "keycloak row inside IDE bucket")
+        assertTrue(html.indexOf("dpaia__spring__petclinic-27") > dpaia, "dpaia row inside DPAIA bucket")
+    }
+
+    @Test
+    fun `an empty bucket renders no heading`() {
+        val runs = listOf(
+            AgentRun("dpaia__spring__petclinic-27", "claude", McpMode.WITH, claimedFix = true),
+            AgentRun("dpaia__spring__petclinic-27", "claude", McpMode.WITHOUT, claimedFix = true),
+        )
+        val html = HtmlRenderer.render(
+            Report(title = "t", generatedAt = "now", comparisons = Aggregator.compare(runs), allRuns = runs)
+        )
+        assertTrue(!html.contains(ScenarioBucket.IDE_SEMANTIC.title), "no IDE heading without IDE rows")
+        assertTrue(html.contains(ScenarioBucket.DPAIA.title))
+    }
+}


### PR DESCRIPTION
Per request: highlight the IDE-power tests in the report and group DPAIA under a dedicated bucket.

Each agent's per-task table is now grouped into buckets, in display order:

| # | Bucket | Scenario prefixes |
|---|--------|-------------------|
| 1 | **IDE semantic power — PSI vs grep** | `keycloak__*`, `youtrackdb__*` (type-hierarchy, find-usages, rename, inspections, change-signature, call-hierarchy, SSR) |
| 2 | **Debugger** | `debugger__*` |
| 3 | **DPAIA arena — fix the build** | `dpaia__*` |
| 4 | **Other experiments** | fallback |

- Pure `scenarioBucket()` prefix mapping (new scenarios land in a bucket automatically).
- Styled header row per non-empty bucket; empty buckets render nothing.
- TDD: `ScenarioBucketTest` (mapping / ordering-with-membership / empty-bucket suppression); full `:experiments-report` suite 34/34.

🤖 Generated with [Claude Code](https://claude.com/claude-code)