### PR TITLE
Kotlin↔Java cross-language find-usages A/B on OkHttp 4.12.0 (okhttp__interop_usages)

### DIFF
--- a/test-experiments/src/test/kotlin/com/jonnyzzz/mcpSteroid/integration/tests/InteropFindUsagesTest.kt
+++ b/test-experiments/src/test/kotlin/com/jonnyzzz/mcpSteroid/integration/tests/InteropFindUsagesTest.kt
@@ -1,0 +1,198 @@
+/* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
+package com.jonnyzzz.mcpSteroid.integration.tests
+
+import com.jonnyzzz.mcpSteroid.integration.infra.AiMode
+import com.jonnyzzz.mcpSteroid.integration.infra.BuildSystem
+import com.jonnyzzz.mcpSteroid.integration.infra.IntelliJContainer
+import com.jonnyzzz.mcpSteroid.integration.infra.IntelliJContainerOpts
+import com.jonnyzzz.mcpSteroid.integration.infra.IntelliJProject
+import com.jonnyzzz.mcpSteroid.integration.infra.McpConnectionMode
+import com.jonnyzzz.mcpSteroid.integration.infra.create
+import com.jonnyzzz.mcpSteroid.integration.infra.waitForProjectReady
+import com.jonnyzzz.mcpSteroid.testHelper.AiAgentSession
+import com.jonnyzzz.mcpSteroid.testHelper.CloseableStackHost
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Timeout
+import java.util.concurrent.TimeUnit
+
+/**
+ * MCP-win experiment: **Kotlin↔Java cross-language find-usages** (jonnyzzz/mcp-steroid#169 family) —
+ * the purest grep-killer. In OkHttp (pinned tag `parent-4.12.0`) the Kotlin property
+ * `okhttp3.mockwebserver.RecordedRequest.requestLine` is consumed from the legacy Java test suite
+ * through its GENERATED getter `getRequestLine()`. The declared name and the call-site spelling
+ * differ in case (`requestLine` vs `getRequestLine`), so:
+ *  - a case-sensitive search for the declared name finds ZERO of the 58 Java call sites,
+ *  - a search for the bare identifier over-matches same-named LOCAL VARIABLES that are not
+ *    property usages at all (`MockWebServer.kt`, `Http1ExchangeCodec.kt`, `RealConnection.kt`,
+ *    and even `QueueDispatcher.kt:35-36`, two lines below a real usage),
+ *  - okhttp core also has an unrelated `okhttp3.internal.http.RequestLine` CLASS that any
+ *    case-insensitive sweep pulls in.
+ *
+ * With MCP the agent resolves the property via PSI and runs `ReferencesSearch` — one query returns
+ * every Kotlin property read AND every Java getter call. Without MCP the agent must know the
+ * Kotlin property↔getter mapping and run two disciplined searches, filtering the shadowing locals
+ * by hand.
+ *
+ * Ground truth ([REQUIRED_USAGES], 60 usages) was hand-derived at the pinned tag: every
+ * `getRequestLine()` line in `*.java` (58 — receiver verified `RecordedRequest`, no line has two
+ * occurrences, no method references exist) plus the two Kotlin property reads outside the declaring
+ * file. Reads inside the declaring file are [OPTIONAL_USAGES] — never required, never penalized.
+ *
+ * Verdict ([scoreInteropUsages]): every required usage reported AND no false positives — emitted
+ * as an `[ARENA]` block. A/B per agent; with-MCP asserts exec_code; correctness is a dashboard
+ * metric, not a hard gate.
+ */
+class InteropFindUsagesTest {
+
+    // 50 min: read-only task. OkHttp is mid-size (Gradle 7.5, ~20 JVM-only modules) — container
+    // start + Gradle import + indexing fit well within, and the enumeration itself is a single
+    // find-usages query (with MCP) or a couple of searches (without).
+
+    @Test @Timeout(value = 50, unit = TimeUnit.MINUTES)
+    fun `claude with mcp`() = run("claude", withMcp = true)
+
+    @Test @Timeout(value = 50, unit = TimeUnit.MINUTES)
+    fun `claude without mcp`() = run("claude", withMcp = false)
+
+    @Test @Timeout(value = 50, unit = TimeUnit.MINUTES)
+    fun `codex with mcp`() = run("codex", withMcp = true)
+
+    @Test @Timeout(value = 50, unit = TimeUnit.MINUTES)
+    fun `codex without mcp`() = run("codex", withMcp = false)
+
+    private fun run(agentName: String, withMcp: Boolean) {
+        val modeLabel = if (withMcp) "mcp" else "none"
+        val lifetime = CloseableStackHost()
+        try {
+            val session = IntelliJContainer.create(lifetime, IntelliJContainerOpts(
+                consoleTitle = "okhttp-interop-$agentName-$modeLabel",
+                project = IntelliJProject.OkHttpPinnedProject,
+                aiMode = if (withMcp) AiMode.AI_MCP else AiMode.NONE,
+                mcpConnectionMode = if (withMcp) null else McpConnectionMode.None,
+            )).waitForProjectReady(buildSystem = BuildSystem.GRADLE)
+
+            val agent: AiAgentSession = when (agentName) {
+                "claude" -> session.aiAgents.claude
+                "codex" -> session.aiAgents.codex
+                else -> error("Unknown agent: $agentName")
+            }
+
+            val startedAt = System.currentTimeMillis()
+            val result = agent.runPrompt(if (withMcp) withMcpPrompt() else baselinePrompt(), timeoutSeconds = 1800)
+                .awaitForProcessFinish()
+            val agentDurationMs = System.currentTimeMillis() - startedAt
+            val combined = result.stdout + "\n" + result.stderr
+
+            val score = scoreInteropUsages(combined, REQUIRED_USAGES, OPTIONAL_USAGES)
+            val requiredTotal = REQUIRED_USAGES.values.sumOf { it.size }
+            val foundTotal = score.foundRequired.values.sumOf { it.size }
+            println("[TEST] okhttp interop-usages [$agentName+$modeLabel] exact=${score.exact} " +
+                    "complete=${score.complete} required=$foundTotal/$requiredTotal " +
+                    "falsePositives=${score.falsePositives.size} reported=${score.reportedPairCount}")
+            if (score.missedRequired.isNotEmpty()) {
+                println("[TEST]   missed required: ${score.missedRequired}")
+            }
+            if (score.falsePositives.isNotEmpty()) {
+                println("[TEST]   false positives: ${score.falsePositives}")
+            }
+
+            recordSemanticRun(
+                scenario = SCENARIO,
+                agentName = agentName,
+                withMcp = withMcp,
+                claimedFix = score.exact,
+                rawOutput = result.rawStdout,
+                exitCode = result.exitCode,
+                agentDurationMs = agentDurationMs,
+                runDir = session.runDirInContainer,
+                summary = "required=$foundTotal/$requiredTotal " +
+                        "missedFiles=${score.missedRequired.keys.size} " +
+                        "falsePositives=${score.falsePositives.size} complete=${score.complete}",
+            )
+
+            if (withMcp) assertUsedExecuteCodeEvidence(combined)
+        } finally {
+            lifetime.closeAllStacks()
+        }
+    }
+
+    private fun taskDescription(): String = buildString {
+        appendLine("Task: enumerate EVERY usage of the Kotlin property `$SYMBOL`")
+        appendLine("across the WHOLE repository — BOTH languages:")
+        appendLine("- Kotlin reads of the property (`.requestLine`),")
+        appendLine("- Java calls of its generated getter (`getRequestLine()`).")
+        appendLine()
+        appendLine("Count only real references to THAT property in `.kt` and `.java` sources.")
+        appendLine("Local variables that merely share the name `requestLine` are NOT usages.")
+        appendLine("Do NOT include the property declaration line itself.")
+        appendLine()
+        appendLine("Output (markers on their own lines, one USAGE line per reference):")
+        appendLine("USAGES_FOUND: <total count>")
+        appendLine("USAGE: <path/relative/to/repo>:<1-based line>")
+    }
+
+    private fun withMcpPrompt(): String = buildString {
+        appendLine("The OkHttp project is open in IntelliJ IDEA — a mixed Kotlin+Java Gradle project.")
+        appendLine()
+        append(taskDescription())
+        appendLine()
+        appendLine("Use IntelliJ's resolve-based search via `steroid_execute_code`: find the class")
+        appendLine("`okhttp3.mockwebserver.RecordedRequest` (e.g. `JavaPsiFacade.findClass`), take the")
+        appendLine("`requestLine` property (the light getter's `navigationElement` is the Kotlin parameter),")
+        appendLine("and run `ReferencesSearch.search(...)` over the project scope — it returns Kotlin property")
+        appendLine("reads AND Java getter calls in one query. Convert each reference to file + line via its")
+        appendLine("PSI element's document. Do NOT rely on text search.")
+        appendLine()
+        appendLine("Additional output marker:")
+        appendLine("TOOL_EVIDENCE: <copy the line starting with execution_id: ...>")
+    }
+
+    private fun baselinePrompt(): String = buildString {
+        appendLine("The OkHttp project is checked out (a mixed Kotlin+Java Gradle project).")
+        appendLine("IntelliJ MCP tools are unavailable in this run — use shell commands only (grep/rg/find).")
+        appendLine()
+        append(taskDescription())
+        appendLine()
+        appendLine("Beware: Kotlin and Java spell member access differently, and unrelated identifiers")
+        appendLine("share this name — a single naive text search will both miss usages and over-match.")
+    }
+
+    companion object {
+        private const val SCENARIO = "okhttp__interop_usages"
+        private const val SYMBOL = "okhttp3.mockwebserver.RecordedRequest.requestLine"
+
+        // Ground truth hand-derived at the pinned `parent-4.12.0` tag (see class kdoc for the
+        // derivation sweep). 58 Java getter call sites + 2 Kotlin property reads outside the
+        // declaring file. The 58 Java sites are the CROSS-LANGUAGE ones a case-sensitive search
+        // for the declared name misses entirely.
+        private val REQUIRED_USAGES: Map<String, Set<Int>> = mapOf(
+            "mockwebserver/src/test/java/okhttp3/mockwebserver/MockWebServerTest.java" to
+                    setOf(152, 172, 174, 458),
+            "okhttp/src/test/java/okhttp3/URLConnectionTest.java" to setOf(
+                511, 619, 622, 732, 880, 924, 929, 964, 1041, 1046, 1052, 1838, 1879, 1914, 1987,
+                2037, 2039, 2065, 2067, 2289, 2293, 2311, 2315, 2335, 2428, 2454, 2484, 2494, 2972,
+            ),
+            "okhttp/src/test/java/okhttp3/CallTest.java" to setOf(
+                1855, 1859, 2085, 2089, 3131, 3135, 3139, 3163, 3167, 3583, 3587,
+            ),
+            "okhttp/src/test/java/okhttp3/CacheTest.java" to setOf(385, 392, 400),
+            "okhttp/src/test/java/okhttp3/internal/http2/HttpOverHttp2Test.java" to setOf(
+                185, 212, 235, 272, 303, 337, 513, 1210, 1216, 1238, 1244,
+            ),
+            // Kotlin property-syntax reads outside the declaring file. QueueDispatcher.kt:34 is a
+            // real read (`request.requestLine`) — while lines 35-36 read a same-named LOCAL and
+            // must NOT be reported. KotlinSourceModernTest.kt lives under `src/test/java`, a .kt
+            // file in a java source root — a `--include=*.kt`-only sweep of kotlin dirs misses it.
+            "mockwebserver/src/main/kotlin/okhttp3/mockwebserver/QueueDispatcher.kt" to setOf(34),
+            "okhttp/src/test/java/okhttp3/KotlinSourceModernTest.kt" to setOf(936),
+        )
+
+        // Reads inside the declaring file (init block, toString) plus the declaration line: agents
+        // legitimately disagree on whether to list them — reported or not, they never count as
+        // false positives, and they are never required.
+        private val OPTIONAL_USAGES: Map<String, Set<Int>> = mapOf(
+            "mockwebserver/src/main/kotlin/okhttp3/mockwebserver/RecordedRequest.kt" to
+                    setOf(33, 96, 97, 98, 99, 100, 137),
+        )
+    }
+}

