### PR TITLE
Run steroid_execute_code as a visible, cancellable IDE background task (#213)

### DIFF
--- a/ij-plugin/src/main/kotlin/com/jonnyzzz/mcpSteroid/execution/ExecutionManager.kt
+++ b/ij-plugin/src/main/kotlin/com/jonnyzzz/mcpSteroid/execution/ExecutionManager.kt
@@ -6,6 +6,7 @@ import com.intellij.openapi.components.Service
 import com.intellij.openapi.components.service
 import com.intellij.openapi.diagnostic.thisLogger
 import com.intellij.openapi.project.Project
+import com.intellij.platform.ide.progress.withBackgroundProgress
 import com.jonnyzzz.mcpSteroid.mcp.ContentItem
 import com.jonnyzzz.mcpSteroid.mcp.ToolCallResult
 import com.jonnyzzz.mcpSteroid.mcp.builder
@@ -53,7 +54,16 @@ class ExecutionManager(
         exec: ExecCodeParams,
         mcpProgressReporter: McpProgressReporter,
     ): ToolCallResult {
-        return coroutineScope {
+        // The execution runs as a VISIBLE, cancellable IDE background task
+        // (com.intellij.platform.ide.progress.withBackgroundProgress — the coroutine-native
+        // progress API). Cancellation is fully platform-handled: the Cancel button cancels
+        // this coroutine (PlatformTaskSupport subscribes to the task entity and calls
+        // context.cancel()), and when the coroutine ends for ANY reason — completion,
+        // failure, script timeout, or the HTTP request coroutine being cancelled on client
+        // disconnect (this suspend fun is a child of the Ktor request coroutine; structured
+        // concurrency propagates) — the task disappears from the status bar automatically.
+        // No manual wiring is needed or wanted.
+        return withBackgroundProgress(project, "devrig -- MCP Steroid task", cancellable = true) { coroutineScope {
             val executionId = project.executionStorage.writeNewExecution(exec)
             withContext(CoroutineName("mcp-steroid-$executionId")) {
                 log.info("Starting execution $executionId-${exec.taskId}-${exec.reason}...")
@@ -121,7 +131,7 @@ class ExecutionManager(
 
                 builder.build()
             }
-        }
+        } }
     }
 
     private fun responseBuilder(parentScope: CoroutineScope, executionId: ExecutionId, mcpProgress: McpProgressReporter) = object : ExecutionResultBuilder {

--- a/ij-plugin/src/main/kotlin/com/jonnyzzz/mcpSteroid/execution/ScriptExecutor.kt
+++ b/ij-plugin/src/main/kotlin/com/jonnyzzz/mcpSteroid/execution/ScriptExecutor.kt
@@ -1,6 +1,7 @@
 /* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
 package com.jonnyzzz.mcpSteroid.execution
 
+import com.intellij.openapi.progress.ProcessCanceledException
 import com.intellij.openapi.Disposable
 import com.intellij.openapi.application.EDT
 import com.intellij.openapi.application.ModalityState
@@ -252,6 +253,12 @@ class ScriptExecutor(
             resultBuilder.logRemappedException("Execution timed out", e, evalResult.lineMapping)
             resultBuilder.reportFailed("Execution timed out after ${exec.timeout} seconds")
         } catch (e: CancellationException) {
+            throw e
+        } catch (e: ProcessCanceledException) {
+            // Control-flow exception (Logger contract): rethrow, never report as a script
+            // failure. On current platforms PCE extends CancellationException, so the CE
+            // branch above already covers it — this branch is explicit defense for any
+            // PCE that does not.
             throw e
         } catch (t: Throwable) {
             // #156: never report an empty error. A messageless throwable (e.g. the bare

--- a/ij-plugin/src/test/kotlin/com/jonnyzzz/mcpSteroid/execution/ExecutionManagerTest.kt
+++ b/ij-plugin/src/test/kotlin/com/jonnyzzz/mcpSteroid/execution/ExecutionManagerTest.kt
@@ -10,6 +10,10 @@ import com.jonnyzzz.mcpSteroid.server.ModalMode
 import com.jonnyzzz.mcpSteroid.server.NoOpProgressReporter
 import com.jonnyzzz.mcpSteroid.setSystemPropertyForTest
 import com.jonnyzzz.mcpSteroid.testExecParams
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 import kotlin.time.Duration.Companion.seconds
 
 /**
@@ -49,6 +53,31 @@ class ExecutionManagerTest : BasePlatformTestCase() {
         )
         assertFalse("non_modal should pass the non-modal gate headless: ${getTextContent(result)}", result.isError)
         assertTrue("Should have output", getTextContent(result).contains("hi non_modal"))
+    }
+
+    fun testParentCoroutineCancellationUnwindsExecution(): Unit = timeoutRunBlocking(60.seconds) {
+        // The execution coroutine is a CHILD of the HTTP request coroutine (executeWithProgress
+        // is a plain suspend fun — no scope hop), so a client disconnect cancels the Ktor
+        // request coroutine and structured concurrency must unwind the running execution —
+        // and with it the visible background task (the platform removes it when the
+        // coroutine ends, PlatformTaskSupport). Simulate the disconnect by cancelling the
+        // calling coroutine mid-script.
+        val manager = project.service<ExecutionManager>()
+        val started = CompletableDeferred<Unit>()
+        val job = launch {
+            started.complete(Unit)
+            manager.executeWithProgress(
+                testExecParams("kotlinx.coroutines.delay(60_000)", timeout = 55),
+                NoOpProgressReporter,
+            )
+        }
+        started.await()
+        delay(2_000) // let the execution get past compile into the script
+        val took = kotlin.time.measureTime { job.cancelAndJoin() }
+        assertTrue(
+            "cancelling the parent coroutine must unwind the execution promptly, took $took",
+            took < 15.seconds,
+        )
     }
 
     fun testExecuteWithProgressSuccess(): Unit = timeoutRunBlocking(30.seconds) {


### PR DESCRIPTION
Fixes #213. Mitigates #179 at the execution boundary (see note).

## What

Every `steroid_execute_code` execution now runs as a **visible IDE background task** — "devrig -- MCP Steroid task" in the status bar — via the platform's coroutine-native progress API:

```kotlin
withBackgroundProgress(project, "devrig -- MCP Steroid task", cancellable = true) {
    // the existing execution, unchanged — withTimeout inside
}
```

One wrapper call in `ExecutionManager`. No custom indicator, no watcher coroutines, no manual cancellation wiring — the platform already handles the full loop (verified in `PlatformTaskSupport`): the task's UI Cancel cancels the coroutine context, and the task is removed from the status bar in a `finally` whenever the coroutine ends — completion, failure, script timeout, or **client disconnect**: `executeWithProgress` is a plain suspend fun with no scope hop, so the execution is a child of the Ktor request coroutine and structured concurrency unwinds it. Pinned by `testParentCoroutineCancellationUnwindsExecution` (cancels the parent mid-script, asserts prompt unwind).

Also included: **`ProcessCanceledException` rethrow** in `ScriptExecutor`'s catch chain (control-flow exception; defensive — PCE extends CE on current platforms).

The wrapper is purely additive: it nests around the existing `coroutineScope`, which keeps owning the sub-task structure (the response builder's supervised storage writes, progress streams) exactly as before — no other line of the execution path changes. The #221 line-mapping fix moved to its own PR.

## #179 note

`runInspectionsDirectly` is deliberately left unchanged in this PR. The in-read-action indicator bridge the platform uses for `inspectEx` (`jobToIndicator`) is `@ApiStatus.Internal`; the public-only alternatives all change the read-action shape. With this PR a stuck sweep is bounded by the visible task + child-of-request cancellation at the execution boundary; interrupting the sweep mid-flight stays open on #179.

## Verification

Full `:ij-plugin:test` green — every existing execution test now flows through the background-progress wrapper in the unit-test environment, plus the new disconnect-simulation test.
