### PR TITLE
Keycloak safe-delete A/B experiment: SafeDeleteProcessor vs blind sed (#169)

### DIFF
--- a/test-experiments/src/test/kotlin/com/jonnyzzz/mcpSteroid/integration/tests/KeycloakSafeDeleteTest.kt
+++ b/test-experiments/src/test/kotlin/com/jonnyzzz/mcpSteroid/integration/tests/KeycloakSafeDeleteTest.kt
@@ -1,0 +1,194 @@
+/* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
+package com.jonnyzzz.mcpSteroid.integration.tests
+
+import com.jonnyzzz.mcpSteroid.integration.infra.AiMode
+import com.jonnyzzz.mcpSteroid.integration.infra.BuildSystem
+import com.jonnyzzz.mcpSteroid.integration.infra.IntelliJContainer
+import com.jonnyzzz.mcpSteroid.integration.infra.IntelliJContainerOpts
+import com.jonnyzzz.mcpSteroid.integration.infra.IntelliJProject
+import com.jonnyzzz.mcpSteroid.integration.infra.McpConnectionMode
+import com.jonnyzzz.mcpSteroid.integration.infra.create
+import com.jonnyzzz.mcpSteroid.integration.infra.waitForProjectReady
+import com.jonnyzzz.mcpSteroid.testHelper.AiAgentSession
+import com.jonnyzzz.mcpSteroid.testHelper.CloseableStackHost
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Timeout
+import java.util.concurrent.TimeUnit
+
+/**
+ * MCP-win experiment: **safe delete** (jonnyzzz/mcp-steroid#169) — the third refactoring sibling after
+ * [KeycloakRenameTest] and [KeycloakChangeSignatureTest]. The agent removes the deprecated
+ * `org.keycloak.jose.jws.JWSBuilder.EncodingBuilder#rsa256(PrivateKey)` wrapper AND migrates every
+ * production usage to the wrapper's own one-line body — `sign(Algorithm.RS256, <same argument>)` —
+ * so the project still compiles.
+ *
+ * Hand-verified against the pinned Keycloak 26.6.4 tag, the wrapper has exactly THREE production
+ * usages scattered across three Maven modules (the reason a local grep-in-one-module sweep misses):
+ *  - `core/…/org/keycloak/KeyPairVerifier.java:50`
+ *  - `integration/client-cli/admin-cli/…/org/keycloak/client/cli/util/AuthUtil.java:213`
+ *  - `services/…/org/keycloak/protocol/docker/DockerAuthV2Protocol.java:132`
+ * None of the three files imports `org.keycloak.jose.jws.Algorithm` yet — the classic sed trap: the
+ * call is rewritten but the import is forgotten and the module stops compiling. A further ~15 usages
+ * live in unit tests / testsuite (out of scope: the verdict's build check covers production sources
+ * only, and test-file edits are not counted as collateral). The sibling `rsa384`/`rsa512` wrappers
+ * must NOT be touched.
+ *
+ * With MCP the agent drives IntelliJ's `SafeDeleteProcessor` (or `ReferencesSearch` + guided edits)
+ * via `steroid_execute_code` — the IDE surfaces every BLOCKING USAGE before deleting, so the agent
+ * migrates exactly the right sites and the delete lands clean. Without MCP, sed deletes blind and
+ * discovers the cross-module usage — or the missing import — only at compile time.
+ *
+ * Verdict ([scoreSafeDelete]): declaration gone AND all 3 ground-truth usages migrated AND the
+ * post-delete build reported SUCCESS AND no production files outside the known 4-file set changed —
+ * emitted as an `[ARENA]` block. A/B per agent; with-MCP asserts exec_code; correctness is a
+ * dashboard metric, not a hard gate.
+ */
+class KeycloakSafeDeleteTest {
+
+    // 80 min, following the KeycloakRenameTest precedent: the without-MCP baseline is edit/build-heavy —
+    // it must hunt usages across modules, migrate them, and rebuild several Maven modules to verify
+    // (rename measured 30.3 min agent time on CI build 991971402, and container start + Keycloak import
+    // + verification pushed the method past 50). The slow baseline IS the experiment's finding — it must
+    // complete and emit its [ARENA] block so the dashboard can show the gap, not die as a timeout with
+    // no data. TC-side executionTimeoutMin=180 fits two 80-min methods.
+
+    @Test @Timeout(value = 80, unit = TimeUnit.MINUTES)
+    fun `claude with mcp`() = run("claude", withMcp = true)
+
+    @Test @Timeout(value = 80, unit = TimeUnit.MINUTES)
+    fun `claude without mcp`() = run("claude", withMcp = false)
+
+    @Test @Timeout(value = 80, unit = TimeUnit.MINUTES)
+    fun `codex with mcp`() = run("codex", withMcp = true)
+
+    @Test @Timeout(value = 80, unit = TimeUnit.MINUTES)
+    fun `codex without mcp`() = run("codex", withMcp = false)
+
+    private fun run(agentName: String, withMcp: Boolean) {
+        val modeLabel = if (withMcp) "mcp" else "none"
+        val lifetime = CloseableStackHost()
+        try {
+            val session = IntelliJContainer.create(lifetime, IntelliJContainerOpts(
+                consoleTitle = "keycloak-safedelete-$agentName-$modeLabel",
+                project = IntelliJProject.KeycloakProject,
+                aiMode = if (withMcp) AiMode.AI_MCP else AiMode.NONE,
+                mcpConnectionMode = if (withMcp) null else McpConnectionMode.None,
+            )).waitForProjectReady(buildSystem = BuildSystem.MAVEN)
+
+            val agent: AiAgentSession = when (agentName) {
+                "claude" -> session.aiAgents.claude
+                "codex" -> session.aiAgents.codex
+                else -> error("Unknown agent: $agentName")
+            }
+
+            val startedAt = System.currentTimeMillis()
+            val result = agent.runPrompt(if (withMcp) withMcpPrompt() else baselinePrompt(), timeoutSeconds = 2400)
+                .awaitForProcessFinish()
+            val agentDurationMs = System.currentTimeMillis() - startedAt
+            val combined = result.stdout + "\n" + result.stderr
+
+            val score = scoreSafeDelete(combined, REQUIRED_USAGE_FILES, ALLOWED_CHANGED_FILES)
+            println("[TEST] keycloak safe-delete [$agentName+$modeLabel] safe=${score.safe} " +
+                    "methodDeleted=${score.methodDeleted} missing=${score.missingMigrations.size} " +
+                    "collateral=${score.collateralFiles.size} buildGreen=${score.buildGreen}")
+            if (score.missingMigrations.isNotEmpty()) {
+                println("[TEST]   missed usages: ${score.missingMigrations}")
+            }
+            if (score.collateralFiles.isNotEmpty()) {
+                println("[TEST]   collateral edits: ${score.collateralFiles}")
+            }
+
+            recordSemanticRun(
+                scenario = SCENARIO,
+                agentName = agentName,
+                withMcp = withMcp,
+                claimedFix = score.safe,
+                rawOutput = result.rawStdout,
+                exitCode = result.exitCode,
+                agentDurationMs = agentDurationMs,
+                runDir = session.runDirInContainer,
+                summary = "methodDeleted=${score.methodDeleted} migrated=${score.reportedMigrated.size} " +
+                        "missing=${score.missingMigrations.size} collateral=${score.collateralFiles.size} " +
+                        "buildGreen=${score.buildGreen}",
+            )
+
+            if (withMcp) assertUsedExecuteCodeEvidence(combined)
+        } finally {
+            lifetime.closeAllStacks()
+        }
+    }
+
+    private fun taskDescription(): String = buildString {
+        appendLine("Task: SAFE-DELETE the deprecated method `$SYMBOL`")
+        appendLine("(the one-line wrapper whose body is `return sign(Algorithm.RS256, privateKey);`).")
+        appendLine()
+        appendLine("Remove the method declaration AND migrate EVERY production usage so the project still")
+        appendLine("compiles: replace each `.rsa256(<arg>)` call with `.sign(Algorithm.RS256, <arg>)` — the")
+        appendLine("wrapper's own body — adding the `org.keycloak.jose.jws.Algorithm` import where needed.")
+        appendLine()
+        appendLine("Scope rules:")
+        appendLine("- Do NOT touch the sibling `rsa384`/`rsa512` wrappers or any other method.")
+        appendLine("- Do NOT modify any other production file — only the declaration and the usage sites.")
+        appendLine("- Files under src/test or testsuite are OUT OF SCOPE (verification compiles production")
+        appendLine("  sources only, e.g. `mvn compile` — do not run test compilation).")
+    }
+
+    private fun outputMarkers(): String = buildString {
+        appendLine("Output (markers on their own lines):")
+        appendLine("METHOD_DELETED: yes")
+        appendLine("MIGRATED: <path/relative/to/repo/File.java>:<line>   ← one line per migrated production usage")
+        appendLine("CHANGED_FILE: <path>   ← one line per file from `git diff --name-only` at the end")
+        appendLine("BUILD_AFTER_DELETE: <SUCCESS or FAILURE>")
+    }
+
+    private fun withMcpPrompt(): String = buildString {
+        appendLine("The Keycloak project is open in IntelliJ IDEA — a large multi-module Java project.")
+        appendLine()
+        append(taskDescription())
+        appendLine()
+        appendLine("Use IntelliJ's Safe Delete refactoring via `steroid_execute_code`:")
+        appendLine("`com.intellij.refactoring.safeDelete.SafeDeleteProcessor` surfaces every BLOCKING USAGE of")
+        appendLine("the method before deleting (alternatively enumerate them with `ReferencesSearch` first).")
+        appendLine("Migrate each surfaced production usage by PSI-guided edits, then delete the declaration.")
+        appendLine("Do NOT sed. After the change, build the production sources of the affected modules")
+        appendLine("(core, services, integration/client-cli/admin-cli) to verify.")
+        appendLine()
+        append(outputMarkers())
+        appendLine("TOOL_EVIDENCE: <copy the line starting with execution_id: ...>")
+    }
+
+    private fun baselinePrompt(): String = buildString {
+        appendLine("The Keycloak project is checked out (a large multi-module Java project).")
+        appendLine("IntelliJ MCP tools are unavailable in this run — use shell commands only.")
+        appendLine()
+        append(taskDescription())
+        appendLine()
+        appendLine("Beware: usages are scattered across multiple Maven modules, a text search also hits")
+        appendLine("out-of-scope test files, and the replacement needs an import the file may not have —")
+        appendLine("deleting blind breaks the build.")
+        appendLine("After the change, build the production sources of the affected modules")
+        appendLine("(core, services, integration/client-cli/admin-cli) to verify.")
+        appendLine()
+        append(outputMarkers())
+    }
+
+    companion object {
+        private const val SCENARIO = "keycloak__safe_delete"
+        private const val SYMBOL = "org.keycloak.jose.jws.JWSBuilder.EncodingBuilder#rsa256(PrivateKey)"
+
+        // Ground truth hand-derived from the pinned Keycloak 26.6.4 tag: every PRODUCTION file with a
+        // usage of EncodingBuilder#rsa256. Verified by hand (grep + receiver-type check): exactly one
+        // call site per file, three Maven modules. Test usages (core RSAVerifierTest ×10,
+        // SkeletonKeyTokenTest ×3, crypto/default CryptoPerfTest ×1, testsuite
+        // OIDCJwksClientRegistrationTest ×1) are deliberately excluded — see scoreSafeDelete docs.
+        private val REQUIRED_USAGE_FILES = setOf(
+            "core/src/main/java/org/keycloak/KeyPairVerifier.java",
+            "integration/client-cli/admin-cli/src/main/java/org/keycloak/client/cli/util/AuthUtil.java",
+            "services/src/main/java/org/keycloak/protocol/docker/DockerAuthV2Protocol.java",
+        )
+
+        // The only production files the task may change: the declaration + the three usage sites.
+        private val ALLOWED_CHANGED_FILES = REQUIRED_USAGE_FILES +
+                "core/src/main/java/org/keycloak/jose/jws/JWSBuilder.java"
+    }
+}

--- a/test-integration/src/main/kotlin/com/jonnyzzz/mcpSteroid/integration/tests/SemanticTaskScoring.kt
+++ b/test-integration/src/main/kotlin/com/jonnyzzz/mcpSteroid/integration/tests/SemanticTaskScoring.kt
@@ -222,6 +222,100 @@ fun scoreChangeSignature(output: String, requiredOverrides: Set<String>): Change
     )
 }
 
