### PR TITLE
feat(experiments): Keycloak move-class A/B — MoveClassesOrPackagesProcessor vs manual sweep

### DIFF
--- a/test-experiments/src/test/kotlin/com/jonnyzzz/mcpSteroid/integration/tests/KeycloakMoveClassTest.kt
+++ b/test-experiments/src/test/kotlin/com/jonnyzzz/mcpSteroid/integration/tests/KeycloakMoveClassTest.kt
@@ -1,0 +1,301 @@
+/* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
+package com.jonnyzzz.mcpSteroid.integration.tests
+
+import com.jonnyzzz.mcpSteroid.integration.infra.AiMode
+import com.jonnyzzz.mcpSteroid.integration.infra.BuildSystem
+import com.jonnyzzz.mcpSteroid.integration.infra.IntelliJContainer
+import com.jonnyzzz.mcpSteroid.integration.infra.IntelliJContainerOpts
+import com.jonnyzzz.mcpSteroid.integration.infra.IntelliJProject
+import com.jonnyzzz.mcpSteroid.integration.infra.McpConnectionMode
+import com.jonnyzzz.mcpSteroid.integration.infra.create
+import com.jonnyzzz.mcpSteroid.integration.infra.waitForProjectReady
+import com.jonnyzzz.mcpSteroid.testHelper.AiAgentSession
+import com.jonnyzzz.mcpSteroid.testHelper.CloseableStackHost
+import com.jonnyzzz.mcpSteroid.testHelper.docker.startProcessInContainer
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Timeout
+import java.util.concurrent.TimeUnit
+
+/**
+ * MCP-win experiment: **move a class between packages** (jonnyzzz/mcp-steroid#169) — the third of the
+ * refactoring trilogy after [KeycloakRenameTest] and [KeycloakChangeSignatureTest]. The agent moves the
+ * enum `org.keycloak.authentication.AuthenticationFlowError` (server-spi-private module) to a new
+ * package `org.keycloak.authentication.errors` in the SAME module, updating every reference so the
+ * project still compiles and ZERO occurrences of the old FQN remain anywhere in the tree.
+ *
+ * Verified against the pinned Keycloak 26.6.4 tag, the production reference sites are:
+ *  - 32 `services`-module files that import the FQN;
+ *  - 8 SAME-PACKAGE users with NO import line at all — `org.keycloak.authentication` is a SPLIT
+ *    package (3 files in server-spi-private: AbstractAuthenticationFlowContext,
+ *    AuthenticationFlowException, ForkFlowException; 5 in services: AuthenticationProcessor,
+ *    DefaultAuthenticationFlow, FormAuthenticationFlow, ClientAuthenticationFlow,
+ *    AuthenticationSelectionResolver). A grep for the old FQN NEVER finds these, yet each needs a NEW
+ *    import added after the move or compilation breaks — the manual-sweep trap;
+ *  - 1 production RESOURCE: `services/src/main/resources/scripts/authenticator-template.js` holds the
+ *    FQN as a string (`Java.type("org.keycloak…AuthenticationFlowError")`) — a pure-source move leaves
+ *    it dangling with the build still green (there is no META-INF/services registration for this enum;
+ *    the JS `Java.type` string IS the resource-file trap here);
+ *  - plus a javadoc code sample in ScriptBasedAuthenticator.java, 4 testsuite JS scripts and one docs
+ *    .adoc — 46 old-FQN occurrences across 45 files tree-wide at the pinned tag.
+ *
+ * With MCP the agent drives IntelliJ's `MoveClassesOrPackagesProcessor` via `steroid_execute_code` —
+ * PSI moves the file, rewrites imports/FQN references/javadoc, adds the missing imports to the
+ * same-package users, and (with text-occurrence search) rewrites the non-Java FQN strings atomically.
+ * Without MCP, a grep-driven sweep must discover the grep-invisible same-package usages by compiling.
+ *
+ * Verdict ([scoreMoveClass]) is EVIDENCE-based: after the agent finishes, the harness itself checks in
+ * the container (identically for both legs) that the file exists at the new path and is gone from the
+ * old one, and greps the whole tree for the old FQN — the OBJECTIVE residue count. Only the per-file
+ * `UPDATED:` list (checked against the hand-derived ground truth above) and the build claim come from
+ * the agent's output. Emitted as an `[ARENA]` block; A/B per agent; with-MCP asserts exec_code;
+ * correctness is a dashboard metric, not a hard gate.
+ */
+class KeycloakMoveClassTest {
+
+    // 80 min, following the KeycloakRenameTest precedent: the without-MCP baseline is edit/build-heavy —
+    // it must update ~40 files, discover the 8 grep-invisible same-package usages via compile errors, and
+    // rebuild (the rename baseline measured 30.3 min agent time on CI build 991971402, and container
+    // start + Keycloak import + verification pushed the method past 50). The slow baseline IS the
+    // experiment's finding — it must complete and emit its [ARENA] block so the dashboard can show the
+    // gap, not die as a timeout with no data. TC-side executionTimeoutMin=180 fits two 80-min methods.
+
+    @Test @Timeout(value = 80, unit = TimeUnit.MINUTES)
+    fun `claude with mcp`() = run("claude", withMcp = true)
+
+    @Test @Timeout(value = 80, unit = TimeUnit.MINUTES)
+    fun `claude without mcp`() = run("claude", withMcp = false)
+
+    @Test @Timeout(value = 80, unit = TimeUnit.MINUTES)
+    fun `codex with mcp`() = run("codex", withMcp = true)
+
+    @Test @Timeout(value = 80, unit = TimeUnit.MINUTES)
+    fun `codex without mcp`() = run("codex", withMcp = false)
+
+    private fun run(agentName: String, withMcp: Boolean) {
+        val modeLabel = if (withMcp) "mcp" else "none"
+        val lifetime = CloseableStackHost()
+        try {
+            val session = IntelliJContainer.create(lifetime, IntelliJContainerOpts(
+                consoleTitle = "keycloak-moveclass-$agentName-$modeLabel",
+                project = IntelliJProject.KeycloakProject,
+                aiMode = if (withMcp) AiMode.AI_MCP else AiMode.NONE,
+                mcpConnectionMode = if (withMcp) null else McpConnectionMode.None,
+            )).waitForProjectReady(buildSystem = BuildSystem.MAVEN)
+
+            val agent: AiAgentSession = when (agentName) {
+                "claude" -> session.aiAgents.claude
+                "codex" -> session.aiAgents.codex
+                else -> error("Unknown agent: $agentName")
+            }
+
+            val startedAt = System.currentTimeMillis()
+            val result = agent.runPrompt(if (withMcp) withMcpPrompt() else baselinePrompt(), timeoutSeconds = 2400)
+                .awaitForProcessFinish()
+            val agentDurationMs = System.currentTimeMillis() - startedAt
+            val combined = result.stdout + "\n" + result.stderr
+
+            // Objective, harness-run verification — identical for both legs. A failure here is logged
+            // loudly but does NOT abort the run: the [ARENA] block must still reach the dashboard.
+            val verification = runCatching { verifyMoveInContainer(session) }.getOrElse { e ->
+                println("[TEST] WARNING: in-container move verification failed: $e")
+                MoveVerification(classAtNewPath = null, classAtOldPath = null, oldFqnResidueCount = null)
+            }
+
+            val score = scoreMoveClass(
+                output = combined,
+                requiredUpdatedFiles = REQUIRED_UPDATED_FILES,
+                classAtNewPath = verification.classAtNewPath,
+                classAtOldPath = verification.classAtOldPath,
+                oldFqnResidueCount = verification.oldFqnResidueCount,
+            )
+            println("[TEST] keycloak move-class [$agentName+$modeLabel] safe=${score.safe} " +
+                    "moveDone=${score.moveDone} missing=${score.missingUpdatedFiles.size} " +
+                    "residue=${score.oldFqnResidueCount} buildGreen=${score.buildGreen}")
+            if (score.missingUpdatedFiles.isNotEmpty()) {
+                println("[TEST]   missed reference sites: ${score.missingUpdatedFiles}")
+            }
+
+            recordSemanticRun(
+                scenario = SCENARIO,
+                agentName = agentName,
+                withMcp = withMcp,
+                claimedFix = score.safe,
+                rawOutput = result.rawStdout,
+                exitCode = result.exitCode,
+                agentDurationMs = agentDurationMs,
+                runDir = session.runDirInContainer,
+                summary = "moveDone=${score.moveDone} updated=${score.reportedUpdatedFiles.size} " +
+                        "missing=${score.missingUpdatedFiles.size} residue=${score.oldFqnResidueCount} " +
+                        "buildGreen=${score.buildGreen}",
+            )
+
+            if (withMcp) assertUsedExecuteCodeEvidence(combined)
+        } finally {
+            lifetime.closeAllStacks()
+        }
+    }
+
+    private data class MoveVerification(
+        val classAtNewPath: Boolean?,
+        val classAtOldPath: Boolean?,
+        val oldFqnResidueCount: Int?,
+    )
+
+    /**
+     * Run the objective checks inside the container: file existence at the old/new path and a tree-wide
+     * grep counting remaining old-FQN occurrences (.git/.idea/target/node_modules excluded). The old FQN
+     * cannot false-positive on the new one — `authentication.errors.AuthenticationFlowError` does not
+     * contain the `authentication.AuthenticationFlowError` substring.
+     */
+    private fun verifyMoveInContainer(session: IntelliJContainer): MoveVerification {
+        val projectDir = session.intellijDriver.getGuestProjectDir()
+        val script = """
+            p='$projectDir'
+            [ -f "${'$'}p/$OLD_PATH" ] && echo "MOVECHECK_OLD_EXISTS: yes" || echo "MOVECHECK_OLD_EXISTS: no"
+            [ -f "${'$'}p/$NEW_PATH" ] && echo "MOVECHECK_NEW_EXISTS: yes" || echo "MOVECHECK_NEW_EXISTS: no"
+            echo "MOVECHECK_RESIDUE: ${'$'}(grep -ro --binary-files=without-match \
+                --exclude-dir=.git --exclude-dir=.idea --exclude-dir=target --exclude-dir=node_modules \
+                'org\.keycloak\.authentication\.AuthenticationFlowError' "${'$'}p" | wc -l)"
+        """.trimIndent()
+        val stdout = session.scope.startProcessInContainer {
+            args("bash", "-c", script)
+                .timeoutSeconds(600)
+                .description("Verify move-class result: file locations + old-FQN residue grep")
+                .quietly()
+        }.awaitForProcessFinish().stdout
+
+        fun flag(marker: String): Boolean? =
+            Regex("""(?m)^$marker:\s*(yes|no)""").find(stdout)?.groupValues?.get(1)?.let { it == "yes" }
+        val residue = Regex("""(?m)^MOVECHECK_RESIDUE:\s*(\d+)""").find(stdout)?.groupValues?.get(1)?.toIntOrNull()
+        return MoveVerification(
+            classAtNewPath = flag("MOVECHECK_NEW_EXISTS"),
+            classAtOldPath = flag("MOVECHECK_OLD_EXISTS"),
+            oldFqnResidueCount = residue,
+        )
+    }
+
+    private fun taskDescription(): String = buildString {
+        appendLine("Task: move the enum class `$OLD_FQN`")
+        appendLine("(declared in the server-spi-private module) to a new package")
+        appendLine("`org.keycloak.authentication.errors` in the SAME module — the new fully-qualified name is")
+        appendLine("`$NEW_FQN`.")
+        appendLine()
+        appendLine("The move must ripple PROJECT-WIDE so everything still compiles:")
+        appendLine("- the class file itself moves to the new package directory and its `package` declaration changes,")
+        appendLine("- every `import` of the old FQN is rewritten,")
+        appendLine("- files that used the class from the SAME package without any import now need a NEW import")
+        appendLine("  (note: `org.keycloak.authentication` is a split package — it exists in BOTH the")
+        appendLine("  server-spi-private and services modules),")
+        appendLine("- FQN strings in non-Java files (resources, script templates, docs) must be updated too.")
+        appendLine()
+        appendLine("We will verify OBJECTIVELY after you finish: the file must exist at")
+        appendLine("`$NEW_PATH`,")
+        appendLine("must be gone from `$OLD_PATH`, and a")
+        appendLine("project-wide search for the old fully-qualified name must return ZERO matches —")
+        appendLine("sources, resources, scripts and docs all count.")
+    }
+
+    private fun outputMarkers(): String = buildString {
+        appendLine("Output (markers on their own lines):")
+        appendLine("MOVE_DONE: yes")
+        appendLine("UPDATED_COUNT: <total number of changed files>")
+        appendLine("UPDATED: <path/relative/to/repo/root>   ← one line per changed file (derive the list from")
+        appendLine("  `git status --porcelain` so nothing is forgotten; include the moved file and every reference site)")
+        appendLine("BUILD_AFTER_MOVE: <SUCCESS or FAILURE>")
+    }
+
+    private fun withMcpPrompt(): String = buildString {
+        appendLine("The Keycloak project is open in IntelliJ IDEA — a large multi-module Java project.")
+        appendLine()
+        append(taskDescription())
+        appendLine()
+        appendLine("Use IntelliJ's Move refactoring via `steroid_execute_code`:")
+        appendLine("`com.intellij.refactoring.move.moveClassesOrPackages.MoveClassesOrPackagesProcessor` with a")
+        appendLine("destination package `org.keycloak.authentication.errors` (create it in the server-spi-private")
+        appendLine("source root) and BOTH `searchInComments` and `searchInNonJavaFiles` set to true — PSI moves the")
+        appendLine("file, rewrites every import/FQN/javadoc reference, adds missing imports to same-package users,")
+        appendLine("and updates non-Java text occurrences atomically. Do NOT sed.")
+        appendLine("After the move, build the affected modules (e.g. server-spi-private + services) to verify.")
+        appendLine()
+        append(outputMarkers())
+        appendLine("TOOL_EVIDENCE: <copy the line starting with execution_id: ...>")
+    }
+
+    private fun baselinePrompt(): String = buildString {
+        appendLine("The Keycloak project is checked out (a large multi-module Java project).")
+        appendLine("IntelliJ MCP tools are unavailable in this run — use shell commands only.")
+        appendLine()
+        append(taskDescription())
+        appendLine()
+        appendLine("Beware: a grep for the old fully-qualified name will NOT find the same-package usages —")
+        appendLine("they have no import line to rewrite, yet they break compilation after the move. And FQN")
+        appendLine("strings hiding in non-Java files do not break the build, but they count in the verification.")
+        appendLine("After the move, build the affected modules (e.g. server-spi-private + services) to verify.")
+        appendLine()
+        append(outputMarkers())
+    }
+
+    companion object {
+        private const val SCENARIO = "keycloak__move_class"
+        private const val OLD_FQN = "org.keycloak.authentication.AuthenticationFlowError"
+        private const val NEW_FQN = "org.keycloak.authentication.errors.AuthenticationFlowError"
+        private const val OLD_PATH =
+            "server-spi-private/src/main/java/org/keycloak/authentication/AuthenticationFlowError.java"
+        private const val NEW_PATH =
+            "server-spi-private/src/main/java/org/keycloak/authentication/errors/AuthenticationFlowError.java"
+
+        // Ground truth derived from the pinned Keycloak 26.6.4 tag: every PRODUCTION reference site
+        // (server-spi-private + services src/main) of the moved enum — 32 import-based users, 8
+        // same-package users with NO import (the grep-invisible ones), and the production JS resource
+        // holding the FQN as a `Java.type(...)` string. Testsuite scripts and docs are deliberately NOT
+        // required here (per the KeycloakChangeSignatureTest precedent — the testsuite may not be part
+        // of the Maven import); they are still covered by the objective tree-wide residue grep.
+        private val REQUIRED_UPDATED_FILES = setOf(
+            // server-spi-private — same-package users, no import line (grep-invisible):
+            "server-spi-private/src/main/java/org/keycloak/authentication/AbstractAuthenticationFlowContext.java",
+            "server-spi-private/src/main/java/org/keycloak/authentication/AuthenticationFlowException.java",
+            "server-spi-private/src/main/java/org/keycloak/authentication/ForkFlowException.java",
+            // services — same-package users, no import line (grep-invisible; split package):
+            "services/src/main/java/org/keycloak/authentication/AuthenticationProcessor.java",
+            "services/src/main/java/org/keycloak/authentication/AuthenticationSelectionResolver.java",
+            "services/src/main/java/org/keycloak/authentication/ClientAuthenticationFlow.java",
+            "services/src/main/java/org/keycloak/authentication/DefaultAuthenticationFlow.java",
+            "services/src/main/java/org/keycloak/authentication/FormAuthenticationFlow.java",
+            // services — import-based reference sites:
+            "services/src/main/java/org/keycloak/authentication/authenticators/access/DenyAccessAuthenticator.java",
+            "services/src/main/java/org/keycloak/authentication/authenticators/broker/AbstractIdpAuthenticator.java",
+            "services/src/main/java/org/keycloak/authentication/authenticators/broker/IdpConfirmLinkAuthenticator.java",
+            "services/src/main/java/org/keycloak/authentication/authenticators/broker/IdpConfirmOverrideLinkAuthenticator.java",
+            "services/src/main/java/org/keycloak/authentication/authenticators/broker/IdpEmailVerificationAuthenticator.java",
+            "services/src/main/java/org/keycloak/authentication/authenticators/broker/IdpUsernamePasswordForm.java",
+            "services/src/main/java/org/keycloak/authentication/authenticators/browser/AbstractUsernameFormAuthenticator.java",
+            "services/src/main/java/org/keycloak/authentication/authenticators/browser/OTPFormAuthenticator.java",
+            "services/src/main/java/org/keycloak/authentication/authenticators/browser/RecoveryAuthnCodesFormAuthenticator.java",
+            "services/src/main/java/org/keycloak/authentication/authenticators/browser/ScriptBasedAuthenticator.java",
+            "services/src/main/java/org/keycloak/authentication/authenticators/browser/SpnegoAuthenticator.java",
+            "services/src/main/java/org/keycloak/authentication/authenticators/browser/WebAuthnAuthenticator.java",
+            "services/src/main/java/org/keycloak/authentication/authenticators/client/AbstractJWTClientValidator.java",
+            "services/src/main/java/org/keycloak/authentication/authenticators/client/ClientIdAndSecretAuthenticator.java",
+            "services/src/main/java/org/keycloak/authentication/authenticators/client/FederatedJWTClientAuthenticator.java",
+            "services/src/main/java/org/keycloak/authentication/authenticators/client/JWTClientAuthenticator.java",
+            "services/src/main/java/org/keycloak/authentication/authenticators/client/JWTClientSecretAuthenticator.java",
+            "services/src/main/java/org/keycloak/authentication/authenticators/client/X509ClientAuthenticator.java",
+            "services/src/main/java/org/keycloak/authentication/authenticators/conditional/ConditionalLoaAuthenticator.java",
+            "services/src/main/java/org/keycloak/authentication/authenticators/conditional/ConditionalUserAttributeValue.java",
+            "services/src/main/java/org/keycloak/authentication/authenticators/directgrant/ValidateOTP.java",
+            "services/src/main/java/org/keycloak/authentication/authenticators/directgrant/ValidatePassword.java",
+            "services/src/main/java/org/keycloak/authentication/authenticators/directgrant/ValidateUsername.java",
+            "services/src/main/java/org/keycloak/authentication/authenticators/resetcred/ResetCredentialChooseUser.java",
+            "services/src/main/java/org/keycloak/authentication/authenticators/resetcred/ResetCredentialEmail.java",
+            "services/src/main/java/org/keycloak/authentication/authenticators/sessionlimits/UserSessionLimitsAuthenticator.java",
+            "services/src/main/java/org/keycloak/authentication/authenticators/x509/ValidateX509CertificateUsername.java",
+            "services/src/main/java/org/keycloak/authentication/forms/RegistrationUserCreation.java",
+            "services/src/main/java/org/keycloak/organization/authentication/authenticators/broker/IdpAddOrganizationMemberAuthenticator.java",
+            "services/src/main/java/org/keycloak/organization/authentication/authenticators/browser/OrganizationAuthenticator.java",
+            "services/src/main/java/org/keycloak/protocol/docker/DockerAuthenticator.java",
+            "services/src/main/java/org/keycloak/protocol/saml/profile/ecp/authenticator/HttpBasicAuthenticator.java",
+            // services — production resource with the FQN as a Java.type("...") string:
+            "services/src/main/resources/scripts/authenticator-template.js",
+        )
+    }
+}