--- a/test-integration/src/main/kotlin/com/jonnyzzz/mcpSteroid/integration/infra/intelliJ-project.kt
+++ b/test-integration/src/main/kotlin/com/jonnyzzz/mcpSteroid/integration/infra/intelliJ-project.kt
@@ -155,6 +155,27 @@ sealed class IntelliJProject{
     )
     object IntelliJPlatformGradlePluginProject : ProjectFromRemoteGit("https://github.com/JetBrains/intellij-platform-gradle-plugin.git")
 
+    /**
+     * OkHttp pinned to the 4.12.0 release tag — the Kotlin↔Java cross-language find-usages
+     * experiment (`InteropFindUsagesTest`). Chosen because it is genuinely mixed: the library is
+     * Kotlin, but a large legacy Java test suite consumes Kotlin `val`s through their generated
+     * getters (e.g. `RecordedRequest.requestLine` → `getRequestLine()` at 58 Java call sites),
+     * so the experiment's ground truth depends on this exact revision. When bumping the tag,
+     * re-derive every dependent ground-truth list.
+     *
+     * The pinned Gradle 7.5 wrapper refuses to run on JDK 19+ ("Unsupported class file major
+     * version"), hence jdkVersion 17 (temurin-17 is preinstalled in the ide-agent image); the
+     * import flow propagates it to gradleJvm. `settings.gradle` only includes the Android module
+     * when ANDROID_SDK_ROOT is set, so a plain IntelliJ Gradle import works.
+     */
+    object OkHttpPinnedProject : ProjectFromRemoteGit(
+        "https://github.com/square/okhttp.git",
+        gitRef = "parent-4.12.0",
+    ) {
+        override val jdkVersion: String = "17"
+        override val openFileOnStart: String = "mockwebserver/src/main/kotlin/okhttp3/mockwebserver/RecordedRequest.kt"
+    }
+
     /** A real Android (Gradle) project, used to exercise Android Studio. Google's official base template. */
     object AndroidSampleProject : ProjectFromRemoteGit("https://github.com/android/architecture-templates.git")
 

