### PR TITLE
Keycloak compile-error triage time-to-green A/B (keycloak__compile_triage)

### DIFF
--- a/test-experiments/src/test/kotlin/com/jonnyzzz/mcpSteroid/integration/tests/KeycloakCompileTriageTest.kt
+++ b/test-experiments/src/test/kotlin/com/jonnyzzz/mcpSteroid/integration/tests/KeycloakCompileTriageTest.kt
@@ -1,0 +1,277 @@
+/* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
+package com.jonnyzzz.mcpSteroid.integration.tests
+
+import com.jonnyzzz.mcpSteroid.integration.infra.AiMode
+import com.jonnyzzz.mcpSteroid.integration.infra.BuildSystem
+import com.jonnyzzz.mcpSteroid.integration.infra.IntelliJContainer
+import com.jonnyzzz.mcpSteroid.integration.infra.IntelliJContainerOpts
+import com.jonnyzzz.mcpSteroid.integration.infra.IntelliJProject
+import com.jonnyzzz.mcpSteroid.integration.infra.McpConnectionMode
+import com.jonnyzzz.mcpSteroid.integration.infra.create
+import com.jonnyzzz.mcpSteroid.integration.infra.waitForProjectReady
+import com.jonnyzzz.mcpSteroid.testHelper.AiAgentSession
+import com.jonnyzzz.mcpSteroid.testHelper.CloseableStackHost
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Timeout
+import java.util.concurrent.TimeUnit
+
+/**
+ * MCP-win experiment: **compile-error triage, time-to-green** (jonnyzzz/mcp-steroid#169 follow-up) —
+ * the pure-efficiency story. A patch applied at IDE start (before the agent runs) seeds exactly
+ * [SEEDED_SITES.size][SEEDED_SITES] deterministic single-line compile errors across TWO modules of the
+ * pinned Keycloak 26.6.4 tree (server-spi-private + services). The agent's task: make the project
+ * compile again, verified by the bounded build `mvn -q -DskipTests -pl server-spi-private,services -am
+ * compile`.
+ *
+ * Every seeded error needs TYPE knowledge, not pattern matching (see [SEEDED_ERRORS_PATCH]):
+ *  1. `JsonUtils:152` — `List<Integer>` local for `splitClaimPath(...)`, which returns `List<String>`
+ *     and feeds `getJsonValue(node, List<String>)` (wrong generic parameter).
+ *  2. `CredentialHelper:77` — return type narrowed to `AuthenticatorFactory`; the body's three casts
+ *     (Authenticator/FormAction/ClientAuthenticator factories) only share the declared supertype
+ *     `ConfigurableAuthenticatorFactory` (incompatible return type; a cast "fix" at the return
+ *     statement compiles but is wrong — the scorer only accepts the declaration site).
+ *  3. `DenyAccessAuthenticator:62` — `Boolean requiresUser()`; primitives have no covariant boxing, so
+ *     it cannot implement `boolean requiresUser()` from the `Authenticator` SPI in the OTHER module.
+ *  4. `ResetOTP:140` — `session.getProvider("keycloak-otp", CredentialProvider.class)`: the
+ *     `KeycloakSession` overloads are `(Class)`, `(Class, String)`, `(Class, ComponentModel)` — the
+ *     called overload does not exist; the arguments must be swapped back.
+ *  5. `ConditionalUserAttributeValue:39` — `Map<String, Object>` for `getConfig()`, which returns
+ *     `Map<String, String>` whose values feed `String` locals and `Boolean.parseBoolean` (wrong
+ *     generic parameter).
+ *
+ * The asymmetry under test: with MCP the IDE's red-code analysis lists every error in ALL modules at
+ * once, with resolved types on both sides of each mismatch. Without MCP the agent pays a multi-minute
+ * Maven cycle per iteration — and Maven stops at the first failing module, so the services errors are
+ * INVISIBLE until server-spi-private is fixed and rebuilt. Correctness should converge; the dashboard
+ * metric that separates the legs is agent time and tool-call/token effort.
+ *
+ * Verdict ([scoreCompileTriage]): every seeded site fixed (evidence-based `FIXED: <file>:<line>`
+ * markers matched against the seeded lines, spam-guarded) AND the bounded build reported SUCCESS —
+ * emitted as an `[ARENA]` block. A/B per agent; with-MCP asserts exec_code; correctness is a dashboard
+ * metric, not a hard gate.
+ */
+class KeycloakCompileTriageTest {
+
+    // 80 min, following the KeycloakRenameTest precedent: the without-MCP baseline is build-heavy — it
+    // legitimately needs several full `mvn -pl server-spi-private,services -am compile` cycles (each a
+    // multi-minute reactor run over ~15 modules) because Maven reveals the seeded errors module by
+    // module (rename's baseline measured 30.3 min agent time on CI build 991971402, and container
+    // start + Keycloak import + verification pushed the method past 50). The slow baseline IS the
+    // experiment's finding — it must complete and emit its [ARENA] block so the dashboard can show the
+    // gap, not die as a timeout with no data. TC-side executionTimeoutMin=180 fits two 80-min methods.
+
+    @Test @Timeout(value = 80, unit = TimeUnit.MINUTES)
+    fun `claude with mcp`() = run("claude", withMcp = true)
+
+    @Test @Timeout(value = 80, unit = TimeUnit.MINUTES)
+    fun `claude without mcp`() = run("claude", withMcp = false)
+
+    @Test @Timeout(value = 80, unit = TimeUnit.MINUTES)
+    fun `codex with mcp`() = run("codex", withMcp = true)
+
+    @Test @Timeout(value = 80, unit = TimeUnit.MINUTES)
+    fun `codex without mcp`() = run("codex", withMcp = false)
+
+    private fun run(agentName: String, withMcp: Boolean) {
+        val modeLabel = if (withMcp) "mcp" else "none"
+        val lifetime = CloseableStackHost()
+        try {
+            val session = IntelliJContainer.create(lifetime, IntelliJContainerOpts(
+                consoleTitle = "keycloak-compiletriage-$agentName-$modeLabel",
+                project = IntelliJProject.ProjectFromGitCommitAndPatch(
+                    cloneUrl = "https://github.com/keycloak/keycloak.git",
+                    repoOwnerAndName = "keycloak/keycloak",
+                    // The commit of the pinned 26.6.4 release tag — the same revision KeycloakProject
+                    // checks out. SEEDED_ERRORS_PATCH and SEEDED_SITES are derived at exactly this
+                    // commit; when bumping it, re-verify the patch applies and re-derive the lines.
+                    baseCommit = "dc1bfc54bf1462f7e79822adb4c59aba7e25d50f",
+                    testPatch = SEEDED_ERRORS_PATCH,
+                    displayName = "keycloak-compile-triage",
+                ),
+                aiMode = if (withMcp) AiMode.AI_MCP else AiMode.NONE,
+                mcpConnectionMode = if (withMcp) null else McpConnectionMode.None,
+            )).waitForProjectReady(buildSystem = BuildSystem.MAVEN)
+
+            val agent: AiAgentSession = when (agentName) {
+                "claude" -> session.aiAgents.claude
+                "codex" -> session.aiAgents.codex
+                else -> error("Unknown agent: $agentName")
+            }
+
+            val startedAt = System.currentTimeMillis()
+            val result = agent.runPrompt(if (withMcp) withMcpPrompt() else baselinePrompt(), timeoutSeconds = 2400)
+                .awaitForProcessFinish()
+            val agentDurationMs = System.currentTimeMillis() - startedAt
+            val combined = result.stdout + "\n" + result.stderr
+
+            val score = scoreCompileTriage(combined, SEEDED_SITES)
+            println("[TEST] keycloak compile-triage [$agentName+$modeLabel] safe=${score.safe} " +
+                    "matched=${score.matchedCount}/${SEEDED_SITES.values.sumOf { it.size }} " +
+                    "reported=${score.reportedCount} buildGreen=${score.buildGreen}")
+            if (score.missingSites.isNotEmpty()) {
+                println("[TEST]   missed seeded sites: ${score.missingSites}")
+            }
+
+            recordSemanticRun(
+                scenario = SCENARIO,
+                agentName = agentName,
+                withMcp = withMcp,
+                claimedFix = score.safe,
+                rawOutput = result.rawStdout,
+                exitCode = result.exitCode,
+                agentDurationMs = agentDurationMs,
+                runDir = session.runDirInContainer,
+                summary = "fixed=${score.matchedCount}/${SEEDED_SITES.values.sumOf { it.size }} " +
+                        "reported=${score.reportedCount} buildGreen=${score.buildGreen}",
+            )
+
+            if (withMcp) assertUsedExecuteCodeEvidence(combined)
+        } finally {
+            lifetime.closeAllStacks()
+        }
+    }
+
+    private fun taskDescription(): String = buildString {
+        appendLine("Task: the working tree does not compile — an interrupted refactoring changed a handful of")
+        appendLine("single lines across the `server-spi-private` and `services` modules. Make the project")
+        appendLine("compile again.")
+        appendLine()
+        appendLine("Rules:")
+        appendLine("- Find EVERY compile error and fix each one at its root cause with the minimal correct")
+        appendLine("  change — restore the intended type / signature / arguments on the broken line.")
+        appendLine("- Do NOT paper over an error with a cast or @SuppressWarnings, and do NOT \"fix\" callers or")
+        appendLine("  interfaces that were already correct.")
+        appendLine("- Verify with the bounded build from the project root:")
+        appendLine("  `mvn -q -DskipTests -pl server-spi-private,services -am compile`")
+    }
+
+    private fun outputMarkers(): String = buildString {
+        appendLine("Output (markers on their own lines):")
+        appendLine("ERRORS_FOUND: <total count of distinct compile errors you found>")
+        appendLine("FIXED: <path>:<line> — <what was wrong and the correct type>   ← one line per source line")
+        appendLine("  you changed; <line> is the line number YOU EDITED in that file")
+        appendLine("BUILD_AFTER_FIX: <SUCCESS or FAILURE>")
+    }
+
+    private fun withMcpPrompt(): String = buildString {
+        appendLine("The Keycloak project is open in IntelliJ IDEA — a large multi-module Java project.")
+        appendLine()
+        append(taskDescription())
+        appendLine()
+        appendLine("Use IntelliJ's project-wide error analysis via `steroid_execute_code`: the IDE sees every")
+        appendLine("compile error in ALL modules at once with both sides of each type mismatch resolved — e.g.")
+        appendLine("compile the project with `com.intellij.openapi.compiler.CompilerManager` and collect the")
+        appendLine("ERROR messages, or collect error-level daemon highlighting for the affected modules. Then")
+        appendLine("fix the broken lines. A Maven run stops at the first failing MODULE, so it cannot show you")
+        appendLine("the full error list in one pass — the IDE can.")
+        appendLine()
+        append(outputMarkers())
+        appendLine("TOOL_EVIDENCE: <copy the line starting with execution_id: ...>")
+    }
+
+    private fun baselinePrompt(): String = buildString {
+        appendLine("The Keycloak project is checked out (a large multi-module Java project).")
+        appendLine("IntelliJ MCP tools are unavailable in this run — use shell commands only.")
+        appendLine()
+        append(taskDescription())
+        appendLine()
+        appendLine("Beware: Maven stops at the first failing module, so a single build run does NOT reveal the")
+        appendLine("errors in downstream modules — keep iterating until the bounded build is green.")
+        appendLine()
+        append(outputMarkers())
+    }
+
+    companion object {
+        private const val SCENARIO = "keycloak__compile_triage"
+
+        /**
+         * Ground truth: the exact lines the seeded patch changed (file simple name → line). The agent
+         * must fix each error AT this site; javac may point elsewhere (e.g. the CredentialHelper error
+         * is reported at the `return factory;` statement on line 85, and the JsonUtils declaration
+         * error cascades to the call on 157), but the one clearly-correct single-line repair is always
+         * the seeded line itself.
+         */
+        private val SEEDED_SITES = mapOf(
+            "JsonUtils.java" to setOf(152),                     // server-spi-private: wrong generic parameter
+            "CredentialHelper.java" to setOf(77),               // server-spi-private: incompatible return type
+            "DenyAccessAuthenticator.java" to setOf(62),        // services: boxed return vs SPI's primitive
+            "ResetOTP.java" to setOf(140),                      // services: call to a non-existent overload
+            "ConditionalUserAttributeValue.java" to setOf(39),  // services: wrong generic parameter
+        )
+
+        /**
+         * The seeded breakage, applied by [IntelliJProject.ProjectFromGitCommitAndPatch] on top of the
+         * 26.6.4 commit before the IDE starts. Five single-line, plausible-looking refactoring leftovers.
+         * Verified against the real tree: `git apply --check` passes on dc1bfc54, the patched tree fails
+         * `mvn -DskipTests -pl server-spi-private,services -am compile` with exactly the errors described
+         * in the class KDoc, and the unpatched tree builds green with the same command.
+         */
+        private val SEEDED_ERRORS_PATCH = """
+            |diff --git a/server-spi-private/src/main/java/org/keycloak/utils/CredentialHelper.java b/server-spi-private/src/main/java/org/keycloak/utils/CredentialHelper.java
+            |index 65fa48d..027858f 100755
+            |--- a/server-spi-private/src/main/java/org/keycloak/utils/CredentialHelper.java
+            |+++ b/server-spi-private/src/main/java/org/keycloak/utils/CredentialHelper.java
+            |@@ -74,7 +74,7 @@ public class CredentialHelper {
+            |                 }));
+            |     }
+            |
+            |-    public static ConfigurableAuthenticatorFactory getConfigurableAuthenticatorFactory(KeycloakSession session, String providerId) {
+            |+    public static AuthenticatorFactory getConfigurableAuthenticatorFactory(KeycloakSession session, String providerId) {
+            |         ConfigurableAuthenticatorFactory factory = (AuthenticatorFactory)session.getKeycloakSessionFactory().getProviderFactory(Authenticator.class, providerId);
+            |         if (factory == null) {
+            |             factory = (FormActionFactory)session.getKeycloakSessionFactory().getProviderFactory(FormAction.class, providerId);
+            |diff --git a/server-spi-private/src/main/java/org/keycloak/utils/JsonUtils.java b/server-spi-private/src/main/java/org/keycloak/utils/JsonUtils.java
+            |index 3a809bf..72e7b88 100644
+            |--- a/server-spi-private/src/main/java/org/keycloak/utils/JsonUtils.java
+            |+++ b/server-spi-private/src/main/java/org/keycloak/utils/JsonUtils.java
+            |@@ -149,7 +149,7 @@ public class JsonUtils {
+            |      */
+            |     public static Object getJsonValue(JsonNode node, String claim) {
+            |         if (node != null && claim != null) {
+            |-            List<String> paths = splitClaimPath(claim);
+            |+            List<Integer> paths = splitClaimPath(claim);
+            |             if (paths.isEmpty() || claim.endsWith(".")) {
+            |                 return null;
+            |             }
+            |diff --git a/services/src/main/java/org/keycloak/authentication/authenticators/access/DenyAccessAuthenticator.java b/services/src/main/java/org/keycloak/authentication/authenticators/access/DenyAccessAuthenticator.java
+            |index 367add4..ce34f8b 100644
+            |--- a/services/src/main/java/org/keycloak/authentication/authenticators/access/DenyAccessAuthenticator.java
+            |+++ b/services/src/main/java/org/keycloak/authentication/authenticators/access/DenyAccessAuthenticator.java
+            |@@ -59,7 +59,7 @@ public class DenyAccessAuthenticator implements Authenticator {
+            |     }
+            |
+            |     @Override
+            |-    public boolean requiresUser() {
+            |+    public Boolean requiresUser() {
+            |         return false;
+            |     }
+            |
+            |diff --git a/services/src/main/java/org/keycloak/authentication/authenticators/conditional/ConditionalUserAttributeValue.java b/services/src/main/java/org/keycloak/authentication/authenticators/conditional/ConditionalUserAttributeValue.java
+            |index a9467d4..937639f 100644
+            |--- a/services/src/main/java/org/keycloak/authentication/authenticators/conditional/ConditionalUserAttributeValue.java
+            |+++ b/services/src/main/java/org/keycloak/authentication/authenticators/conditional/ConditionalUserAttributeValue.java
+            |@@ -36,7 +36,7 @@ public class ConditionalUserAttributeValue implements ConditionalAuthenticator {
+            |     @Override
+            |     public boolean matchCondition(AuthenticationFlowContext context) {
+            |         // Retrieve configuration
+            |-        Map<String, String> config = context.getAuthenticatorConfig().getConfig();
+            |+        Map<String, Object> config = context.getAuthenticatorConfig().getConfig();
+            |         String attributeName = config.get(ConditionalUserAttributeValueFactory.CONF_ATTRIBUTE_NAME);
+            |         String attributeValue = config.get(ConditionalUserAttributeValueFactory.CONF_ATTRIBUTE_EXPECTED_VALUE);
+            |         boolean includeGroupAttributes = Boolean.parseBoolean(config.get(ConditionalUserAttributeValueFactory.CONF_INCLUDE_GROUP_ATTRIBUTES));
+            |diff --git a/services/src/main/java/org/keycloak/authentication/authenticators/resetcred/ResetOTP.java b/services/src/main/java/org/keycloak/authentication/authenticators/resetcred/ResetOTP.java
+            |index 41d315f..b0a7439 100755
+            |--- a/services/src/main/java/org/keycloak/authentication/authenticators/resetcred/ResetOTP.java
+            |+++ b/services/src/main/java/org/keycloak/authentication/authenticators/resetcred/ResetOTP.java
+            |@@ -137,7 +137,7 @@ public class ResetOTP extends AbstractSetRequiredActionAuthenticator implements
+            |
+            |     @Override
+            |     public OTPCredentialProvider getCredentialProvider(KeycloakSession session) {
+            |-        return (OTPCredentialProvider)session.getProvider(CredentialProvider.class, "keycloak-otp");
+            |+        return (OTPCredentialProvider)session.getProvider("keycloak-otp", CredentialProvider.class);
+            |     }
+            |
+            |     @Override
+            |""".trimMargin()
+    }
+}

