### PR TITLE
feat(experiments): x11k A/B trio — split god file, extract test-setup helper, Kotlin data-flow inspections

### DIFF
--- a/test-experiments/src/test/kotlin/com/jonnyzzz/mcpSteroid/integration/tests/X11kInspectionsTest.kt
+++ b/test-experiments/src/test/kotlin/com/jonnyzzz/mcpSteroid/integration/tests/X11kInspectionsTest.kt
@@ -1,0 +1,179 @@
+/* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
+package com.jonnyzzz.mcpSteroid.integration.tests
+
+import com.jonnyzzz.mcpSteroid.integration.infra.AiMode
+import com.jonnyzzz.mcpSteroid.integration.infra.IntelliJContainer
+import com.jonnyzzz.mcpSteroid.integration.infra.IntelliJContainerOpts
+import com.jonnyzzz.mcpSteroid.integration.infra.IntelliJProject
+import com.jonnyzzz.mcpSteroid.integration.infra.McpConnectionMode
+import com.jonnyzzz.mcpSteroid.integration.infra.create
+import com.jonnyzzz.mcpSteroid.integration.infra.waitForProjectReady
+import com.jonnyzzz.mcpSteroid.testHelper.AiAgentSession
+import com.jonnyzzz.mcpSteroid.testHelper.CloseableStackHost
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Timeout
+import java.util.concurrent.TimeUnit
+
+/**
+ * MCP-win experiment: **IDE data-flow inspections find what grep can't** — the Kotlin twin of
+ * [KeycloakInspectionsTest], on the pinned github.com/jonnyzzz/x11k commit `cfdf1f7d…`. Among a
+ * fixed list of candidate files, the agent must report every LOCAL `var` that data-flow analysis
+ * proves is never reassigned after initialization (should be `val`) or never read at all.
+ *
+ * Ground truth ([EXPECTED_ISSUES]) was derived mechanically: kotlinc 2.4.0 with
+ * `compilerOptions.extraWarnings = true` (K2 `-Wextra`) over the pinned commit emits warnings at
+ * exactly 9 sites — `X11Connection.kt:4400` (a `var idOffset` that is read but never reassigned,
+ * buried in a 13.9k-line file) and two 4-line clusters of never-updated min/max trackers in
+ * `XFramebuffer.kt`. The default compile shows ZERO warnings, so the answer cannot be read off a
+ * plain build log.
+ *
+ * The decoys make grep lose: `X11State.kt` alone declares ~198 `var`s — every one of them IS
+ * reassigned somewhere in its 11.6k lines, which text search cannot verify. With MCP the agent
+ * runs IntelliJ's Kotlin inspections ("local `var` is never modified — can be `val`", unused
+ * variable) per file via `steroid_execute_code`. Verdict ([scoreKotlinInspections]): reported
+ * `file:line` pairs matched against ground truth with a spam guard — emitted as an `[ARENA]`
+ * block. A/B per agent; with-MCP asserts exec_code; correctness is a dashboard metric.
+ */
+class X11kInspectionsTest {
+
+    // 50 min (read-only precedent): no edits or rebuild sweeps, but the without-MCP leg may still
+    // attempt per-var data-flow reasoning across an 11.6k-line decoy — it must finish and emit its
+    // [ARENA] block so the dashboard can show the gap, not die as a timeout with no data.
+
+    @Test @Timeout(value = 50, unit = TimeUnit.MINUTES)
+    fun `claude with mcp`() = run("claude", withMcp = true)
+
+    @Test @Timeout(value = 50, unit = TimeUnit.MINUTES)
+    fun `claude without mcp`() = run("claude", withMcp = false)
+
+    @Test @Timeout(value = 50, unit = TimeUnit.MINUTES)
+    fun `codex with mcp`() = run("codex", withMcp = true)
+
+    @Test @Timeout(value = 50, unit = TimeUnit.MINUTES)
+    fun `codex without mcp`() = run("codex", withMcp = false)
+
+    private fun run(agentName: String, withMcp: Boolean) {
+        val modeLabel = if (withMcp) "mcp" else "none"
+        val lifetime = CloseableStackHost()
+        try {
+            val session = IntelliJContainer.create(lifetime, IntelliJContainerOpts(
+                consoleTitle = "x11k-inspections-$agentName-$modeLabel",
+                project = IntelliJProject.X11kPinnedProject,
+                aiMode = if (withMcp) AiMode.AI_MCP else AiMode.NONE,
+                mcpConnectionMode = if (withMcp) null else McpConnectionMode.None,
+            )).waitForProjectReady()
+
+            val agent: AiAgentSession = when (agentName) {
+                "claude" -> session.aiAgents.claude
+                "codex" -> session.aiAgents.codex
+                else -> error("Unknown agent: $agentName")
+            }
+
+            val startedAt = System.currentTimeMillis()
+            val result = agent.runPrompt(if (withMcp) withMcpPrompt() else baselinePrompt(), timeoutSeconds = 1800)
+                .awaitForProcessFinish()
+            val agentDurationMs = System.currentTimeMillis() - startedAt
+            val combined = result.stdout + "\n" + result.stderr
+
+            val score = scoreKotlinInspections(combined, EXPECTED_ISSUES, MIN_MATCHES)
+            println("[TEST] x11k inspections [$agentName+$modeLabel] detected=${score.detected} " +
+                    "matched=${score.matchedCount}/${EXPECTED_ISSUES.values.sumOf { it.size }} " +
+                    "reported=${score.reportedCount} issuesFound=${score.issuesFound}")
+
+            recordSemanticRun(
+                scenario = SCENARIO,
+                agentName = agentName,
+                withMcp = withMcp,
+                claimedFix = score.detected,
+                rawOutput = result.rawStdout,
+                exitCode = result.exitCode,
+                agentDurationMs = agentDurationMs,
+                runDir = session.runDirInContainer,
+                summary = "matched=${score.matchedCount} reported=${score.reportedCount} issuesFound=${score.issuesFound}",
+            )
+
+            if (withMcp) assertUsedExecuteCodeEvidence(combined)
+        } finally {
+            lifetime.closeAllStacks()
+        }
+    }
+
+    private fun taskDescription(): String = buildString {
+        appendLine("Task: among the candidate files below, find every LOCAL `var` for which data-flow")
+        appendLine("analysis proves one of:")
+        appendLine("- it is never reassigned after its initializer (so it should be declared `val`), or")
+        appendLine("- its value is never read at all.")
+        appendLine("Beware: these files declare hundreds of `var`s and almost all of them ARE genuinely")
+        appendLine("mutated somewhere later in the same (very long) function or file — the declaration syntax")
+        appendLine("alone proves nothing. Report ONLY the provable findings, with exact line numbers.")
+        appendLine()
+        appendLine("Candidate files:")
+        for (file in CANDIDATE_FILES) appendLine("- $file")
+    }
+
+    private fun outputFormat(): String = buildString {
+        appendLine("Output (markers on their own lines):")
+        appendLine("ISSUES_FOUND: <total count of provable findings>")
+        appendLine("ISSUE: <path>:<line> — <short description>   ← one per finding, exact line number")
+    }
+
+    private fun withMcpPrompt(): String = buildString {
+        appendLine("The x11k project is open in IntelliJ IDEA — a single-module Kotlin/JVM Gradle project")
+        appendLine("(a headless X11 server implementation).")
+        appendLine()
+        append(taskDescription())
+        appendLine()
+        appendLine("Use IntelliJ's Kotlin inspections via `steroid_execute_code` on each candidate file —")
+        appendLine("\"Local 'var' is never modified, can be declared 'val'\" (CanBeVal) and unused-variable")
+        appendLine("analysis — and read their results. Do NOT guess from grep — \"never written after")
+        appendLine("initialization\" requires data-flow analysis.")
+        appendLine()
+        append(outputFormat())
+        appendLine("TOOL_EVIDENCE: <copy the line starting with execution_id: ...>")
+    }
+
+    private fun baselinePrompt(): String = buildString {
+        appendLine("The x11k project is checked out — a single-module Kotlin/JVM Gradle project")
+        appendLine("(a headless X11 server implementation).")
+        appendLine("IntelliJ MCP tools are unavailable in this run — use shell commands only (grep/rg/find/cat).")
+        appendLine()
+        append(taskDescription())
+        appendLine()
+        append(outputFormat())
+    }
+
+    companion object {
+        private const val SCENARIO = "x11k__inspections"
+
+        /**
+         * 2 files with all 9 true findings + 4 var-heavy decoys with none. `X11State.kt` is the
+         * flagship decoy: ~198 `var` declarations, every one genuinely mutated. Interleaved so the
+         * true positives don't cluster at the top of the list.
+         */
+        private val CANDIDATE_FILES = listOf(
+            "src/main/kotlin/org/jonnyzzz/xserver/X11State.kt",
+            "src/main/kotlin/org/jonnyzzz/xserver/XFramebuffer.kt",
+            "src/main/kotlin/org/jonnyzzz/xserver/SvgScreenRenderer.kt",
+            "src/main/kotlin/org/jonnyzzz/xserver/X11Connection.kt",
+            "src/main/kotlin/org/jonnyzzz/xserver/Main.kt",
+            "src/main/kotlin/org/jonnyzzz/xserver/HttpScreenConnection.kt",
+        )
+
+        /**
+         * Ground truth from kotlinc 2.4.0 `extraWarnings` (K2 `-Wextra`) at the pinned commit:
+         *  - X11Connection.kt:4400   `var idOffset = 8` — read, never reassigned (can be `val`)
+         *  - XFramebuffer.kt:1598-1601 and 1746-1749 — two clusters of `var min/maxPaintedX/Y`
+         *    trackers that are never updated (never written, never read).
+         */
+        private val EXPECTED_ISSUES = mapOf(
+            "X11Connection.kt" to setOf(4400),
+            "XFramebuffer.kt" to setOf(1598, 1599, 1600, 1601, 1746, 1747, 1748, 1749),
+        )
+
+        /**
+         * 6 of 9 — finding both XFramebuffer clusters (8 sites) or one cluster + the
+         * X11Connection needle passes; tolerates inspection/kotlinc disagreement on single lines.
+         */
+        private const val MIN_MATCHES = 6
+    }
+}