+data class SafeDeleteScore(
+    /** The agent reported the method declaration itself was removed. */
+    val methodDeleted: Boolean,
+    /** Normalized paths from the agent's `MIGRATED: <file>[:<line>]` markers. */
+    val reportedMigrated: Set<String>,
+    /** Ground-truth usage files the agent did NOT report migrating — the blind-sweep misses. */
+    val missingMigrations: Set<String>,
+    /** Normalized paths from the agent's `CHANGED_FILE:` markers (the full reported diff). */
+    val changedFiles: Set<String>,
+    /** Changed PRODUCTION files outside the known set — "while I'm here" collateral edits. */
+    val collateralFiles: Set<String>,
+    /** The post-delete build result the agent reported (null if it never reported one). */
+    val buildGreen: Boolean?,
+    /** Method deleted AND every ground-truth usage site was reported migrated. */
+    val complete: Boolean,
+    /** A safe delete = complete AND the build stays green AND no collateral production edits. */
+    val safe: Boolean,
+)
+
+/**
+ * Score a SAFE DELETE of a method for completeness + safety + precision. With MCP the agent drives
+ * IntelliJ's `SafeDeleteProcessor` (or `ReferencesSearch` + guided edits) via `steroid_execute_code`:
+ * the IDE surfaces every BLOCKING USAGE up front, the agent migrates each one (inline the deprecated
+ * wrapper's trivial body / call the documented successor) and the deletion lands only when nothing
+ * references the method anymore. Without MCP, a shell sweep deletes blind and discovers the missed
+ * cross-module usage — or the forgotten import — only at compile time. Scored identically for both.
+ *
+ * Expected markers (the prompt asks the agent to compile after the delete and report):
+ *   METHOD_DELETED: yes
+ *   MIGRATED: <path/relative/to/repo/File.java>:<line>   (one line per migrated production usage)
+ *   CHANGED_FILE: <path>                                  (one line per file from `git diff --name-only`)
+ *   BUILD_AFTER_DELETE: SUCCESS | FAILURE
+ *
+ * Matching is markdown-normalized and suffix-based (absolute in-container paths and short relative
+ * spellings both count). Lines in `MIGRATED` markers are informational — the file is the evidence:
+ * an agent cannot name the exact usage files without finding them, which is what the experiment
+ * measures (a hallucinated "done" cannot list `integration/…/AuthUtil.java`). Changed files under
+ * `src/test` or `testsuite/` are NOT collateral — deleting a method legitimately ripples into tests,
+ * and the build verdict covers production sources only.
+ *
+ * @param requiredUsageFiles  hand-derived ground truth: every production file with a usage of the
+ *                            method that must be migrated.
+ * @param allowedChangedFiles the full set of files the task is allowed to touch (declaration file +
+ *                            usage files); any other changed production file is collateral.
+ */
+fun scoreSafeDelete(
+    output: String,
+    requiredUsageFiles: Set<String>,
+    allowedChangedFiles: Set<String>,
+): SafeDeleteScore {
+    val methodDeleted = findMarkerValue(output, "METHOD_DELETED", "Method deleted")
+        ?.contains("yes", ignoreCase = true) == true
+
+    val migrated = Regex("""(?im)^\s*[*_`>#|:-]*\s*MIGRATED\s*[*_`]*\s*:\s*(.+)$""")
+        .findAll(output)
+        .map { normalizeReportedPath(it.groupValues[1]) }
+        .filter { it.isNotEmpty() }
+        .toSet()
+    val missing = requiredUsageFiles.filterNot { truth ->
+        migrated.any { pathsReferToSameFile(it, truth) }
+    }.toSet()
+
+    val changed = Regex("""(?im)^\s*[*_`>#|:-]*\s*CHANGED_FILE\s*[*_`]*\s*:\s*(.+)$""")
+        .findAll(output)
+        .map { normalizeReportedPath(it.groupValues[1].replace(Regex("""^\s*[MADRCU?!]{1,2}\s+"""), "")) }
+        .filter { it.isNotEmpty() }
+        .toSet()
+    val collateral = changed.filterNot { file ->
+        val isTestFile = file.contains("/src/test/") || file.startsWith("testsuite/") || file.contains("/testsuite/")
+        isTestFile || allowedChangedFiles.any { pathsReferToSameFile(file, it) }
+    }.toSet()
+
+    val build = findMarkerValue(output, "BUILD_AFTER_DELETE", "Build after delete")
+    val buildGreen = build?.let {
+        when {
+            it.contains("SUCCESS", ignoreCase = true) || it.equals("pass", ignoreCase = true) || it.equals("green", ignoreCase = true) -> true
+            it.contains("FAIL", ignoreCase = true) || it.contains("error", ignoreCase = true) || it.contains("broke", ignoreCase = true) -> false
+            else -> null
+        }
+    }
+
+    val complete = methodDeleted && missing.isEmpty()
+    return SafeDeleteScore(
+        methodDeleted = methodDeleted,
+        reportedMigrated = migrated,
+        missingMigrations = missing,
+        changedFiles = changed,
+        collateralFiles = collateral,
+        buildGreen = buildGreen,
+        complete = complete,
+        safe = complete && buildGreen == true && collateral.isEmpty(),
+    )
+}
+
 data class InspectionScore(
     /** The agent's self-reported `ISSUES_FOUND:` count (informational only — never trusted for the verdict). */
     val issuesFound: Int?,

--- a/test-integration/src/test/kotlin/com/jonnyzzz/mcpSteroid/integration/tests/SafeDeleteScoringTest.kt
+++ b/test-integration/src/test/kotlin/com/jonnyzzz/mcpSteroid/integration/tests/SafeDeleteScoringTest.kt
@@ -1,0 +1,227 @@
+/* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
+package com.jonnyzzz.mcpSteroid.integration.tests
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * Pure, local tests for [scoreSafeDelete] — the verdict for the Keycloak safe-delete A/B.
+ * The point of the experiment: IntelliJ's SafeDeleteProcessor surfaces BLOCKING USAGES of a method
+ * before deleting it, while a blind sed delete discovers the breakage only at compile time. The
+ * scorer checks four things from the agent's marker output: the method declaration is gone, EVERY
+ * hand-derived production usage site was migrated, the post-delete build was reported green, and
+ * NO production files outside the known set were touched (collateral edits). No IDE/Docker needed.
+ */
+class SafeDeleteScoringTest {
+
+    // A toy ground truth mirroring the Keycloak rsa256 shape: a declaration file plus three usage
+    // files scattered across three modules.
+    private val requiredUsageFiles = setOf(
+        "core/src/main/java/org/kc/KeyPairVerifier.java",
+        "integration/admin-cli/src/main/java/org/kc/cli/AuthUtil.java",
+        "services/src/main/java/org/kc/docker/DockerAuthV2Protocol.java",
+    )
+    private val allowedChangedFiles = requiredUsageFiles +
+            "core/src/main/java/org/kc/jose/JWSBuilder.java"
+
+    private fun score(output: String) = scoreSafeDelete(output, requiredUsageFiles, allowedChangedFiles)
+
+    @Test
+    fun `MCP-style answer with all migrations, clean diff and green build scores safe`() {
+        val mcp = """
+            Used SafeDeleteProcessor via steroid_execute_code; it surfaced 3 blocking usages.
+            METHOD_DELETED: yes
+            MIGRATED: core/src/main/java/org/kc/KeyPairVerifier.java:50
+            MIGRATED: integration/admin-cli/src/main/java/org/kc/cli/AuthUtil.java:213
+            MIGRATED: services/src/main/java/org/kc/docker/DockerAuthV2Protocol.java:132
+            CHANGED_FILE: core/src/main/java/org/kc/jose/JWSBuilder.java
+            CHANGED_FILE: core/src/main/java/org/kc/KeyPairVerifier.java
+            CHANGED_FILE: integration/admin-cli/src/main/java/org/kc/cli/AuthUtil.java
+            CHANGED_FILE: services/src/main/java/org/kc/docker/DockerAuthV2Protocol.java
+            BUILD_AFTER_DELETE: SUCCESS
+        """.trimIndent()
+        val s = score(mcp)
+        assertTrue(s.methodDeleted)
+        assertEquals(emptySet<String>(), s.missingMigrations)
+        assertEquals(emptySet<String>(), s.collateralFiles)
+        assertEquals(true, s.buildGreen)
+        assertTrue(s.complete)
+        assertTrue(s.safe)
+    }
+
+    @Test
+    fun `sweep that misses the cross-module usage scores incomplete`() {
+        // The classic blind-sed miss: the usage in another module never shows up in the local grep.
+        val sweep = """
+            METHOD_DELETED: yes
+            MIGRATED: core/src/main/java/org/kc/KeyPairVerifier.java:50
+            MIGRATED: services/src/main/java/org/kc/docker/DockerAuthV2Protocol.java:132
+            CHANGED_FILE: core/src/main/java/org/kc/jose/JWSBuilder.java
+            CHANGED_FILE: core/src/main/java/org/kc/KeyPairVerifier.java
+            CHANGED_FILE: services/src/main/java/org/kc/docker/DockerAuthV2Protocol.java
+            BUILD_AFTER_DELETE: FAILURE
+        """.trimIndent()
+        val s = score(sweep)
+        assertTrue(s.methodDeleted)
+        assertEquals(setOf("integration/admin-cli/src/main/java/org/kc/cli/AuthUtil.java"), s.missingMigrations)
+        assertEquals(false, s.buildGreen)
+        assertFalse(s.complete)
+        assertFalse(s.safe)
+    }
+
+    @Test
+    fun `collateral edit to a production file outside the known set fails the verdict`() {
+        // "While I'm here" over-edits: a sibling file changed although it was not part of the task.
+        val out = """
+            METHOD_DELETED: yes
+            MIGRATED: core/src/main/java/org/kc/KeyPairVerifier.java:50
+            MIGRATED: integration/admin-cli/src/main/java/org/kc/cli/AuthUtil.java:213
+            MIGRATED: services/src/main/java/org/kc/docker/DockerAuthV2Protocol.java:132
+            CHANGED_FILE: core/src/main/java/org/kc/jose/JWSBuilder.java
+            CHANGED_FILE: core/src/main/java/org/kc/KeyPairVerifier.java
+            CHANGED_FILE: integration/admin-cli/src/main/java/org/kc/cli/AuthUtil.java
+            CHANGED_FILE: services/src/main/java/org/kc/docker/DockerAuthV2Protocol.java
+            CHANGED_FILE: core/src/main/java/org/kc/jose/JWSInput.java
+            BUILD_AFTER_DELETE: SUCCESS
+        """.trimIndent()
+        val s = score(out)
+        assertEquals(setOf("core/src/main/java/org/kc/jose/JWSInput.java"), s.collateralFiles)
+        assertTrue(s.complete)
+        assertFalse(s.safe)
+    }
+
+    @Test
+    fun `changed test files are not collateral`() {
+        // Deleting the method legitimately ripples into unit tests / testsuite; those edits are out of
+        // scope for the verdict (the build check covers production sources only).
+        val out = """
+            METHOD_DELETED: yes
+            MIGRATED: core/src/main/java/org/kc/KeyPairVerifier.java:50
+            MIGRATED: integration/admin-cli/src/main/java/org/kc/cli/AuthUtil.java:213
+            MIGRATED: services/src/main/java/org/kc/docker/DockerAuthV2Protocol.java:132
+            CHANGED_FILE: core/src/main/java/org/kc/jose/JWSBuilder.java
+            CHANGED_FILE: core/src/main/java/org/kc/KeyPairVerifier.java
+            CHANGED_FILE: integration/admin-cli/src/main/java/org/kc/cli/AuthUtil.java
+            CHANGED_FILE: services/src/main/java/org/kc/docker/DockerAuthV2Protocol.java
+            CHANGED_FILE: core/src/test/java/org/kc/RSAVerifierTest.java
+            CHANGED_FILE: testsuite/integration-arquillian/tests/base/src/test/java/org/kc/SomeTest.java
+            BUILD_AFTER_DELETE: SUCCESS
+        """.trimIndent()
+        val s = score(out)
+        assertEquals(emptySet<String>(), s.collateralFiles)
+        assertTrue(s.safe)
+    }
+
+    @Test
+    fun `complete migration but red build is complete yet not safe`() {
+        val out = """
+            METHOD_DELETED: yes
+            MIGRATED: core/src/main/java/org/kc/KeyPairVerifier.java:50
+            MIGRATED: integration/admin-cli/src/main/java/org/kc/cli/AuthUtil.java:213
+            MIGRATED: services/src/main/java/org/kc/docker/DockerAuthV2Protocol.java:132
+            CHANGED_FILE: core/src/main/java/org/kc/jose/JWSBuilder.java
+            BUILD_AFTER_DELETE: FAILURE — missing import of Algorithm in AuthUtil
+        """.trimIndent()
+        val s = score(out)
+        assertTrue(s.complete)
+        assertEquals(false, s.buildGreen)
+        assertFalse(s.safe)
+    }
+
+    @Test
+    fun `markdown-formatted markers with backticked paths and status prefixes still parse`() {
+        // Agents love markdown, and `git status --porcelain` output sneaks `M ` prefixes into
+        // CHANGED_FILE lines — both must parse (the exact failure mode that broke raw substring
+        // scoring before; see scoreSortedByDescendingRootCause).
+        val md = """
+            **METHOD_DELETED**: yes
+            - MIGRATED: `core/src/main/java/org/kc/KeyPairVerifier.java:51`
+            - MIGRATED: `integration/admin-cli/src/main/java/org/kc/cli/AuthUtil.java:214`
+            - MIGRATED: `services/src/main/java/org/kc/docker/DockerAuthV2Protocol.java:133`
+            CHANGED_FILE: M core/src/main/java/org/kc/jose/JWSBuilder.java
+            CHANGED_FILE: M core/src/main/java/org/kc/KeyPairVerifier.java
+            CHANGED_FILE: M integration/admin-cli/src/main/java/org/kc/cli/AuthUtil.java
+            CHANGED_FILE: M services/src/main/java/org/kc/docker/DockerAuthV2Protocol.java
+            **BUILD_AFTER_DELETE**: SUCCESS
+        """.trimIndent()
+        val s = score(md)
+        assertTrue(s.methodDeleted, "markdown-wrapped METHOD_DELETED must parse")
+        assertEquals(emptySet<String>(), s.missingMigrations, "backticked paths must parse")
+        assertEquals(emptySet<String>(), s.collateralFiles, "git-status prefixes must be stripped")
+        assertTrue(s.safe)
+    }
+
+    @Test
+    fun `absolute in-container paths still match the relative ground truth`() {
+        val out = """
+            METHOD_DELETED: yes
+            MIGRATED: /home/agent/project/core/src/main/java/org/kc/KeyPairVerifier.java:50
+            MIGRATED: /home/agent/project/integration/admin-cli/src/main/java/org/kc/cli/AuthUtil.java:213
+            MIGRATED: /home/agent/project/services/src/main/java/org/kc/docker/DockerAuthV2Protocol.java:132
+            CHANGED_FILE: /home/agent/project/core/src/main/java/org/kc/jose/JWSBuilder.java
+            BUILD_AFTER_DELETE: SUCCESS
+        """.trimIndent()
+        val s = score(out)
+        assertEquals(emptySet<String>(), s.missingMigrations)
+        assertEquals(emptySet<String>(), s.collateralFiles)
+        assertTrue(s.safe)
+    }
+
+    @Test
+    fun `method not deleted scores unsafe regardless of everything else`() {
+        val out = """
+            METHOD_DELETED: no
+            MIGRATED: core/src/main/java/org/kc/KeyPairVerifier.java:50
+            MIGRATED: integration/admin-cli/src/main/java/org/kc/cli/AuthUtil.java:213
+            MIGRATED: services/src/main/java/org/kc/docker/DockerAuthV2Protocol.java:132
+            BUILD_AFTER_DELETE: SUCCESS
+        """.trimIndent()
+        val s = score(out)
+        assertFalse(s.methodDeleted)
+        assertFalse(s.complete)
+        assertFalse(s.safe)
+    }
+
+    @Test
+    fun `missing build marker yields null buildGreen and unsafe`() {
+        val out = """
+            METHOD_DELETED: yes
+            MIGRATED: core/src/main/java/org/kc/KeyPairVerifier.java:50
+            MIGRATED: integration/admin-cli/src/main/java/org/kc/cli/AuthUtil.java:213
+            MIGRATED: services/src/main/java/org/kc/docker/DockerAuthV2Protocol.java:132
+        """.trimIndent()
+        val s = score(out)
+        assertNull(s.buildGreen)
+        assertTrue(s.complete)
+        assertFalse(s.safe)
+    }
+
+    @Test
+    fun `no markers at all scores fully unsafe with all migrations missing`() {
+        val s = score("I could not complete the task, the build kept failing.")
+        assertFalse(s.methodDeleted)
+        assertEquals(requiredUsageFiles, s.missingMigrations)
+        assertNull(s.buildGreen)
+        assertFalse(s.safe)
+    }
+
+    @Test
+    fun `migration markers without line numbers still count by file`() {
+        // Line numbers drift by a couple of lines when the import block above the call site grows —
+        // matching is by file, the line is informational.
+        val out = """
+            METHOD_DELETED: yes
+            MIGRATED: core/src/main/java/org/kc/KeyPairVerifier.java
+            MIGRATED: integration/admin-cli/src/main/java/org/kc/cli/AuthUtil.java
+            MIGRATED: services/src/main/java/org/kc/docker/DockerAuthV2Protocol.java
+            CHANGED_FILE: core/src/main/java/org/kc/jose/JWSBuilder.java
+            BUILD_AFTER_DELETE: SUCCESS
+        """.trimIndent()
+        val s = score(out)
+        assertEquals(emptySet<String>(), s.missingMigrations)
+        assertTrue(s.safe)
+    }
+}


### PR DESCRIPTION
## What

Third refactoring sibling after `KeycloakRenameTest` and `KeycloakChangeSignatureTest` (#169): a safe-delete A/B experiment on the pinned Keycloak 26.6.4 tree.

The agent must **remove** the deprecated `org.keycloak.jose.jws.JWSBuilder.EncodingBuilder#rsa256(PrivateKey)` wrapper **and migrate every production usage** to the wrapper's own one-line body — `sign(Algorithm.RS256, <same arg>)` — so the project still compiles.

## Why this target (hand-verified at 26.6.4)

- Exactly **3 production usages across 3 Maven modules**:
  - `core/src/main/java/org/keycloak/KeyPairVerifier.java:50`
  - `integration/client-cli/admin-cli/src/main/java/org/keycloak/client/cli/util/AuthUtil.java:213`
  - `services/src/main/java/org/keycloak/protocol/docker/DockerAuthV2Protocol.java:132`
- **None of the three files imports `org.keycloak.jose.jws.Algorithm` yet** — the classic sed trap: the call is rewritten, the import is forgotten, the module stops compiling.
- ~15 further usages live in unit tests / testsuite (`RSAVerifierTest` ×10, `SkeletonKeyTokenTest` ×3, `CryptoPerfTest` ×1, arquillian ×1) — deliberately **out of scope**: the build verdict covers production sources only (`mvn compile`), and test-file edits are not counted as collateral.
- Sibling `rsa384`/`rsa512` wrappers must NOT be touched — an over-eager sweep gets caught.

With MCP the agent drives IntelliJ's `SafeDeleteProcessor` (or `ReferencesSearch` + guided edits) via `steroid_execute_code`: the IDE surfaces every **blocking usage** before deleting. Without MCP, sed deletes blind and discovers the cross-module usage — or the missing import — only at compile time.

## Scoring (`scoreSafeDelete`, pure + TDD)

Evidence-based markers, scored identically for both legs:
- `METHOD_DELETED: yes`
- `MIGRATED: <file>:<line>` — matched (file-suffix, markdown-normalized) against the hand-derived 3-file list; an agent cannot name `integration/…/AuthUtil.java` without finding it
- `CHANGED_FILE: <path>` (from `git diff --name-only`) — **any changed production file outside the known 4-file set fails the verdict** (collateral edits); `src/test`/`testsuite` changes ignored
- `BUILD_AFTER_DELETE: SUCCESS|FAILURE`

`safe = deleted ∧ all 3 migrated ∧ build green ∧ no collateral`. Correctness is a dashboard metric (not a hard gate); with-MCP legs assert exec_code evidence; `[ARENA]` scenario `keycloak__safe_delete`; 80-min `@Timeout` per leg (edit/build-heavy baseline, KeycloakRenameTest precedent).

## Verified

- `:test-integration:test --tests "*SafeDeleteScoringTest"` — 11/11 green (watched them fail first)
- `:test-experiments:compileTestKotlin` — green
- Docker/IDE E2E left to CI

## TeamCity registration expected

- `IntegrationTests_KeycloakSafeDelete_Claude` (filter `*KeycloakSafeDeleteTest.claude*`)
- `IntegrationTests_KeycloakSafeDelete_Codex` (filter `*KeycloakSafeDeleteTest.codex*`)
- `executionTimeoutMin=180` (two 80-min legs per config)

🤖 Generated with [Claude Code](https://claude.com/claude-code)