### PR TITLE
Diagnostic thread+coroutine dump to the execution folder on execute_code timeout (#215)

### DIFF
--- a/ij-plugin/src/main/kotlin/com/jonnyzzz/mcpSteroid/execution/ScriptExecutor.kt
+++ b/ij-plugin/src/main/kotlin/com/jonnyzzz/mcpSteroid/execution/ScriptExecutor.kt
@@ -18,6 +18,7 @@ import com.intellij.util.concurrency.ThreadingAssertions
 import com.jonnyzzz.mcpSteroid.koltinc.LineMapping
 import com.jonnyzzz.mcpSteroid.mcp.ToolCallErrorException
 import com.intellij.diagnostic.ThreadDumper
+import java.nio.file.Path
 import com.jonnyzzz.mcpSteroid.server.ExecCodeParams
 import com.jonnyzzz.mcpSteroid.server.ModalMode
 import com.jonnyzzz.mcpSteroid.storage.ExecutionId
@@ -227,6 +228,7 @@ class ScriptExecutor(
         }
     }
 
+    @OptIn(InternalCoroutinesApi::class)
     private suspend fun executeCodeBlocks(
         exec: ExecCodeParams,
         context: McpScriptContextImpl,
@@ -234,8 +236,26 @@ class ScriptExecutor(
         executionId: ExecutionId,
         resultBuilder: ExecutionResultBuilder
     ) {
+        // Bridge between the completion handler (fires synchronously on the canceller's thread
+        // the instant the body starts cancelling — even if the body is wedged and never unwinds)
+        // and the timeout catch below (a different thread). The handler completes this exactly once;
+        // the catch reads it bounded + under NonCancellable so a racing external cancel can't strand it.
+        val dumpPath = CompletableDeferred<Path?>()
         try {
+            // withTimeout installs its own child Job; register the native-dump capture on THAT job,
+            // now that the execution folder is known. onCancelling = true makes the handler run on the
+            // Cancelling transition — before the body is torn down — so the deadlocked frames are captured.
+            // This is the same idiom the platform's coroutine<->indicator bridge uses (coroutines.kt).
             withTimeout(exec.timeout.seconds) {
+                coroutineContext.job.invokeOnCompletion(onCancelling = true) { cause ->
+                    // Fire only on the timeout (TimeoutCancellationException), not on a normal completion
+                    // or an ordinary external cancel — a deadlock is the case we want a dump for.
+                    if (cause is TimeoutCancellationException) {
+                        dumpPath.complete(TimeoutDiagnosticDump.writeBlocking(project, executionId))
+                    } else {
+                        dumpPath.complete(null)
+                    }
+                }
                 val capturedBlocks = evalResult.result
                 for ((index, block) in capturedBlocks.withIndex()) {
                     yield()
@@ -251,7 +271,16 @@ class ScriptExecutor(
             // Timeout - report as error (must be caught before CancellationException since it's a subclass)
             log.warn("Execution $executionId timed out: ${e.message}")
             resultBuilder.logRemappedException("Execution timed out", e, evalResult.lineMapping)
-            resultBuilder.reportFailed("Execution timed out after ${exec.timeout} seconds")
+            // The onCancelling handler above already captured the native dump into the execution folder;
+            // read the path it wrote (bounded, and under NonCancellable so a concurrent external cancel of
+            // the whole tool call can't strand this read) and mention ONLY the path — never the dump content.
+            val diagnosticPath = withContext(NonCancellable) {
+                withTimeoutOrNull(5.seconds) { dumpPath.await() }
+            }
+            val suffix = if (diagnosticPath != null) {
+                " Diagnostic thread + coroutine dump stored at $diagnosticPath"
+            } else ""
+            resultBuilder.reportFailed("Execution timed out after ${exec.timeout} seconds.$suffix")
         } catch (e: CancellationException) {
             throw e
         } catch (e: ProcessCanceledException) {

--- a/ij-plugin/src/main/kotlin/com/jonnyzzz/mcpSteroid/execution/TimeoutDiagnosticDump.kt
+++ b/ij-plugin/src/main/kotlin/com/jonnyzzz/mcpSteroid/execution/TimeoutDiagnosticDump.kt
@@ -1,0 +1,79 @@
+/* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
+package com.jonnyzzz.mcpSteroid.execution
+
+import com.intellij.diagnostic.COROUTINE_DUMP_HEADER
+import com.intellij.diagnostic.ThreadDumper
+import com.intellij.diagnostic.dumpCoroutines
+import com.intellij.openapi.diagnostic.Logger
+import com.intellij.openapi.project.Project
+import com.jonnyzzz.mcpSteroid.storage.ExecutionId
+import com.jonnyzzz.mcpSteroid.storage.executionStorage
+import java.nio.file.Path
+import kotlin.io.path.writeText
+
+/**
+ * Captures a native IntelliJ diagnostic dump (JVM threads + kotlinx coroutines)
+ * and stores it in the per-execution storage folder (`.idea/mcp-steroid/eid_...`).
+ *
+ * This deliberately reconstructs the *same* combined dump the platform builds in
+ * [ThreadDumper.getThreadDumpInfo] (which is `@ApiStatus.Internal` and therefore
+ * off-limits here) out of its two PUBLIC parts:
+ *
+ *  - [ThreadDumper.dumpThreadsToString] — full JVM thread dump (public, no `@ApiStatus`).
+ *  - [dumpCoroutines] with `stripDump = false` — the kotlinx coroutine dump (public,
+ *    no `@ApiStatus`); the platform installs the coroutine debug probes at IDE startup.
+ *
+ * They are concatenated with the platform's public [COROUTINE_DUMP_HEADER] so the file
+ * is byte-for-byte the format the IDE itself writes to its log dir — except it lands in
+ * the execution folder instead, satisfying the requirement that the dump live *with the
+ * execution* and that the tool result mention only its path, never its content.
+ *
+ * The capture is a plain, fast, non-suspending, non-throwing operation on purpose: it is
+ * invoked from a coroutine completion handler ([kotlinx.coroutines.Job.invokeOnCompletion])
+ * that runs synchronously on the canceller's thread the moment the execution job starts
+ * cancelling — so it observes the wedged/deadlocked frames even if the body never unwinds.
+ */
+object TimeoutDiagnosticDump {
+    const val FILE_NAME: String = "diagnostic-dump-timeout.txt"
+
+    private const val COROUTINE_DUMP_UNAVAILABLE =
+        "coroutine dump unavailable: kotlinx debug probes not installed"
+
+    private val log = Logger.getInstance(TimeoutDiagnosticDump::class.java)
+
+    /**
+     * Build the combined native dump text (threads + coroutines). Pure, non-throwing:
+     * every failure is folded into the returned string so a broken dump never masks the
+     * timeout report. Safe to call from a completion handler.
+     */
+    fun captureText(): String = buildString {
+        appendLine(ThreadDumper.dumpThreadsToString())
+        appendLine()
+        appendLine(COROUTINE_DUMP_HEADER)
+        // stripDump = false: keep the full coroutine frames — this is a suspected-deadlock
+        // diagnostic, the "useless" kotlinx internal frames are exactly what we want here.
+        val coroutines = try {
+            dumpCoroutines(stripDump = false)
+        } catch (t: Throwable) {
+            "coroutine dump failed: ${t.message}"
+        }
+        appendLine(coroutines ?: COROUTINE_DUMP_UNAVAILABLE)
+    }
+
+    /**
+     * Capture the combined dump and write it into the execution folder using a *blocking*
+     * write — intended for a completion handler, which must not suspend. Returns the path
+     * written, or `null` if capture/write failed (logged, never thrown).
+     */
+    fun writeBlocking(project: Project, executionId: ExecutionId): Path? {
+        return try {
+            val text = captureText()
+            val path = project.executionStorage.resolveExecutionPath(executionId, FILE_NAME)
+            path.writeText(text)
+            path
+        } catch (t: Throwable) {
+            log.warn("[$executionId] failed to capture timeout diagnostic dump: ${t.message}", t)
+            null
+        }
+    }
+}

--- a/ij-plugin/src/test/kotlin/com/jonnyzzz/mcpSteroid/execution/ScriptExecutorTest.kt
+++ b/ij-plugin/src/test/kotlin/com/jonnyzzz/mcpSteroid/execution/ScriptExecutorTest.kt
@@ -6,6 +6,7 @@ import com.intellij.testFramework.common.timeoutRunBlocking
 import com.intellij.testFramework.fixtures.BasePlatformTestCase
 import com.jonnyzzz.mcpSteroid.TestResultBuilder
 import com.jonnyzzz.mcpSteroid.storage.ExecutionId
+import com.jonnyzzz.mcpSteroid.storage.executionStorage
 import com.jonnyzzz.mcpSteroid.testExecParams
 import kotlin.time.Duration.Companion.seconds
 
@@ -204,6 +205,66 @@ class ScriptExecutorTest : BasePlatformTestCase() {
 
         // Should fail due to timeout (or error if engine not available)
         assertTrue("Should fail", builder.isFailed)
+    }
+
+    /**
+     * #215: when an execution times out (suspected deadlock), a native IntelliJ diagnostic
+     * dump (JVM threads + kotlinx coroutines) must be written INTO the per-execution storage
+     * folder (`.idea/mcp-steroid/eid_...`), and the tool result must mention ONLY that file's
+     * path — never any dump content.
+     *
+     * The dump is captured from a `Job.invokeOnCompletion(onCancelling = true)` handler on the
+     * `withTimeout` job, so it fires even if the body is wedged. This test wedges the body with a
+     * non-cancellable `Thread.sleep` (not `delay`) under a short timeout, mirroring the #177
+     * deadlock reproducer.
+     *
+     * Engine-tolerant per this class's convention: the file/message assertions apply only when
+     * the run actually reached the timeout path (failure message carries "Execution timed out
+     * after"); an environment without the script engine fails earlier with a different message.
+     */
+    fun testTimeoutWritesDiagnosticDumpToExecutionFolder(): Unit = timeoutRunBlocking(60.seconds) {
+        val wedgedCode = """
+            println("Starting")
+            Thread.sleep(30000) // non-interruptible; outlives the 1s timeout
+            println("Done")
+        """.trimIndent()
+
+        val executionId = nextExecutionId()
+        val builder = TestResultBuilder()
+        executor.executeWithProgress(executionId, testExecParams(wedgedCode, timeout = 1), builder)
+
+        assertTrue("Should fail (timeout or engine-missing)", builder.isFailed)
+
+        val failure = builder.failureMessage ?: ""
+        if (failure.startsWith("Execution timed out after")) {
+            val dumpFile = project.executionStorage
+                .resolveExecutionPath(executionId, TimeoutDiagnosticDump.FILE_NAME)
+            assertTrue(
+                "Diagnostic dump must be written into the execution folder: $dumpFile",
+                java.nio.file.Files.isRegularFile(dumpFile)
+            )
+
+            val dumpText = java.nio.file.Files.readString(dumpFile)
+            // The native combined dump must include both a thread dump and the coroutine section.
+            assertTrue(
+                "Dump must contain thread-dump content:\n$dumpText",
+                dumpText.contains("java.lang.Thread.State") || dumpText.contains("\" ") || dumpText.contains("at ")
+            )
+            assertTrue(
+                "Dump must contain the coroutine-dump section header:\n$dumpText",
+                dumpText.contains("Coroutine dump")
+            )
+
+            // The failure message mentions ONLY the path — no dump content leaks into the result.
+            assertTrue(
+                "Failure message must mention the dump-folder path:\n$failure",
+                failure.contains(dumpFile.toString()) || failure.contains(dumpFile.parent.toString())
+            )
+            assertFalse(
+                "Failure message must NOT contain dump content (thread/coroutine frames):\n$failure",
+                failure.contains("Coroutine dump") || failure.contains("java.lang.Thread.State")
+            )
+        }
     }
 
     /**


### PR DESCRIPTION
Fixes #215.

When a `steroid_execute_code` execution times out (suspected deadlock), the plugin writes a diagnostic dump **into the execution folder** and the tool result names **only the path** — never the dump content.

## Design (per review)

- **Location: the execution folder.** The dump lands in `.idea/mcp-steroid/eid_.../diagnostic-dump-timeout.txt`, alongside the execution's other artifacts (not the IDE log dir), via `executionStorage`.
- **Native dump incl. coroutines, from public parts.** Content = `ThreadDumper.dumpThreadsToString()` (threads) + the platform's `COROUTINE_DUMP_HEADER` + `dumpCoroutines(stripDump = false)` (coroutines) — all public. This is exactly what the platform's own combined-dump builder (`ThreadDumper.getThreadDumpInfo`, which is `@ApiStatus.Internal` and off-limits) produces, without the internal dependency or the log-dir coupling of `PerformanceWatcher.dumpThreads`.
- **Captured before/independent of the catch.** A completion handler on the timeout coroutine's own `Job` (`invokeOnCompletion(onCancelling = true)`, the platform's pattern) fires synchronously the instant the deadline moves the Job to *Cancelling* — on the canceller's thread, before the wedged body unwinds and even if the `catch` never runs. The handler writes the dump and completes a `CompletableDeferred<Path?>`; the timeout catch reads it bounded + under `NonCancellable` and reports the path. No capture in the catch, no watchdog scope, no `runCatching`.

## Tests

`testTimeoutWritesDiagnosticDumpToExecutionFolder` (engine-tolerant): a timed-out execution writes the dump file into the execution folder with both thread and coroutine content, and the failure message contains the folder path and **no** dump content. Full `:ij-plugin:test` green.