--- a/test-experiments/src/test/kotlin/com/jonnyzzz/mcpSteroid/integration/tests/X11kSplitFileTest.kt
+++ b/test-experiments/src/test/kotlin/com/jonnyzzz/mcpSteroid/integration/tests/X11kSplitFileTest.kt
@@ -1,0 +1,189 @@
+/* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
+package com.jonnyzzz.mcpSteroid.integration.tests
+
+import com.jonnyzzz.mcpSteroid.integration.infra.AiMode
+import com.jonnyzzz.mcpSteroid.integration.infra.IntelliJContainer
+import com.jonnyzzz.mcpSteroid.integration.infra.IntelliJContainerOpts
+import com.jonnyzzz.mcpSteroid.integration.infra.IntelliJProject
+import com.jonnyzzz.mcpSteroid.integration.infra.McpConnectionMode
+import com.jonnyzzz.mcpSteroid.integration.infra.create
+import com.jonnyzzz.mcpSteroid.integration.infra.waitForProjectReady
+import com.jonnyzzz.mcpSteroid.testHelper.AiAgentSession
+import com.jonnyzzz.mcpSteroid.testHelper.CloseableStackHost
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Timeout
+import java.util.concurrent.TimeUnit
+
+/**
+ * MCP-win experiment: **split the god file** (jonnyzzz/mcp-steroid#169 family) on the pinned
+ * github.com/jonnyzzz/x11k commit `cfdf1f7d…`. The agent splits `X11State.kt` — 11,567 lines —
+ * into cohesive files while the project keeps compiling.
+ *
+ * Why THIS file: x11k's two biggest sources are `X11Connection.kt` (13,892 lines — but ONE
+ * monolithic `internal class` with ~690 members, splitting it means deep class surgery) and
+ * `X11State.kt`, which has clean seams: ~75 top-level declarations (the XSync/XKB/keyboard/
+ * window/pixmap/Render model types, ~1,900 lines) surrounding the central `X11State` class.
+ * Reaching the ≤10,000-line threshold requires moving essentially ALL of them out into cohesive
+ * groups — a genuine multi-file split; the agent chooses the seams (the `X11State` class itself
+ * may stay put or be split further).
+ *
+ * With MCP the agent drives IntelliJ's Move declarations refactoring via `steroid_execute_code`
+ * — references, imports and KDoc links update atomically. Without MCP it is a manual cut-and-paste
+ * sweep across 11.6k lines. Verdict ([scoreSplitFile]) is evidence-based and identical for both
+ * legs: both run the SAME verification commands (`wc -l`, `./gradlew compileKotlin
+ * compileTestKotlin`, sentinel `grep`s proving moved declarations exist exactly once) and report
+ * raw results — emitted as an `[ARENA]` block. A/B per agent; with-MCP asserts exec_code;
+ * correctness is a dashboard metric, not a hard gate.
+ */
+class X11kSplitFileTest {
+
+    // 80 min, following the KeycloakRenameTest/KeycloakChangeSignatureTest precedent: the
+    // without-MCP baseline is edit-heavy — a manual 1,900-line declaration sweep plus rebuilds
+    // legitimately needs a long tail, and the slow baseline IS the experiment's finding — it must
+    // complete and emit its [ARENA] block so the dashboard can show the gap, not die as a timeout
+    // with no data. TC-side executionTimeoutMin=180 fits two 80-min methods.
+
+    @Test @Timeout(value = 80, unit = TimeUnit.MINUTES)
+    fun `claude with mcp`() = run("claude", withMcp = true)
+
+    @Test @Timeout(value = 80, unit = TimeUnit.MINUTES)
+    fun `claude without mcp`() = run("claude", withMcp = false)
+
+    @Test @Timeout(value = 80, unit = TimeUnit.MINUTES)
+    fun `codex with mcp`() = run("codex", withMcp = true)
+
+    @Test @Timeout(value = 80, unit = TimeUnit.MINUTES)
+    fun `codex without mcp`() = run("codex", withMcp = false)
+
+    private fun run(agentName: String, withMcp: Boolean) {
+        val modeLabel = if (withMcp) "mcp" else "none"
+        val lifetime = CloseableStackHost()
+        try {
+            val session = IntelliJContainer.create(lifetime, IntelliJContainerOpts(
+                consoleTitle = "x11k-splitfile-$agentName-$modeLabel",
+                project = IntelliJProject.X11kPinnedProject,
+                aiMode = if (withMcp) AiMode.AI_MCP else AiMode.NONE,
+                mcpConnectionMode = if (withMcp) null else McpConnectionMode.None,
+            )).waitForProjectReady()
+
+            val agent: AiAgentSession = when (agentName) {
+                "claude" -> session.aiAgents.claude
+                "codex" -> session.aiAgents.codex
+                else -> error("Unknown agent: $agentName")
+            }
+
+            val startedAt = System.currentTimeMillis()
+            val result = agent.runPrompt(if (withMcp) withMcpPrompt() else baselinePrompt(), timeoutSeconds = 2400)
+                .awaitForProcessFinish()
+            val agentDurationMs = System.currentTimeMillis() - startedAt
+            val combined = result.stdout + "\n" + result.stderr
+
+            val score = scoreSplitFile(combined, ORIGINAL_FILE_NAME, MAX_REMAINING_LINES, MIN_NEW_FILES, SENTINELS)
+            println("[TEST] x11k split-file [$agentName+$modeLabel] safe=${score.safe} " +
+                    "remaining=${score.remainingLines} newFiles=${score.newFiles.size} " +
+                    "buildGreen=${score.buildGreen} residueClean=${score.residueClean}")
+            if (!score.residueClean) {
+                println("[TEST]   residue counts: ${score.residueCounts}")
+            }
+
+            recordSemanticRun(
+                scenario = SCENARIO,
+                agentName = agentName,
+                withMcp = withMcp,
+                claimedFix = score.safe,
+                rawOutput = result.rawStdout,
+                exitCode = result.exitCode,
+                agentDurationMs = agentDurationMs,
+                runDir = session.runDirInContainer,
+                summary = "remaining=${score.remainingLines} newFiles=${score.newFiles.size} " +
+                        "buildGreen=${score.buildGreen} residueClean=${score.residueClean}",
+            )
+
+            if (withMcp) assertUsedExecuteCodeEvidence(combined)
+        } finally {
+            lifetime.closeAllStacks()
+        }
+    }
+
+    private fun taskDescription(): String = buildString {
+        appendLine("Task: split the file `$TARGET_FILE` (11,567 lines)")
+        appendLine("into cohesive files. You choose the seams — the file mixes the central `X11State` class")
+        appendLine("with dozens of top-level model declarations (sync counters/alarms/fences, keyboard/XKB")
+        appendLine("maps, windows/pixmaps/drawables, Render pictures/gradients/glyphs, drawing commands…).")
+        appendLine()
+        appendLine("Requirements:")
+        appendLine("- create at least $MIN_NEW_FILES new .kt files (same package), grouped by responsibility;")
+        appendLine("- the original file must end up at most $MAX_REMAINING_LINES lines (or be removed entirely);")
+        appendLine("- NO behavior change: declarations are MOVED, never rewritten, deleted or duplicated;")
+        appendLine("- the project must still compile (main and test sources).")
+        appendLine()
+        appendLine("Then run these verification commands and report their raw results:")
+        appendLine("- `wc -l $TARGET_FILE`")
+        appendLine("- `./gradlew compileKotlin compileTestKotlin`")
+        for (sentinel in SENTINELS) {
+            appendLine("- `grep -rn \"data class $sentinel(\" src/main/kotlin | wc -l`   (must be exactly 1)")
+        }
+    }
+
+    private fun outputFormat(): String = buildString {
+        appendLine("Output (markers on their own lines):")
+        appendLine("SPLIT_DONE: yes")
+        appendLine("REMAINING_LINES: <wc -l of the original file after the split; 0 if removed>")
+        appendLine("NEW_FILE: <path of one newly created .kt file>   ← one line per new file")
+        appendLine("BUILD_AFTER_SPLIT: <SUCCESS or FAILURE>")
+        for (sentinel in SENTINELS) {
+            appendLine("RESIDUE: $sentinel=<the grep count for $sentinel>")
+        }
+    }
+
+    private fun withMcpPrompt(): String = buildString {
+        appendLine("The x11k project is open in IntelliJ IDEA — a single-module Kotlin/JVM Gradle project")
+        appendLine("(a headless X11 server implementation).")
+        appendLine()
+        append(taskDescription())
+        appendLine()
+        appendLine("Use IntelliJ's Move refactoring via `steroid_execute_code` (e.g. the Kotlin Move")
+        appendLine("declarations processor — `org.jetbrains.kotlin.idea.refactoring.move…` — moving groups of")
+        appendLine("top-level declarations into new files): PSI updates every reference and import atomically.")
+        appendLine("Do NOT cut-and-paste text between files with sed/manual edits.")
+        appendLine()
+        append(outputFormat())
+        appendLine("TOOL_EVIDENCE: <copy the line starting with execution_id: ...>")
+    }
+
+    private fun baselinePrompt(): String = buildString {
+        appendLine("The x11k project is checked out — a single-module Kotlin/JVM Gradle project")
+        appendLine("(a headless X11 server implementation).")
+        appendLine("IntelliJ MCP tools are unavailable in this run — use shell commands only.")
+        appendLine()
+        append(taskDescription())
+        appendLine()
+        appendLine("Beware: manual cut-and-paste must keep every declaration exactly once and keep all")
+        appendLine("references compiling — a missed dependency between the moved declarations breaks the build.")
+        appendLine()
+        append(outputFormat())
+    }
+
+    companion object {
+        private const val SCENARIO = "x11k__split_file"
+        private const val TARGET_FILE = "src/main/kotlin/org/jonnyzzz/xserver/X11State.kt"
+        private const val ORIGINAL_FILE_NAME = "X11State.kt"
+
+        /**
+         * At the pinned commit the file is 11,567 lines; its ~75 top-level non-`X11State`
+         * declarations span ~1,900 lines (1–125 + 9,772–11,567). Reaching ≤10,000 requires moving
+         * essentially all of them — a genuine multi-file split — without demanding surgery on the
+         * central class.
+         */
+        private const val MAX_REMAINING_LINES = 10_000
+        private const val MIN_NEW_FILES = 3
+
+        /**
+         * Top-level `internal data class` declarations from three different responsibility groups
+         * of the file (sync, keyboard, drawing). Both legs report `grep -rn "data class <name>(" |
+         * wc -l` — exactly 1 proves the declaration was MOVED (not deleted with its usages, not
+         * left duplicated in both the old and the new file).
+         */
+        private val SENTINELS = setOf("XSyncCounter", "XKeyboardMapping", "XDrawingCommand")
+    }
+}

