### PR TITLE
Survive the Gradle project-rename race in exec_code (x11k setup failures)

### DIFF
--- a/test-integration/src/main/kotlin/com/jonnyzzz/mcpSteroid/integration/infra/mcp-steroid.kt
+++ b/test-integration/src/main/kotlin/com/jonnyzzz/mcpSteroid/integration/infra/mcp-steroid.kt
@@ -80,6 +80,18 @@ private const val INDEXING_POLL_BUDGET_MS = 60 * 60 * 1000L
 /** Pure: does this tool-result text say the IDE is still indexing (so we should call again)? */
 internal fun isIndexingInProgress(text: String): Boolean = text.contains(INDEXING_IN_PROGRESS_MARKER)
 
+/**
+ * Pure: does this tool-result text say the addressed project name does not exist (server-side)?
+ *
+ * On Gradle projects whose `rootProject.name` differs from the checkout folder, the IDE RENAMES the
+ * project when the Gradle sync lands (`project-home` → e.g. `x-m90g7r9u`) — racing the driver's
+ * name resolution. A request that resolved the name a moment too early gets this error even though
+ * the project is open and healthy (observed on the x11k builds 993299640/993296335/993298537). The
+ * caller re-resolves and retries; a name that no longer changes means it is NOT the rename race and
+ * the error is genuine.
+ */
+internal fun isProjectNotFound(text: String): Boolean = text.contains("Project not found:")
+
 /** The message the plugin logs (SteroidsMcpServer) when its MCP web server cannot start. */
 internal const val MCP_SERVER_STARTUP_FAILURE_MARKER = "Failed to start MCP server"
 
@@ -507,7 +519,13 @@ try {
         taskId: String = "integration-test",
         reason: String = "Integration test execution",
         timeout: Int = 600,
-        projectName: String = resolveProjectName(),
+        /**
+         * Explicit project name, or null (default) to resolve the project at [IntelliJDriver.getGuestProjectDir]
+         * FRESH ON EVERY ATTEMPT. Per-attempt resolution matters: on Gradle projects whose `rootProject.name`
+         * differs from the checkout folder, the IDE renames the project when the sync lands, racing a
+         * name resolved once at call entry (see [isProjectNotFound]).
+         */
+        projectName: String? = null,
         /**
          * How exec_code treats IDE modality around the script. Mindfully defaulted to [ModalMode.DEFAULT]
          * and always sent explicitly on the wire, so every driver-issued exec_code makes a deliberate
@@ -522,8 +540,18 @@ try {
         // retrying a genuine crash for the whole budget. The last "busy" signal is a clean INDEXING IN
         // PROGRESS result → null → call again.
         waitForValue(INDEXING_POLL_BUDGET_MS, "exec_code '$taskId' to run (IDE busy with import/indexing)") {
-            mcpExecuteCodeOnce(code, taskId, reason, timeout, projectName, modal)
-                .takeUnless { isIndexingInProgress(it.stdout) }
+            val name = projectName ?: resolveProjectName()
+            val result = mcpExecuteCodeOnce(code, taskId, reason, timeout, name, modal)
+            when {
+                isIndexingInProgress(result.stdout) -> null // busy — call again
+                // Rename race: the addressed name vanished server-side. When the CALLER pinned the name
+                // or a fresh resolution still returns the same name, it is a genuine error — surface it.
+                // Otherwise the project was renamed under us (Gradle sync landing) — call again with the
+                // re-resolved name.
+                isProjectNotFound(result.stdout) &&
+                    projectName == null && resolveProjectName() != name -> null
+                else -> result
+            }
         }
 
     private fun mcpExecuteCodeOnce(

--- a/test-integration/src/test/kotlin/com/jonnyzzz/mcpSteroid/integration/infra/McpBusyRetryTest.kt
+++ b/test-integration/src/test/kotlin/com/jonnyzzz/mcpSteroid/integration/infra/McpBusyRetryTest.kt
@@ -123,4 +123,16 @@ class McpBusyRetryTest {
         // and the isError read is guarded the same way
         assertThrows<McpRequestFailedError> { parseMcpToolResultIsError("""{"result":"oops"}""") }
     }
+
+    @Test
+    fun `isProjectNotFound detects the rename-race error verbatim from CI`() {
+        // Verbatim from builds 993299640/993296335/993298537: x11k's Gradle sync renames the project
+        // (project-home -> rootProject.name + suffix) between the driver's name resolution and the
+        // execute_code call — the "not found" is a rename race, not a missing project.
+        assertTrue(isProjectNotFound(
+            """ERROR: Project not found: "project-home". Available project_name values: x-m90g7r9u"""))
+        assertFalse(isProjectNotFound("done"))
+        assertFalse(isProjectNotFound("ERROR: compilation failed: unresolved reference"))
+        assertFalse(isProjectNotFound(""))
+    }
 }


### PR DESCRIPTION
First x11k CI runs: **11/14 green**; the 3 failures (993299640, 993296335, 993298537) shared one signature —

```
Process failed to register JDKs: ERROR: Project not found: "project-home".
Available project_name values: x-m90g7r9u
```

## Root cause
x11k is the first experiment repo whose Gradle `rootProject.name` differs from the checkout folder. When the Gradle sync lands, the IDE **renames the open project**, racing the driver's one-time name resolution in `mcpExecuteCode`'s default argument. 3 of 6 legs lost the race (timing-dependent); Keycloak/okhttp never hit it because their imports keep the folder-derived name.

## Fix
- `projectName` defaults to **null = resolve fresh on every retry attempt** (resolution is path-based, and paths survive renames).
- A `Project not found` result is a retry-signal **only when** the caller didn't pin a name **and** fresh resolution returns a *different* name (i.e. the rename actually landed). A pinned name or a stable re-resolution surfaces the error immediately — a genuinely missing project is never masked by an hour of polling (same fail-fast philosophy as the typed retry contract).
- TDD: `isProjectNotFound` regression test with the verbatim CI error text; `McpBusyRetryTest` 10/10.

After merge: re-trigger the 3 failed builds → expect the x11k matrix at 6/6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)