### PR TITLE
ci: publish devrig binary from buildPluginOnCI

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -170,6 +170,25 @@ dependencies {
 }
 
 /**
+ * Root configuration that resolves the devrig distribution .zip produced by :npx-kt (its
+ * `distZip`, exposed via the `devrig-package` usage). Consumed by [buildPluginOnCI] so the
+ * devrig binary is published as a CI artifact alongside the plugin. :npx-kt's distZip bundles
+ * :ij-plugin's plugin .zip, so resolving both configurations still drives :ij-plugin:buildPlugin
+ * exactly once within a single Gradle invocation.
+ */
+val devrigZip by configurations.creating {
+    isCanBeConsumed = false
+    isCanBeResolved = true
+    attributes {
+        attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage::class, "devrig-package"))
+    }
+}
+
+dependencies {
+    devrigZip(project(":npx-kt"))
+}
+
+/**
  * CI entry point that builds the plugin and publishes the resulting .zip(s) as build artifacts.
  *
  * Depends on :ij-plugin's plugin-zip configuration (so Gradle drives the buildPlugin task for us),
@@ -183,18 +202,23 @@ dependencies {
  */
 val buildPluginOnCI by tasks.registering {
     group = "ci"
-    description = "Build the plugin distribution and publish its binaries via TeamCity service messages."
+    description = "Build the plugin + devrig distributions and publish their binaries via TeamCity service messages."
     inputs.files(pluginZip)
+    inputs.files(devrigZip)
     outputs.upToDateWhen { false }
 
     doLast {
-        val zips = pluginZip.files
-        require(zips.isNotEmpty()) {
+        val pluginZips = pluginZip.files
+        require(pluginZips.isNotEmpty()) {
             "No plugin .zip resolved from :ij-plugin's plugin-zip configuration"
         }
-        zips.forEach { zip ->
-            require(zip.isFile) { "Plugin zip not a file: ${zip.absolutePath}" }
-            logger.lifecycle("Plugin binary: ${zip.absolutePath} (${zip.length()} bytes)")
+        val devrigZips = devrigZip.files
+        require(devrigZips.isNotEmpty()) {
+            "No devrig .zip resolved from :npx-kt's devrig-package configuration"
+        }
+        (pluginZips + devrigZips).forEach { zip ->
+            require(zip.isFile) { "Distribution zip not a file: ${zip.absolutePath}" }
+            logger.lifecycle("Release binary: ${zip.absolutePath} (${zip.length()} bytes)")
             // TeamCity service message — ignored by GitHub Actions runners.
             // See https://www.jetbrains.com/help/teamcity/service-messages.html#Publishing+Artifacts+while+the+Build+is+Still+in+Progress
             println("##teamcity[publishArtifacts '${zip.absolutePath}']")


### PR DESCRIPTION
## What

Make the `buildPluginOnCI` Gradle task build **and** publish the devrig release binary (`devrig-<version>.zip`, from `:npx-kt:distZip`) alongside the plugin `.zip`, using the same `##teamcity[publishArtifacts …]` service-message mechanism already used for the plugin.

## Why

The `build plugin` TeamCity config (and the GitHub Actions build) runs `buildPluginOnCI` as the single CI entry point for producing release binaries. The devrig binary — the agent's stdio MCP entrypoint, which now ships as a release artifact — had **no** CI build coverage: only `:npx-kt:test` / `:integrationTest` ran (via `installDist`), never the release `distZip`. This wires the devrig binary into the existing publish flow so both archives are produced from one build.

Keeping it inside `buildPluginOnCI` (rather than adding a separate TeamCity task + `artifactRules`) means **no TeamCity DSL change is needed** — the TC config keeps invoking `buildPluginOnCI` unchanged.

## How

- Add a `devrigZip` resolvable configuration (usage `devrig-package`) consuming `:npx-kt`, mirroring the existing `pluginZip` configuration.
- `buildPluginOnCI` resolves both configurations and emits one publish service message per archive.

## Notes

- `:npx-kt:distZip` bundles `:ij-plugin`'s plugin `.zip`, so `:ij-plugin:buildPlugin` still runs **exactly once** per invocation, and both archives carry the same `BUILD_NUMBER`-derived version.
- `distZip`'s finalizers (`verifyBundledLibraries`, `verifyClassFileVersions`) now also run in CI — a free contents/class-file-version check on the shipped devrig binary.
- Service messages are no-ops on GitHub Actions; its own `upload-artifact` step is unchanged (it still globs only `ij-plugin/build/distributions/*.zip`, so it will build but not upload the devrig zip).

## Verification

`./gradlew buildPluginOnCI --dry-run` → `BUILD SUCCESSFUL`; the task graph includes `:npx-kt:distZip` and `:ij-plugin:buildPlugin` (once), confirming the `devrig-package` attribute resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)