--- a/test-experiments/src/test/kotlin/com/jonnyzzz/mcpSteroid/integration/tests/X11kTestSetupHelperTest.kt
+++ b/test-experiments/src/test/kotlin/com/jonnyzzz/mcpSteroid/integration/tests/X11kTestSetupHelperTest.kt
@@ -1,0 +1,177 @@
+/* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
+package com.jonnyzzz.mcpSteroid.integration.tests
+
+import com.jonnyzzz.mcpSteroid.integration.infra.AiMode
+import com.jonnyzzz.mcpSteroid.integration.infra.IntelliJContainer
+import com.jonnyzzz.mcpSteroid.integration.infra.IntelliJContainerOpts
+import com.jonnyzzz.mcpSteroid.integration.infra.IntelliJProject
+import com.jonnyzzz.mcpSteroid.integration.infra.McpConnectionMode
+import com.jonnyzzz.mcpSteroid.integration.infra.create
+import com.jonnyzzz.mcpSteroid.integration.infra.waitForProjectReady
+import com.jonnyzzz.mcpSteroid.testHelper.AiAgentSession
+import com.jonnyzzz.mcpSteroid.testHelper.CloseableStackHost
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Timeout
+import java.util.concurrent.TimeUnit
+
+/**
+ * MCP-win experiment: **extract the copy-pasted test setup into a shared helper**
+ * (jonnyzzz/mcp-steroid#169 family) on the pinned github.com/jonnyzzz/x11k commit `cfdf1f7d…`.
+ *
+ * x11k's protocol tests boot an in-process X server with the SAME 6-line block — construct
+ * `XServer(ServerOptions(port = 0, …))`, spawn a daemon `serveForever()` thread, connect a
+ * `Socket`, set `soTimeout`, run the handshake `setup(socket)`, and tear down with
+ * `server.close()` + `serverThread.join(…)` — repeated 800+ times repo-wide. The experiment
+ * scopes the migration to `XSyncProtocolTest.kt` (905 lines), where the block appears in every
+ * one of its 15 test methods at hand-derived line numbers.
+ *
+ * With MCP the agent uses IntelliJ's Extract Method / Introduce Parameter refactorings and usage
+ * search via `steroid_execute_code` to introduce a lambda-accepting helper and migrate the call
+ * sites; without MCP it is 15 manual block rewrites. Verdict ([scoreTestSetupHelper]): helper
+ * exists, ≥13 of the 15 ground-truth call sites reported migrated (original line numbers matched
+ * against the hand-derived list, spam-capped), and `XSyncProtocolTest` still passes — emitted as
+ * an `[ARENA]` block. A/B per agent; with-MCP asserts exec_code; correctness is a dashboard
+ * metric, not a hard gate.
+ */
+class X11kTestSetupHelperTest {
+
+    // 80 min, following the KeycloakRenameTest/KeycloakChangeSignatureTest precedent: the
+    // without-MCP baseline is edit-heavy (15 block rewrites + a Gradle test run per iteration) and
+    // must complete and emit its [ARENA] block so the dashboard can show the gap, not die as a
+    // timeout with no data. TC-side executionTimeoutMin=180 fits two 80-min methods.
+
+    @Test @Timeout(value = 80, unit = TimeUnit.MINUTES)
+    fun `claude with mcp`() = run("claude", withMcp = true)
+
+    @Test @Timeout(value = 80, unit = TimeUnit.MINUTES)
+    fun `claude without mcp`() = run("claude", withMcp = false)
+
+    @Test @Timeout(value = 80, unit = TimeUnit.MINUTES)
+    fun `codex with mcp`() = run("codex", withMcp = true)
+
+    @Test @Timeout(value = 80, unit = TimeUnit.MINUTES)
+    fun `codex without mcp`() = run("codex", withMcp = false)
+
+    private fun run(agentName: String, withMcp: Boolean) {
+        val modeLabel = if (withMcp) "mcp" else "none"
+        val lifetime = CloseableStackHost()
+        try {
+            val session = IntelliJContainer.create(lifetime, IntelliJContainerOpts(
+                consoleTitle = "x11k-setuphelper-$agentName-$modeLabel",
+                project = IntelliJProject.X11kPinnedProject,
+                aiMode = if (withMcp) AiMode.AI_MCP else AiMode.NONE,
+                mcpConnectionMode = if (withMcp) null else McpConnectionMode.None,
+            )).waitForProjectReady()
+
+            val agent: AiAgentSession = when (agentName) {
+                "claude" -> session.aiAgents.claude
+                "codex" -> session.aiAgents.codex
+                else -> error("Unknown agent: $agentName")
+            }
+
+            val startedAt = System.currentTimeMillis()
+            val result = agent.runPrompt(if (withMcp) withMcpPrompt() else baselinePrompt(), timeoutSeconds = 2400)
+                .awaitForProcessFinish()
+            val agentDurationMs = System.currentTimeMillis() - startedAt
+            val combined = result.stdout + "\n" + result.stderr
+
+            val score = scoreTestSetupHelper(combined, TARGET_FILE_NAME, EXPECTED_CALL_SITE_LINES, MIN_MIGRATED, LINE_TOLERANCE)
+            println("[TEST] x11k setup-helper [$agentName+$modeLabel] safe=${score.safe} " +
+                    "helper=${score.helperCreated} matched=${score.matchedCount}/${EXPECTED_CALL_SITE_LINES.size} " +
+                    "reported=${score.reportedCount} testsGreen=${score.testsGreen}")
+            if (score.missingLines.isNotEmpty()) {
+                println("[TEST]   missed call sites at original lines: ${score.missingLines.sorted()}")
+            }
+
+            recordSemanticRun(
+                scenario = SCENARIO,
+                agentName = agentName,
+                withMcp = withMcp,
+                claimedFix = score.safe,
+                rawOutput = result.rawStdout,
+                exitCode = result.exitCode,
+                agentDurationMs = agentDurationMs,
+                runDir = session.runDirInContainer,
+                summary = "helper=${score.helperCreated} matched=${score.matchedCount} " +
+                        "reported=${score.reportedCount} testsGreen=${score.testsGreen}",
+            )
+
+            if (withMcp) assertUsedExecuteCodeEvidence(combined)
+        } finally {
+            lifetime.closeAllStacks()
+        }
+    }
+
+    private fun taskDescription(): String = buildString {
+        appendLine("Task: `$TARGET_FILE` repeats the same test-setup block in EVERY one of its 15 test")
+        appendLine("methods — construct `XServer(ServerOptions(port = 0, …))`, start a daemon thread running")
+        appendLine("`server.serveForever()`, connect a `Socket` to `server.localPort`, set `soTimeout`, call the")
+        appendLine("`setup(socket)` handshake, and tear down with `server.close()` + `serverThread.join(…)`.")
+        appendLine()
+        appendLine("Replace this duplication with ONE shared helper (e.g. a lambda-accepting")
+        appendLine("`withSyncServer { server, socket -> … }` — you choose the name, signature and placement)")
+        appendLine("and migrate ALL 15 test methods of this file to it.")
+        appendLine()
+        appendLine("Rules:")
+        appendLine("- BEFORE editing, record the original line number of each duplicated block, e.g. via")
+        appendLine("  `grep -n \"XServer(ServerOptions(\" $TARGET_FILE` — you must report THOSE original lines;")
+        appendLine("- migrate only `$TARGET_FILE_NAME` — do NOT touch the other protocol test files;")
+        appendLine("- no behavior change: same server options, same handshake, same teardown, same assertions;")
+        appendLine("- afterwards run `./gradlew test --tests \"org.jonnyzzz.xserver.XSyncProtocolTest\"` and")
+        appendLine("  report the result. (Do NOT run the full `test` task — the Docker-based suites cannot run here.)")
+    }
+
+    private fun outputFormat(): String = buildString {
+        appendLine("Output (markers on their own lines):")
+        appendLine("HELPER_CREATED: <path of the file that now contains the shared helper>")
+        appendLine("MIGRATED: $TARGET_FILE:<original line of the migrated block>   ← one line per migrated call site")
+        appendLine("TESTS_AFTER_CHANGE: <SUCCESS or FAILURE>")
+    }
+
+    private fun withMcpPrompt(): String = buildString {
+        appendLine("The x11k project is open in IntelliJ IDEA — a single-module Kotlin/JVM Gradle project")
+        appendLine("(a headless X11 server implementation).")
+        appendLine()
+        append(taskDescription())
+        appendLine()
+        appendLine("Use IntelliJ via `steroid_execute_code`: Extract Method (or introduce the helper once and")
+        appendLine("apply it to each duplicate found by the IDE's duplicate detection / structural search),")
+        appendLine("and let PSI keep imports and references consistent. Do NOT sed.")
+        appendLine()
+        append(outputFormat())
+        appendLine("TOOL_EVIDENCE: <copy the line starting with execution_id: ...>")
+    }
+
+    private fun baselinePrompt(): String = buildString {
+        appendLine("The x11k project is checked out — a single-module Kotlin/JVM Gradle project")
+        appendLine("(a headless X11 server implementation).")
+        appendLine("IntelliJ MCP tools are unavailable in this run — use shell commands only.")
+        appendLine()
+        append(taskDescription())
+        appendLine()
+        appendLine("Beware: the 15 blocks are NOT byte-identical (different soTimeout usage, different join")
+        appendLine("timeouts, different body shapes) — a naive regex replace breaks the tests.")
+        appendLine()
+        append(outputFormat())
+    }
+
+    companion object {
+        private const val SCENARIO = "x11k__test_setup_helper"
+        private const val TARGET_FILE = "src/test/kotlin/org/jonnyzzz/xserver/XSyncProtocolTest.kt"
+        private const val TARGET_FILE_NAME = "XSyncProtocolTest.kt"
+
+        /**
+         * Ground truth at the pinned x11k commit `cfdf1f7d171df2581b63f7dfe675c343f6c86882`:
+         * `grep -n "XServer(ServerOptions(" src/test/kotlin/org/jonnyzzz/xserver/XSyncProtocolTest.kt`
+         * — the start line of the duplicated setup block in each of the 15 test methods.
+         */
+        private val EXPECTED_CALL_SITE_LINES =
+            setOf(14, 110, 163, 198, 240, 272, 302, 334, 387, 429, 484, 517, 574, 612, 650)
+
+        /** 13 of 15 — tolerates a couple of mis-reported originals without letting a partial sweep win. */
+        private const val MIN_MIGRATED = 13
+
+        /** Agents occasionally report the `use {`/thread line instead of the constructor line. */
+        private const val LINE_TOLERANCE = 5
+    }
+}