--- a/test-integration/src/main/kotlin/com/jonnyzzz/mcpSteroid/integration/tests/SemanticTaskScoring.kt
+++ b/test-integration/src/main/kotlin/com/jonnyzzz/mcpSteroid/integration/tests/SemanticTaskScoring.kt
@@ -378,6 +378,110 @@ private fun normalizeReportedPath(raw: String): String {
 private fun pathsReferToSameFile(a: String, b: String): Boolean =
     a == b || a.endsWith("/$b") || b.endsWith("/$a")
 
+data class InteropUsagesScore(
+    /** The `USAGES_FOUND:` total the agent reported (null if it never reported one). */
+    val reportedCount: Int?,
+    /** Distinct (path, line) pairs parsed from `USAGE:` markers — non-source paths already dropped. */
+    val reportedPairCount: Int,
+    /** Ground-truth required usages the agent DID report (ground-truth path → matched lines). */
+    val foundRequired: Map<String, Set<Int>>,
+    /** Ground-truth required usages the agent FAILED to report — the cross-language ones grep misses. */
+    val missedRequired: Map<String, Set<Int>>,
+    /** Reported `path:line` pairs that are neither required nor optional — e.g. same-named locals. */
+    val falsePositives: Set<String>,
+    /** True when EVERY required usage was reported (within the ±1 line tolerance). */
+    val complete: Boolean,
+    /** [complete] AND no false positives — the resolve-exact answer. */
+    val exact: Boolean,
+)
+
+/**
+ * Score a "enumerate EVERY usage of a symbol across BOTH languages" answer against a hand-derived
+ * `file → lines` ground truth (pinned revision, so lines are stable). The scenario this scores:
+ * a Kotlin `val requestLine` consumed from Java as the generated getter `getRequestLine()` —
+ * a case-sensitive search for the declared name finds ZERO Java call sites, while a loose search
+ * for the identifier over-matches same-named LOCAL VARIABLES that are not property usages at all.
+ * Resolve-based find-usages (`ReferencesSearch` on the property) answers this exactly; the scorer
+ * treats both failure modes separately: [InteropUsagesScore.missedRequired] (under-match) and
+ * [InteropUsagesScore.falsePositives] (over-match).
+ *
+ * Expected markers (mode-independent — with-MCP and shell runs are scored identically):
+ *   USAGES_FOUND: <total count>
+ *   USAGE: <path/relative/to/repo>:<line>      (one line per usage)
+ *
+ * Matching rules:
+ *  - only `.java` / `.kt` paths count; anything else (README snippets, `.api` dumps) is ignored,
+ *  - paths are markdown-normalized and suffix-matched, so absolute in-container spellings and
+ *    shorter-but-unambiguous relative spellings both count,
+ *  - lines match with ±1 tolerance (multi-line expressions), exact matches claimed first, and each
+ *    reported line satisfies at most one ground-truth line (and vice versa),
+ *  - [optional] usages (e.g. reads inside the declaring file, the declaration line itself) are
+ *    never required and never counted as false positives — agents legitimately disagree on them.
+ */
+fun scoreInteropUsages(
+    output: String,
+    required: Map<String, Set<Int>>,
+    optional: Map<String, Set<Int>> = emptyMap(),
+): InteropUsagesScore {
+    val reportedCount = findMarkerValue(output, "USAGES_FOUND", "Usages found")
+        ?.let { Regex("""\d+""").find(it)?.value?.toIntOrNull() }
+
+    // Every `USAGE:` marker line contributes one (normalized path, line) pair. `USAGE` must be
+    // followed by the separator, so the `USAGES_FOUND:` count line can never match.
+    val usageLine = Regex("""(?im)^\s*[*_`>#|:\s-]*USAGE\s*[*_`]*\s*:\s*(.+)$""")
+    val pathAndLine = Regex("""([^\s:`*"']+\.(?:java|kt))\s*:\s*(\d+)""")
+    val reportedPairs: Set<Pair<String, Int>> = usageLine.findAll(output)
+        .mapNotNull { usage ->
+            val m = pathAndLine.find(usage.groupValues[1]) ?: return@mapNotNull null
+            normalizeReportedPath(m.groupValues[1]) to m.groupValues[2].toInt()
+        }
+        .filter { it.first.isNotEmpty() }
+        .toSet()
+
+    // Group the reported lines under the ground-truth file they refer to (suffix path matching).
+    // A reported pair may sit in `remaining` for at most one ground-truth file — files in the
+    // ground truth have distinct suffix-disjoint paths.
+    fun matchAgainst(truth: Map<String, Set<Int>>, pool: MutableSet<Pair<String, Int>>): Map<String, Set<Int>> {
+        val matched = mutableMapOf<String, MutableSet<Int>>()
+        for ((truthFile, truthLines) in truth) {
+            val candidates = pool.filter { pathsReferToSameFile(it.first, truthFile) }.toMutableList()
+            for (tolerance in 0..1) {
+                for (truthLine in truthLines.sorted()) {
+                    if (truthLine in (matched[truthFile] ?: emptySet<Int>())) continue
+                    val hit = candidates.firstOrNull { kotlin.math.abs(it.second - truthLine) <= tolerance }
+                        ?: continue
+                    candidates.remove(hit)
+                    pool.remove(hit)
+                    matched.getOrPut(truthFile) { mutableSetOf() }.add(truthLine)
+                }
+            }
+        }
+        return matched
+    }
+
+    val pool = reportedPairs.toMutableSet()
+    val foundRequired = matchAgainst(required, pool)
+    matchAgainst(optional, pool) // consume optional hits so they are not false positives
+
+    val missedRequired = required.mapNotNull { (file, lines) ->
+        val missing = lines - (foundRequired[file] ?: emptySet())
+        if (missing.isEmpty()) null else file to missing
+    }.toMap()
+
+    val falsePositives = pool.map { "${it.first}:${it.second}" }.toSet()
+    val complete = missedRequired.isEmpty()
+
+    return InteropUsagesScore(
+        reportedCount = reportedCount,
+        reportedPairCount = reportedPairs.size,
+        foundRequired = foundRequired,
+        missedRequired = missedRequired,
+        falsePositives = falsePositives,
+        complete = complete,
+        exact = complete && falsePositives.isEmpty(),
+    )
+}
+
 data class RootCauseScore(
     val mentionsIgnoredReturn: Boolean,
     val mentionsNewList: Boolean,

--- a/test-integration/src/test/kotlin/com/jonnyzzz/mcpSteroid/integration/tests/InteropUsagesScoringTest.kt
+++ b/test-integration/src/test/kotlin/com/jonnyzzz/mcpSteroid/integration/tests/InteropUsagesScoringTest.kt
@@ -1,0 +1,204 @@
+/* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
+package com.jonnyzzz.mcpSteroid.integration.tests
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * Pure, local tests for [scoreInteropUsages] — the found/missed/false-positive verdict for the
+ * Kotlin↔Java cross-language find-usages A/B (OkHttp `RecordedRequest.requestLine`).
+ *
+ * The interop trap being scored: a Kotlin `val requestLine` is consumed from Java as
+ * `getRequestLine()`, so a case-sensitive text search for the declared name finds ZERO of the
+ * Java call sites, while a loose search for the property name over-matches unrelated local
+ * variables that merely share the identifier (`val requestLine = "$method $path HTTP/1.1"`).
+ * Only resolve-based find-usages crosses the language boundary exactly. No IDE/Docker needed —
+ * scored on text only.
+ */
+class InteropUsagesScoringTest {
+
+    // A toy ground truth mirroring the okhttp shape: Java call sites of the generated getter
+    // (cross-language — REQUIRED) plus a Kotlin property read in another file (also REQUIRED),
+    // and the declaring-file internal reads (OPTIONAL — reported or not, never penalized).
+    private val required = mapOf(
+        "okhttp/src/test/java/okhttp3/CacheTest.java" to setOf(385, 392, 400),
+        "mockwebserver/src/main/kotlin/okhttp3/mockwebserver/QueueDispatcher.kt" to setOf(34),
+    )
+    private val optional = mapOf(
+        "mockwebserver/src/main/kotlin/okhttp3/mockwebserver/RecordedRequest.kt" to setOf(33, 96, 137),
+    )
+
+    private fun score(output: String) = scoreInteropUsages(output, required, optional)
+
+    @Test
+    fun `exact enumeration scores complete and exact`() {
+        val output = """
+            USAGES_FOUND: 4
+            USAGE: okhttp/src/test/java/okhttp3/CacheTest.java:385
+            USAGE: okhttp/src/test/java/okhttp3/CacheTest.java:392
+            USAGE: okhttp/src/test/java/okhttp3/CacheTest.java:400
+            USAGE: mockwebserver/src/main/kotlin/okhttp3/mockwebserver/QueueDispatcher.kt:34
+        """.trimIndent()
+        val s = score(output)
+        assertTrue(s.complete, "missed=${s.missedRequired}")
+        assertTrue(s.exact, "falsePositives=${s.falsePositives}")
+        assertEquals(4, s.reportedCount)
+        assertEquals(4, s.reportedPairCount)
+        assertEquals(required, s.foundRequired)
+        assertTrue(s.missedRequired.isEmpty())
+        assertTrue(s.falsePositives.isEmpty())
+    }
+
+    @Test
+    fun `getter-only grep misses the Kotlin property read`() {
+        // A baseline that only searched for "getRequestLine" finds every Java call site but
+        // no Kotlin property-syntax usage.
+        val output = """
+            USAGES_FOUND: 3
+            USAGE: okhttp/src/test/java/okhttp3/CacheTest.java:385
+            USAGE: okhttp/src/test/java/okhttp3/CacheTest.java:392
+            USAGE: okhttp/src/test/java/okhttp3/CacheTest.java:400
+        """.trimIndent()
+        val s = score(output)
+        assertFalse(s.complete)
+        assertEquals(
+            mapOf("mockwebserver/src/main/kotlin/okhttp3/mockwebserver/QueueDispatcher.kt" to setOf(34)),
+            s.missedRequired,
+        )
+        assertTrue(s.falsePositives.isEmpty())
+    }
+
+    @Test
+    fun `property-name grep over-matches unrelated locals and misses Java sites`() {
+        // A baseline that only searched for "requestLine" reports same-named LOCAL VARIABLES
+        // (not property usages) and finds zero Java getter call sites.
+        val output = """
+            USAGES_FOUND: 3
+            USAGE: mockwebserver/src/main/kotlin/okhttp3/mockwebserver/QueueDispatcher.kt:34
+            USAGE: mockwebserver/src/main/kotlin/okhttp3/mockwebserver/MockWebServer.kt:1037
+            USAGE: okhttp/src/main/kotlin/okhttp3/internal/http1/Http1ExchangeCodec.kt:118
+        """.trimIndent()
+        val s = score(output)
+        assertFalse(s.complete)
+        assertEquals(setOf("okhttp/src/test/java/okhttp3/CacheTest.java"), s.missedRequired.keys)
+        assertEquals(
+            setOf(
+                "mockwebserver/src/main/kotlin/okhttp3/mockwebserver/MockWebServer.kt:1037",
+                "okhttp/src/main/kotlin/okhttp3/internal/http1/Http1ExchangeCodec.kt:118",
+            ),
+            s.falsePositives,
+        )
+        assertFalse(s.exact)
+    }
+
+    @Test
+    fun `markdown decoration and absolute container paths are normalized`() {
+        val output = """
+            **USAGES_FOUND**: 4
+            - **USAGE:** `/home/agent/project/okhttp/src/test/java/okhttp3/CacheTest.java:385`
+            - USAGE: `/home/agent/project/okhttp/src/test/java/okhttp3/CacheTest.java:392`
+            > USAGE: /home/agent/project/okhttp/src/test/java/okhttp3/CacheTest.java:400
+            USAGE: mockwebserver/src/main/kotlin/okhttp3/mockwebserver/QueueDispatcher.kt:34
+        """.trimIndent()
+        val s = score(output)
+        assertTrue(s.complete, "missed=${s.missedRequired}")
+        assertTrue(s.exact, "falsePositives=${s.falsePositives}")
+        assertEquals(4, s.reportedCount)
+    }
+
+    @Test
+    fun `one line of tolerance is allowed for multi-line expressions`() {
+        val output = """
+            USAGE: okhttp/src/test/java/okhttp3/CacheTest.java:386
+            USAGE: okhttp/src/test/java/okhttp3/CacheTest.java:392
+            USAGE: okhttp/src/test/java/okhttp3/CacheTest.java:400
+            USAGE: mockwebserver/src/main/kotlin/okhttp3/mockwebserver/QueueDispatcher.kt:34
+        """.trimIndent()
+        val s = score(output)
+        assertTrue(s.complete, "missed=${s.missedRequired}")
+        assertTrue(s.exact, "falsePositives=${s.falsePositives}")
+    }
+
+    @Test
+    fun `adjacent ground-truth lines are not double-claimed by one reported line`() {
+        // Two required lines 1 apart must need two reported lines: one report cannot satisfy both.
+        val tightTruth = mapOf("a/B.java" to setOf(10, 11))
+        val s = scoreInteropUsages("USAGE: a/B.java:10", tightTruth)
+        assertFalse(s.complete)
+        assertEquals(mapOf("a/B.java" to setOf(11)), s.missedRequired)
+    }
+
+    @Test
+    fun `declaring-file internal reads are optional - neither required nor penalized`() {
+        val output = """
+            USAGE: okhttp/src/test/java/okhttp3/CacheTest.java:385
+            USAGE: okhttp/src/test/java/okhttp3/CacheTest.java:392
+            USAGE: okhttp/src/test/java/okhttp3/CacheTest.java:400
+            USAGE: mockwebserver/src/main/kotlin/okhttp3/mockwebserver/QueueDispatcher.kt:34
+            USAGE: mockwebserver/src/main/kotlin/okhttp3/mockwebserver/RecordedRequest.kt:96
+            USAGE: mockwebserver/src/main/kotlin/okhttp3/mockwebserver/RecordedRequest.kt:137
+        """.trimIndent()
+        val s = score(output)
+        assertTrue(s.complete)
+        assertTrue(s.exact, "falsePositives=${s.falsePositives}")
+    }
+
+    @Test
+    fun `non-source paths are ignored - a README mention is neither found nor penalized`() {
+        val output = """
+            USAGE: okhttp/src/test/java/okhttp3/CacheTest.java:385
+            USAGE: okhttp/src/test/java/okhttp3/CacheTest.java:392
+            USAGE: okhttp/src/test/java/okhttp3/CacheTest.java:400
+            USAGE: mockwebserver/src/main/kotlin/okhttp3/mockwebserver/QueueDispatcher.kt:34
+            USAGE: mockwebserver/README.md:109
+        """.trimIndent()
+        val s = score(output)
+        assertTrue(s.complete)
+        assertTrue(s.exact, "falsePositives=${s.falsePositives}")
+        assertEquals(4, s.reportedPairCount)
+    }
+
+    @Test
+    fun `duplicate USAGE lines are deduplicated`() {
+        val output = """
+            USAGE: okhttp/src/test/java/okhttp3/CacheTest.java:385
+            USAGE: okhttp/src/test/java/okhttp3/CacheTest.java:385
+        """.trimIndent()
+        val s = score(output)
+        assertEquals(1, s.reportedPairCount)
+        assertEquals(mapOf("okhttp/src/test/java/okhttp3/CacheTest.java" to setOf(385)), s.foundRequired)
+        assertTrue(s.falsePositives.isEmpty())
+    }
+
+    @Test
+    fun `a shorter but unambiguous relative path still counts`() {
+        val output = """
+            USAGE: okhttp3/CacheTest.java:385
+            USAGE: okhttp3/CacheTest.java:392
+            USAGE: okhttp3/CacheTest.java:400
+            USAGE: okhttp3/mockwebserver/QueueDispatcher.kt:34
+        """.trimIndent()
+        val s = score(output)
+        assertTrue(s.complete, "missed=${s.missedRequired}")
+        assertTrue(s.exact, "falsePositives=${s.falsePositives}")
+    }
+
+    @Test
+    fun `no USAGE markers at all scores everything missed and no count`() {
+        val s = score("I searched but could not enumerate the usages.")
+        assertFalse(s.complete)
+        assertFalse(s.exact)
+        assertEquals(required, s.missedRequired)
+        assertEquals(null, s.reportedCount)
+        assertEquals(0, s.reportedPairCount)
+    }
+
+    @Test
+    fun `USAGES_FOUND count line is not mis-parsed as a USAGE marker`() {
+        val s = score("USAGES_FOUND: 60")
+        assertEquals(60, s.reportedCount)
+        assertEquals(0, s.reportedPairCount)
+    }
+}


### PR DESCRIPTION
## What

New A/B experiment `InteropFindUsagesTest` (scenario `okhttp__interop_usages`): the agent must enumerate **every** usage of the Kotlin property `okhttp3.mockwebserver.RecordedRequest.requestLine` across **both** languages of the pinned OkHttp checkout.

This is the purest grep-killer shape: the Kotlin `val requestLine` is consumed from OkHttp's large legacy **Java** test suite through the **generated getter** `getRequestLine()`:

- a case-sensitive search for the declared name (`requestLine`) finds **zero** of the 58 Java call sites (`getRequestLine` capitalizes the R),
- a loose identifier search over-matches same-named **local variables** that are not property usages (`MockWebServer.kt:1037/1123`, `Http1ExchangeCodec.kt`, `RealConnection.kt`, and `QueueDispatcher.kt:35-36` — two lines below a *real* usage at line 34),
- a case-insensitive sweep additionally pulls in the unrelated `okhttp3.internal.http.RequestLine` **class**.

Only resolve-based find-usages (`ReferencesSearch` on the property) returns the Kotlin property reads **and** the Java getter calls in one exact query.

## Repo selection (the track's core decision)

Verified by shallow-cloning and counting, at the pinned revision:

| Candidate | Verdict |
|---|---|
| **square/okhttp @ `parent-4.12.0`** | **Winner.** Genuinely mixed (251 .kt / 152 .java files); `RecordedRequest.requestLine` has **58 Java getter call sites** across 5 test files + 2 Kotlin property reads outside the declaring file. Gradle-importable (wrapper 7.5; `settings.gradle` self-excludes the Android module without `ANDROID_SDK_ROOT`); `gradlew help` + `:mockwebserver:compileKotlin` verified green on temurin-17. Mid-size — import in minutes. |
| apache/kafka | Zero Kotlin (Java+Scala) — no interop at all. |
| spring-projects/spring-framework | Real interop exists, but 51 MB of Java / ~243k KB repo — IDE import too heavy for a 50-min test. |
| square/retrofit | Java core uses fluent no-prefix accessors (`baseUrl()`, not `getBaseUrl()`), so Kotlin cannot use property syntax — the mismatch this track needs doesn't exist. Only 16 .kt files. |
| mockito/mockito | Kotlin surface is ~13 files of coroutine/inline-class tests via the external `org.mockito.kotlin` API — no single Java symbol with 10+ Kotlin property usages. |
| square/moshi | Mixed, but the Java side (~57 files, tests/examples) is far smaller than okhttp's; okhttp dominates on cross-language call-site volume. |

## Ground truth (hand-derived at `parent-4.12.0`)

Derivation sweep, all machine-checked against the tag:
- `grep -rn "getRequestLine()" --include=*.java` → 58 lines; verified **no** line has two occurrences, **no** `getRequestLine` method references without parens exist, **no** other `getRequestLine` declaration exists in the repo, and every receiver is a `RecordedRequest` (spot-checked all non-obvious variable names);
- all `requestLine` token occurrences in `.kt` audited by hand: 2 true property reads outside the declaring file — `QueueDispatcher.kt:34` and `KotlinSourceModernTest.kt:936` (a `.kt` file under `src/test/java`, so kotlin-dir-only sweeps miss it) — the rest are shadowing locals (traps, scored as false positives);
- declaring-file reads (`RecordedRequest.kt` init block + `toString`) and the declaration line are **optional**: never required, never a false positive;
- the only non-source mention (`mockwebserver/README.md:109`) is ignored by construction (scorer only parses `.java`/`.kt` paths).

**Required = 60 usages** (58 cross-language Java + 2 Kotlin). Same scoring for both legs; `claimedFix` = `exact` (all required found, zero false positives) — a dashboard metric, not a hard gate. With-MCP legs assert `exec_code` evidence.

## Implementation

- `IntelliJProject.OkHttpPinnedProject` — `ProjectFromRemoteGit` pinned via `gitRef = "parent-4.12.0"`, `jdkVersion = "17"` (Gradle 7.5 refuses JDK 19+; temurin-17 is in the ide-agent image and flows into gradleJvm via the existing import path).
- `scoreInteropUsages` in `SemanticTaskScoring.kt` — pure scorer: markdown-tolerant `USAGE: <path>:<line>` parsing, suffix path matching (absolute in-container and short relative spellings count), ±1 line tolerance with exact-first greedy claiming (adjacent ground-truth lines cannot be double-claimed), separate `missedRequired` / `falsePositives` failure modes.
- TDD: `InteropUsagesScoringTest` (12 unit tests, written first and watched fail) — includes the getter-only-grep and property-name-grep failure archetypes.
- `InteropFindUsagesTest` — 4 methods with the exact required names (`claude with mcp` / `claude without mcp` / `codex with mcp` / `codex without mcp`), 50-min `@Timeout` (read-only task), `waitForProjectReady(buildSystem = BuildSystem.GRADLE)`, `[ARENA]` block via `recordSemanticRun`.

Verified: `:test-experiments:compileTestKotlin` green; `:test-integration:test --tests "*InteropUsagesScoringTest*"` 12/12 pass; ground-truth constants re-checked programmatically against the pinned clone.

## TeamCity registration expected

`IntegrationTests_InteropFindUsages_{Claude,Codex}` — test filter `*InteropFindUsagesTest.<agent>*`, two 50-min methods per config (TC-side `executionTimeoutMin=180` cap is ample).

🤖 Generated with [Claude Code](https://claude.com/claude-code)