### PR TITLE
Lock-free project-name resolution — one hung read action no longer wedges every tool (#214)

### DIFF
--- a/ij-plugin/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/ListProjectsToolHandler.kt
+++ b/ij-plugin/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/ListProjectsToolHandler.kt
@@ -38,15 +38,14 @@ class SelfBackendDescription(
     val projects: List<ListedProject>,
 )
 
-fun describeSelfBackend(): SelfBackendDescription {
+suspend fun describeSelfBackend(): SelfBackendDescription {
     val ide = IdeInfo.ofApplication()
     val pid = ProcessHandle.current().pid()
     val selfBackendName = backendNameForMarker(pid = pid, build = ide.build)
 
-    // Lock-free (#214): ProjectManager.getOpenProjects() is documented safe outside a read
-    // action when each project is filtered for isDisposed — this keeps steroid_list_projects /
-    // steroid_list_windows responsive while a hung read action blocks a pending write action.
-    val openProjects = ProjectManager.getInstance().openProjects.filter { !it.isDisposed }
+    val openProjects = run { // #214: no read action — must not park behind a pending write (wedges every tool)
+        ProjectManager.getInstance().openProjects.toList()
+    }
 
     val listedProjects = openProjects.map { project ->
         ListedProject(

--- a/ij-plugin/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/ListProjectsToolHandler.kt
+++ b/ij-plugin/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/ListProjectsToolHandler.kt
@@ -1,7 +1,6 @@
 /* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
 package com.jonnyzzz.mcpSteroid.server
 
-import com.intellij.openapi.application.readAction
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.project.ProjectManager
 import com.jonnyzzz.mcpSteroid.IdeInfo
@@ -39,14 +38,15 @@ class SelfBackendDescription(
     val projects: List<ListedProject>,
 )
 
-suspend fun describeSelfBackend(): SelfBackendDescription {
+fun describeSelfBackend(): SelfBackendDescription {
     val ide = IdeInfo.ofApplication()
     val pid = ProcessHandle.current().pid()
     val selfBackendName = backendNameForMarker(pid = pid, build = ide.build)
 
-    val openProjects = readAction {
-        ProjectManager.getInstance().openProjects.toList()
-    }
+    // Lock-free (#214): ProjectManager.getOpenProjects() is documented safe outside a read
+    // action when each project is filtered for isDisposed — this keeps steroid_list_projects /
+    // steroid_list_windows responsive while a hung read action blocks a pending write action.
+    val openProjects = ProjectManager.getInstance().openProjects.filter { !it.isDisposed }
 
     val listedProjects = openProjects.map { project ->
         ListedProject(

--- a/ij-plugin/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/OpenProjectToolHandler.kt
+++ b/ij-plugin/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/OpenProjectToolHandler.kt
@@ -3,7 +3,6 @@ package com.jonnyzzz.mcpSteroid.server
 
 import com.intellij.ide.GeneralSettings
 import com.intellij.ide.trustedProjects.TrustedProjects
-import com.intellij.openapi.application.readAction
 import com.intellij.openapi.diagnostic.thisLogger
 import com.intellij.openapi.progress.ProcessCanceledException
 import com.intellij.openapi.project.ProjectManager
@@ -33,12 +32,14 @@ class OpenProjectToolHandlerIJ : OpenProjectToolHandler {
             logger.info("steroid_open_project received backend_name='$it' on a direct IDE connection; ignoring (routing applies only via devrig).")
         }
 
-        // Check if project is already open
-        val existingProject = readAction {
-            ProjectManager.getInstance().openProjects.find { project ->
+        // Check if project is already open. Lock-free (#214): getOpenProjects() is documented
+        // safe outside a read action when each project is checked for isDisposed — a suspend
+        // readAction here would park behind any pending write action and wedge the tool.
+        val existingProject = ProjectManager.getInstance().openProjects
+            .filter { !it.isDisposed }
+            .find { project ->
                 project.basePath?.let { Path.of(it).toAbsolutePath().normalize() == projectPath.normalize() } == true
             }
-        }
 
         if (existingProject != null) {
             return ToolCallResult.builder()

--- a/ij-plugin/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/OpenProjectToolHandler.kt
+++ b/ij-plugin/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/OpenProjectToolHandler.kt
@@ -32,14 +32,12 @@ class OpenProjectToolHandlerIJ : OpenProjectToolHandler {
             logger.info("steroid_open_project received backend_name='$it' on a direct IDE connection; ignoring (routing applies only via devrig).")
         }
 
-        // Check if project is already open. Lock-free (#214): getOpenProjects() is documented
-        // safe outside a read action when each project is checked for isDisposed — a suspend
-        // readAction here would park behind any pending write action and wedge the tool.
-        val existingProject = ProjectManager.getInstance().openProjects
-            .filter { !it.isDisposed }
-            .find { project ->
+        // Check if project is already open
+        val existingProject = run { // #214: no read action — must not park behind a pending write (wedges every tool)
+            ProjectManager.getInstance().openProjects.find { project ->
                 project.basePath?.let { Path.of(it).toAbsolutePath().normalize() == projectPath.normalize() } == true
             }
+        }
 
         if (existingProject != null) {
             return ToolCallResult.builder()

--- a/ij-plugin/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/ProjectScopedToolHandler.kt
+++ b/ij-plugin/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/ProjectScopedToolHandler.kt
@@ -1,7 +1,6 @@
 /* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
 package com.jonnyzzz.mcpSteroid.server
 
-import com.intellij.openapi.application.readAction
 import com.intellij.openapi.components.Service
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.project.ProjectManager
@@ -11,7 +10,7 @@ import com.jonnyzzz.mcpSteroid.mcp.ToolCallErrorException
  * Shared base for `*ToolHandlerIJ` implementations that resolve a
  * `projectName: String` argument to an open IDE [Project].
  *
- * Centralizes the read-action lookup and the not-found error message
+ * Centralizes the lock-free lookup and the not-found error message
  * (which lists the currently-open `project_name` routing keys to help the
  * caller correct a typo) so each handler only writes the project-scoped body.
  */
@@ -22,21 +21,29 @@ class ProjectScopedToolHandler {
      * [ToolCallErrorException] if no project matches — `McpToolRegistry.callTool`
      * catches it and turns it into an MCP error result naming the missing project
      * plus the list of currently-open `project_name` values.
+     *
+     * Deliberately lock-free (#214): a suspend `readAction {}` here parks behind any
+     * pending write action, so one hung read action (e.g. a stuck inspection script)
+     * would wedge EVERY steroid tool for the duration. [ProjectManager.getOpenProjects]
+     * is documented as safe outside a read action provided each project is checked for
+     * [Project.isDisposed] before use; [projectNameFor] only reads plain getters
+     * (`name`, `basePath`). The returned project can still be disposed concurrently —
+     * project-scoped handlers re-check [Project.isDisposed] at use.
      */
     @Throws(ToolCallErrorException::class)
-    suspend fun resolveProject(projectName: String): Project {
-        val (project, availableProjectNames) = readAction {
-            // (project_name, name, project) per open project — match by the OPAQUE project_name first,
-            // then by the raw folder name ONLY when unambiguous (exactly one match), never first-match,
-            // so two same-named projects (e.g. a checkout and its git worktree) can't silently collapse
-            // to the wrong one (#92).
-            val triples = ProjectManager.getInstance().openProjects.map { Triple(projectNameFor(it), it.name, it) }
-            val resolved = triples.firstOrNull { it.first == projectName }?.third
-                ?: triples.singleOrNull { it.second == projectName }?.third
-            // Surface the sorted project_name routing keys (not raw names) — that is the key callers must pass.
-            resolved to triples.map { it.first }.sorted()
-        }
-        return project ?: throw ToolCallErrorException(
+    fun resolveProject(projectName: String): Project {
+        // (project_name, name, project) per open project — match by the OPAQUE project_name first,
+        // then by the raw folder name ONLY when unambiguous (exactly one match), never first-match,
+        // so two same-named projects (e.g. a checkout and its git worktree) can't silently collapse
+        // to the wrong one (#92).
+        val triples = ProjectManager.getInstance().openProjects
+            .filter { !it.isDisposed }
+            .map { Triple(projectNameFor(it), it.name, it) }
+        val resolved = triples.firstOrNull { it.first == projectName }?.third
+            ?: triples.singleOrNull { it.second == projectName }?.third
+        // Surface the sorted project_name routing keys (not raw names) — that is the key callers must pass.
+        val availableProjectNames = triples.map { it.first }.sorted()
+        return resolved ?: throw ToolCallErrorException(
             "Project not found: \"$projectName\". Available project_name values: ${availableProjectNames.joinToString()}"
         )
     }

--- a/ij-plugin/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/ProjectScopedToolHandler.kt
+++ b/ij-plugin/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/ProjectScopedToolHandler.kt
@@ -10,7 +10,7 @@ import com.jonnyzzz.mcpSteroid.mcp.ToolCallErrorException
  * Shared base for `*ToolHandlerIJ` implementations that resolve a
  * `projectName: String` argument to an open IDE [Project].
  *
- * Centralizes the lock-free lookup and the not-found error message
+ * Centralizes the read-action lookup and the not-found error message
  * (which lists the currently-open `project_name` routing keys to help the
  * caller correct a typo) so each handler only writes the project-scoped body.
  */
@@ -21,29 +21,21 @@ class ProjectScopedToolHandler {
      * [ToolCallErrorException] if no project matches — `McpToolRegistry.callTool`
      * catches it and turns it into an MCP error result naming the missing project
      * plus the list of currently-open `project_name` values.
-     *
-     * Deliberately lock-free (#214): a suspend `readAction {}` here parks behind any
-     * pending write action, so one hung read action (e.g. a stuck inspection script)
-     * would wedge EVERY steroid tool for the duration. [ProjectManager.getOpenProjects]
-     * is documented as safe outside a read action provided each project is checked for
-     * [Project.isDisposed] before use; [projectNameFor] only reads plain getters
-     * (`name`, `basePath`). The returned project can still be disposed concurrently —
-     * project-scoped handlers re-check [Project.isDisposed] at use.
      */
     @Throws(ToolCallErrorException::class)
-    fun resolveProject(projectName: String): Project {
-        // (project_name, name, project) per open project — match by the OPAQUE project_name first,
-        // then by the raw folder name ONLY when unambiguous (exactly one match), never first-match,
-        // so two same-named projects (e.g. a checkout and its git worktree) can't silently collapse
-        // to the wrong one (#92).
-        val triples = ProjectManager.getInstance().openProjects
-            .filter { !it.isDisposed }
-            .map { Triple(projectNameFor(it), it.name, it) }
-        val resolved = triples.firstOrNull { it.first == projectName }?.third
-            ?: triples.singleOrNull { it.second == projectName }?.third
-        // Surface the sorted project_name routing keys (not raw names) — that is the key callers must pass.
-        val availableProjectNames = triples.map { it.first }.sorted()
-        return resolved ?: throw ToolCallErrorException(
+    suspend fun resolveProject(projectName: String): Project {
+        val (project, availableProjectNames) = run { // #214: no read action — must not park behind a pending write (wedges every tool)
+            // (project_name, name, project) per open project — match by the OPAQUE project_name first,
+            // then by the raw folder name ONLY when unambiguous (exactly one match), never first-match,
+            // so two same-named projects (e.g. a checkout and its git worktree) can't silently collapse
+            // to the wrong one (#92).
+            val triples = ProjectManager.getInstance().openProjects.map { Triple(projectNameFor(it), it.name, it) }
+            val resolved = triples.firstOrNull { it.first == projectName }?.third
+                ?: triples.singleOrNull { it.second == projectName }?.third
+            // Surface the sorted project_name routing keys (not raw names) — that is the key callers must pass.
+            resolved to triples.map { it.first }.sorted()
+        }
+        return project ?: throw ToolCallErrorException(
             "Project not found: \"$projectName\". Available project_name values: ${availableProjectNames.joinToString()}"
         )
     }

--- a/ij-plugin/src/test/kotlin/com/jonnyzzz/mcpSteroid/server/ProjectResolutionLockFreeTest.kt
+++ b/ij-plugin/src/test/kotlin/com/jonnyzzz/mcpSteroid/server/ProjectResolutionLockFreeTest.kt
@@ -148,7 +148,7 @@ class ProjectResolutionLockFreeTest : BasePlatformTestCase() {
         }
     }
 
-    fun testResolveProjectNotFoundListsAvailableProjectNames() {
+    fun testResolveProjectNotFoundListsAvailableProjectNames(): Unit = timeoutRunBlocking(30.seconds) {
         try {
             service<ProjectScopedToolHandler>().resolveProject("no-such-project-214")
             fail("resolveProject must throw ToolCallErrorException for an unknown project name")

--- a/ij-plugin/src/test/kotlin/com/jonnyzzz/mcpSteroid/server/ProjectResolutionLockFreeTest.kt
+++ b/ij-plugin/src/test/kotlin/com/jonnyzzz/mcpSteroid/server/ProjectResolutionLockFreeTest.kt
@@ -1,0 +1,219 @@
+/* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
+package com.jonnyzzz.mcpSteroid.server
+
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.application.ex.ApplicationManagerEx
+import com.intellij.openapi.components.service
+import com.intellij.testFramework.common.timeoutRunBlocking
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
+import com.jonnyzzz.mcpSteroid.mcp.*
+import com.jonnyzzz.mcpSteroid.setServerPortProperties
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.cio.CIO
+import io.ktor.client.request.*
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.*
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.withTimeout
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.decodeFromJsonElement
+import kotlinx.serialization.json.put
+import kotlinx.serialization.json.putJsonObject
+import java.util.concurrent.atomic.AtomicBoolean
+import kotlin.concurrent.thread
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Regression test for #214: one hung read action plus one queued write action must NOT
+ * wedge the trivial steroid tools. Project-name resolution ([ProjectScopedToolHandler.resolveProject],
+ * [describeSelfBackend]) is lock-free by design — a suspend `readAction {}` there would park behind
+ * the pending write action for as long as the hung read action lives, turning `steroid_fetch_resource`
+ * and `steroid_list_projects` into dead 60 s client timeouts.
+ *
+ * The wedge is simulated exactly as observed in the field: a background thread holds a read action
+ * (the stuck inspection script), then a write action is queued on the EDT and parks behind it
+ * (`isWriteActionPending == true`). While wedged, the resolution paths and both HTTP tool calls
+ * must complete within a short timeout.
+ */
+class ProjectResolutionLockFreeTest : BasePlatformTestCase() {
+
+    private lateinit var client: HttpClient
+
+    override fun runInDispatchThread(): Boolean = false
+
+    override fun setUp() {
+        setServerPortProperties()
+        super.setUp()
+        client = HttpClient(CIO) {
+            expectSuccess = false
+            install(io.ktor.client.plugins.HttpTimeout) {
+                requestTimeoutMillis = 60_000
+                connectTimeoutMillis = 10_000
+            }
+        }
+    }
+
+    override fun tearDown() {
+        try {
+            client.close()
+        } finally {
+            super.tearDown()
+        }
+    }
+
+    fun testToolsRespondWhileReadActionHeldAndWriteActionQueued(): Unit = timeoutRunBlocking(120.seconds) {
+        val server = SteroidsMcpServer.getInstance()
+        server.startServerIfNeeded()
+        val sessionId = initializeSession(server)
+        // Resolve the app service BEFORE wedging the lock so service instantiation cost/locking
+        // cannot leak into the wedged-window assertions below.
+        val projectScoped = service<ProjectScopedToolHandler>()
+        val application = ApplicationManager.getApplication()
+        val applicationEx = ApplicationManagerEx.getApplicationEx()
+
+        val readHeld = CompletableDeferred<Unit>()
+        val releaseRead = AtomicBoolean(false)
+        // A raw thread (not coroutine code) blocked inside runReadAction — this is the
+        // "hung inspection script" from #214: the read permit stays held until released.
+        val readHolder = thread(name = "mcp-steroid-test-read-action-holder") {
+            application.runReadAction {
+                readHeld.complete(Unit)
+                while (!releaseRead.get()) {
+                    Thread.sleep(10)
+                }
+            }
+        }
+        val writeCompleted = CompletableDeferred<Unit>()
+        try {
+            withTimeout(10.seconds) { readHeld.await() }
+
+            // Queue a write action behind the held read action. The EDT runnable starts acquiring
+            // the write lock, cannot get it while the read permit is held, and from that moment
+            // every NEW suspend readAction {} parks (platform lock policy) — the wedge.
+            application.invokeLater {
+                application.runWriteAction { }
+                writeCompleted.complete(Unit)
+            }
+            withTimeout(10.seconds) {
+                while (!applicationEx.isWriteActionPending) {
+                    delay(10)
+                }
+            }
+
+            // 1. resolveProject completes while wedged (would park in a readAction before #214).
+            val projectKey = projectNameFor(project)
+            val resolved = projectScoped.resolveProject(projectKey)
+            assertSame("resolveProject must return the open fixture project", project, resolved)
+
+            // 2. describeSelfBackend (list_projects / list_windows backend) completes while wedged.
+            val self = describeSelfBackend()
+            assertTrue(
+                "describeSelfBackend must list the fixture project",
+                self.projects.any { it.projectName == projectKey },
+            )
+
+            // 3. steroid_fetch_resource responds normally through the full HTTP tool path.
+            val skillUri = com.jonnyzzz.mcpSteroid.prompts.generated.prompt.SkillPromptArticle().uri
+            val fetchResult = withTimeout(15.seconds) {
+                callTool(server, sessionId, "steroid_fetch_resource", buildJsonObject {
+                    put("uri", skillUri)
+                    put("project_name", projectKey)
+                })
+            }
+            assertFalse("steroid_fetch_resource must succeed while wedged", fetchResult.isError)
+            val fetchText = fetchResult.content.filterIsInstance<ContentItem.Text>().joinToString("\n") { it.text }
+            assertTrue("steroid_fetch_resource must return the skill guide", fetchText.contains("MCP Steroid"))
+
+            // 4. steroid_list_projects responds normally through the full HTTP tool path.
+            val listResult = withTimeout(15.seconds) {
+                callTool(server, sessionId, "steroid_list_projects", buildJsonObject { })
+            }
+            assertFalse("steroid_list_projects must succeed while wedged", listResult.isError)
+            val listText = listResult.content.filterIsInstance<ContentItem.Text>().joinToString("\n") { it.text }
+            assertTrue("steroid_list_projects must list the fixture project", listText.contains(projectKey))
+
+            // The write action must STILL be pending — proves every call above completed during
+            // the starvation window, not after it accidentally resolved.
+            assertFalse("write action must not have run while the read action is held", writeCompleted.isCompleted)
+            assertTrue("write action must still be pending", applicationEx.isWriteActionPending)
+        } finally {
+            releaseRead.set(true)
+            while (readHolder.isAlive) {
+                delay(10)
+            }
+            // Let the queued write action drain so tearDown gets a healthy EDT.
+            withTimeout(30.seconds) { writeCompleted.await() }
+        }
+    }
+
+    fun testResolveProjectNotFoundListsAvailableProjectNames() {
+        try {
+            service<ProjectScopedToolHandler>().resolveProject("no-such-project-214")
+            fail("resolveProject must throw ToolCallErrorException for an unknown project name")
+        } catch (e: ToolCallErrorException) {
+            val message = e.message ?: ""
+            assertTrue(
+                "not-found message must keep the pre-#214 shape, got: $message",
+                message.startsWith("Project not found: \"no-such-project-214\". Available project_name values: "),
+            )
+            assertTrue(
+                "not-found message must list the open project_name keys, got: $message",
+                message.contains(projectNameFor(project)),
+            )
+        }
+    }
+
+    private suspend fun initializeSession(server: SteroidsMcpServer): String {
+        val initResponse = client.post(server.mcpUrl) {
+            contentType(ContentType.Application.Json)
+            accept(ContentType.Application.Json)
+            setBody(buildJsonObject {
+                put("jsonrpc", "2.0")
+                put("id", "init-1")
+                put("method", "initialize")
+                putJsonObject("params") {
+                    put("protocolVersion", MCP_PROTOCOL_VERSION)
+                    putJsonObject("capabilities") {}
+                    putJsonObject("clientInfo") {
+                        put("name", "lock-free-resolution-test-client")
+                        put("version", "1.0.0")
+                    }
+                }
+            }.toString())
+        }
+
+        assertEquals(HttpStatusCode.OK, initResponse.status)
+        val sessionId = initResponse.headers[McpHttpTransport.SESSION_HEADER]
+        assertNotNull("Server must issue an MCP session ID", sessionId)
+        return sessionId!!
+    }
+
+    private suspend fun callTool(
+        server: SteroidsMcpServer,
+        sessionId: String,
+        toolName: String,
+        arguments: JsonObject,
+    ): ToolCallResult {
+        val response = client.post(server.mcpUrl) {
+            contentType(ContentType.Application.Json)
+            accept(ContentType.Application.Json)
+            header(McpHttpTransport.SESSION_HEADER, sessionId)
+            setBody(buildJsonObject {
+                put("jsonrpc", "2.0")
+                put("id", "call-$toolName")
+                put("method", "tools/call")
+                putJsonObject("params") {
+                    put("name", toolName)
+                    put("arguments", arguments)
+                }
+            }.toString())
+        }
+
+        assertEquals(HttpStatusCode.OK, response.status)
+        val rpc = McpJson.decodeFromString<JsonRpcResponse>(response.bodyAsText())
+        assertNull("$toolName should not return JSON-RPC error", rpc.error)
+        return McpJson.decodeFromJsonElement(rpc.result!!)
+    }
+}


### PR DESCRIPTION
Fixes #214. Companion to #177/#179.

One hung read action + one queued write action starves every new read action (platform lock fairness) — and every steroid tool took a read action before doing anything, so a single stuck script turned the whole tool surface into 60s dead timeouts (the confirmed `service-45` wedge: hung `execute_code`, then even a static `fetch_resource` timed out).

The read actions were never needed:

- `ProjectScopedToolHandler.resolveProject`, `describeSelfBackend`, and `open_project`'s already-open check now read `ProjectManager.getInstance().openProjects` directly with `!isDisposed` filtering — the platform documents this as safe outside a read action (`ProjectManager.java:70-74`). `projectNameFor` reads only `name`/`basePath` getters.
- Not-found error message stays byte-identical; the #92 opaque-key matching is preserved; disposal races surface via `AlreadyDisposedException` on next use in project-scoped handlers (documented contract).
- The bounded-readAction diagnostic (issue design item 2) is deferred per the issue decision.

Regression test (`ProjectResolutionLockFreeTest`) reproduces the wedge for real: a raw thread holds a read action, a write action is queued on the EDT (verified via public `isWriteActionPending`), then full HTTP `steroid_fetch_resource` + `steroid_list_projects` calls are asserted to complete **while the write is still pending** — the exact `service-45` signature, now impossible.

Verification: full `:ij-plugin:test` green. 3-agent quorum review: codex APPROVE, claude APPROVE, gemini APPROVE — zero required changes. Transcripts in the private eval-logs repo.