--- a/test-integration/src/main/kotlin/com/jonnyzzz/mcpSteroid/integration/infra/intelliJ-project.kt
+++ b/test-integration/src/main/kotlin/com/jonnyzzz/mcpSteroid/integration/infra/intelliJ-project.kt
@@ -176,6 +176,27 @@ sealed class IntelliJProject{
         override val openFileOnStart: String = "mockwebserver/src/main/kotlin/okhttp3/mockwebserver/RecordedRequest.kt"
     }
 
+    /**
+     * github.com/jonnyzzz/x11k — a single-module Kotlin/JVM headless X11 server (~97k LOC, Gradle
+     * 9.6, Kotlin 2.4.0, `jvmToolchain(25)`, JUnit Jupiter + kotlin-test), pinned to a fixed
+     * commit because every x11k experiment scores against ground truth derived AT this revision
+     * (kotlinc `extraWarnings` sites, `XSyncProtocolTest.kt` call-site line numbers, `X11State.kt`
+     * line counts). The repo's Docker-based tests (Xvfb parity, IntelliJ smoke) need
+     * docker-in-docker and are NOT exercised — experiments build/test only the in-process suites.
+     * When bumping the pin, re-derive every dependent ground-truth list at the new commit.
+     */
+    object X11kPinnedProject : ProjectFromRemoteGit(
+        "https://github.com/jonnyzzz/x11k.git",
+        // main @ 2026-07-03
+        gitRef = "cfdf1f7d171df2581b63f7dfe675c343f6c86882",
+    ) {
+        // build.gradle.kts pins jvmToolchain(25) + JvmTarget.JVM_25; the container ships temurin-25.
+        override val jdkVersion: String = "25"
+        override val buildSystems: Set<ProjectBuildSystem> =
+            setOf(ProjectBuildSystem(BuildSystem.GRADLE, "settings.gradle.kts"))
+        override val openFileOnStart: String = "README.md"
+    }
+
     /** A real Android (Gradle) project, used to exercise Android Studio. Google's official base template. */
     object AndroidSampleProject : ProjectFromRemoteGit("https://github.com/android/architecture-templates.git")
 