--- a/test-integration/src/main/kotlin/com/jonnyzzz/mcpSteroid/integration/tests/SemanticTaskScoring.kt
+++ b/test-integration/src/main/kotlin/com/jonnyzzz/mcpSteroid/integration/tests/SemanticTaskScoring.kt
@@ -300,6 +300,107 @@ fun scoreInspections(output: String, expected: Map<String, Set<Int>>, minMatches
     )
 }
 
+data class CompileTriageScore(
+    /** The agent's self-reported `ERRORS_FOUND:` count (informational only — never trusted for the verdict). */
+    val errorsFound: Int?,
+    /** `file simple name → line numbers` parsed from the agent's `FIXED: <path>:<line>` markers. */
+    val reportedFixes: Map<String, Set<Int>>,
+    /** Total number of reported `file:line` fix pairs. */
+    val reportedCount: Int,
+    /** Seeded `file:line` sites the agent actually fixed (±1 line tolerance, each consumed once). */
+    val matchedSites: Map<String, Set<Int>>,
+    val matchedCount: Int,
+    /** Seeded sites the agent did NOT report fixing. */
+    val missingSites: Map<String, Set<Int>>,
+    /** The post-fix bounded-build result the agent reported (null if it never reported one). */
+    val buildGreen: Boolean?,
+    /** Every seeded site was fixed (regardless of build state / spam). */
+    val allSitesFixed: Boolean,
+    /** All seeded sites fixed AND build green AND no shotgun spam — the full win. */
+    val safe: Boolean,
+)
+
+/**
+ * Score a COMPILE-ERROR TRIAGE (time-to-green) run against the KNOWN seeded breakage: a patch applied
+ * at IDE start plants deterministic single-line compile errors across modules, and the agent must make
+ * the project compile again. With MCP the IDE's red-code analysis lists every error with resolved
+ * types instantly (all modules at once); without MCP the agent pays a multi-minute `mvn` cycle per
+ * iteration — and Maven stops at the first failing module, hiding the downstream errors entirely.
+ *
+ * The verdict is evidence-based, NOT self-report-based (the lesson from [scoreInspections], CI builds
+ * 991971406/991971408, where a hallucinated count won):
+ *  - each reported `FIXED: <path>:<line>` is matched against [seededSites] by file simple name and
+ *    line (±1 tolerance; each seeded line consumes at most one reported line and vice versa) — the
+ *    agent must fix each error AT ITS SEEDED SITE, so papering over a symptom elsewhere (e.g. a cast
+ *    at the error line instead of restoring the declaration) does not count;
+ *  - `safe` additionally requires the reported bounded build to be SUCCESS and at most
+ *    `3 × |seeded|` total FIXED lines — carpet-editing the tree cannot win by luck.
+ *
+ * Expected markers (scored identically for both modes):
+ *   ERRORS_FOUND: <count>
+ *   FIXED: <path>:<line> — <what was wrong and the correct type>
+ *   BUILD_AFTER_FIX: SUCCESS | FAILURE
+ *
+ * @param seededSites ground truth: file simple name → the line numbers of the seeded edits.
+ */
+fun scoreCompileTriage(output: String, seededSites: Map<String, Set<Int>>): CompileTriageScore {
+    // Strip markdown code/bold marks so `path.java:112` and **path.java:112** parse the same.
+    // Underscores are NOT stripped — they are significant in marker names (ERRORS_FOUND) and paths.
+    val text = output.replace(Regex("[`*]"), "")
+    val count = findMarkerValue(text, "ERRORS_FOUND", "Errors found")
+        ?.let { Regex("""\d+""").find(it)?.value?.toIntOrNull() }
+
+    // Every `FIXED:` marker line contributes one (file simple name, line) pair. The file-name
+    // pattern has no `/`, so it naturally captures the last path segment.
+    val reported = mutableMapOf<String, MutableList<Int>>()
+    Regex("""(?im)^\s*[-•>#\s]*FIXED\s*:\s*(.+)$""").findAll(text).forEach { fix ->
+        val m = Regex("""([\w$.-]+\.java)\s*:\s*(\d+)""").find(fix.groupValues[1]) ?: return@forEach
+        reported.getOrPut(m.groupValues[1]) { mutableListOf() }.add(m.groupValues[2].toInt())
+    }
+    val reportedCount = reported.values.sumOf { it.size }
+
+    // Greedy bipartite match per file: exact line first, then ±1; each reported line consumed once.
+    val matched = mutableMapOf<String, MutableSet<Int>>()
+    for ((file, seededLines) in seededSites) {
+        val available = reported[file]?.toMutableList() ?: continue
+        for (tolerance in 0..1) {
+            for (seededLine in seededLines.sorted()) {
+                if (seededLine in (matched[file] ?: emptySet<Int>())) continue
+                val hit = available.firstOrNull { kotlin.math.abs(it - seededLine) <= tolerance } ?: continue
+                available.remove(hit)
+                matched.getOrPut(file) { mutableSetOf() }.add(seededLine)
+            }
+        }
+    }
+    val matchedCount = matched.values.sumOf { it.size }
+    val seededCount = seededSites.values.sumOf { it.size }
+    val missing = seededSites
+        .mapValues { (file, lines) -> lines - (matched[file] ?: emptySet()) }
+        .filterValues { it.isNotEmpty() }
+
+    val build = findMarkerValue(text, "BUILD_AFTER_FIX", "Build after fix")
+    val buildGreen = build?.let {
+        when {
+            it.contains("SUCCESS", ignoreCase = true) || it.equals("pass", ignoreCase = true) || it.equals("green", ignoreCase = true) -> true
+            it.contains("FAIL", ignoreCase = true) || it.contains("error", ignoreCase = true) || it.contains("broke", ignoreCase = true) -> false
+            else -> null
+        }
+    }
+
+    val allSitesFixed = matchedCount == seededCount
+    return CompileTriageScore(
+        errorsFound = count,
+        reportedFixes = reported.mapValues { it.value.toSet() },
+        reportedCount = reportedCount,
+        matchedSites = matched.mapValues { it.value.toSet() },
+        matchedCount = matchedCount,
+        missingSites = missing,
+        buildGreen = buildGreen,
+        allSitesFixed = allSitesFixed,
+        safe = allSitesFixed && buildGreen == true && reportedCount <= 3 * seededCount,
+    )
+}
+
 data class SsrOptionalGetScore(
     /** The OPTIONAL_GET_MATCHES total the agent reported (null if it never reported one). */
     val reportedCount: Int?,

--- a/test-integration/src/test/kotlin/com/jonnyzzz/mcpSteroid/integration/tests/CompileTriageScoringTest.kt
+++ b/test-integration/src/test/kotlin/com/jonnyzzz/mcpSteroid/integration/tests/CompileTriageScoringTest.kt
@@ -1,0 +1,238 @@
+/* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
+package com.jonnyzzz.mcpSteroid.integration.tests
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * TDD unit tests for [scoreCompileTriage] — the verdict for the Keycloak compile-error triage A/B
+ * (jonnyzzz/mcp-steroid#169 follow-up, time-to-green experiment).
+ *
+ * The scenario seeds 5 deterministic single-line compile errors across server-spi-private + services
+ * via a patch applied at IDE start. The scorer is evidence-based (the lesson from the inspections
+ * scorer, CI builds 991971406/991971408, where a hallucinated self-report won): each reported
+ * `FIXED: <path>:<line>` is matched against the SEEDED sites by file simple name and line (±1),
+ * with a spam guard, and the verdict additionally requires the agent-reported bounded build to be
+ * green. Both legs (with/without MCP) are scored identically.
+ */
+class CompileTriageScoringTest {
+
+    /** The real seeded sites of the Keycloak scenario (file simple name → line of the seeded edit). */
+    private val seeded = mapOf(
+        "JsonUtils.java" to setOf(152),
+        "CredentialHelper.java" to setOf(77),
+        "DenyAccessAuthenticator.java" to setOf(62),
+        "ResetOTP.java" to setOf(140),
+        "ConditionalUserAttributeValue.java" to setOf(39),
+    )
+
+    @Test
+    fun `all five sites fixed and build green scores safe`() {
+        val output = """
+            ERRORS_FOUND: 5
+            FIXED: server-spi-private/src/main/java/org/keycloak/utils/JsonUtils.java:152 — List<Integer> should be List<String> (splitClaimPath returns List<String>)
+            FIXED: server-spi-private/src/main/java/org/keycloak/utils/CredentialHelper.java:77 — return type must be ConfigurableAuthenticatorFactory, the common supertype of all three factory casts
+            FIXED: services/src/main/java/org/keycloak/authentication/authenticators/access/DenyAccessAuthenticator.java:62 — Boolean is not a covariant return for boolean requiresUser()
+            FIXED: services/src/main/java/org/keycloak/authentication/authenticators/resetcred/ResetOTP.java:140 — getProvider has no (String, Class) overload; arguments were swapped
+            FIXED: services/src/main/java/org/keycloak/authentication/authenticators/conditional/ConditionalUserAttributeValue.java:39 — getConfig() returns Map<String, String>
+            BUILD_AFTER_FIX: SUCCESS
+            TOOL_EVIDENCE: execution_id: eid_x
+        """.trimIndent()
+        val s = scoreCompileTriage(output, seeded)
+        assertEquals(5, s.errorsFound)
+        assertEquals(5, s.reportedCount)
+        assertEquals(5, s.matchedCount)
+        assertTrue(s.missingSites.isEmpty())
+        assertEquals(true, s.buildGreen)
+        assertTrue(s.allSitesFixed)
+        assertTrue(s.safe)
+    }
+
+    @Test
+    fun `fixing only the first module's errors is incomplete and unsafe`() {
+        // The classic baseline trap: Maven stops at the first failing module (server-spi-private),
+        // so a shell agent that does not re-iterate never even SEES the services errors.
+        val output = """
+            ERRORS_FOUND: 2
+            FIXED: server-spi-private/src/main/java/org/keycloak/utils/JsonUtils.java:152 — wrong generic parameter
+            FIXED: server-spi-private/src/main/java/org/keycloak/utils/CredentialHelper.java:77 — wrong return type
+            BUILD_AFTER_FIX: FAILURE
+        """.trimIndent()
+        val s = scoreCompileTriage(output, seeded)
+        assertEquals(2, s.matchedCount)
+        assertEquals(
+            setOf("DenyAccessAuthenticator.java", "ResetOTP.java", "ConditionalUserAttributeValue.java"),
+            s.missingSites.keys,
+        )
+        assertEquals(false, s.buildGreen)
+        assertFalse(s.allSitesFixed)
+        assertFalse(s.safe)
+    }
+
+    @Test
+    fun `all sites fixed but red build is complete yet not safe`() {
+        val output = """
+            FIXED: JsonUtils.java:152 — a
+            FIXED: CredentialHelper.java:77 — b
+            FIXED: DenyAccessAuthenticator.java:62 — c
+            FIXED: ResetOTP.java:140 — d
+            FIXED: ConditionalUserAttributeValue.java:39 — e
+            BUILD_AFTER_FIX: FAILURE — services still does not compile
+        """.trimIndent()
+        val s = scoreCompileTriage(output, seeded)
+        assertTrue(s.allSitesFixed)
+        assertEquals(false, s.buildGreen)
+        assertFalse(s.safe)
+    }
+
+    @Test
+    fun `off-by-one line numbers still match`() {
+        // javac reports the CredentialHelper error at the return statement (85) but the fix is the
+        // declaration (77) — that stays a miss; genuine ±1 drift (e.g. 151 vs 152) is tolerated.
+        val output = """
+            FIXED: JsonUtils.java:151 — wrong generic
+            FIXED: CredentialHelper.java:78 — wrong return type
+            FIXED: DenyAccessAuthenticator.java:63 — boxed return
+            FIXED: ResetOTP.java:139 — swapped args
+            FIXED: ConditionalUserAttributeValue.java:40 — wrong map value type
+            BUILD_AFTER_FIX: SUCCESS
+        """.trimIndent()
+        val s = scoreCompileTriage(output, seeded)
+        assertEquals(5, s.matchedCount)
+        assertTrue(s.safe)
+    }
+
+    @Test
+    fun `patching over the symptom at a different line does not count as the seeded fix`() {
+        // A cast at the return statement (line 85) makes CredentialHelper compile but is the wrong
+        // repair (ClassCastException at runtime for FormAction/ClientAuthenticator factories) — it
+        // is far from the seeded declaration line 77 and must not match.
+        val output = """
+            FIXED: CredentialHelper.java:85 — added a cast to AuthenticatorFactory
+            FIXED: JsonUtils.java:152 — restored List<String>
+            FIXED: DenyAccessAuthenticator.java:62 — boolean
+            FIXED: ResetOTP.java:140 — argument order
+            FIXED: ConditionalUserAttributeValue.java:39 — Map<String, String>
+            BUILD_AFTER_FIX: SUCCESS
+        """.trimIndent()
+        val s = scoreCompileTriage(output, seeded)
+        assertEquals(4, s.matchedCount)
+        assertEquals(setOf("CredentialHelper.java"), s.missingSites.keys)
+        assertFalse(s.allSitesFixed)
+        assertFalse(s.safe)
+    }
+
+    @Test
+    fun `markdown-formatted FIXED lines are parsed (backticks, bold, bullets)`() {
+        // Agents love markdown — normalize before parsing (the exact failure mode that broke raw
+        // substring scorers before, see scoreSortedByDescendingRootCause).
+        val output = """
+            **ERRORS_FOUND:** 5
+            - FIXED: `server-spi-private/src/main/java/org/keycloak/utils/JsonUtils.java:152` — *wrong generic*
+            - **FIXED**: **CredentialHelper.java:77** — wrong return type
+            - FIXED: `DenyAccessAuthenticator.java:62`
+            - FIXED: `ResetOTP.java:140` — swapped arguments
+            - FIXED: `ConditionalUserAttributeValue.java:39` — value type
+            **BUILD_AFTER_FIX**: SUCCESS
+        """.trimIndent()
+        val s = scoreCompileTriage(output, seeded)
+        assertEquals(5, s.errorsFound)
+        assertEquals(5, s.matchedCount)
+        assertTrue(s.safe)
+    }
+
+    @Test
+    fun `hallucinated fixes in the wrong files never match`() {
+        val output = """
+            ERRORS_FOUND: 5
+            FIXED: AuthenticationManagementResource.java:729 — fixed factory type
+            FIXED: AbstractClaimMapper.java:54 — fixed claim split
+            FIXED: TotpLoginBean.java:54 — fixed provider lookup
+            FIXED: OTPFormAuthenticator.java:170 — fixed provider lookup
+            FIXED: ConditionalUserConfiguredAuthenticator.java:39 — fixed config map
+            BUILD_AFTER_FIX: SUCCESS
+        """.trimIndent()
+        val s = scoreCompileTriage(output, seeded)
+        assertEquals(0, s.matchedCount)
+        assertFalse(s.allSitesFixed)
+        assertFalse(s.safe)
+    }
+
+    @Test
+    fun `shotgunning edits across the tree is rejected by the spam guard`() {
+        // Even if the five true sites appear among dozens of claimed "fixes", an agent that carpet
+        // edits cannot win: more than 3x the seeded count of FIXED lines fails the verdict.
+        val output = buildString {
+            appendLine("ERRORS_FOUND: 20")
+            appendLine("FIXED: JsonUtils.java:152 — a")
+            appendLine("FIXED: CredentialHelper.java:77 — b")
+            appendLine("FIXED: DenyAccessAuthenticator.java:62 — c")
+            appendLine("FIXED: ResetOTP.java:140 — d")
+            appendLine("FIXED: ConditionalUserAttributeValue.java:39 — e")
+            for (line in 1..16) appendLine("FIXED: SomeOtherFile.java:${line * 11} — speculative edit")
+            appendLine("BUILD_AFTER_FIX: SUCCESS")
+        }
+        val s = scoreCompileTriage(output, seeded)
+        assertEquals(5, s.matchedCount)
+        assertEquals(21, s.reportedCount)
+        assertTrue(s.allSitesFixed)
+        assertFalse(s.safe)
+    }
+
+    @Test
+    fun `missing build marker yields null buildGreen and unsafe`() {
+        val output = """
+            FIXED: JsonUtils.java:152 — a
+            FIXED: CredentialHelper.java:77 — b
+            FIXED: DenyAccessAuthenticator.java:62 — c
+            FIXED: ResetOTP.java:140 — d
+            FIXED: ConditionalUserAttributeValue.java:39 — e
+        """.trimIndent()
+        val s = scoreCompileTriage(output, seeded)
+        assertNull(s.buildGreen)
+        assertTrue(s.allSitesFixed)
+        assertFalse(s.safe)
+    }
+
+    @Test
+    fun `absolute in-container paths still match by file simple name`() {
+        val output = """
+            FIXED: /home/agent/project/server-spi-private/src/main/java/org/keycloak/utils/JsonUtils.java:152 — a
+            FIXED: /home/agent/project/server-spi-private/src/main/java/org/keycloak/utils/CredentialHelper.java:77 — b
+            FIXED: /home/agent/project/services/src/main/java/org/keycloak/authentication/authenticators/access/DenyAccessAuthenticator.java:62 — c
+            FIXED: /home/agent/project/services/src/main/java/org/keycloak/authentication/authenticators/resetcred/ResetOTP.java:140 — d
+            FIXED: /home/agent/project/services/src/main/java/org/keycloak/authentication/authenticators/conditional/ConditionalUserAttributeValue.java:39 — e
+            BUILD_AFTER_FIX: SUCCESS
+        """.trimIndent()
+        val s = scoreCompileTriage(output, seeded)
+        assertEquals(5, s.matchedCount)
+        assertTrue(s.safe)
+    }
+
+    @Test
+    fun `each reported line is consumed by at most one seeded site`() {
+        val s = scoreCompileTriage(
+            """
+                FIXED: F.java:113 — x
+                BUILD_AFTER_FIX: SUCCESS
+            """.trimIndent(),
+            mapOf("F.java" to setOf(112, 114)),
+        )
+        assertEquals(1, s.matchedCount)
+        assertFalse(s.allSitesFixed)
+    }
+
+    @Test
+    fun `empty answer parses cleanly and is unsafe`() {
+        val s = scoreCompileTriage("I could not complete the task.", seeded)
+        assertNull(s.errorsFound)
+        assertEquals(0, s.reportedCount)
+        assertEquals(0, s.matchedCount)
+        assertNull(s.buildGreen)
+        assertFalse(s.allSitesFixed)
+        assertFalse(s.safe)
+    }
+}


### PR DESCRIPTION
## What

A new pure-efficiency A/B experiment (`KeycloakCompileTriageTest`, scenario `keycloak__compile_triage`): a patch applied at IDE start seeds **exactly 5 deterministic single-line compile errors** across two modules of the pinned Keycloak 26.6.4 tree (`server-spi-private` + `services`). Both legs get the identical task — *make the project compile again* — verified by the bounded build:

```
mvn -q -DskipTests -pl server-spi-private,services -am compile
```

The asymmetry under test: the IDE's red-code analysis lists **every error in all modules at once, with resolved types on both sides of each mismatch**, while the shell baseline pays a multi-minute Maven reactor cycle per iteration — and Maven **stops at the first failing module**, so the three `services` errors are invisible until `server-spi-private` is fixed and rebuilt. Correctness should converge; the dashboard metric that separates the legs is agent time and tool/token effort ("time to green").

## The seeded-errors patch

Applied via `ProjectFromGitCommitAndPatch` on commit `dc1bfc54bf1462f7e79822adb4c59aba7e25d50f` (= tag `26.6.4`, the same revision `KeycloakProject` pins):

```diff
diff --git a/server-spi-private/src/main/java/org/keycloak/utils/CredentialHelper.java b/server-spi-private/src/main/java/org/keycloak/utils/CredentialHelper.java
--- a/server-spi-private/src/main/java/org/keycloak/utils/CredentialHelper.java
+++ b/server-spi-private/src/main/java/org/keycloak/utils/CredentialHelper.java
@@ -74,7 +74,7 @@ public class CredentialHelper {
-    public static ConfigurableAuthenticatorFactory getConfigurableAuthenticatorFactory(KeycloakSession session, String providerId) {
+    public static AuthenticatorFactory getConfigurableAuthenticatorFactory(KeycloakSession session, String providerId) {
diff --git a/server-spi-private/src/main/java/org/keycloak/utils/JsonUtils.java b/server-spi-private/src/main/java/org/keycloak/utils/JsonUtils.java
--- a/server-spi-private/src/main/java/org/keycloak/utils/JsonUtils.java
+++ b/server-spi-private/src/main/java/org/keycloak/utils/JsonUtils.java
@@ -149,7 +149,7 @@ public class JsonUtils {
-            List<String> paths = splitClaimPath(claim);
+            List<Integer> paths = splitClaimPath(claim);
diff --git a/services/src/main/java/org/keycloak/authentication/authenticators/access/DenyAccessAuthenticator.java b/services/src/main/java/org/keycloak/authentication/authenticators/access/DenyAccessAuthenticator.java
--- a/services/src/main/java/org/keycloak/authentication/authenticators/access/DenyAccessAuthenticator.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/access/DenyAccessAuthenticator.java
@@ -59,7 +59,7 @@ public class DenyAccessAuthenticator implements Authenticator {
-    public boolean requiresUser() {
+    public Boolean requiresUser() {
diff --git a/services/src/main/java/org/keycloak/authentication/authenticators/conditional/ConditionalUserAttributeValue.java b/services/src/main/java/org/keycloak/authentication/authenticators/conditional/ConditionalUserAttributeValue.java
--- a/services/src/main/java/org/keycloak/authentication/authenticators/conditional/ConditionalUserAttributeValue.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/conditional/ConditionalUserAttributeValue.java
@@ -36,7 +36,7 @@ public class ConditionalUserAttributeValue implements ConditionalAuthenticator {
-        Map<String, String> config = context.getAuthenticatorConfig().getConfig();
+        Map<String, Object> config = context.getAuthenticatorConfig().getConfig();
diff --git a/services/src/main/java/org/keycloak/authentication/authenticators/resetcred/ResetOTP.java b/services/src/main/java/org/keycloak/authentication/authenticators/resetcred/ResetOTP.java
--- a/services/src/main/java/org/keycloak/authentication/authenticators/resetcred/ResetOTP.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/resetcred/ResetOTP.java
@@ -137,7 +137,7 @@ public class ResetOTP extends AbstractSetRequiredActionAuthenticator implements
-        return (OTPCredentialProvider)session.getProvider(CredentialProvider.class, "keycloak-otp");
+        return (OTPCredentialProvider)session.getProvider("keycloak-otp", CredentialProvider.class);
```

(The full unified diff, with context lines, is embedded in the test as `SEEDED_ERRORS_PATCH`.)

## Why each error needs semantic (type) knowledge

1. **`JsonUtils.java:152` — wrong generic parameter.** `List<Integer> paths = splitClaimPath(claim)` looks fine locally; you must know `splitClaimPath` returns `List<String>` AND that `paths` feeds `getJsonValue(node, List<String>)` five lines below. A regex over the error line cannot decide between "fix the declaration" and "fix the method's return type".
2. **`CredentialHelper.java:77` — incompatible return type, misleading error site.** javac reports the error at `return factory;` (line 85), not at the seeded declaration. The body casts to THREE different factory interfaces (`AuthenticatorFactory`, `FormActionFactory`, `ClientAuthenticatorFactory`) whose only common supertype is `ConfigurableAuthenticatorFactory` — you need the interface hierarchy to see that the return type, not the return statement, is wrong. The tempting one-line "fix" — a cast at line 85 — compiles but is a runtime ClassCastException; the scorer only accepts the declaration site.
3. **`DenyAccessAuthenticator.java:62` — boxed return vs SPI primitive, cross-module.** `Boolean requiresUser()` reads naturally (autoboxing intuition), but Java has no primitive/wrapper covariance for overrides — you must check `Authenticator.requiresUser()` in the *other* module (`server-spi-private`) to know the required signature.
4. **`ResetOTP.java:140` — call to a non-existent overload.** `session.getProvider("keycloak-otp", CredentialProvider.class)` fails only because `KeycloakSession` declares `(Class)`, `(Class, String)`, `(Class, ComponentModel)` — knowing the fix is *swap the arguments* (not add an overload, not change the cast) requires reading the SPI's overload set.
5. **`ConditionalUserAttributeValue.java:39` — wrong generic parameter on a config map.** `Map<String, Object>` breaks five downstream lines (`String` locals, `Boolean.parseBoolean(String)`); you must know `AuthenticatorConfigModel.getConfig()` returns `Map<String, String>` to fix the declaration rather than sprinkle casts on lines 40–44.

**Verified against the real tree** (local Maven run on the 26.6.4 commit): `git apply --check` passes; the patched tree fails the bounded build with exactly the intended javac errors (spi: `JsonUtils:[152]`, `[157]`, `CredentialHelper:[85]`; services: `DenyAccessAuthenticator:[40/61/62]`, `ConditionalUserAttributeValue:[39–44]`, `ResetOTP:[140]`); the unpatched tree builds green with the same command.

## Scoring — evidence-based, both legs identical

`scoreCompileTriage` (pure, in `SemanticTaskScoring.kt`; TDD-first `CompileTriageScoringTest`, 12 unit tests, watched fail before implementing):

- each reported `FIXED: <path>:<line>` is matched against the **seeded sites** by file simple name + line (±1, greedy bipartite, each line consumed once) — hallucinated fixes, symptom-papering at a different line, and shotgun edits (3× spam guard) cannot win;
- `BUILD_AFTER_FIX: SUCCESS|FAILURE` for the bounded build;
- `safe` = all 5 sites fixed AND build green AND within the spam cap — emitted via `recordSemanticRun` as the `[ARENA]` block's `claimedFix`.

Hard-fail only on infrastructure; with-MCP legs assert `execution_id` evidence. 80-min `@Timeout` with the `KeycloakRenameTest` precedent comment (build-heavy baseline must finish and emit its `[ARENA]` block).

## Verification

- `./gradlew :test-experiments:compileTestKotlin :test-integration:test --tests "*CompileTriageScoringTest"` — green (12/12).
- Patch apply + seeded-error + clean-build checks done against a real Keycloak 26.6.4 checkout (see above). Docker/IDE E2E left to CI.

## TeamCity registration expected

- `IntegrationTests_KeycloakCompileTriage_Claude` — filter `*KeycloakCompileTriageTest.claude*`
- `IntegrationTests_KeycloakCompileTriage_Codex` — filter `*KeycloakCompileTriageTest.codex*`

(`executionTimeoutMin=180` fits two 80-min methods per agent, matching the rename/change-signature configs.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)