### PR TITLE
report: recency-weighted aggregation over ALL past runs (~6 months of history)

### DIFF
--- a/experiments-report/src/main/kotlin/com/jonnyzzz/mcpSteroid/report/HtmlRenderer.kt
+++ b/experiments-report/src/main/kotlin/com/jonnyzzz/mcpSteroid/report/HtmlRenderer.kt
@@ -89,6 +89,7 @@ object HtmlRenderer {
 
     // ── Primary: per-agent with/without tables, grouped into scenario buckets ───
     private fun renderComparisons(sb: StringBuilder, report: Report) {
+        val histories = report.histories.associateBy { Triple(it.scenario, it.agent, it.mode) }
         val byAgent = report.comparisons.groupBy { it.agent }.toSortedMap()
         for ((agent, comps) in byAgent) {
             sb.append("<section><h2>").append(esc(agent)).append(" — per task</h2>\n")
@@ -113,6 +114,14 @@ object HtmlRenderer {
                     val toolDiff = renderToolDiff(c.withMcp, c.without)
                     if (toolDiff.isNotEmpty()) {
                         sb.append("<tr class=\"detail\"><td colspan=\"6\">").append(toolDiff).append("</td></tr>\n")
+                    }
+                    // Recency-weighted history over ALL cached builds — one line per leg, and only
+                    // when there is actual history (n > 1): a single run is just the row above.
+                    for ((legLabel, mode) in listOf("with MCP" to McpMode.WITH, "without MCP" to McpMode.WITHOUT)) {
+                        val h = histories[Triple(c.scenario, c.agent, mode)] ?: continue
+                        if (h.runs <= 1) continue
+                        sb.append("<tr class=\"detail\"><td colspan=\"6\"><span class=\"detail-label\">run history — ")
+                            .append(legLabel).append(":</span> ").append(historyLine(h)).append("</td></tr>\n")
                     }
                     val summary = c.withMcp?.summary ?: c.without?.summary
                     if (!summary.isNullOrBlank()) {
@@ -170,6 +179,35 @@ object HtmlRenderer {
 
     private fun shortTool(name: String): String =
         if (name.startsWith("mcp__")) name.substringAfterLast("__") else name
+
+    /**
+     * One leg's history over all cached builds, e.g.
+     * `9 runs over 4 months · 82% ✓ (weighted) · median 4m 58s · $1.02 · 1 crashed · 3 models: a → b`.
+     * Crash count and model-drift note appear only when there is something to disclose.
+     */
+    private fun historyLine(h: RunHistory): String {
+        val bits = mutableListOf<String>()
+        bits += "${h.runs} runs" + (h.spanDays?.let { " over " + fmtSpan(it) } ?: "")
+        h.weightedSuccessPct?.let { bits += "$it% ✓ (weighted)" }
+        h.weightedMedianDurationMs?.let { bits += "median " + fmtDuration(it) }
+        h.weightedMedianCostUsd?.let { bits += "$" + String.format("%.2f", it) }
+        if (h.crashed > 0) bits += "${h.crashed} crashed"
+        if (h.models.size > 1) {
+            bits += "${h.models.size} models: " + esc(h.models.first()) + " → " + esc(h.models.last())
+        }
+        return bits.joinToString(" · ")
+    }
+
+    /** Human age span: days under two weeks, then weeks, then months. */
+    private fun fmtSpan(days: Double): String {
+        val d = Math.round(days).toInt()
+        return when {
+            d <= 1 -> "1 day"
+            d < 14 -> "$d days"
+            d < 61 -> "${Math.round(d / 7.0)} weeks"
+            else -> "${Math.round(d / 30.44)} months"
+        }
+    }
 
     private fun fmtInt(n: Long?): String = if (n == null) "?" else String.format("%,d", n)
 

--- a/experiments-report/src/main/kotlin/com/jonnyzzz/mcpSteroid/report/InputReader.kt
+++ b/experiments-report/src/main/kotlin/com/jonnyzzz/mcpSteroid/report/InputReader.kt
@@ -29,14 +29,32 @@ import java.io.File
 object InputReader {
     private val json = Json { ignoreUnknownKeys = true; isLenient = true }
 
-    fun read(root: File): List<AgentRun> {
+    fun read(root: File): List<AgentRun> = readAll(root).latest
+
+    /**
+     * Both views of the cache:
+     *  - [latest] — per (scenario, agent, mode) only the LATEST build's merged run; the primary
+     *    comparison is built exclusively from these.
+     *  - [allBuilds] — one merged run per (scenario, agent, mode, build): every cached build,
+     *    including superseded ones, contributes one attempt to the run history.
+     */
+    data class CollectedRuns(val latest: List<AgentRun>, val allBuilds: List<AgentRun>)
+
+    fun readAll(root: File): CollectedRuns {
         val buildsDir = File(root, "builds")
-        val runs = if (buildsDir.isDirectory) {
-            buildsDir.listFiles { f -> f.isDirectory }.orEmpty().flatMap { readBuildFolder(it) }
-        } else {
-            readFlat(root)
+        if (!buildsDir.isDirectory) {
+            val flat = mergeRuns(readFlat(root))
+            return CollectedRuns(latest = flat, allBuilds = flat)
         }
-        return mergeRuns(latestBuildOnly(runs))
+        // Source-merge stays WITHIN one build folder: each cached build yields its own merged run
+        // per (scenario, agent, mode), so a superseded build survives as a distinct history attempt
+        // and can never leak fields across builds.
+        val perBuild = buildsDir.listFiles { f -> f.isDirectory }.orEmpty().sortedBy { it.name }
+            .flatMap { mergeRuns(readBuildFolder(it)) }
+        return CollectedRuns(
+            latest = mergeRuns(latestBuildOnly(perBuild)),
+            allBuilds = perBuild,
+        )
     }
 
     /**
@@ -105,6 +123,9 @@ object InputReader {
         // latest-build selection can tell fresh runs from a superseded build's leftovers. The folder
         // name (`<configId>__<buildId>`) is the fallback when meta.json is missing.
         val (buildConfigId, buildId) = readBuildIdentity(dir)
+        // …and its finish date (collector meta.json `finishDate` — ISO-8601 or TeamCity format),
+        // the recency signal for the run-history weighting. Old caches without it stay undated.
+        val finishedAt = parseFinishDate(readMetaField(dir, "finishDate"))
 
         val ndjsonRuns = if (ctx == null) emptyList() else files
             .filter { it.name.lowercase().endsWith(".ndjson") }
@@ -127,8 +148,16 @@ object InputReader {
             r.copy(
                 buildConfigId = r.buildConfigId ?: buildConfigId,
                 buildId = r.buildId ?: buildId,
+                finishedAt = r.finishedAt ?: finishedAt,
             )
         }
+    }
+
+    /** One string field out of the folder's meta.json, or null when the file/field is absent. */
+    private fun readMetaField(dir: File, field: String): String? {
+        val meta = File(dir, "meta.json").takeIf { it.isFile } ?: return null
+        val o = runCatching { json.parseToJsonElement(meta.readText()).jsonObject }.getOrNull() ?: return null
+        return o[field]?.jsonPrimitive?.contentOrNull
     }
 
     /** (buildConfigId, buildId) from meta.json, falling back to the `<configId>__<buildId>` dir name. */

--- a/experiments-report/src/main/kotlin/com/jonnyzzz/mcpSteroid/report/Merge.kt
+++ b/experiments-report/src/main/kotlin/com/jonnyzzz/mcpSteroid/report/Merge.kt
@@ -20,6 +20,7 @@ fun mergeRuns(runs: List<AgentRun>): List<AgentRun> {
 private fun mergeTwo(a: AgentRun, b: AgentRun): AgentRun = a.copy(
     buildConfigId = a.buildConfigId ?: b.buildConfigId,
     buildId = a.buildId ?: b.buildId,
+    finishedAt = a.finishedAt ?: b.finishedAt,
     testStatus = a.testStatus ?: b.testStatus,
     testDurationMs = a.testDurationMs ?: b.testDurationMs,
     agentDurationMs = a.agentDurationMs ?: b.agentDurationMs,

--- a/experiments-report/src/main/kotlin/com/jonnyzzz/mcpSteroid/report/Model.kt
+++ b/experiments-report/src/main/kotlin/com/jonnyzzz/mcpSteroid/report/Model.kt
@@ -17,6 +17,8 @@ data class AgentRun(
     val mode: McpMode,
     val buildConfigId: String? = null,
     val buildId: Long? = null,
+    /** When the build that produced this run finished (collector meta.json `finishDate`); null for old caches. */
+    val finishedAt: java.time.Instant? = null,
     // JUnit / CI test occurrence (authoritative pass/fail of the *test*, lenient: passes if the
     // agent exited cleanly or claimed a fix — NOT a quality signal on its own).
     val testStatus: String? = null,

--- a/experiments-report/src/main/kotlin/com/jonnyzzz/mcpSteroid/report/Report.kt
+++ b/experiments-report/src/main/kotlin/com/jonnyzzz/mcpSteroid/report/Report.kt
@@ -8,6 +8,8 @@ data class Report(
     val allRuns: List<AgentRun>,
     /** Every build the collector pulled (incl. ones that produced no parseable run data). Empty for a flat local run. */
     val collectedBuilds: List<BuildMeta> = emptyList(),
+    /** Recency-weighted aggregation over ALL cached builds per (scenario, agent, mode) — see [runHistories]. */
+    val histories: List<RunHistory> = emptyList(),
 )
 
 /** One collected build's identity + outcome, from the collector's `meta.json`. Drives the coverage view. */

--- a/experiments-report/src/main/kotlin/com/jonnyzzz/mcpSteroid/report/ReportMain.kt
+++ b/experiments-report/src/main/kotlin/com/jonnyzzz/mcpSteroid/report/ReportMain.kt
@@ -9,13 +9,16 @@ import java.time.Instant
  * output side.
  */
 fun buildReport(inputDir: File, title: String, generatedAt: String): Report {
-    val runs = InputReader.read(inputDir)
+    val collected = InputReader.readAll(inputDir)
     return Report(
         title = title,
         generatedAt = generatedAt,
-        comparisons = Aggregator.compare(runs),
-        allRuns = runs,
+        comparisons = Aggregator.compare(collected.latest),
+        allRuns = collected.latest,
         collectedBuilds = InputReader.readBuildMetas(inputDir),
+        // generatedAt is the "now" of the recency weighting — the clock is threaded through, the
+        // pure pipeline never reads the wall clock itself.
+        histories = runHistories(collected.allBuilds, parseFinishDate(generatedAt)),
     )
 }
 

--- a/experiments-report/src/main/kotlin/com/jonnyzzz/mcpSteroid/report/RunHistory.kt
+++ b/experiments-report/src/main/kotlin/com/jonnyzzz/mcpSteroid/report/RunHistory.kt
@@ -1,0 +1,175 @@
+package com.jonnyzzz.mcpSteroid.report
+
+import java.time.Duration
+import java.time.Instant
+import java.time.LocalDateTime
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
+import java.time.format.DateTimeFormatter
+import kotlin.math.abs
+import kotlin.math.pow
+import kotlin.math.roundToInt
+import kotlin.math.roundToLong
+
+/**
+ * Half-life of a run's influence on the history aggregates, in days.
+ *
+ * Both the plugin under test AND the LLMs behind the agents turn over on roughly a 1–2 month
+ * cadence, so 45 days makes the current generation dominate: a run one half-life old counts half,
+ * and anything beyond ~4 half-lives (≈ 6 months — the collector's fetch depth) contributes under
+ * 7% — still visible as history, but powerless over the aggregate.
+ */
+const val HALF_LIFE_DAYS = 45.0
+
+private const val MILLIS_PER_DAY = 86_400_000.0
+
+/** Exponential recency decay: weight = 0.5^(ageDays / [HALF_LIFE_DAYS]). Never reaches zero. */
+fun decayWeight(ageDays: Double): Double = 0.5.pow(ageDays / HALF_LIFE_DAYS)
+
+/**
+ * Weighted median: sort by value and return the first value whose cumulative weight reaches half
+ * the total — the "lower weighted median": deterministic, no interpolation, always an actually
+ * observed value. Null for an empty list or all-zero weights (never divides by zero).
+ */
+fun weightedMedian(valuesToWeights: List<Pair<Double, Double>>): Double? {
+    val sorted = valuesToWeights.filter { it.second > 0.0 }.sortedBy { it.first }
+    val total = sorted.sumOf { it.second }
+    if (total <= 0.0) return null
+    var cumulative = 0.0
+    for ((value, weight) in sorted) {
+        cumulative += weight
+        if (cumulative >= total / 2) return value
+    }
+    return sorted.last().first // unreachable in exact arithmetic; guards float drift
+}
+
+/** TeamCity's `finishDate` shape, e.g. `20260620T101530+0000`. */
+private val TEAMCITY_DATE: DateTimeFormatter = DateTimeFormatter.ofPattern("yyyyMMdd'T'HHmmssZ")
+
+/**
+ * Lenient `finishDate` parsing: ISO-8601 instant (`2026-06-20T10:15:30Z`), ISO offset date-time
+ * (`…+02:00`), TeamCity's `yyyyMMdd'T'HHmmssZ`, or a bare local date-time (read as UTC). Returns
+ * null — never throws — on anything else, so an old cache without dates degrades gracefully.
+ */
+fun parseFinishDate(text: String?): Instant? {
+    val s = text?.trim()?.takeIf { it.isNotEmpty() } ?: return null
+    runCatching { return Instant.parse(s) }
+    runCatching { return OffsetDateTime.parse(s).toInstant() }
+    runCatching { return OffsetDateTime.parse(s, TEAMCITY_DATE).toInstant() }
+    runCatching { return LocalDateTime.parse(s).toInstant(ZoneOffset.UTC) }
+    return null
+}
+
+/**
+ * Recency-weighted aggregate of EVERY cached attempt at one (scenario, agent, mode) — not a re-run
+ * median of an identical task, but the task's whole trajectory over ~6 months of collected builds,
+ * where newer runs count more ([decayWeight]) because the plugin and the LLMs both change.
+ *
+ * Crashed attempts ([AgentRun.agentCrashed] — the tooling died, not the task) are COUNTED in
+ * [crashed] but excluded from the rate and the medians so a 2-second 429 corpse can never drag a
+ * median down. Attempts whose outcome is unknown ([succeeded] == null) stay out of the rate's
+ * denominator.
+ */
+data class RunHistory(
+    val scenario: String,
+    val agent: String,
+    val mode: McpMode,
+    /** Total attempts, including crashed ones. */
+    val runs: Int,
+    /** Attempts where the agent tooling itself failed. */
+    val crashed: Int,
+    /** Σ w·success / Σ w over clean attempts with a known outcome, in percent; null if none. */
+    val weightedSuccessPct: Int?,
+    /** Weighted median agent duration over clean attempts; null when no clean attempt has one. */
+    val weightedMedianDurationMs: Long?,
+    /** Weighted median cost over clean attempts; null when no clean attempt has one. */
+    val weightedMedianCostUsd: Double?,
+    /** Oldest → newest dated attempt, in days; null when no attempt carries a date. */
+    val spanDays: Double?,
+    /** Distinct models seen, oldest → newest — discloses that old runs were a different beast. */
+    val models: List<String>,
+)
+
+/**
+ * Aggregate [allBuilds] (one merged run per scenario/agent/mode/build — [InputReader.readAll])
+ * into one [RunHistory] per (scenario, agent, mode).
+ *
+ * [now] is the report's own generatedAt so the whole pipeline stays pure — pass null only when no
+ * clock is known, in which case the newest dated run acts as "now".
+ */
+fun runHistories(allBuilds: List<AgentRun>, now: Instant?): List<RunHistory> =
+    allBuilds.groupBy { Triple(it.scenario, it.agent, it.mode) }
+        .map { (key, group) -> historyOf(key.first, key.second, key.third, group, now) }
+        .sortedWith(compareBy({ it.scenario }, { it.agent }, { it.mode }))
+
+private fun historyOf(scenario: String, agent: String, mode: McpMode, group: List<AgentRun>, now: Instant?): RunHistory {
+    val ages = assignAgesDays(group, now)
+    val weights = ages.map(::decayWeight)
+    val clean = group.indices.filter { !group[it].agentCrashed() }
+
+    var weightTotal = 0.0
+    var weightSucceeded = 0.0
+    for (i in clean) {
+        val succeeded = group[i].succeeded() ?: continue
+        weightTotal += weights[i]
+        if (succeeded) weightSucceeded += weights[i]
+    }
+
+    val dated = group.mapNotNull { it.finishedAt }
+
+    return RunHistory(
+        scenario = scenario,
+        agent = agent,
+        mode = mode,
+        runs = group.size,
+        crashed = group.size - clean.size,
+        weightedSuccessPct = if (weightTotal > 0.0) (weightSucceeded / weightTotal * 100).roundToInt() else null,
+        weightedMedianDurationMs = weightedMedian(
+            clean.mapNotNull { i -> group[i].agentDurationMs?.let { it.toDouble() to weights[i] } }
+        )?.roundToLong(),
+        weightedMedianCostUsd = weightedMedian(
+            clean.mapNotNull { i -> group[i].costUsd?.let { it to weights[i] } }
+        ),
+        spanDays = if (dated.isEmpty()) null
+        else Duration.between(dated.min(), dated.max()).toMillis() / MILLIS_PER_DAY,
+        // oldest → newest: stable sort by age descending keeps same-age runs in input order.
+        models = group.indices.sortedByDescending { ages[it] }.mapNotNull { group[it].model }.distinct(),
+    )
+}
+
+/**
+ * Age in days of every run in [runs] (a single (scenario, agent, mode) group), relative to [now].
+ *
+ * Graceful degradation, in order:
+ *  1. a dated run ([AgentRun.finishedAt]) → its actual age, clamped at 0 (never negative);
+ *  2. an undated run with a buildId, when the group has dated runs → borrows the age of the dated
+ *     run with the NEAREST buildId (buildIds are monotonic, so neighbours finished around the
+ *     same time);
+ *  3. no dated runs at all → order-only decay: distinct buildIds newest-first, one half-life per
+ *     step back (weights 1, ½, ¼, …);
+ *  4. neither date nor buildId (flat local layout) → age 0: what you just ran is fresh.
+ *
+ * A null [now] falls back to the newest dated run — that run IS the clock, at age 0.
+ */
+fun assignAgesDays(runs: List<AgentRun>, now: Instant?): List<Double> {
+    val clock: Instant? = now ?: runs.mapNotNull { it.finishedAt }.maxOrNull()
+
+    fun ageOf(finishedAt: Instant): Double =
+        maxOf(0.0, Duration.between(finishedAt, clock!!).toMillis() / MILLIS_PER_DAY)
+
+    val anchors = runs.filter { it.finishedAt != null && it.buildId != null }
+    val rankOfBuild: Map<Long, Int> = runs.mapNotNull { it.buildId }.distinct().sortedDescending()
+        .withIndex().associate { (rank, id) -> id to rank }
+
+    return runs.map { r ->
+        val finishedAt = r.finishedAt
+        val buildId = r.buildId
+        when {
+            finishedAt != null && clock != null -> ageOf(finishedAt)
+            buildId != null && anchors.isNotEmpty() && clock != null ->
+                ageOf(anchors.minBy { abs(it.buildId!! - buildId) }.finishedAt!!)
+            buildId != null && anchors.isEmpty() -> (rankOfBuild[buildId] ?: 0) * HALF_LIFE_DAYS
+            else -> 0.0
+        }
+    }
+}

--- a/experiments-report/src/test/kotlin/com/jonnyzzz/mcpSteroid/report/HtmlRendererTest.kt
+++ b/experiments-report/src/test/kotlin/com/jonnyzzz/mcpSteroid/report/HtmlRendererTest.kt
@@ -93,6 +93,73 @@ class HtmlRendererTest {
     }
 
     @Test
+    fun `shows a weighted history line under a leg with repeat runs and none for a single run`() {
+        val runs = listOf(
+            AgentRun("petclinic-27", "claude", McpMode.WITH, claimedFix = true, agentDurationMs = 312_000),
+            AgentRun("petclinic-27", "claude", McpMode.WITHOUT, claimedFix = true, agentDurationMs = 400_000),
+        )
+        val histories = listOf(
+            // 9 attempts for the WITH leg spread over ~4 months and 3 model generations
+            RunHistory(
+                scenario = "petclinic-27", agent = "claude", mode = McpMode.WITH,
+                runs = 9, crashed = 1, weightedSuccessPct = 82,
+                weightedMedianDurationMs = 298_000, weightedMedianCostUsd = 1.02,
+                spanDays = 120.0,
+                models = listOf("claude-opus-4-6", "claude-opus-4-7", "claude-opus-4-8"),
+            ),
+            // single attempt for the WITHOUT leg — no history line
+            RunHistory(
+                scenario = "petclinic-27", agent = "claude", mode = McpMode.WITHOUT,
+                runs = 1, crashed = 0, weightedSuccessPct = 100,
+                weightedMedianDurationMs = 400_000, weightedMedianCostUsd = 2.0,
+                spanDays = null, models = listOf("claude-opus-4-8"),
+            ),
+        )
+        val html = HtmlRenderer.render(
+            Report("t", "2026-07-03T00:00:00Z", Aggregator.compare(runs), runs, histories = histories)
+        )
+        assertTrue(html.contains("run history"), "repeat-run leg gets a history line")
+        assertTrue(html.contains("9 runs"))
+        assertTrue(html.contains("over 4 months"), "age span disclosed")
+        assertTrue(html.contains("82% ✓ (weighted)"), "recency-weighted success rate, labelled as such")
+        assertTrue(html.contains("median 4m 58s"))
+        assertTrue(html.contains("$1.02"))
+        assertTrue(html.contains("1 crashed"))
+        assertTrue(html.contains("3 models"), "model drift disclosed compactly")
+        assertTrue(html.contains("claude-opus-4-6 → claude-opus-4-8"), "oldest → newest model")
+        // the n=1 leg renders NO history line: its numbers must not read as history
+        assertFalse(html.contains("1 runs"), "a single run is not a history")
+    }
+
+    @Test
+    fun `omits crash count and model note when there is nothing to disclose`() {
+        val runs = listOf(
+            AgentRun("x", "claude", McpMode.WITH, claimedFix = true),
+            AgentRun("x", "claude", McpMode.WITHOUT, claimedFix = true),
+        )
+        val histories = listOf(
+            RunHistory(
+                scenario = "x", agent = "claude", mode = McpMode.WITH,
+                runs = 3, crashed = 0, weightedSuccessPct = 100,
+                weightedMedianDurationMs = null, weightedMedianCostUsd = null,
+                spanDays = 2.0, models = listOf("claude-opus-4-8"),
+            ),
+        )
+        val html = HtmlRenderer.render(
+            Report("t", "now", Aggregator.compare(runs), runs, histories = histories)
+        )
+        assertTrue(html.contains("run history"))
+        assertFalse(html.contains("crashed"), "no crash note when crashed == 0")
+        assertFalse(html.contains("models"), "no drift note for a single model")
+    }
+
+    @Test
+    fun `no history line at all when the report carries no histories`() {
+        val html = HtmlRenderer.render(sampleReport())
+        assertFalse(html.contains("run history"))
+    }
+
+    @Test
     fun `escapes html special characters in agent text`() {
         val runs = listOf(
             AgentRun("x", "claude", McpMode.WITH, claimedFix = true, summary = "<script>alert(1)</script> & co"),

--- a/experiments-report/src/test/kotlin/com/jonnyzzz/mcpSteroid/report/RecencyWeightsTest.kt
+++ b/experiments-report/src/test/kotlin/com/jonnyzzz/mcpSteroid/report/RecencyWeightsTest.kt
@@ -1,0 +1,116 @@
+package com.jonnyzzz.mcpSteroid.report
+
+import org.junit.jupiter.api.Test
+import java.time.Instant
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Pure unit tests for the recency-weighting math: exponential decay by age (half-life
+ * [HALF_LIFE_DAYS]), the weighted median, and the lenient `finishDate` parsing — the three
+ * building blocks of the run-history aggregation.
+ */
+class RecencyWeightsTest {
+
+    // ── exponential decay ────────────────────────────────────────────────────
+
+    @Test
+    fun `a run finished today has full weight`() {
+        assertEquals(1.0, decayWeight(0.0))
+    }
+
+    @Test
+    fun `a run one half-life old has half the weight`() {
+        assertEquals(0.5, decayWeight(HALF_LIFE_DAYS), 1e-12)
+    }
+
+    @Test
+    fun `two half-lives quarter the weight`() {
+        assertEquals(0.25, decayWeight(2 * HALF_LIFE_DAYS), 1e-12)
+    }
+
+    @Test
+    fun `a half-year-old run contributes less than 7 percent`() {
+        // ~4 half-lives at H=45 — the design point: runs from a previous plugin/LLM generation
+        // are still visible in the aggregate but can no longer dominate it.
+        assertTrue(decayWeight(180.0) < 0.07)
+        assertEquals(0.0625, decayWeight(180.0), 1e-12)
+    }
+
+    @Test
+    fun `decay is monotonically decreasing`() {
+        assertTrue(decayWeight(1.0) > decayWeight(2.0))
+        assertTrue(decayWeight(100.0) > decayWeight(101.0))
+        assertTrue(decayWeight(10_000.0) > 0.0, "never hits zero — old runs keep a trace")
+    }
+
+    // ── weighted median ──────────────────────────────────────────────────────
+
+    @Test
+    fun `weighted median of nothing is null`() {
+        assertNull(weightedMedian(emptyList()))
+    }
+
+    @Test
+    fun `weighted median of a single value is that value`() {
+        assertEquals(5.0, weightedMedian(listOf(5.0 to 0.3)))
+    }
+
+    @Test
+    fun `equal weights pick the middle value`() {
+        assertEquals(2.0, weightedMedian(listOf(3.0 to 1.0, 1.0 to 1.0, 2.0 to 1.0)))
+    }
+
+    @Test
+    fun `a heavy fresh run pulls the median to itself`() {
+        // old cheap run (w=1) vs fresh expensive run (w=9): cumulative weight crosses 50% at the
+        // fresh value — the aggregate reads as "what a run costs NOW".
+        assertEquals(10.0, weightedMedian(listOf(1.0 to 1.0, 10.0 to 9.0)))
+    }
+
+    @Test
+    fun `input order does not matter`() {
+        val a = weightedMedian(listOf(4.0 to 1.0, 1.0 to 2.0, 9.0 to 0.5))
+        val b = weightedMedian(listOf(9.0 to 0.5, 4.0 to 1.0, 1.0 to 2.0))
+        assertEquals(a, b)
+    }
+
+    @Test
+    fun `all-zero weights yield null instead of dividing by zero`() {
+        assertNull(weightedMedian(listOf(1.0 to 0.0, 2.0 to 0.0)))
+    }
+
+    @Test
+    fun `exactly two equal weights pick the lower value (cumulative crossing rule)`() {
+        // cum(100)=1.0 ≥ total/2=1.0 → 100. Documented: lower weighted median, deterministic.
+        assertEquals(100.0, weightedMedian(listOf(200.0 to 1.0, 100.0 to 1.0)))
+    }
+
+    // ── lenient finishDate parsing ───────────────────────────────────────────
+
+    @Test
+    fun `parses an ISO-8601 instant`() {
+        assertEquals(Instant.parse("2026-06-20T10:15:30Z"), parseFinishDate("2026-06-20T10:15:30Z"))
+    }
+
+    @Test
+    fun `parses an ISO-8601 offset date-time`() {
+        assertEquals(Instant.parse("2026-06-20T10:15:30Z"), parseFinishDate("2026-06-20T12:15:30+02:00"))
+    }
+
+    @Test
+    fun `parses TeamCity's yyyyMMdd'T'HHmmssZ format`() {
+        assertEquals(Instant.parse("2026-06-20T10:15:30Z"), parseFinishDate("20260620T101530+0000"))
+        assertEquals(Instant.parse("2026-06-20T08:15:30Z"), parseFinishDate("20260620T101530+0200"))
+    }
+
+    @Test
+    fun `garbage, blank and null yield null — never an exception`() {
+        assertNull(parseFinishDate("not-a-date"))
+        assertNull(parseFinishDate(""))
+        assertNull(parseFinishDate("   "))
+        assertNull(parseFinishDate(null))
+        assertNull(parseFinishDate("2026-13-45T99:99:99Z"))
+    }
+}

--- a/experiments-report/src/test/kotlin/com/jonnyzzz/mcpSteroid/report/RunHistoryFromCacheTest.kt
+++ b/experiments-report/src/test/kotlin/com/jonnyzzz/mcpSteroid/report/RunHistoryFromCacheTest.kt
@@ -1,0 +1,139 @@
+package com.jonnyzzz.mcpSteroid.report
+
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Path
+import java.time.Instant
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * History across the WHOLE fetch cache: superseded builds' folders stay on disk, and while the
+ * PRIMARY comparison row is still built exclusively from the LATEST build (pinned by
+ * [FailedLegAndStaleBuildTest] — do not regress), every cached build contributes one attempt to the
+ * recency-weighted per-(scenario, agent, mode) run history.
+ *
+ * Built on the same VERBATIM fixtures: build 992109227 (both legs crashed, exit 1) is superseded by
+ * build 992152358 (mcp leg clean 459s + claimed fix, none leg crashed). The metas carry the new
+ * `finishDate` — one in TeamCity's `yyyyMMdd'T'HHmmssZ`, one in ISO-8601, both must parse.
+ */
+class RunHistoryFromCacheTest {
+    private fun fixtureText(name: String): String =
+        requireNotNull(javaClass.classLoader.getResourceAsStream("fixtures/$name")) { "missing $name" }
+            .bufferedReader().readText()
+
+    private fun place(dir: Path, rel: String, content: String) {
+        val f = dir.resolve(rel).toFile()
+        f.parentFile.mkdirs()
+        f.writeText(content)
+    }
+
+    private val cfg = "mcp_steroid_IntegrationTests_KeycloakRename_Claude"
+
+    private fun meta(buildId: Long, status: String, finishDate: String?) = buildString {
+        append("""{"buildConfigId":"$cfg","buildId":$buildId,"scenario":"KeycloakRename","agent":"claude","status":"$status"""")
+        if (finishDate != null) append(""","finishDate":"$finishDate"""")
+        append("}")
+    }
+
+    /** Older crashed build finished 40 days before the newest — TC-format date; newest is ISO. */
+    private fun placeBothBuilds(dir: Path) {
+        place(dir, "builds/${cfg}__992109227/log.txt", fixtureText("arena-rename-crash429.txt"))
+        place(dir, "builds/${cfg}__992109227/meta.json", meta(992109227, "FAILURE", "20260523T120000+0000"))
+        place(dir, "builds/${cfg}__992152358/log.txt", fixtureText("arena-rename-final.txt"))
+        place(dir, "builds/${cfg}__992152358/meta.json", meta(992152358, "SUCCESS", "2026-07-02T12:00:00Z"))
+    }
+
+    @Test
+    fun `readAll keeps one merged run per build while latest stays latest-build-only`(@TempDir dir: Path) {
+        placeBothBuilds(dir)
+
+        val collected = InputReader.readAll(dir.toFile())
+
+        // latest — exactly the runs the primary comparison is built from (with + without).
+        assertEquals(2, collected.latest.size)
+        assertTrue(collected.latest.all { it.buildId == 992152358L })
+
+        // allBuilds — one merged run per (mode, build): 2 modes × 2 builds. The doubled [ARENA]
+        // blocks inside one build's log still collapse into one run (source-merge stays per build).
+        assertEquals(4, collected.allBuilds.size)
+        val withRuns = collected.allBuilds.filter { it.mode == McpMode.WITH }.sortedBy { it.buildId }
+        assertEquals(listOf(992109227L, 992152358L), withRuns.map { it.buildId })
+        assertEquals(2_000L, withRuns[0].agentDurationMs, "crashed attempt kept as history")
+        assertEquals(459_000L, withRuns[1].agentDurationMs)
+    }
+
+    @Test
+    fun `runs are stamped with the build's finishDate in either format`(@TempDir dir: Path) {
+        placeBothBuilds(dir)
+
+        val all = InputReader.readAll(dir.toFile()).allBuilds
+        assertEquals(
+            Instant.parse("2026-05-23T12:00:00Z"),
+            all.first { it.buildId == 992109227L }.finishedAt,
+            "TeamCity yyyyMMdd'T'HHmmssZ finishDate parsed",
+        )
+        assertEquals(
+            Instant.parse("2026-07-02T12:00:00Z"),
+            all.first { it.buildId == 992152358L }.finishedAt,
+            "ISO-8601 finishDate parsed",
+        )
+    }
+
+    @Test
+    fun `a meta without finishDate leaves runs undated and nothing crashes`(@TempDir dir: Path) {
+        place(dir, "builds/${cfg}__992152358/log.txt", fixtureText("arena-rename-final.txt"))
+        place(dir, "builds/${cfg}__992152358/meta.json", meta(992152358, "SUCCESS", finishDate = null))
+
+        val all = InputReader.readAll(dir.toFile()).allBuilds
+        assertTrue(all.isNotEmpty())
+        assertTrue(all.all { it.finishedAt == null })
+        // the whole pipeline still renders
+        assertTrue(HtmlRenderer.render(buildReport(dir.toFile(), "t", "2026-07-03T00:00:00Z")).isNotEmpty())
+    }
+
+    @Test
+    fun `report carries per-leg weighted history over all cached builds`(@TempDir dir: Path) {
+        placeBothBuilds(dir)
+
+        val report = buildReport(dir.toFile(), "t", "2026-07-03T00:00:00Z")
+
+        val with = report.histories.single { it.mode == McpMode.WITH }
+        assertEquals(2, with.runs)
+        assertEquals(1, with.crashed, "the 429 corpse counts as a crash, not an attempt")
+        assertEquals(100, with.weightedSuccessPct, "the only CLEAN attempt succeeded")
+        assertEquals(459_000L, with.weightedMedianDurationMs, "median over clean attempts only — never the 2s corpse")
+        assertEquals(40.0, with.spanDays!!, 0.5, "2026-05-23 → 2026-07-02")
+
+        val without = report.histories.single { it.mode == McpMode.WITHOUT }
+        assertEquals(2, without.runs)
+        assertEquals(2, without.crashed, "both baseline attempts crashed (exit 1)")
+        assertNull(without.weightedSuccessPct)
+
+        // The PRIMARY comparison is untouched: still exclusively the latest build's runs.
+        val cmp = report.comparisons.single()
+        assertEquals(459_000L, cmp.withMcp?.agentDurationMs)
+        assertEquals(true, cmp.withMcp?.claimedFix)
+    }
+
+    @Test
+    fun `dashboard shows a history line for repeat runs`(@TempDir dir: Path) {
+        placeBothBuilds(dir)
+
+        val html = HtmlRenderer.render(buildReport(dir.toFile(), "t", "2026-07-03T00:00:00Z"))
+        assertTrue(html.contains("run history"), "repeat runs must surface a history line")
+        assertTrue(html.contains("2 runs"))
+        assertTrue(html.contains("1 crashed"))
+    }
+
+    @Test
+    fun `no history line when the cache holds a single build`(@TempDir dir: Path) {
+        place(dir, "builds/${cfg}__992152358/log.txt", fixtureText("arena-rename-final.txt"))
+        place(dir, "builds/${cfg}__992152358/meta.json", meta(992152358, "SUCCESS", "2026-07-02T12:00:00Z"))
+
+        val html = HtmlRenderer.render(buildReport(dir.toFile(), "t", "2026-07-03T00:00:00Z"))
+        assertFalse(html.contains("run history"), "n=1 is not a history")
+    }
+}

--- a/experiments-report/src/test/kotlin/com/jonnyzzz/mcpSteroid/report/RunHistoryTest.kt
+++ b/experiments-report/src/test/kotlin/com/jonnyzzz/mcpSteroid/report/RunHistoryTest.kt
@@ -1,0 +1,278 @@
+package com.jonnyzzz.mcpSteroid.report
+
+import org.junit.jupiter.api.Test
+import java.time.Instant
+import java.time.temporal.ChronoUnit
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+/**
+ * Unit tests for [runHistories]: recency-weighted aggregation of ALL past runs of one
+ * (scenario, agent, mode) — one attempt per cached build, newer runs counting more
+ * (weight = 0.5^(ageDays / [HALF_LIFE_DAYS])), crashes excluded from rates but reported.
+ */
+class RunHistoryTest {
+    private val now: Instant = Instant.parse("2026-07-01T00:00:00Z")
+    private fun daysAgo(d: Long): Instant = now.minus(d, ChronoUnit.DAYS)
+
+    private fun run(
+        buildId: Long? = null,
+        finishedAt: Instant? = null,
+        exitCode: Int? = 0,
+        claimedFix: Boolean? = true,
+        durationMs: Long? = null,
+        costUsd: Double? = null,
+        model: String? = null,
+        mode: McpMode = McpMode.WITH,
+        scenario: String = "s",
+    ) = AgentRun(
+        scenario = scenario, agent = "claude", mode = mode, buildId = buildId,
+        finishedAt = finishedAt, exitCode = exitCode, claimedFix = claimedFix,
+        agentDurationMs = durationMs, costUsd = costUsd, model = model,
+    )
+
+    // ── grouping ─────────────────────────────────────────────────────────────
+
+    @Test
+    fun `aggregates per scenario-agent-mode`() {
+        val histories = runHistories(
+            listOf(
+                run(buildId = 1, finishedAt = daysAgo(1)),
+                run(buildId = 2, finishedAt = daysAgo(0)),
+                run(buildId = 9, finishedAt = daysAgo(0), mode = McpMode.WITHOUT),
+            ),
+            now,
+        )
+        assertEquals(2, histories.size)
+        assertEquals(2, histories.single { it.mode == McpMode.WITH }.runs)
+        assertEquals(1, histories.single { it.mode == McpMode.WITHOUT }.runs)
+    }
+
+    @Test
+    fun `empty input yields no histories`() {
+        assertEquals(emptyList(), runHistories(emptyList(), now))
+    }
+
+    // ── recency-weighted success rate ────────────────────────────────────────
+
+    @Test
+    fun `a fresh success outweighs an old failure`() {
+        // failure 90 days ago (w = 0.25) vs success today (w = 1.0):
+        // rate = 1.0 / 1.25 = 80% — history says "mostly works NOW", not 50/50.
+        val h = runHistories(
+            listOf(
+                run(buildId = 1, finishedAt = daysAgo(90), claimedFix = false),
+                run(buildId = 2, finishedAt = daysAgo(0), claimedFix = true),
+            ),
+            now,
+        ).single()
+        assertEquals(80, h.weightedSuccessPct)
+    }
+
+    @Test
+    fun `equally fresh runs weigh equally`() {
+        val h = runHistories(
+            listOf(
+                run(buildId = 1, finishedAt = daysAgo(0), claimedFix = false),
+                run(buildId = 2, finishedAt = daysAgo(0), claimedFix = true),
+            ),
+            now,
+        ).single()
+        assertEquals(50, h.weightedSuccessPct)
+    }
+
+    @Test
+    fun `runs with unknown outcome are excluded from the rate denominator`() {
+        val h = runHistories(
+            listOf(
+                run(buildId = 1, finishedAt = daysAgo(0), claimedFix = null), // succeeded() == null
+                run(buildId = 2, finishedAt = daysAgo(0), claimedFix = true),
+            ),
+            now,
+        ).single()
+        assertEquals(2, h.runs)
+        assertEquals(100, h.weightedSuccessPct)
+    }
+
+    // ── crashes: counted, never aggregated ──────────────────────────────────
+
+    @Test
+    fun `crashed runs are counted but excluded from rate and medians`() {
+        val h = runHistories(
+            listOf(
+                // crash (exit 2): its bogus 2s / $0 numbers must not poison anything
+                run(buildId = 1, finishedAt = daysAgo(0), exitCode = 2, claimedFix = false, durationMs = 2_000, costUsd = 0.0),
+                run(buildId = 2, finishedAt = daysAgo(0), exitCode = 0, claimedFix = true, durationMs = 400_000, costUsd = 1.0),
+                run(buildId = 3, finishedAt = daysAgo(0), exitCode = 0, claimedFix = false, durationMs = 600_000, costUsd = 3.0),
+            ),
+            now,
+        ).single()
+        assertEquals(3, h.runs)
+        assertEquals(1, h.crashed)
+        assertEquals(50, h.weightedSuccessPct, "1 of 2 CLEAN attempts succeeded")
+        assertEquals(400_000L, h.weightedMedianDurationMs, "medians over clean attempts only")
+        assertEquals(1.0, h.weightedMedianCostUsd)
+    }
+
+    @Test
+    fun `a timeout (exit -1) is a clean attempt, not a crash`() {
+        val h = runHistories(
+            listOf(
+                run(buildId = 1, finishedAt = daysAgo(0), exitCode = -1, claimedFix = false, durationMs = 900_000),
+                run(buildId = 2, finishedAt = daysAgo(0), exitCode = 0, claimedFix = true, durationMs = 300_000),
+            ),
+            now,
+        ).single()
+        assertEquals(0, h.crashed)
+        assertEquals(50, h.weightedSuccessPct)
+    }
+
+    @Test
+    fun `all runs crashed yields counts but no rates or medians`() {
+        val h = runHistories(
+            listOf(
+                run(buildId = 1, finishedAt = daysAgo(0), exitCode = 7, durationMs = 1_000),
+                run(buildId = 2, finishedAt = daysAgo(0), exitCode = 7, durationMs = 2_000),
+            ),
+            now,
+        ).single()
+        assertEquals(2, h.runs)
+        assertEquals(2, h.crashed)
+        assertNull(h.weightedSuccessPct)
+        assertNull(h.weightedMedianDurationMs)
+        assertNull(h.weightedMedianCostUsd)
+    }
+
+    // ── weighted medians ─────────────────────────────────────────────────────
+
+    @Test
+    fun `null durations and costs are skipped, not treated as zero`() {
+        val h = runHistories(
+            listOf(
+                run(buildId = 1, finishedAt = daysAgo(0), durationMs = null, costUsd = null),
+                run(buildId = 2, finishedAt = daysAgo(0), durationMs = 100_000, costUsd = null),
+            ),
+            now,
+        ).single()
+        assertEquals(100_000L, h.weightedMedianDurationMs, "single known duration")
+        assertNull(h.weightedMedianCostUsd, "no cost known anywhere")
+    }
+
+    @Test
+    fun `a fresh duration dominates the weighted median over stale ones`() {
+        // two ancient fast runs (w ≈ 0.0625 each) vs one fresh slow run (w = 1.0):
+        // cumulative weight crosses 50% at the fresh value.
+        val h = runHistories(
+            listOf(
+                run(buildId = 1, finishedAt = daysAgo(180), durationMs = 60_000),
+                run(buildId = 2, finishedAt = daysAgo(180), durationMs = 90_000),
+                run(buildId = 3, finishedAt = daysAgo(0), durationMs = 500_000),
+            ),
+            now,
+        ).single()
+        assertEquals(500_000L, h.weightedMedianDurationMs)
+    }
+
+    // ── missing-date fallback: order from buildId, never crash ───────────────
+
+    @Test
+    fun `with no dates at all, buildId order drives the decay — one half-life per step back`() {
+        // newest build (id 3) w=1, next (id 2) w=0.5, oldest (id 1) w=0.25.
+        // Only the newest succeeded: rate = 1 / 1.75 ≈ 57%.
+        val h = runHistories(
+            listOf(
+                run(buildId = 1, claimedFix = false),
+                run(buildId = 2, claimedFix = false),
+                run(buildId = 3, claimedFix = true),
+            ),
+            now,
+        ).single()
+        assertEquals(57, h.weightedSuccessPct)
+    }
+
+    @Test
+    fun `an undated run borrows the age of the dated run with the nearest buildId`() {
+        val ages = assignAgesDays(
+            listOf(
+                run(buildId = 10, finishedAt = daysAgo(30)),
+                run(buildId = 11, finishedAt = null),
+                run(buildId = 100, finishedAt = daysAgo(1)),
+            ),
+            now,
+        )
+        assertEquals(30.0, ages[0], 1e-9)
+        assertEquals(30.0, ages[1], 1e-9, "undated buildId=11 anchors to dated buildId=10, not 100")
+        assertEquals(1.0, ages[2], 1e-9)
+    }
+
+    @Test
+    fun `runs with neither date nor buildId are treated as fresh`() {
+        val ages = assignAgesDays(listOf(run(buildId = null, finishedAt = null)), now)
+        assertEquals(listOf(0.0), ages)
+    }
+
+    @Test
+    fun `a null now falls back to the newest dated run`() {
+        val ages = assignAgesDays(
+            listOf(
+                run(buildId = 1, finishedAt = daysAgo(10)),
+                run(buildId = 2, finishedAt = daysAgo(0)),
+            ),
+            now = null,
+        )
+        assertEquals(10.0, ages[0], 1e-9)
+        assertEquals(0.0, ages[1], 1e-9, "the newest dated run IS the clock when now is unknown")
+    }
+
+    @Test
+    fun `a run dated after now clamps to age zero`() {
+        val ages = assignAgesDays(listOf(run(buildId = 1, finishedAt = now.plusSeconds(3600))), now)
+        assertEquals(listOf(0.0), ages)
+    }
+
+    // ── age span + model drift ───────────────────────────────────────────────
+
+    @Test
+    fun `span covers oldest to newest dated run`() {
+        val h = runHistories(
+            listOf(
+                run(buildId = 1, finishedAt = daysAgo(120)),
+                run(buildId = 2, finishedAt = daysAgo(30)),
+                run(buildId = 3, finishedAt = daysAgo(0)),
+            ),
+            now,
+        ).single()
+        assertEquals(120.0, h.spanDays!!, 1e-9)
+    }
+
+    @Test
+    fun `no dated runs means no span`() {
+        val h = runHistories(listOf(run(buildId = 1), run(buildId = 2)), now).single()
+        assertNull(h.spanDays)
+    }
+
+    @Test
+    fun `distinct models are listed oldest to newest`() {
+        val h = runHistories(
+            listOf(
+                run(buildId = 3, finishedAt = daysAgo(0), model = "claude-opus-4-8"),
+                run(buildId = 1, finishedAt = daysAgo(90), model = "claude-opus-4-6"),
+                run(buildId = 2, finishedAt = daysAgo(30), model = "claude-opus-4-6"),
+            ),
+            now,
+        ).single()
+        assertEquals(listOf("claude-opus-4-6", "claude-opus-4-8"), h.models)
+    }
+
+    @Test
+    fun `runs without a model do not contribute a model entry`() {
+        val h = runHistories(
+            listOf(
+                run(buildId = 1, finishedAt = daysAgo(1), model = null),
+                run(buildId = 2, finishedAt = daysAgo(0), model = "claude-opus-4-8"),
+            ),
+            now,
+        ).single()
+        assertEquals(listOf("claude-opus-4-8"), h.models)
+    }
+}


### PR DESCRIPTION
## What

The experiments dashboard showed exactly ONE run per (scenario, agent, mode) — `InputReader.latestBuildOnly()` kept only the latest build. That stays (it is the correctness fix pinned by `FailedLegAndStaleBuildTest`, which passes **unchanged**), but the thrown-away history is now aggregated: every cached build contributes one attempt to a **recency-weighted run history** per (scenario, agent, mode), rendered as a compact per-leg line under each comparison row when n > 1:

> **run history — with MCP:** 9 runs over 4 months · 82% ✓ (weighted) · median 4m 58s · $1.02 · 1 crashed · 3 models: claude-opus-4-6 → claude-opus-4-8

## Weighting formula

```
weight = 0.5 ^ (ageDays / H),   H = HALF_LIFE_DAYS = 45
```

- **Why H = 45:** the plugin under test AND the LLMs behind the agents turn over on roughly a 1–2 month cadence, so the current generation must dominate. A run one half-life old counts half; anything beyond ~4 half-lives (≈ 6 months — the collector's fetch depth) contributes **< 7%** — visible as history, powerless over the aggregate.
- **"now"** is the report's own `generatedAt`, threaded through `buildReport` — no `Instant.now()`/`Date.now()` in pure code; the pipeline is deterministic and fully unit-testable.
- Per (scenario, agent, mode), over **clean** attempts (`agentCrashed()` runs — API 429s, mid-run CLI deaths — are *counted* and disclosed but excluded from rates and medians; exit −1 timeouts remain legitimate attempts):
  - **weighted success rate** = Σ w·success / Σ w (runs with unknown outcome stay out of the denominator),
  - **weighted lower-median** duration + cost: sort by value, take the first value whose cumulative weight reaches 50% — deterministic, always an actually observed value; handles empty / single / all-null,
  - n total, n crashed, age span (oldest → newest), and a **model-drift note** when the history spans multiple models (one line, no per-model tables).

## Invariants kept

- **Primary comparison rows are built exclusively from the LATEST build** per (scenario, agent, mode) — `FailedLegAndStaleBuildTest` byte-for-byte unchanged and green.
- **Source-merge stays WITHIN one build**: `InputReader.readAll()` merges log/summary/ndjson sources per build folder, so a superseded build survives as a distinct history attempt and can never leak fields across builds.
- Bucketed per-agent table layout intact (`ScenarioBucketTest` green).

## Missing-date degradation (old caches)

`AgentRun.finishedAt` comes from the collector's `meta.json` **`finishDate`**, parsed leniently — **both** ISO-8601 (`2026-07-02T12:00:00Z`, offsets too) **and** TeamCity's `yyyyMMdd'T'HHmmssZ` (`20260702T120000+0000`). When absent, the order degrades gracefully (never crashes):

1. dated run → actual age (clamped ≥ 0);
2. undated run with a buildId, group has dated runs → borrows the age of the dated run with the **nearest buildId** (buildIds are monotonic);
3. no dated runs at all → order-only decay: distinct buildIds newest-first, one half-life per step back (weights 1, ½, ¼, …);
4. neither date nor buildId (flat local layout) → age 0;
5. null "now" → the newest dated run *is* the clock.

## Collector-side expectations (internal repo, handled separately)

- `meta.json` gains a `finishDate` field (either format above);
- fetch depth extended to **~180 days** so ~4 half-lives of history are actually on disk.

Nothing here *requires* the collector change — old caches simply render undated histories via the fallbacks.

## Tests (TDD — written first, watched fail, then implemented)

- `RecencyWeightsTest` — decay math incl. the H boundary (45 d → 0.5, 180 d < 7%), weighted-quantile edge cases (empty, single, zero weights, order independence, crossing rule), lenient date parsing for both formats + garbage → null.
- `RunHistoryTest` — weighted rate (fresh success outweighs old failure), crash exclusion, timeout-is-clean, null-metric skipping, buildId-order fallback, nearest-anchor borrowing, clamping, span, model ordering.
- `RunHistoryFromCacheTest` — verbatim KeycloakRename fixtures: `readAll` latest-vs-allBuilds, finishDate stamping in both formats, report histories, primary comparison untouched, history line rendered for n > 1 and absent for n = 1.
- `HtmlRendererTest` — full history line content for n > 1, omitted crash/model notes when there's nothing to disclose, no line without histories.

Full suite: **78 tests, 0 failures** with `./gradlew :experiments-report:test --rerun-tasks`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)