--- a/test-integration/src/main/kotlin/com/jonnyzzz/mcpSteroid/integration/tests/X11kTaskScoring.kt
+++ b/test-integration/src/main/kotlin/com/jonnyzzz/mcpSteroid/integration/tests/X11kTaskScoring.kt
@@ -1,0 +1,266 @@
+/* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
+package com.jonnyzzz.mcpSteroid.integration.tests
+
+/**
+ * Pure scorers for the x11k A/B experiments (jonnyzzz/mcp-steroid#169 family) against the pinned
+ * github.com/jonnyzzz/x11k commit `cfdf1f7d171df2581b63f7dfe675c343f6c86882`:
+ *
+ *  - [scoreSplitFile]        — `x11k__split_file`: split the 11.6k-line `X11State.kt` into cohesive files;
+ *  - [scoreTestSetupHelper]  — `x11k__test_setup_helper`: extract the copy-pasted in-process X-server boot
+ *                              block of `XSyncProtocolTest.kt` into a shared helper and migrate all 15 sites;
+ *  - [scoreKotlinInspections] — `x11k__inspections`: report the `file:line` sites kotlinc `extraWarnings`
+ *                              flags (never-reassigned / never-read local `var`s), Kotlin-path twin of
+ *                              [scoreInspections].
+ *
+ * Same design rules as [SemanticTaskScoring.kt]: mode-independent (with-MCP and shell-only runs are
+ * scored identically), evidence-based (markers matched against hand-derived / mechanically-derived
+ * ground truth, spam caps against shotgun answers), no IDE / Docker / agent needed → unit-tested directly.
+ */
+
+/** Parse a SUCCESS/FAILURE-ish marker value into a tri-state build/tests verdict. */
+private fun parseGreen(value: String?): Boolean? = value?.let {
+    when {
+        it.contains("SUCCESS", ignoreCase = true) || it.equals("pass", ignoreCase = true) ||
+            it.equals("passed", ignoreCase = true) || it.equals("green", ignoreCase = true) -> true
+        it.contains("FAIL", ignoreCase = true) || it.contains("error", ignoreCase = true) ||
+            it.contains("broke", ignoreCase = true) -> false
+        else -> null
+    }
+}
+
+data class SplitFileScore(
+    /** The agent reported the split itself was performed. */
+    val splitDone: Boolean,
+    /** `wc -l` of the original file after the split as reported (0 = file removed); null = never reported. */
+    val remainingLines: Int?,
+    /** Distinct new `.kt` file paths reported via `NEW_FILE:` (the original file never counts). */
+    val newFiles: Set<String>,
+    /** The post-split build result the agent reported (null if it never reported one). */
+    val buildGreen: Boolean?,
+    /** Sentinel declaration name → reported `grep` occurrence count (from `RESIDUE: <name>=<count>`). */
+    val residueCounts: Map<String, Int>,
+    /** Every sentinel was reported with count exactly 1 — moved once, not deleted, not duplicated. */
+    val residueClean: Boolean,
+    /** Split done AND file below threshold AND enough new files AND build green AND residue clean. */
+    val safe: Boolean,
+)
+
+/**
+ * Score a "split the god file into cohesive files" run. With MCP the agent drives IntelliJ's Move
+ * declarations / Move members refactorings via `steroid_execute_code` (references and imports update
+ * atomically); without MCP it is a manual cut-and-paste sweep. Both legs run the SAME verification
+ * commands and report their raw results, which this scorer cross-checks:
+ *
+ *   SPLIT_DONE: yes
+ *   REMAINING_LINES: <wc -l of the original file after the split; 0 if the file was removed>
+ *   NEW_FILE: <path of one newly created .kt file>          (one line per file)
+ *   BUILD_AFTER_SPLIT: SUCCESS | FAILURE
+ *   RESIDUE: <SentinelClassName>=<count>                    (grep -r occurrence count, must be 1)
+ *
+ * @param originalFileName  simple name of the file being split (a NEW_FILE with this name is ignored).
+ * @param maxRemainingLines the shrink threshold the original file must reach.
+ * @param minNewFiles       minimum number of distinct new files for a real multi-file split.
+ * @param sentinels         declaration names whose `RESIDUE:` count must be exactly 1 — checks that the
+ *                          moved code still exists exactly once (a deleted or copy-duplicated declaration
+ *                          fails even when the build-green claim is a lie of omission).
+ */
+fun scoreSplitFile(
+    output: String,
+    originalFileName: String,
+    maxRemainingLines: Int,
+    minNewFiles: Int,
+    sentinels: Set<String>,
+): SplitFileScore {
+    // Strip markdown code/bold marks so `- **NEW_FILE**: `path`` and plain markers parse the same.
+    val text = output.replace(Regex("[`*]"), "")
+
+    val splitDone = findMarkerValue(text, "SPLIT_DONE", "Split done")
+        ?.contains("yes", ignoreCase = true) == true
+
+    val remainingRaw = findMarkerValue(text, "REMAINING_LINES", "Remaining lines")
+    val remainingLines = remainingRaw?.let { raw ->
+        Regex("""\d+""").find(raw)?.value?.toIntOrNull()
+            ?: if (raw.contains("remov", ignoreCase = true) || raw.contains("delet", ignoreCase = true)) 0 else null
+    }
+
+    // Every `NEW_FILE:` marker contributes one path (markdown marks already stripped above).
+    val newFiles = Regex("""(?im)^\s*[-•>#|\s]*NEW_FILE\s*:\s*(.+)$""")
+        .findAll(text)
+        .map { it.groupValues[1].trim().trim('_', '"', '\'').removePrefix("./").trim('/') }
+        .filter { it.endsWith(".kt") && !it.endsWith("/$originalFileName") && it != originalFileName }
+        .toSet()
+
+    val buildGreen = parseGreen(findMarkerValue(text, "BUILD_AFTER_SPLIT", "Build after split"))
+
+    // `RESIDUE: <name>=<count>` — tolerate spaces around `=`.
+    val residueCounts = mutableMapOf<String, Int>()
+    Regex("""(?im)^\s*[-•>#|\s]*RESIDUE\s*:\s*([\w$]+)\s*=\s*(\d+)""")
+        .findAll(text).forEach { m ->
+            residueCounts[m.groupValues[1]] = m.groupValues[2].toInt()
+        }
+    val residueClean = sentinels.isNotEmpty() && sentinels.all { residueCounts[it] == 1 }
+
+    return SplitFileScore(
+        splitDone = splitDone,
+        remainingLines = remainingLines,
+        newFiles = newFiles,
+        buildGreen = buildGreen,
+        residueCounts = residueCounts,
+        residueClean = residueClean,
+        safe = splitDone &&
+            remainingLines != null && remainingLines <= maxRemainingLines &&
+            newFiles.size >= minNewFiles &&
+            buildGreen == true &&
+            residueClean,
+    )
+}
+
+data class TestSetupHelperScore(
+    /** The agent reported creating the shared helper (`HELPER_CREATED:`). */
+    val helperCreated: Boolean,
+    /** The helper path/name as reported (null when never reported). */
+    val helperRef: String?,
+    /** Original-file line numbers parsed from `MIGRATED: <expectedFile>:<line>` markers. */
+    val reportedLines: List<Int>,
+    val reportedCount: Int,
+    /** How many ground-truth call sites were hit (tolerance-matched, each consumed once). */
+    val matchedCount: Int,
+    /** Ground-truth call-site lines the agent did NOT report migrating. */
+    val missingLines: Set<Int>,
+    /** The post-change test-run result the agent reported (null if it never reported one). */
+    val testsGreen: Boolean?,
+    /** Enough ground-truth call sites hit AND the answer is not a shotgun spam of line numbers. */
+    val migrated: Boolean,
+    /** Helper created AND migrated AND the tests still pass. */
+    val safe: Boolean,
+)
+
+/**
+ * Score a "replace the copy-pasted test setup with a shared helper" run. The ground truth is the
+ * hand-derived list of call-site line numbers (where each duplicated setup block starts) in the
+ * target test file at the pinned revision. The prompt asks the agent to report each migrated call
+ * site by its ORIGINAL line number, so a fabricated answer must guess 60-line-spaced positions:
+ *
+ *   HELPER_CREATED: <path or name of the new shared helper>
+ *   MIGRATED: <path ending with expectedFile>:<original line>   (one per migrated call site)
+ *   TESTS_AFTER_CHANGE: SUCCESS | FAILURE
+ *
+ * Matching is greedy-bipartite per tolerance ring (exact first, then growing distance up to
+ * [lineTolerance]); each reported line is consumed at most once, so repeating one true line N times
+ * counts as one match. `migrated` additionally requires the spam cap: at most `3 × |expected|`
+ * reported pairs.
+ *
+ * @param expectedFile  simple name of the test file whose call sites are migrated; `MIGRATED:` markers
+ *                      for other files are ignored (suffix path match, absolute container paths OK).
+ * @param expectedLines hand-derived original line numbers of every duplicated setup block.
+ * @param minMigrated   how many ground-truth call sites must be hit.
+ * @param lineTolerance per-site line drift tolerance (agents occasionally report the `use {` line or
+ *                      an off-by-few position from their editor context).
+ */
+fun scoreTestSetupHelper(
+    output: String,
+    expectedFile: String,
+    expectedLines: Set<Int>,
+    minMigrated: Int,
+    lineTolerance: Int,
+): TestSetupHelperScore {
+    val text = output.replace(Regex("[`*]"), "")
+
+    val helperRef = findMarkerValue(text, "HELPER_CREATED", "Helper created")
+    val helperCreated = !helperRef.isNullOrBlank() &&
+        !helperRef.equals("no", ignoreCase = true) && !helperRef.equals("none", ignoreCase = true)
+
+    // `MIGRATED: <path>:<line>` — keep only markers whose path refers to the expected file.
+    val reportedLines = mutableListOf<Int>()
+    Regex("""(?im)^\s*[-•>#|\s]*MIGRATED\s*:\s*(.+)$""").findAll(text).forEach { m ->
+        val match = Regex("""([\w$./\\-]+\.kts?)\s*:\s*(\d+)""").find(m.groupValues[1]) ?: return@forEach
+        val path = match.groupValues[1].replace('\\', '/')
+        if (path == expectedFile || path.endsWith("/$expectedFile")) {
+            reportedLines.add(match.groupValues[2].toInt())
+        }
+    }
+
+    // Greedy bipartite match: exact lines first, then growing tolerance; each reported line consumed once.
+    val available = reportedLines.toMutableList()
+    val matched = mutableSetOf<Int>()
+    for (tolerance in 0..lineTolerance) {
+        for (expectedLine in expectedLines.sorted()) {
+            if (expectedLine in matched) continue
+            val hit = available.firstOrNull { kotlin.math.abs(it - expectedLine) <= tolerance } ?: continue
+            available.remove(hit)
+            matched.add(expectedLine)
+        }
+    }
+
+    val testsGreen = parseGreen(findMarkerValue(text, "TESTS_AFTER_CHANGE", "Tests after change"))
+    val migrated = matched.size >= minMigrated && reportedLines.size <= 3 * expectedLines.size
+
+    return TestSetupHelperScore(
+        helperCreated = helperCreated,
+        helperRef = helperRef,
+        reportedLines = reportedLines,
+        reportedCount = reportedLines.size,
+        matchedCount = matched.size,
+        missingLines = expectedLines - matched,
+        testsGreen = testsGreen,
+        migrated = migrated,
+        safe = helperCreated && migrated && testsGreen == true,
+    )
+}
+
+/**
+ * Score a "run IDE inspections + report issues" answer for KOTLIN (or mixed) sources — identical
+ * verdict logic to [scoreInspections], whose `ISSUE:` parser is limited to `.java` paths. Ground
+ * truth for the x11k scenario: the `file:line` sites kotlinc 2.4.0 `extraWarnings` (K2 `-Wextra`)
+ * reports at the pinned commit — local `var`s never reassigned (should be `val`) or never read.
+ * With MCP the agent runs IntelliJ's Kotlin inspections (`CanBeVal` / unused symbol) per candidate
+ * file; grep sees `var` declarations everywhere but cannot determine "never written after
+ * initialization" without data-flow analysis.
+ *
+ * Expected markers:
+ *   ISSUES_FOUND: <count>                                  (informational — never trusted)
+ *   ISSUE: <path>:<line> — <description>                   (one per finding)
+ *
+ * `detected` requires ≥ [minMatches] ground-truth hits (±1 line tolerance, greedy-bipartite, each
+ * line consumed once) AND at most `3 × |expected|` total reported pairs (spam cap).
+ */
+fun scoreKotlinInspections(output: String, expected: Map<String, Set<Int>>, minMatches: Int): InspectionScore {
+    // Strip markdown code/bold marks; underscores stay (significant in marker names and paths).
+    val text = output.replace(Regex("[`*]"), "")
+    val count = findMarkerValue(text, "ISSUES_FOUND", "Issues found")
+        ?.let { Regex("""\d+""").find(it)?.value?.toIntOrNull() }
+
+    // Every `ISSUE:` line contributes one (file simple name, line) pair; the file-name pattern has
+    // no `/`, so it naturally captures the last path segment. Accepts .kt/.kts/.java.
+    val reported = mutableMapOf<String, MutableList<Int>>()
+    Regex("""(?im)^\s*[-•>#\s]*ISSUE\s*:\s*(.+)$""").findAll(text).forEach { issue ->
+        val m = Regex("""([\w$.-]+\.(?:java|kts?))\s*:\s*(\d+)""").find(issue.groupValues[1]) ?: return@forEach
+        reported.getOrPut(m.groupValues[1]) { mutableListOf() }.add(m.groupValues[2].toInt())
+    }
+    val reportedCount = reported.values.sumOf { it.size }
+
+    // Greedy bipartite match per file: exact line first, then ±1; each reported line consumed once.
+    val matched = mutableMapOf<String, MutableSet<Int>>()
+    for ((file, expectedLines) in expected) {
+        val available = reported[file]?.toMutableList() ?: continue
+        for (tolerance in 0..1) {
+            for (expectedLine in expectedLines.sorted()) {
+                if (expectedLine in (matched[file] ?: emptySet<Int>())) continue
+                val hit = available.firstOrNull { kotlin.math.abs(it - expectedLine) <= tolerance } ?: continue
+                available.remove(hit)
+                matched.getOrPut(file) { mutableSetOf() }.add(expectedLine)
+            }
+        }
+    }
+    val matchedCount = matched.values.sumOf { it.size }
+    val expectedCount = expected.values.sumOf { it.size }
+
+    return InspectionScore(
+        issuesFound = count,
+        reportedLines = reported.mapValues { it.value.toSet() },
+        reportedCount = reportedCount,
+        matchedLines = matched,
+        matchedCount = matchedCount,
+        detected = matchedCount >= minMatches && reportedCount <= 3 * expectedCount,
+    )
+}