--- a/test-integration/src/main/kotlin/com/jonnyzzz/mcpSteroid/integration/tests/SemanticTaskScoring.kt
+++ b/test-integration/src/main/kotlin/com/jonnyzzz/mcpSteroid/integration/tests/SemanticTaskScoring.kt
@@ -677,6 +677,94 @@ fun scoreInteropUsages(
     )
 }
 
+data class MoveClassScore(
+    /** The class file exists at the new package AND is gone from the old one — HARNESS-measured. */
+    val moveDone: Boolean,
+    /** Normalized (deduplicated) file paths extracted from the agent's `UPDATED:` lines. */
+    val reportedUpdatedFiles: Set<String>,
+    /** Ground-truth reference sites the agent did NOT report updating — the manual-sweep misses. */
+    val missingUpdatedFiles: Set<String>,
+    /** The post-move build result the agent reported (null if it never reported one). */
+    val buildGreen: Boolean?,
+    /** Occurrences of the OLD fully-qualified name left in the tree — HARNESS-measured grep count. */
+    val oldFqnResidueCount: Int?,
+    /** True when the harness grep found ZERO old-FQN occurrences (null count = not clean). */
+    val residueClean: Boolean,
+    /** Move performed AND every ground-truth reference site was reported updated. */
+    val complete: Boolean,
+    /** A safe move = complete AND build green AND zero old-FQN residue. */
+    val safe: Boolean,
+)
+
+/**
+ * Score a project-wide MOVE CLASS (between packages) for completeness + safety. With MCP the agent
+ * drives IntelliJ's `MoveClassesOrPackagesProcessor` (PSI): the class file moves, its package
+ * declaration changes, and every import, FQN reference, javadoc link and (with text-occurrence
+ * search) non-Java FQN string is rewritten atomically. Without MCP a grep-driven sweep has two
+ * blind spots: same-package usages carry NO import line to rewrite (they need a NEW import added
+ * or the build breaks), and FQN strings hide in resource/script/doc files (the build stays green
+ * but the runtime reference dangles). Scored identically for both modes.
+ *
+ * Evidence-based by construction — the three load-bearing inputs are measured by the test harness
+ * (identically for both legs), NOT self-reported:
+ *  - [classAtNewPath] / [classAtOldPath]: container file-existence checks — a `MOVE_DONE: yes`
+ *    claim with the file still at the old path (copy, not move) scores false;
+ *  - [oldFqnResidueCount]: a project-wide grep for the old FQN run by the harness — the objective
+ *    residue check; any count other than exactly 0 (including a failed check = null) is unclean.
+ *
+ * Only the per-file list and the build claim come from the agent's marker output:
+ *   MOVE_DONE: yes
+ *   UPDATED: <path/relative/to/repo/File.java>       (one line per updated file)
+ *   BUILD_AFTER_MOVE: SUCCESS | FAILURE
+ *
+ * Path matching is markdown-normalized and suffix-based (see [pathsReferToSameFile]), so absolute
+ * in-container paths and repo-relative spellings both count.
+ *
+ * @param requiredUpdatedFiles ground-truth reference-site paths derived by hand from the pinned
+ *                             project revision — every one must appear among the `UPDATED:` lines.
+ */
+fun scoreMoveClass(
+    output: String,
+    requiredUpdatedFiles: Set<String>,
+    classAtNewPath: Boolean?,
+    classAtOldPath: Boolean?,
+    oldFqnResidueCount: Int?,
+): MoveClassScore {
+    // `UPDATED\b` keeps `UPDATED_COUNT:` (same prefix) from contributing a fake path.
+    val updatedLine = Regex("""(?im)^\s*[*_`>#|:-]*\s*UPDATED\b\s*[*_`]*\s*:\s*(.+)$""")
+    val reported = updatedLine.findAll(output)
+        .map { normalizeReportedPath(it.groupValues[1]) }
+        .filter { it.isNotEmpty() }
+        .toSet()
+
+    val missing = requiredUpdatedFiles.filterNot { truth ->
+        reported.any { pathsReferToSameFile(it, truth) }
+    }.toSet()
+
+    val build = findMarkerValue(output, "BUILD_AFTER_MOVE", "Build after move")
+    val buildGreen = build?.let {
+        when {
+            it.contains("SUCCESS", ignoreCase = true) || it.equals("pass", ignoreCase = true) || it.equals("green", ignoreCase = true) -> true
+            it.contains("FAIL", ignoreCase = true) || it.contains("error", ignoreCase = true) || it.contains("broke", ignoreCase = true) -> false
+            else -> null
+        }
+    }
+
+    val moveDone = classAtNewPath == true && classAtOldPath == false
+    val residueClean = oldFqnResidueCount == 0
+    val complete = moveDone && missing.isEmpty()
+    return MoveClassScore(
+        moveDone = moveDone,
+        reportedUpdatedFiles = reported,
+        missingUpdatedFiles = missing,
+        buildGreen = buildGreen,
+        oldFqnResidueCount = oldFqnResidueCount,
+        residueClean = residueClean,
+        complete = complete,
+        safe = complete && buildGreen == true && residueClean,
+    )
+}
+
 data class RootCauseScore(
     val mentionsIgnoredReturn: Boolean,
     val mentionsNewList: Boolean,

--- a/test-integration/src/test/kotlin/com/jonnyzzz/mcpSteroid/integration/tests/MoveClassScoringTest.kt
+++ b/test-integration/src/test/kotlin/com/jonnyzzz/mcpSteroid/integration/tests/MoveClassScoringTest.kt
@@ -1,0 +1,187 @@
+/* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
+package com.jonnyzzz.mcpSteroid.integration.tests
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * Pure, local tests for [scoreMoveClass] — the verdict for the Keycloak move-class A/B.
+ * The point of the experiment: IntelliJ's MoveClassesOrPackagesProcessor moves a class between
+ * packages and rewrites imports, FQN references, javadoc links AND non-Java text occurrences
+ * atomically, while a grep-driven manual move misses (a) same-package usages that have NO import
+ * line to rewrite and (b) FQN strings hiding in resource/script/doc files.
+ *
+ * The scorer is evidence-based: the move itself and the old-FQN residue are measured by the test
+ * HARNESS (file-existence checks + a project-wide grep run in the container, identical for both
+ * legs) and passed in as parameters — the agent's own "MOVE_DONE: yes" claim is never trusted.
+ * Only the per-file `UPDATED:` list and the build claim come from the agent's output.
+ * No IDE/Docker needed → unit-tested directly.
+ */
+class MoveClassScoringTest {
+
+    // A toy ground truth mirroring the Keycloak shape: an import-based reference in another module,
+    // a same-package (no-import) user, and a non-Java resource holding the FQN as a string.
+    private val required = setOf(
+        "services/src/main/java/org/kc/auth/authenticators/FooAuthenticator.java",
+        "server-spi-private/src/main/java/org/kc/auth/FlowContext.java",
+        "services/src/main/resources/scripts/template.js",
+    )
+
+    @Test
+    fun `full move with all files updated, green build and zero residue scores safe`() {
+        val out = """
+            Used MoveClassesOrPackagesProcessor via steroid_execute_code.
+            MOVE_DONE: yes
+            UPDATED_COUNT: 3
+            UPDATED: services/src/main/java/org/kc/auth/authenticators/FooAuthenticator.java
+            UPDATED: server-spi-private/src/main/java/org/kc/auth/FlowContext.java
+            UPDATED: services/src/main/resources/scripts/template.js
+            BUILD_AFTER_MOVE: SUCCESS
+        """.trimIndent()
+        val s = scoreMoveClass(out, required, classAtNewPath = true, classAtOldPath = false, oldFqnResidueCount = 0)
+        assertTrue(s.moveDone)
+        assertEquals(emptySet<String>(), s.missingUpdatedFiles)
+        assertEquals(true, s.buildGreen)
+        assertTrue(s.residueClean)
+        assertTrue(s.complete)
+        assertTrue(s.safe)
+    }
+
+    @Test
+    fun `missing the same-package no-import file scores incomplete`() {
+        // The classic grep-based miss: same-package usages have no import line to rewrite.
+        val out = """
+            MOVE_DONE: yes
+            UPDATED: services/src/main/java/org/kc/auth/authenticators/FooAuthenticator.java
+            UPDATED: services/src/main/resources/scripts/template.js
+            BUILD_AFTER_MOVE: FAILURE
+        """.trimIndent()
+        val s = scoreMoveClass(out, required, classAtNewPath = true, classAtOldPath = false, oldFqnResidueCount = 4)
+        assertTrue(s.moveDone)
+        assertTrue(s.missingUpdatedFiles.contains("server-spi-private/src/main/java/org/kc/auth/FlowContext.java"))
+        assertEquals(false, s.buildGreen)
+        assertFalse(s.complete)
+        assertFalse(s.safe)
+    }
+
+    @Test
+    fun `nonzero old-FQN residue is not safe even when complete and green`() {
+        // E.g. the agent fixed all sources but left the FQN string in a script template or doc —
+        // the harness-run project-wide grep is the objective residue check.
+        val out = """
+            MOVE_DONE: yes
+            UPDATED: services/src/main/java/org/kc/auth/authenticators/FooAuthenticator.java
+            UPDATED: server-spi-private/src/main/java/org/kc/auth/FlowContext.java
+            UPDATED: services/src/main/resources/scripts/template.js
+            BUILD_AFTER_MOVE: SUCCESS
+        """.trimIndent()
+        val s = scoreMoveClass(out, required, classAtNewPath = true, classAtOldPath = false, oldFqnResidueCount = 2)
+        assertTrue(s.complete)
+        assertEquals(true, s.buildGreen)
+        assertFalse(s.residueClean)
+        assertFalse(s.safe)
+    }
+
+    @Test
+    fun `class copied instead of moved scores moveDone false`() {
+        // Old file still exists → it was a copy, not a move — harness evidence beats MOVE_DONE: yes.
+        val out = """
+            MOVE_DONE: yes
+            UPDATED: services/src/main/java/org/kc/auth/authenticators/FooAuthenticator.java
+            UPDATED: server-spi-private/src/main/java/org/kc/auth/FlowContext.java
+            UPDATED: services/src/main/resources/scripts/template.js
+            BUILD_AFTER_MOVE: SUCCESS
+        """.trimIndent()
+        val s = scoreMoveClass(out, required, classAtNewPath = true, classAtOldPath = true, oldFqnResidueCount = 0)
+        assertFalse(s.moveDone)
+        assertFalse(s.complete)
+        assertFalse(s.safe)
+    }
+
+    @Test
+    fun `class never created at new path scores moveDone false regardless of claims`() {
+        val out = """
+            MOVE_DONE: yes
+            BUILD_AFTER_MOVE: SUCCESS
+        """.trimIndent()
+        val s = scoreMoveClass(out, required, classAtNewPath = false, classAtOldPath = true, oldFqnResidueCount = 40)
+        assertFalse(s.moveDone)
+        assertFalse(s.safe)
+    }
+
+    @Test
+    fun `failed harness verification (nulls) is conservative - not safe`() {
+        val out = """
+            MOVE_DONE: yes
+            UPDATED: services/src/main/java/org/kc/auth/authenticators/FooAuthenticator.java
+            UPDATED: server-spi-private/src/main/java/org/kc/auth/FlowContext.java
+            UPDATED: services/src/main/resources/scripts/template.js
+            BUILD_AFTER_MOVE: SUCCESS
+        """.trimIndent()
+        val s = scoreMoveClass(out, required, classAtNewPath = null, classAtOldPath = null, oldFqnResidueCount = null)
+        assertFalse(s.moveDone)
+        assertFalse(s.residueClean)
+        assertNull(s.oldFqnResidueCount)
+        assertFalse(s.safe)
+    }
+
+    @Test
+    fun `markdown-formatted markers and backticked or absolute paths still parse`() {
+        // Agents love markdown and absolute in-container paths — suffix matching must cope
+        // (the exact failure mode that broke raw substring scoring in earlier experiments).
+        val out = """
+            **MOVE_DONE**: yes
+            - UPDATED: `/home/agent/project/services/src/main/java/org/kc/auth/authenticators/FooAuthenticator.java`
+            - UPDATED: `/home/agent/project/server-spi-private/src/main/java/org/kc/auth/FlowContext.java`
+            - UPDATED: `/home/agent/project/services/src/main/resources/scripts/template.js`
+            **BUILD_AFTER_MOVE**: SUCCESS
+        """.trimIndent()
+        val s = scoreMoveClass(out, required, classAtNewPath = true, classAtOldPath = false, oldFqnResidueCount = 0)
+        assertEquals(emptySet<String>(), s.missingUpdatedFiles, "backticked absolute paths must parse")
+        assertTrue(s.safe)
+    }
+
+    @Test
+    fun `UPDATED lines with trailing line numbers still count`() {
+        val out = """
+            MOVE_DONE: yes
+            UPDATED: services/src/main/java/org/kc/auth/authenticators/FooAuthenticator.java:23
+            UPDATED: server-spi-private/src/main/java/org/kc/auth/FlowContext.java:7
+            UPDATED: services/src/main/resources/scripts/template.js:1
+            BUILD_AFTER_MOVE: SUCCESS
+        """.trimIndent()
+        val s = scoreMoveClass(out, required, classAtNewPath = true, classAtOldPath = false, oldFqnResidueCount = 0)
+        assertEquals(emptySet<String>(), s.missingUpdatedFiles)
+    }
+
+    @Test
+    fun `UPDATED_COUNT line is not mistaken for an UPDATED path`() {
+        val out = """
+            MOVE_DONE: yes
+            UPDATED_COUNT: 3
+            UPDATED: services/src/main/java/org/kc/auth/authenticators/FooAuthenticator.java
+            UPDATED: server-spi-private/src/main/java/org/kc/auth/FlowContext.java
+            UPDATED: services/src/main/resources/scripts/template.js
+            BUILD_AFTER_MOVE: SUCCESS
+        """.trimIndent()
+        val s = scoreMoveClass(out, required, classAtNewPath = true, classAtOldPath = false, oldFqnResidueCount = 0)
+        assertEquals(3, s.reportedUpdatedFiles.size, "UPDATED_COUNT must not contribute a fake path")
+    }
+
+    @Test
+    fun `missing build marker yields null buildGreen and unsafe`() {
+        val out = """
+            MOVE_DONE: yes
+            UPDATED: services/src/main/java/org/kc/auth/authenticators/FooAuthenticator.java
+            UPDATED: server-spi-private/src/main/java/org/kc/auth/FlowContext.java
+            UPDATED: services/src/main/resources/scripts/template.js
+        """.trimIndent()
+        val s = scoreMoveClass(out, required, classAtNewPath = true, classAtOldPath = false, oldFqnResidueCount = 0)
+        assertNull(s.buildGreen)
+        assertTrue(s.complete)
+        assertFalse(s.safe)
+    }
+}


### PR DESCRIPTION
## What

Third experiment of the Keycloak refactoring trilogy (after rename #? and change-signature): an A/B (`claude`/`codex` × with/without MCP) where the agent must **move a class between packages** project-wide — scenario `keycloak__move_class`.

**Task**: move the enum `org.keycloak.authentication.AuthenticationFlowError` (server-spi-private module) to a new package `org.keycloak.authentication.errors` in the **same module**, update every reference, keep the project compiling, and leave **zero occurrences of the old FQN** anywhere in the tree.

## Why this class (ground truth at pinned Keycloak 26.6.4)

41 production reference sites across 2 modules, with the two traps a grep-driven manual move misses:

- **Split package, no-import usages**: `org.keycloak.authentication` exists in BOTH server-spi-private and services. 8 files (3 + 5) use the enum with **no import line at all** — a grep for the old FQN never finds them, yet each needs a **new** import after the move or compilation breaks. `MoveClassesOrPackagesProcessor` adds those imports atomically.
- **FQN string in a production resource**: `services/src/main/resources/scripts/authenticator-template.js` holds the FQN as `Java.type("org.keycloak.authentication.AuthenticationFlowError")`. A pure-source move leaves it dangling with the build still green. (Verified: **no** META-INF/services registration exists for this enum — the JS `Java.type` string is the resource-file trap here, plus a javadoc code sample in `ScriptBasedAuthenticator.java`, 4 testsuite JS scripts and one docs `.adoc` — 46 old-FQN occurrences in 45 files tree-wide.)

## Scoring (evidence-based, both legs identical)

Pure scorer `scoreMoveClass` in `SemanticTaskScoring.kt`, TDD-first (`MoveClassScoringTest`, 10 unit tests, watched red before implementing):

- (a) **class at new path / gone from old path** — measured by the HARNESS via container file-existence checks, never trusted from `MOVE_DONE: yes` (a copy-not-move scores false);
- (b) **known reference sites updated** — agent's `UPDATED: <file>` markers vs the hand-derived 41-file ground truth (markdown-normalized, suffix path matching; testsuite/docs deliberately excluded per the change-signature precedent);
- (c) **build-green claim** — `BUILD_AFTER_MOVE: SUCCESS|FAILURE` (dashboard metric);
- (d) **zero old-FQN residue** — the harness greps the whole tree in the container and reports the count; the old FQN cannot false-positive on the new one. `safe = moveDone && all sites updated && build green && residue == 0`.

Correctness is a dashboard metric, not a hard gate — both legs always emit their `[ARENA]` block via `recordSemanticRun`; with-MCP legs assert `exec_code` evidence. 80-min `@Timeout` per the `KeycloakRenameTest` precedent (edit/build-heavy baseline; TC-side 180-min cap fits two legs).

## Verification

- `./gradlew :test-experiments:compileTestKotlin :test-integration:test --tests "*MoveClassScoringTest"` — BUILD SUCCESSFUL, 10/10 tests pass.
- Ground truth derived directly from a Keycloak 26.6.4 checkout (import grep + same-package simple-name grep + non-Java FQN grep); no Docker/IDE E2E run locally — CI validates those.

## TeamCity registration expected

- `IntegrationTests_KeycloakMoveClass_Claude`
- `IntegrationTests_KeycloakMoveClass_Codex`

(test filter `*KeycloakMoveClassTest.<agent>*`, method names `claude with mcp` / `claude without mcp` / `codex with mcp` / `codex without mcp`, executionTimeoutMin=180)

🤖 Generated with [Claude Code](https://claude.com/claude-code)