--- a/test-integration/src/test/kotlin/com/jonnyzzz/mcpSteroid/integration/tests/X11kInspectionScoringTest.kt
+++ b/test-integration/src/test/kotlin/com/jonnyzzz/mcpSteroid/integration/tests/X11kInspectionScoringTest.kt
@@ -1,0 +1,128 @@
+/* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
+package com.jonnyzzz.mcpSteroid.integration.tests
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * TDD unit tests for [scoreKotlinInspections] — the Kotlin-file twin of [scoreInspections] (whose
+ * `ISSUE:` parser only accepts `.java` paths). Used by the x11k inspections A/B
+ * (`x11k__inspections`): ground truth is the set of `file:line` sites kotlinc's
+ * `extraWarnings` (K2 `-Wextra`) flags at the pinned x11k commit cfdf1f7d — local `var`s that are
+ * never reassigned / never read. Same evidence-based verdict as the Keycloak scorer: reported
+ * `file:line` pairs are matched against ground truth (±1 tolerance, each consumed once) with a
+ * spam cap, so a hallucinated `ISSUES_FOUND` count or shotgunning every `var` cannot win.
+ */
+class X11kInspectionScoringTest {
+
+    /** kotlinc 2.4.0 `extraWarnings` on x11k @ cfdf1f7d — 9 distinct warning sites. */
+    private val expected = mapOf(
+        "X11Connection.kt" to setOf(4400),
+        "XFramebuffer.kt" to setOf(1598, 1599, 1600, 1601, 1746, 1747, 1748, 1749),
+    )
+
+    @Test
+    fun `correct answer with matching kt file-line pairs is detected`() {
+        val output = buildString {
+            appendLine("ISSUES_FOUND: 9")
+            appendLine("ISSUE: src/main/kotlin/org/jonnyzzz/xserver/X11Connection.kt:4400 — 'var idOffset' is never reassigned")
+            for (line in listOf(1598, 1599, 1600, 1601, 1746, 1747, 1748, 1749)) {
+                appendLine("ISSUE: src/main/kotlin/org/jonnyzzz/xserver/XFramebuffer.kt:$line — unused local var")
+            }
+            appendLine("TOOL_EVIDENCE: execution_id: eid_x")
+        }
+        val score = scoreKotlinInspections(output, expected, minMatches = 6)
+        assertEquals(9, score.issuesFound)
+        assertEquals(9, score.matchedCount)
+        assertEquals(9, score.reportedCount)
+        assertTrue(score.detected)
+    }
+
+    @Test
+    fun `finding only the XFramebuffer clusters still passes minMatches`() {
+        val output = buildString {
+            appendLine("ISSUES_FOUND: 8")
+            for (line in listOf(1598, 1599, 1600, 1601, 1746, 1747, 1748, 1749)) {
+                appendLine("ISSUE: src/main/kotlin/org/jonnyzzz/xserver/XFramebuffer.kt:$line — unused local var")
+            }
+        }
+        val score = scoreKotlinInspections(output, expected, minMatches = 6)
+        assertEquals(8, score.matchedCount)
+        assertTrue(score.detected)
+    }
+
+    @Test
+    fun `hallucinated big count with wrong lines is NOT detected`() {
+        val output = buildString {
+            appendLine("ISSUES_FOUND: 20")
+            for (line in listOf(100, 200, 300, 400, 500, 600, 700, 800, 900)) {
+                appendLine("ISSUE: src/main/kotlin/org/jonnyzzz/xserver/X11State.kt:$line — var could be val")
+            }
+        }
+        val score = scoreKotlinInspections(output, expected, minMatches = 6)
+        assertEquals(0, score.matchedCount)
+        assertFalse(score.detected)
+    }
+
+    @Test
+    fun `shotgunning every var line is rejected by the spam cap`() {
+        // 40 reported pairs cover all true sites but exceed 3x the 9-line ground truth.
+        val output = buildString {
+            appendLine("ISSUES_FOUND: 40")
+            for (line in 1590..1609) appendLine("ISSUE: XFramebuffer.kt:$line — var")
+            for (line in 1740..1755) appendLine("ISSUE: XFramebuffer.kt:$line — var")
+            for (line in listOf(4398, 4399, 4400, 4401)) appendLine("ISSUE: X11Connection.kt:$line — var")
+        }
+        val score = scoreKotlinInspections(output, expected, minMatches = 6)
+        assertTrue(score.reportedCount > 27)
+        assertFalse(score.detected)
+    }
+
+    @Test
+    fun `off-by-one line numbers are tolerated`() {
+        val output = buildString {
+            appendLine("ISSUES_FOUND: 9")
+            appendLine("ISSUE: X11Connection.kt:4401 — var never reassigned")
+            for (line in listOf(1597, 1599, 1600, 1601, 1746, 1747, 1748, 1750)) {
+                appendLine("ISSUE: XFramebuffer.kt:$line — unused var")
+            }
+        }
+        val score = scoreKotlinInspections(output, expected, minMatches = 6)
+        assertTrue(score.matchedCount >= 6)
+        assertTrue(score.detected)
+    }
+
+    @Test
+    fun `markdown wrapping and absolute paths are tolerated`() {
+        val output = buildString {
+            appendLine("**ISSUES_FOUND**: 9")
+            appendLine("- **ISSUE**: `/home/agent/project/src/main/kotlin/org/jonnyzzz/xserver/X11Connection.kt:4400` — never reassigned")
+            for (line in listOf(1598, 1599, 1600, 1601, 1746, 1747, 1748, 1749)) {
+                appendLine("- **ISSUE**: `XFramebuffer.kt:$line` — unused")
+            }
+        }
+        val score = scoreKotlinInspections(output, expected, minMatches = 6)
+        assertEquals(9, score.matchedCount)
+        assertTrue(score.detected)
+    }
+
+    @Test
+    fun `java paths still parse — the scorer is a superset of the java one`() {
+        val output = """
+            ISSUES_FOUND: 1
+            ISSUE: services/src/main/java/org/keycloak/Foo.java:42 — redundant cast
+        """.trimIndent()
+        val score = scoreKotlinInspections(output, mapOf("Foo.java" to setOf(42)), minMatches = 1)
+        assertEquals(1, score.matchedCount)
+        assertTrue(score.detected)
+    }
+
+    @Test
+    fun `empty answer is NOT detected`() {
+        val score = scoreKotlinInspections("I could not find any issues.", expected, minMatches = 6)
+        assertEquals(0, score.reportedCount)
+        assertFalse(score.detected)
+    }
+}

--- a/test-integration/src/test/kotlin/com/jonnyzzz/mcpSteroid/integration/tests/X11kSplitFileScoringTest.kt
+++ b/test-integration/src/test/kotlin/com/jonnyzzz/mcpSteroid/integration/tests/X11kSplitFileScoringTest.kt
@@ -1,0 +1,203 @@
+/* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
+package com.jonnyzzz.mcpSteroid.integration.tests
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * TDD unit tests for [scoreSplitFile] — the evidence-based scorer of the x11k "split the god file"
+ * A/B experiment (`x11k__split_file`). The agent splits `X11State.kt` (11,567 lines at the pinned
+ * x11k commit cfdf1f7d) into cohesive files; the scorer never trusts a bare "done" claim:
+ *  - `REMAINING_LINES` (from `wc -l`, both legs run it identically) must be ≤ the threshold,
+ *  - at least N distinct `NEW_FILE:` paths (`.kt`, different from the original file),
+ *  - `BUILD_AFTER_SPLIT: SUCCESS`,
+ *  - a residue check both legs run identically: `RESIDUE: <SentinelClass>=<grep -c count>` must be
+ *    exactly 1 for every sentinel — proving the moved declarations still exist exactly once
+ *    (not deleted, not left duplicated in both the old and the new file).
+ */
+class X11kSplitFileScoringTest {
+
+    private val sentinels = setOf("XSyncCounter", "XKeyboardMapping", "XDrawingCommand")
+
+    private fun score(output: String) = scoreSplitFile(
+        output = output,
+        originalFileName = "X11State.kt",
+        maxRemainingLines = 10_000,
+        minNewFiles = 3,
+        sentinels = sentinels,
+    )
+
+    @Test
+    fun `full success run is safe`() {
+        val output = """
+            I used IntelliJ's Move refactoring for each declaration group.
+            SPLIT_DONE: yes
+            REMAINING_LINES: 9650
+            NEW_FILE: src/main/kotlin/org/jonnyzzz/xserver/X11SyncModel.kt
+            NEW_FILE: src/main/kotlin/org/jonnyzzz/xserver/X11KeyboardModel.kt
+            NEW_FILE: src/main/kotlin/org/jonnyzzz/xserver/X11DrawingModel.kt
+            NEW_FILE: src/main/kotlin/org/jonnyzzz/xserver/X11WindowModel.kt
+            BUILD_AFTER_SPLIT: SUCCESS
+            RESIDUE: XSyncCounter=1
+            RESIDUE: XKeyboardMapping=1
+            RESIDUE: XDrawingCommand=1
+        """.trimIndent()
+        val s = score(output)
+        assertTrue(s.splitDone)
+        assertEquals(9650, s.remainingLines)
+        assertEquals(4, s.newFiles.size)
+        assertEquals(true, s.buildGreen)
+        assertTrue(s.residueClean)
+        assertTrue(s.safe)
+    }
+
+    @Test
+    fun `file barely shrunk is not safe`() {
+        val output = """
+            SPLIT_DONE: yes
+            REMAINING_LINES: 11200
+            NEW_FILE: src/main/kotlin/org/jonnyzzz/xserver/A.kt
+            NEW_FILE: src/main/kotlin/org/jonnyzzz/xserver/B.kt
+            NEW_FILE: src/main/kotlin/org/jonnyzzz/xserver/C.kt
+            BUILD_AFTER_SPLIT: SUCCESS
+            RESIDUE: XSyncCounter=1
+            RESIDUE: XKeyboardMapping=1
+            RESIDUE: XDrawingCommand=1
+        """.trimIndent()
+        assertFalse(score(output).safe)
+    }
+
+    @Test
+    fun `duplicated residue declaration is not safe`() {
+        // A copy-paste split that left XDrawingCommand in BOTH the old and the new file.
+        val output = """
+            SPLIT_DONE: yes
+            REMAINING_LINES: 9650
+            NEW_FILE: src/main/kotlin/org/jonnyzzz/xserver/A.kt
+            NEW_FILE: src/main/kotlin/org/jonnyzzz/xserver/B.kt
+            NEW_FILE: src/main/kotlin/org/jonnyzzz/xserver/C.kt
+            BUILD_AFTER_SPLIT: SUCCESS
+            RESIDUE: XSyncCounter=1
+            RESIDUE: XKeyboardMapping=1
+            RESIDUE: XDrawingCommand=2
+        """.trimIndent()
+        val s = score(output)
+        assertFalse(s.residueClean)
+        assertFalse(s.safe)
+    }
+
+    @Test
+    fun `missing residue markers is not safe`() {
+        val output = """
+            SPLIT_DONE: yes
+            REMAINING_LINES: 9650
+            NEW_FILE: src/main/kotlin/org/jonnyzzz/xserver/A.kt
+            NEW_FILE: src/main/kotlin/org/jonnyzzz/xserver/B.kt
+            NEW_FILE: src/main/kotlin/org/jonnyzzz/xserver/C.kt
+            BUILD_AFTER_SPLIT: SUCCESS
+        """.trimIndent()
+        val s = score(output)
+        assertFalse(s.residueClean)
+        assertFalse(s.safe)
+    }
+
+    @Test
+    fun `build failure is not safe`() {
+        val output = """
+            SPLIT_DONE: yes
+            REMAINING_LINES: 9650
+            NEW_FILE: src/main/kotlin/org/jonnyzzz/xserver/A.kt
+            NEW_FILE: src/main/kotlin/org/jonnyzzz/xserver/B.kt
+            NEW_FILE: src/main/kotlin/org/jonnyzzz/xserver/C.kt
+            BUILD_AFTER_SPLIT: FAILURE
+            RESIDUE: XSyncCounter=1
+            RESIDUE: XKeyboardMapping=1
+            RESIDUE: XDrawingCommand=1
+        """.trimIndent()
+        val s = score(output)
+        assertEquals(false, s.buildGreen)
+        assertFalse(s.safe)
+    }
+
+    @Test
+    fun `too few new files is not safe`() {
+        val output = """
+            SPLIT_DONE: yes
+            REMAINING_LINES: 9650
+            NEW_FILE: src/main/kotlin/org/jonnyzzz/xserver/A.kt
+            NEW_FILE: src/main/kotlin/org/jonnyzzz/xserver/B.kt
+            BUILD_AFTER_SPLIT: SUCCESS
+            RESIDUE: XSyncCounter=1
+            RESIDUE: XKeyboardMapping=1
+            RESIDUE: XDrawingCommand=1
+        """.trimIndent()
+        assertFalse(score(output).safe)
+    }
+
+    @Test
+    fun `duplicate and original-file NEW_FILE entries are not counted`() {
+        val output = """
+            SPLIT_DONE: yes
+            REMAINING_LINES: 9650
+            NEW_FILE: src/main/kotlin/org/jonnyzzz/xserver/A.kt
+            NEW_FILE: src/main/kotlin/org/jonnyzzz/xserver/A.kt
+            NEW_FILE: src/main/kotlin/org/jonnyzzz/xserver/X11State.kt
+            BUILD_AFTER_SPLIT: SUCCESS
+            RESIDUE: XSyncCounter=1
+            RESIDUE: XKeyboardMapping=1
+            RESIDUE: XDrawingCommand=1
+        """.trimIndent()
+        val s = score(output)
+        assertEquals(1, s.newFiles.size)
+        assertFalse(s.safe)
+    }
+
+    @Test
+    fun `original file removed entirely counts as remaining zero`() {
+        val output = """
+            SPLIT_DONE: yes
+            REMAINING_LINES: 0
+            NEW_FILE: src/main/kotlin/org/jonnyzzz/xserver/A.kt
+            NEW_FILE: src/main/kotlin/org/jonnyzzz/xserver/B.kt
+            NEW_FILE: src/main/kotlin/org/jonnyzzz/xserver/C.kt
+            BUILD_AFTER_SPLIT: SUCCESS
+            RESIDUE: XSyncCounter=1
+            RESIDUE: XKeyboardMapping=1
+            RESIDUE: XDrawingCommand=1
+        """.trimIndent()
+        val s = score(output)
+        assertEquals(0, s.remainingLines)
+        assertTrue(s.safe)
+    }
+
+    @Test
+    fun `markdown-wrapped markers still parse`() {
+        val output = """
+            **SPLIT_DONE**: yes
+            **REMAINING_LINES**: 9650
+            - **NEW_FILE**: `src/main/kotlin/org/jonnyzzz/xserver/A.kt`
+            - **NEW_FILE**: `src/main/kotlin/org/jonnyzzz/xserver/B.kt`
+            - **NEW_FILE**: `src/main/kotlin/org/jonnyzzz/xserver/C.kt`
+            **BUILD_AFTER_SPLIT**: SUCCESS
+            RESIDUE: `XSyncCounter=1`
+            RESIDUE: XKeyboardMapping = 1
+            RESIDUE: XDrawingCommand=1
+        """.trimIndent()
+        val s = score(output)
+        assertEquals(3, s.newFiles.size)
+        assertTrue(s.residueClean)
+        assertTrue(s.safe)
+    }
+
+    @Test
+    fun `no markers at all is not safe`() {
+        val s = score("I refactored the file successfully, everything is great now.")
+        assertFalse(s.splitDone)
+        assertNull(s.remainingLines)
+        assertEquals(0, s.newFiles.size)
+        assertFalse(s.safe)
+    }
+}

--- a/test-integration/src/test/kotlin/com/jonnyzzz/mcpSteroid/integration/tests/X11kTestSetupHelperScoringTest.kt
+++ b/test-integration/src/test/kotlin/com/jonnyzzz/mcpSteroid/integration/tests/X11kTestSetupHelperScoringTest.kt
@@ -1,0 +1,161 @@
+/* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
+package com.jonnyzzz.mcpSteroid.integration.tests
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * TDD unit tests for [scoreTestSetupHelper] — the evidence-based scorer of the x11k "replace the
+ * copy-pasted test setup with a shared helper" A/B experiment (`x11k__test_setup_helper`).
+ *
+ * Ground truth at the pinned x11k commit cfdf1f7d: `XSyncProtocolTest.kt` boots the in-process
+ * X server with the same 6-line block in every one of its 15 test methods; the block starts
+ * (`XServer(ServerOptions(`) at 15 known line numbers. The agent must extract a shared helper and
+ * migrate the call sites, reporting `MIGRATED: <file>:<line>` with the ORIGINAL line of each
+ * migrated block — matched against the hand-derived list with a small tolerance and a spam cap,
+ * so inventing line numbers or shotgunning every line of the file cannot win.
+ */
+class X11kTestSetupHelperScoringTest {
+
+    /** `grep -n "XServer(ServerOptions(" XSyncProtocolTest.kt` at x11k commit cfdf1f7d. */
+    private val expectedLines = setOf(14, 110, 163, 198, 240, 272, 302, 334, 387, 429, 484, 517, 574, 612, 650)
+
+    private fun score(output: String) = scoreTestSetupHelper(
+        output = output,
+        expectedFile = "XSyncProtocolTest.kt",
+        expectedLines = expectedLines,
+        minMigrated = 13,
+        lineTolerance = 5,
+    )
+
+    private fun migratedLines(lines: Collection<Int>, file: String = "src/test/kotlin/org/jonnyzzz/xserver/XSyncProtocolTest.kt") =
+        lines.joinToString("\n") { "MIGRATED: $file:$it" }
+
+    @Test
+    fun `all call sites migrated with helper and green tests is safe`() {
+        val output = """
+            HELPER_CREATED: src/test/kotlin/org/jonnyzzz/xserver/XServerTestHarness.kt
+            ${migratedLines(expectedLines)}
+            TESTS_AFTER_CHANGE: SUCCESS
+        """.trimIndent()
+        val s = score(output)
+        assertTrue(s.helperCreated)
+        assertEquals(15, s.matchedCount)
+        assertEquals(true, s.testsGreen)
+        assertTrue(s.safe)
+    }
+
+    @Test
+    fun `lines drifted within tolerance still match`() {
+        val output = """
+            HELPER_CREATED: XServerTestHarness.kt
+            ${migratedLines(expectedLines.map { it + 3 })}
+            TESTS_AFTER_CHANGE: SUCCESS
+        """.trimIndent()
+        val s = score(output)
+        assertEquals(15, s.matchedCount)
+        assertTrue(s.safe)
+    }
+
+    @Test
+    fun `too few migrated call sites is not safe`() {
+        val output = """
+            HELPER_CREATED: XServerTestHarness.kt
+            ${migratedLines(listOf(14, 110, 163, 198, 240))}
+            TESTS_AFTER_CHANGE: SUCCESS
+        """.trimIndent()
+        val s = score(output)
+        assertEquals(5, s.matchedCount)
+        assertFalse(s.safe)
+    }
+
+    @Test
+    fun `shotgunning every 10th line cannot win`() {
+        // 66 fabricated markers covering the whole file: enough to hit every expected line by
+        // accident, but the spam cap (3x expected) rejects the answer.
+        val output = """
+            HELPER_CREATED: XServerTestHarness.kt
+            ${migratedLines((1..660 step 10).toList())}
+            TESTS_AFTER_CHANGE: SUCCESS
+        """.trimIndent()
+        val s = score(output)
+        assertTrue(s.reportedCount > 45)
+        assertFalse(s.migrated)
+        assertFalse(s.safe)
+    }
+
+    @Test
+    fun `hallucinated line numbers do not match`() {
+        val output = """
+            HELPER_CREATED: XServerTestHarness.kt
+            ${migratedLines(listOf(30, 75, 130, 260, 320, 410, 470, 530, 590, 700, 720, 740, 760))}
+            TESTS_AFTER_CHANGE: SUCCESS
+        """.trimIndent()
+        val s = score(output)
+        assertTrue(s.matchedCount < 13)
+        assertFalse(s.safe)
+    }
+
+    @Test
+    fun `missing helper marker is not safe`() {
+        val output = """
+            ${migratedLines(expectedLines)}
+            TESTS_AFTER_CHANGE: SUCCESS
+        """.trimIndent()
+        val s = score(output)
+        assertFalse(s.helperCreated)
+        assertFalse(s.safe)
+    }
+
+    @Test
+    fun `red tests after change is not safe`() {
+        val output = """
+            HELPER_CREATED: XServerTestHarness.kt
+            ${migratedLines(expectedLines)}
+            TESTS_AFTER_CHANGE: FAILURE
+        """.trimIndent()
+        val s = score(output)
+        assertEquals(false, s.testsGreen)
+        assertFalse(s.safe)
+    }
+
+    @Test
+    fun `markers for a different file do not count`() {
+        val output = """
+            HELPER_CREATED: XServerTestHarness.kt
+            ${migratedLines(expectedLines, file = "src/test/kotlin/org/jonnyzzz/xserver/XRandrProtocolTest.kt")}
+            TESTS_AFTER_CHANGE: SUCCESS
+        """.trimIndent()
+        val s = score(output)
+        assertEquals(0, s.matchedCount)
+        assertFalse(s.safe)
+    }
+
+    @Test
+    fun `absolute container paths and markdown wrapping are tolerated`() {
+        val output = """
+            **HELPER_CREATED**: `src/test/kotlin/org/jonnyzzz/xserver/XServerTestHarness.kt`
+            ${expectedLines.joinToString("\n") { "- **MIGRATED**: `/home/agent/project/src/test/kotlin/org/jonnyzzz/xserver/XSyncProtocolTest.kt:$it`" }}
+            **TESTS_AFTER_CHANGE**: SUCCESS
+        """.trimIndent()
+        val s = score(output)
+        assertTrue(s.helperCreated)
+        assertEquals(15, s.matchedCount)
+        assertTrue(s.safe)
+    }
+
+    @Test
+    fun `each expected line consumes at most one reported line`() {
+        // 13 reports all pointing at the same call site must count as ONE match, not 13.
+        val output = """
+            HELPER_CREATED: XServerTestHarness.kt
+            ${migratedLines(List(13) { 14 })}
+            TESTS_AFTER_CHANGE: SUCCESS
+        """.trimIndent()
+        val s = score(output)
+        assertEquals(1, s.matchedCount)
+        assertFalse(s.safe)
+    }
+}


### PR DESCRIPTION
## Summary

Adds **github.com/jonnyzzz/x11k** — a Kotlin/JVM headless X11 server — as a new pinned experiment source, plus THREE A/B scenarios (claude/codex × with/without MCP each), following the KeycloakChangeSignatureTest / KeycloakInspectionsTest template: evidence-based scoring, `[ARENA]` dashboard blocks, exec_code evidence asserted on with-MCP legs, correctness as a dashboard metric.

**Pinned revision:** `cfdf1f7d171df2581b63f7dfe675c343f6c86882` (main @ 2026-07-03), recorded in `IntelliJProject.X11kPinnedProject` (`jdkVersion = "25"` — the repo pins `jvmToolchain(25)`; Gradle 9.6 via `settings.gradle.kts`). Every ground-truth list below was derived AT this commit; bumping the pin requires re-deriving all of them.

### Repo profile (research)

| Trait | Value |
|---|---|
| Language / build | 100% Kotlin (2.4.0), single-module Gradle 9.6, JVM toolchain 25 |
| Size | ~97k LOC across only 51 files — extreme file sizes by design |
| Biggest files | `XCoreDrawingProtocolTest.kt` 22,887 · `XRenderProtocolTest.kt` 15,252 · `X11Connection.kt` 13,892 (ONE class, ~690 members) · `X11State.kt` 11,567 · `XFramebuffer.kt` 5,549 |
| Tests | JUnit Jupiter + kotlin-test; in-process X11-over-TCP protocol tests (no Docker needed) + Testcontainers-based Xvfb/IntelliJ parity suites (Docker — NOT runnable in the ide-agent container, experiments avoid them) |
| Hygiene | compiles with ZERO default kotlinc warnings; K2 `extraWarnings` finds exactly 9 sites |
| Duplication | the same 6-line X-server boot block appears 800+ times across the test suite |

### Scenario 1 — `x11k__split_file` (`X11kSplitFileTest`, edit-heavy, 80 min)

Split `X11State.kt` (11,567 lines) into cohesive files, agent chooses the seams. Why this file and not the bigger `X11Connection.kt`: X11Connection is one monolithic class (splitting = deep class surgery); X11State has clean seams — ~75 top-level model declarations (~1,900 lines) around the central class, so reaching the **≤10,000-line threshold** requires moving essentially all of them, which IntelliJ's Move-declarations refactoring does atomically and a manual sweep does painfully.

Scoring (`scoreSplitFile`): `SPLIT_DONE` + `REMAINING_LINES` (from `wc -l`, both legs run it identically) ≤ 10,000 + ≥3 distinct `NEW_FILE`s + `BUILD_AFTER_SPLIT: SUCCESS` (`./gradlew compileKotlin compileTestKotlin`) + a residue check both legs run identically: `grep -rn "data class <sentinel>(" src/main/kotlin | wc -l` must be exactly **1** for three sentinels from different responsibility groups (`XSyncCounter`, `XKeyboardMapping`, `XDrawingCommand`) — a declaration that was deleted or left duplicated in both files fails.

### Scenario 2 — `x11k__test_setup_helper` (`X11kTestSetupHelperTest`, edit-heavy, 80 min)

`XSyncProtocolTest.kt` (905 lines) repeats the identical server-boot block (`XServer(ServerOptions(…))` + daemon `serveForever()` thread + `Socket` + `setup(socket)` handshake + `close/join` teardown) in **every one of its 15 test methods** — hand-derived occurrence list at the pin: lines 14, 110, 163, 198, 240, 272, 302, 334, 387, 429, 484, 517, 574, 612, 650. The agent extracts one shared lambda-accepting helper and migrates all 15 call sites (this file only).

Scoring (`scoreTestSetupHelper`): `HELPER_CREATED` + `MIGRATED: <file>:<original line>` matched against the hand-derived list (greedy-bipartite, ±5 tolerance, each line consumed once, spam cap 3×15 — shotgunning the file cannot win) with ≥13/15 required + `TESTS_AFTER_CHANGE: SUCCESS` from `./gradlew test --tests "org.jonnyzzz.xserver.XSyncProtocolTest"` (verified green at the pin, pure in-process — no Docker).

### Scenario 3 — `x11k__inspections` (`X11kInspectionsTest`, read-only, 50 min)

The codebase is TOO CLEAN for the default-warnings ground truth (zero kotlinc warnings), so the mechanical ground truth is kotlinc 2.4.0 **`extraWarnings` (K2 `-Wextra`)**: exactly 9 warning sites at the pin — `X11Connection.kt:4400` (a `var` that is read but never reassigned, buried in 13.9k lines) and two 4-line clusters of never-updated `min/maxPainted` trackers in `XFramebuffer.kt` (1598-1601, 1746-1749). Task: find every local `var` that data-flow proves never-reassigned (should be `val`) or never-read, among 6 candidate files — 4 of them var-heavy decoys, flagship decoy `X11State.kt` with ~198 `var`s and ZERO findings (all genuinely mutated — grep can see `var` syntax but cannot verify "never written later").

Scoring (`scoreKotlinInspections`, the `.kt`-capable twin of `scoreInspections` — same greedy `file:line` matching, ±1 tolerance, spam cap 3×9, `ISSUES_FOUND` never trusted): ≥6/9 matches required. With MCP: IntelliJ's `CanBeVal` / unused-variable inspections via `steroid_execute_code`.

### Scorers & TDD

All three scorers live in a new `test-integration/...tests/X11kTaskScoring.kt` (kept out of `SemanticTaskScoring.kt` to avoid conflicts with the concurrent experiment PRs), unit-tested TDD-first (red observed before implementation): 28 tests across `X11kSplitFileScoringTest`, `X11kTestSetupHelperScoringTest`, `X11kInspectionScoringTest` — all green, `:test-experiments:compileTestKotlin` green.

### Expected TeamCity configs

- `IntegrationTests_X11kSplitFile_{Claude,Codex}` — filter `*X11kSplitFileTest.claude*` / `*X11kSplitFileTest.codex*`, executionTimeoutMin=180
- `IntegrationTests_X11kTestSetupHelper_{Claude,Codex}` — filter `*X11kTestSetupHelperTest.claude*` / `…codex*`, executionTimeoutMin=180
- `IntegrationTests_X11kInspections_{Claude,Codex}` — filter `*X11kInspectionsTest.claude*` / `…codex*`, executionTimeoutMin=120

### RESEARCH — what else x11k is good for as an experiment source

x11k is unlike Keycloak (huge multi-module Java/Maven) and YouTrackDB (large Java/Gradle): it is a **small-file-count, giant-file, single-module, pure-Kotlin, binary-protocol** codebase with byte-level wire assertions and zero external runtime deps. Ranked future ideas:

1. **God-class decomposition** of `X11Connection.kt` (13.9k lines, ONE class, ~690 members) — the ultimate "Extract Class / Move members" IDE-refactoring stress test; a manual attempt is near-hopeless, making the A/B gap maximal.
2. **Repo-wide setup-helper migration** — scale scenario 2 from 15 call sites to the 800+ occurrences across 20+ test files (incl. the per-class duplicated `setup(socket)` handshake): tests IDE structural search/replace + duplicate detection at scale.
3. **Byte-offset semantics tasks** — the protocol code is full of hand-computed little-endian offsets (`u32le(reply, 8)`); a "find the off-by-one in this reply encoder" debugger/inspection scenario has mechanically verifiable ground truth via the existing wire tests.
4. **Dead-opcode audit** — "which X11 request opcodes/extension minor ops are declared but unhandled in the dispatcher" — an IDE find-usages/call-hierarchy task with mechanical ground truth from the `when` dispatch tables.
5. **Kotlin-specific inspection sweeps** — the repo's scale (97k LOC in 51 files) makes per-file IDE inspection runs (redundant qualifiers, `CanBeVal`, unused params via `-Wextra` re-derivation) cheap to ground-truth mechanically at each pin bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
