### PR TITLE
Add :test-integration-windows — Windows launch + installer behaviour tests

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -409,6 +409,22 @@ val ciIntegrationTests by tasks.registering {
 }
 
 /**
+ * Aggregator for the Windows-only behaviour suite ([:test-integration-windows]). Invoked by
+ * TeamCity's dedicated Windows build config (see `~/Work/mcp-steroid-teamcity`,
+ * `builds/_18_windows_tests.kt`). The suite's own `test` task is gated `enabled = isWindows`, so on
+ * macOS/Linux this aggregator resolves to a skipped task — safe to invoke from any host.
+ *
+ * Covers, on a real Windows agent: (1) how Claude Code's Windows build resolves + launches a plugin's
+ * stdio MCP `command` and hooks (jonnyzzz/mcp-steroid#253), and (2) that the generated `install.ps1`
+ * is valid, parseable Windows PowerShell (#254).
+ */
+val ciWindowsTests by tasks.registering {
+    group = "ci"
+    description = "Run the Windows-only behaviour tests: :test-integration-windows:test (Claude launch + installer scripts)."
+    dependsOn(":test-integration-windows:test")
+}
+
+/**
  * Ordered task paths for the devrig (`:npx-kt`) CI aggregator — the standalone stdio MCP
  * entrypoint that agents launch directly (`devrig mpc`), as opposed to the IDE's HTTP
  * transport. Historically `npx-kt` was in [nonPluginTestSubprojects] with NO CI coverage;

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -39,6 +39,7 @@ include(":ocr-tesseract")
 
 include(":test-helper")
 include(":test-integration")
+include(":test-integration-windows")
 include(":test-experiments")
 
 include(":npx")

--- a/test-integration-windows/CLAUDE.md
+++ b/test-integration-windows/CLAUDE.md
@@ -1,0 +1,37 @@
+# test-integration-windows — Agent Guide
+
+**Windows-only** behaviour tests. They verify things that can only be observed on a real Windows agent
+against the real Windows build of the tools:
+
+| Test | Verifies |
+|---|---|
+| `ClaudeWindowsLaunchTest` | How Claude Code's **Windows** build resolves + launches a plugin stdio MCP `command` and hooks: an extensionless `${CLAUDE_PLUGIN_ROOT}/bin/probe` resolves via cross-spawn/PATHEXT to the `.cmd` sibling (script-only launcher, no native binary); a bare name does NOT resolve (plugin `bin/` not on the MCP subprocess PATH); the extensionless Unix script is never run. Live counterpart to jonnyzzz/mcp-steroid#253. |
+| `InstallerScriptWindowsTest` | The generated `install.ps1` (from `:installer-gen`) is ASCII-only and **parses** under Windows PowerShell 5.1. See #254. |
+
+## Why the whole suite is gated at the Gradle task level
+
+This suite is **structurally incompatible** with macOS/Linux (Windows Claude build, `cmd.exe`/PATHEXT
+resolution, Windows PowerShell). Per the root `CLAUDE.md` rule — *"The only acceptable skip is at the
+Gradle task level (`enabled = !condition`) when an entire suite is structurally incompatible with the
+platform"* — `build.gradle.kts` sets `tasks.test { enabled = OperatingSystem.current().isWindows }`.
+There are deliberately **no** runtime `assumeTrue` / `@EnabledOnOs` / `TestAbortedException` skips.
+
+So on macOS/Linux, `./gradlew :test-integration-windows:test` and `./gradlew ciWindowsTests` are
+no-ops (the task is skipped); `compileTestKotlin` still runs, so the tests stay compilation-checked
+everywhere.
+
+## Running
+
+```bash
+# On Windows (real behaviour):
+./gradlew :test-integration-windows:test
+./gradlew ciWindowsTests           # the CI aggregator TeamCity invokes
+
+# On macOS/Linux: both are skipped (see above). Verify it still compiles:
+./gradlew :test-integration-windows:compileTestKotlin
+```
+
+`ClaudeWindowsLaunchTest` downloads the official `win32-x64` `claude.exe` (cached under
+`build/windows-test-cache/`) and needs **no API key** — Claude spawns plugin MCP servers + hooks during
+session init, before the `-p` turn fails auth. TeamCity wiring lives in the separate
+`~/Work/mcp-steroid-teamcity` repo (`builds/_18_windows_tests.kt`).

--- a/test-integration-windows/build.gradle.kts
+++ b/test-integration-windows/build.gradle.kts
@@ -1,0 +1,53 @@
+import org.gradle.internal.os.OperatingSystem
+
+plugins {
+    kotlin("jvm")
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    implementation(platform("org.junit:junit-bom:5.11.4"))
+    implementation("org.junit.jupiter:junit-jupiter-api")
+    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+    testImplementation("org.slf4j:slf4j-simple:2.0.17")
+}
+
+kotlin {
+    jvmToolchain(25)
+}
+
+// This whole suite is STRUCTURALLY Windows-only: it downloads the Windows build of Claude Code and
+// drives Windows PowerShell / cmd.exe command resolution — behaviour that cannot be reproduced on
+// macOS/Linux. Per the repo rule (root CLAUDE.md → "The only acceptable skip is at the Gradle task
+// level (enabled = !condition) when an entire suite is structurally incompatible with the platform"),
+// we gate the whole test task on the host OS instead of using runtime assumeTrue/@EnabledOnOs skips.
+val isWindows = OperatingSystem.current().isWindows
+
+// The generated install.ps1 the InstallerScriptWindowsTest validates comes from :installer-gen. Read
+// the TEMPLATE from that module's SOURCE tree (never its build/ output — cross-subproject build/ access
+// is banned). Resolved at configuration time; passed to the test as a system property.
+val installPs1Template =
+    project(":installer-gen").projectDir.resolve("src/main/resources/templates/install.ps1.tmpl")
+
+tasks.test {
+    useJUnitPlatform()
+    testLogging { showStandardStreams = true }
+    systemProperty("junit.jupiter.execution.timeout.default", "15m")
+
+    // Windows-only gate (see note above). Off Windows this task is skipped, so `./gradlew test`,
+    // `ciWindowsTests`, and IDE runs on macOS/Linux are all no-ops for this module.
+    enabled = isWindows
+    onlyIf("test-integration-windows is a Windows-only suite (Claude Windows build + PowerShell)") { isWindows }
+
+    doFirst {
+        systemProperty(
+            "windows.test.cache.dir",
+            layout.buildDirectory.dir("windows-test-cache").get().asFile.also { it.mkdirs() }.absolutePath,
+        )
+        systemProperty("windows.installer.ps1.template", installPs1Template.absolutePath)
+    }
+}

--- a/test-integration-windows/build.gradle.kts
+++ b/test-integration-windows/build.gradle.kts
@@ -9,6 +9,11 @@ repositories {
 }
 
 dependencies {
+    // Shared process-runner util (RunProcessRequest / ProcessRunner) — the same pipeline every other
+    // process-driving test in the repo uses: consistent [prefix] logging, timeout + destroyForcibly,
+    // captured stdout/stderr in the returned ProcessResult.
+    implementation(project(":test-helper"))
+
     implementation(platform("org.junit:junit-bom:5.11.4"))
     implementation("org.junit.jupiter:junit-jupiter-api")
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")

--- a/test-integration-windows/src/test/kotlin/com/jonnyzzz/mcpSteroid/windows/ClaudeWindowsLaunchTest.kt
+++ b/test-integration-windows/src/test/kotlin/com/jonnyzzz/mcpSteroid/windows/ClaudeWindowsLaunchTest.kt
@@ -1,5 +1,7 @@
 package com.jonnyzzz.mcpSteroid.windows
 
+import com.jonnyzzz.mcpSteroid.testHelper.process.RunProcessRequest
+import com.jonnyzzz.mcpSteroid.testHelper.process.startProcess
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
@@ -10,6 +12,7 @@ import java.net.http.HttpRequest
 import java.net.http.HttpResponse
 import java.nio.file.Files
 import java.nio.file.Path
+import java.time.Duration
 import kotlin.io.path.absolutePathString
 import kotlin.io.path.createDirectories
 import kotlin.io.path.readText
@@ -56,24 +59,27 @@ class ClaudeWindowsLaunchTest {
         val logFile = fakeHome.resolve("portable-probe.log")
         Files.deleteIfExists(logFile)
 
-        val pb = ProcessBuilder(
-            claudeExe.absolutePathString(),
-            "--plugin-dir", pluginDir.absolutePathString(),
-            "-p", "reply with OK",
+        // Drive Claude through the repo's shared process-runner util (RunProcessRequest → ProcessRunner):
+        // consistent [claude-win] logging, timeout + destroyForcibly, captured stdout/stderr.
+        val result = RunProcessRequest(
+            args = listOf(
+                claudeExe.absolutePathString(),
+                "--plugin-dir", pluginDir.absolutePathString(),
+                "-p", "reply with OK",
+            ),
         )
-        pb.environment()["USERPROFILE"] = fakeHome.toString()
-        pb.environment()["HOME"] = fakeHome.toString()
-        pb.redirectOutput(fakeHome.resolve("claude-stdout.txt").toFile())
-        pb.redirectError(fakeHome.resolve("claude-stderr.txt").toFile())
-
-        val proc = pb.start()
-        // Claude fails auth quickly, but MCP servers + hooks spawn during init first. Bound it anyway.
-        if (!proc.waitFor(3, java.util.concurrent.TimeUnit.MINUTES)) {
-            proc.destroyForcibly()
-        }
+            // Override only HOME/USERPROFILE (isolated fake home) — ProcessRunner inherits the rest of
+            // the environment (PATH, SystemRoot, …) which Claude needs.
+            .withEnvironment(mapOf("USERPROFILE" to fakeHome.toString(), "HOME" to fakeHome.toString()))
+            // Claude fails auth quickly, but MCP servers + hooks spawn during init first. Bound it anyway.
+            .withTimeout(Duration.ofMinutes(3))
+            .withLogPrefix("claude-win")
+            .withDescription("claude --plugin-dir <probe> -p (Windows launch probe)")
+            .startProcess()
+            .awaitForProcessFinish()
 
         logLines = if (Files.exists(logFile)) logFile.readText().lines() else emptyList()
-        println("[probe] claude exit=${runCatching { proc.exitValue() }.getOrDefault(-1)}")
+        println("[probe] claude exit=${result.exitCode}")
         println("[probe] portable-probe.log:\n${if (logLines.isEmpty()) "(empty / not created)" else logLines.joinToString("\n")}")
     }
 

--- a/test-integration-windows/src/test/kotlin/com/jonnyzzz/mcpSteroid/windows/ClaudeWindowsLaunchTest.kt
+++ b/test-integration-windows/src/test/kotlin/com/jonnyzzz/mcpSteroid/windows/ClaudeWindowsLaunchTest.kt
@@ -1,0 +1,188 @@
+package com.jonnyzzz.mcpSteroid.windows
+
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import java.net.URI
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.io.path.absolutePathString
+import kotlin.io.path.createDirectories
+import kotlin.io.path.readText
+import kotlin.io.path.writeText
+
+/**
+ * Verifies — on a real Windows agent, against the real Windows build of Claude Code — HOW Claude
+ * resolves and launches a plugin's stdio MCP `command`. This is the live counterpart to the static
+ * analysis + Docker/Linux findings in jonnyzzz/mcp-steroid#253.
+ *
+ * The suite is Windows-only and is gated OFF on macOS/Linux at the Gradle task level
+ * (`test-integration-windows/build.gradle.kts` → `tasks.test { enabled = isWindows }`), per the repo
+ * rule that the only acceptable skip is a structurally-incompatible suite disabled at the task level.
+ * There is deliberately NO runtime `assumeTrue` / `@EnabledOnOs` skip here.
+ *
+ * What it proves (script-only launcher design, no native binary):
+ *  - An **extensionless** MCP `command` (`${CLAUDE_PLUGIN_ROOT}/bin/probe`) is resolved by Claude's
+ *    bundled cross-spawn via PATHEXT to the sibling `probe.cmd` and run through `cmd.exe` — so a pure
+ *    `.cmd` script can serve as the launcher. (Tag `mcp-fullpath`.)
+ *  - A **bare** command name (`probe`) does NOT resolve — the plugin `bin/` is not on the MCP
+ *    subprocess PATH (Option B is dead; matches the Linux finding). (Tag `mcp-bare` must be absent.)
+ *  - The extensionless Unix `probe` shell script is NEVER executed on Windows (cross-spawn skips the
+ *    exact no-extension name and only tries PATHEXT candidates). (Tag `UNIX-*` must be absent.)
+ *  - Whether a `SessionStart` hook (exec-form) resolves the same way. (Tag `hook-sessionstart`.)
+ *
+ * No API key is needed: Claude spawns plugin MCP servers + hooks during session init, before the
+ * `-p` turn fails auth. The probe just appends a line to `%USERPROFILE%\portable-probe.log` and exits.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class ClaudeWindowsLaunchTest {
+
+    private lateinit var logLines: List<String>
+
+    @BeforeAll
+    fun runClaudeOnceAndCaptureProbeLog() {
+        val cacheDir = Path.of(System.getProperty("windows.test.cache.dir"))
+        cacheDir.createDirectories()
+
+        val claudeExe = downloadWindowsClaude(cacheDir)
+        val pluginDir = writeProbePlugin(cacheDir.resolve("probe-plugin"))
+
+        // Isolated fake home so (a) the probe log is easy to find and (b) Claude has no real auth/config.
+        val fakeHome = Files.createTempDirectory(cacheDir, "home").toAbsolutePath()
+        val logFile = fakeHome.resolve("portable-probe.log")
+        Files.deleteIfExists(logFile)
+
+        val pb = ProcessBuilder(
+            claudeExe.absolutePathString(),
+            "--plugin-dir", pluginDir.absolutePathString(),
+            "-p", "reply with OK",
+        )
+        pb.environment()["USERPROFILE"] = fakeHome.toString()
+        pb.environment()["HOME"] = fakeHome.toString()
+        pb.redirectOutput(fakeHome.resolve("claude-stdout.txt").toFile())
+        pb.redirectError(fakeHome.resolve("claude-stderr.txt").toFile())
+
+        val proc = pb.start()
+        // Claude fails auth quickly, but MCP servers + hooks spawn during init first. Bound it anyway.
+        if (!proc.waitFor(3, java.util.concurrent.TimeUnit.MINUTES)) {
+            proc.destroyForcibly()
+        }
+
+        logLines = if (Files.exists(logFile)) logFile.readText().lines() else emptyList()
+        println("[probe] claude exit=${runCatching { proc.exitValue() }.getOrDefault(-1)}")
+        println("[probe] portable-probe.log:\n${if (logLines.isEmpty()) "(empty / not created)" else logLines.joinToString("\n")}")
+    }
+
+    @Test
+    fun `extensionless MCP command resolves to the cmd sibling (script-only launcher)`() {
+        assertTrue(logLines.isNotEmpty()) {
+            "probe log is empty — Claude never spawned the MCP server. See claude-stderr.txt in the cache dir."
+        }
+        assertTrue(logLines.any { it.contains("tag=mcp-fullpath") }) {
+            "Expected the extensionless MCP command \${CLAUDE_PLUGIN_ROOT}/bin/probe to resolve to probe.cmd " +
+                "and run (tag=mcp-fullpath). Log:\n${logLines.joinToString("\n")}"
+        }
+        assertTrue(logLines.none { it.contains("UNIX-SHOULD-NOT-RUN") }) {
+            "The extensionless Unix shell script bin/probe was executed on Windows — cross-spawn should " +
+                "skip the exact no-extension name and only try PATHEXT candidates. Log:\n${logLines.joinToString("\n")}"
+        }
+    }
+
+    @Test
+    fun `bare command name does not resolve (plugin bin not on MCP subprocess PATH)`() {
+        assertTrue(logLines.none { it.contains("tag=mcp-bare") }) {
+            "The bare command name 'probe' resolved and launched — this would mean the plugin bin/ IS on " +
+                "the MCP subprocess PATH on Windows, contradicting the Linux finding. Log:\n${logLines.joinToString("\n")}"
+        }
+    }
+
+    @Test
+    fun `SessionStart hook (exec-form) launches`() {
+        assertTrue(logLines.any { it.contains("tag=hook-sessionstart") }) {
+            "The exec-form SessionStart hook (command + args, extensionless) did not launch on Windows. " +
+                "This reveals hooks resolve differently from MCP (possibly Bun-native spawn, not cross-spawn). " +
+                "Log:\n${logLines.joinToString("\n")}"
+        }
+    }
+
+    // --- helpers -------------------------------------------------------------------------------------
+
+    /** Download the official win32-x64 Claude Code binary (latest), cached by version. */
+    private fun downloadWindowsClaude(cacheDir: Path): Path {
+        val base = "https://downloads.claude.ai/claude-code-releases"
+        val http = HttpClient.newHttpClient()
+        val version = http.send(
+            HttpRequest.newBuilder(URI.create("$base/latest")).GET().build(),
+            HttpResponse.BodyHandlers.ofString(),
+        ).body().trim()
+        require(version.matches(Regex("""\d+\.\d+\.\d+"""))) { "Unexpected latest version from $base/latest: '$version'" }
+
+        val exe = cacheDir.resolve("claude-$version-win32-x64.exe")
+        if (Files.exists(exe) && Files.size(exe) > 50_000_000) return exe
+
+        val url = "$base/$version/win32-x64/claude.exe"
+        Files.deleteIfExists(exe)
+        http.send(
+            HttpRequest.newBuilder(URI.create(url)).GET().build(),
+            HttpResponse.BodyHandlers.ofFile(exe),
+        )
+        require(Files.exists(exe) && Files.size(exe) > 50_000_000) {
+            "Downloaded claude.exe looks wrong (size=${runCatching { Files.size(exe) }.getOrDefault(-1)}) from $url"
+        }
+        return exe
+    }
+
+    /** Write a throwaway plugin whose "servers"/hooks are the launch probe. Returns the plugin dir. */
+    private fun writeProbePlugin(root: Path): Path {
+        root.resolve(".claude-plugin").createDirectories()
+        root.resolve("hooks").createDirectories()
+        root.resolve("bin").createDirectories()
+
+        root.resolve(".claude-plugin/plugin.json").writeText(
+            """{ "name": "windows-probe", "description": "launch probe", "version": "0.0.1", "author": {"name":"probe"} }""",
+        )
+        // Two MCP servers: extensionless full path (script-only resolution) + bare name (PATH resolution).
+        root.resolve(".mcp.json").writeText(
+            """
+            {
+              "mcpServers": {
+                "probefull": { "type": "stdio", "command": "${'$'}{CLAUDE_PLUGIN_ROOT}/bin/probe", "args": ["mcp-fullpath"] },
+                "probebare": { "type": "stdio", "command": "probe", "args": ["mcp-bare"] }
+              }
+            }
+            """.trimIndent(),
+        )
+        // Exec-form SessionStart hook (command + args, extensionless).
+        root.resolve("hooks/hooks.json").writeText(
+            """
+            {
+              "hooks": {
+                "SessionStart": [ { "hooks": [
+                  { "type": "command", "command": "${'$'}{CLAUDE_PLUGIN_ROOT}/bin/probe", "args": ["hook-sessionstart"] }
+                ] } ]
+              }
+            }
+            """.trimIndent(),
+        )
+        // The Windows probe: a pure batch script that records how it was launched, then exits.
+        // (No JSON-RPC handshake — the launch + log line is what we assert; Claude marking the server
+        //  "failed" afterwards is irrelevant.)
+        root.resolve("bin/probe.cmd").writeText(
+            "@echo off\r\n" +
+                ">>\"%USERPROFILE%\\portable-probe.log\" echo LAUNCHED tag=%1 root=%CLAUDE_PLUGIN_ROOT%\r\n" +
+                "exit /b 0\r\n",
+        )
+        // Negative control: the extensionless Unix shell script. On Windows, cross-spawn must NOT run
+        // this (it resolves probe -> probe.cmd via PATHEXT). If it ever fires we see the UNIX tag.
+        root.resolve("bin/probe").writeText(
+            "#!/bin/sh\n" +
+                "echo \"LAUNCHED tag=UNIX-SHOULD-NOT-RUN arg=\$1\" >> \"\$HOME/portable-probe.log\"\n",
+        )
+        root.resolve("bin/probe").toFile().setExecutable(true)
+        return root
+    }
+}

--- a/test-integration-windows/src/test/kotlin/com/jonnyzzz/mcpSteroid/windows/InstallerScriptWindowsTest.kt
+++ b/test-integration-windows/src/test/kotlin/com/jonnyzzz/mcpSteroid/windows/InstallerScriptWindowsTest.kt
@@ -1,0 +1,86 @@
+package com.jonnyzzz.mcpSteroid.windows
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.io.path.absolutePathString
+import kotlin.io.path.createDirectories
+import kotlin.io.path.readText
+import kotlin.io.path.writeText
+
+/**
+ * Validates the generated Windows installer (`install.ps1`, produced by :installer-gen) against a REAL
+ * Windows PowerShell, on a Windows agent. Windows-only; gated OFF elsewhere at the Gradle task level
+ * (see build.gradle.kts) — no runtime skips.
+ *
+ * Scope: it renders the `install.ps1.tmpl` template with placeholder values and asserts the result
+ * (a) is ASCII-only (Windows PowerShell 5.1 misreads UTF-8 — the generator enforces this; we verify the
+ * rendered instance), and (b) PARSES with zero syntax errors under Windows PowerShell 5.1 via the
+ * PowerShell AST parser. A full ~611 MB end-to-end install (real devrig + JDK) is intentionally NOT run
+ * here — that belongs with the sh/PowerShell polyglot verification in jonnyzzz/mcp-steroid#254.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class InstallerScriptWindowsTest {
+
+    private fun renderInstallPs1(): String {
+        val templatePath = Path.of(System.getProperty("windows.installer.ps1.template"))
+        val sha = "a".repeat(64)
+        // Placeholder values chosen only to be syntactically valid + ASCII; the script is parsed, not run.
+        val platformTable = buildString {
+            append("\$Platforms = @{ ")
+            append("'win32-x64' = @{ url = 'https://example.invalid/jdk-x64.zip'; sha256 = '$sha'; binsub = 'jdk\\bin' }; ")
+            append("'win32-arm64' = @{ url = 'https://example.invalid/jdk-arm64.zip'; sha256 = '$sha'; binsub = 'jdk\\bin' } }")
+        }
+        return templatePath.readText()
+            .replace("@@VERSION@@", "0.0.0-test")
+            .replace("@@DEVRIG_URL@@", "https://example.invalid/devrig.zip")
+            .replace("@@DEVRIG_SHA256@@", sha)
+            .replace("@@DEVRIG_FORMAT@@", "zip")
+            .replace("@@DEVRIG_BINSUB@@", "devrig\\bin\\devrig.bat")
+            .replace("@@PLATFORM_TABLE_PS@@", platformTable)
+    }
+
+    @Test
+    fun `rendered install_ps1 is ASCII-only`() {
+        val rendered = renderInstallPs1()
+        val firstNonAscii = rendered.indexOfFirst { it.code > 0x7F }
+        assertEquals(-1, firstNonAscii) {
+            "install.ps1 must be ASCII-only (Windows PowerShell 5.1 misreads UTF-8). First non-ASCII char " +
+                "at index $firstNonAscii: '${rendered.getOrNull(firstNonAscii)}'"
+        }
+    }
+
+    @Test
+    fun `generated install_ps1 parses under Windows PowerShell 5_1`() {
+        val cacheDir = Path.of(System.getProperty("windows.test.cache.dir")).also { it.createDirectories() }
+        val script = cacheDir.resolve("install-rendered.ps1")
+        script.writeText(renderInstallPs1())
+
+        // Parse (do NOT execute) via the PowerShell AST parser; non-zero exit == syntax errors.
+        val parseCmd =
+            "\$errs = \$null; " +
+                "[System.Management.Automation.Language.Parser]::ParseFile('${script.absolutePathString().replace("\\", "\\\\")}', [ref]\$null, [ref]\$errs); " +
+                "if (\$errs -and \$errs.Count -gt 0) { \$errs | ForEach-Object { [Console]::Error.WriteLine(\$_.ToString()) }; exit 1 } else { exit 0 }"
+
+        val out = cacheDir.resolve("installer-parse-out.txt")
+        val proc = ProcessBuilder("powershell", "-NoProfile", "-NonInteractive", "-Command", parseCmd)
+            .redirectErrorStream(true)
+            .redirectOutput(out.toFile())
+            .start()
+        val finished = proc.waitFor(2, java.util.concurrent.TimeUnit.MINUTES)
+        assertTrue(finished) { "PowerShell parse of install.ps1 did not finish in time" }
+        val exit = proc.exitValue()
+        val output = if (Files.exists(out)) out.readText() else ""
+        assertEquals(0, exit) { "install.ps1 failed to parse under Windows PowerShell 5.1:\n$output" }
+    }
+
+    @Test
+    fun `rendered install_ps1 bakes the Windows platform table`() {
+        val rendered = renderInstallPs1()
+        assertTrue(rendered.contains("win32-x64")) { "install.ps1 should reference the win32-x64 platform" }
+        assertTrue(rendered.contains("\$Version")) { "install.ps1 should define \$Version" }
+    }
+}

--- a/test-integration-windows/src/test/kotlin/com/jonnyzzz/mcpSteroid/windows/InstallerScriptWindowsTest.kt
+++ b/test-integration-windows/src/test/kotlin/com/jonnyzzz/mcpSteroid/windows/InstallerScriptWindowsTest.kt
@@ -1,11 +1,13 @@
 package com.jonnyzzz.mcpSteroid.windows
 
+import com.jonnyzzz.mcpSteroid.testHelper.process.RunProcessRequest
+import com.jonnyzzz.mcpSteroid.testHelper.process.startProcess
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
-import java.nio.file.Files
 import java.nio.file.Path
+import java.time.Duration
 import kotlin.io.path.absolutePathString
 import kotlin.io.path.createDirectories
 import kotlin.io.path.readText
@@ -65,16 +67,19 @@ class InstallerScriptWindowsTest {
                 "[System.Management.Automation.Language.Parser]::ParseFile('${script.absolutePathString().replace("\\", "\\\\")}', [ref]\$null, [ref]\$errs); " +
                 "if (\$errs -and \$errs.Count -gt 0) { \$errs | ForEach-Object { [Console]::Error.WriteLine(\$_.ToString()) }; exit 1 } else { exit 0 }"
 
-        val out = cacheDir.resolve("installer-parse-out.txt")
-        val proc = ProcessBuilder("powershell", "-NoProfile", "-NonInteractive", "-Command", parseCmd)
-            .redirectErrorStream(true)
-            .redirectOutput(out.toFile())
-            .start()
-        val finished = proc.waitFor(2, java.util.concurrent.TimeUnit.MINUTES)
-        assertTrue(finished) { "PowerShell parse of install.ps1 did not finish in time" }
-        val exit = proc.exitValue()
-        val output = if (Files.exists(out)) out.readText() else ""
-        assertEquals(0, exit) { "install.ps1 failed to parse under Windows PowerShell 5.1:\n$output" }
+        // Parse via the shared process-runner util (RunProcessRequest → ProcessRunner).
+        val result = RunProcessRequest(
+            args = listOf("powershell", "-NoProfile", "-NonInteractive", "-Command", parseCmd),
+        )
+            .withTimeout(Duration.ofMinutes(2))
+            .withLogPrefix("ps-parse")
+            .withDescription("PowerShell 5.1 AST parse of install.ps1")
+            .startProcess()
+            .awaitForProcessFinish()
+
+        assertEquals(0, result.exitCode) {
+            "install.ps1 failed to parse under Windows PowerShell 5.1:\n${result.stdout}\n${result.stderr}"
+        }
     }
 
     @Test


### PR DESCRIPTION
## What

New Windows-only Gradle module **`:test-integration-windows`** that verifies behaviour observable only on a real Windows agent against the real Windows builds of Claude Code and the installer. Plus the `ciWindowsTests` root aggregator and settings wiring. TeamCity build config lives in the separate `mcp-steroid-teamcity` repo (see below).

Empirically grounds the cross-platform launcher investigation in #253 and the polyglot installer work in #254.

## Tests

- **`ClaudeWindowsLaunchTest`** — downloads the official `win32-x64` `claude.exe` (cached; **no API key** — MCP servers + hooks spawn during session init before the `-p` turn fails auth), loads a throwaway probe plugin via `--plugin-dir`, and asserts from the probe log:
  - an **extensionless** MCP `command` (`${CLAUDE_PLUGIN_ROOT}/bin/probe`) resolves via Claude's bundled cross-spawn/PATHEXT to the sibling **`probe.cmd`** and runs — i.e. a **script-only** launcher works, no native binary;
  - a **bare** command name does **not** resolve (plugin `bin/` is not on the MCP subprocess PATH — Option B stays dead, matching the Linux finding);
  - the extensionless **Unix** shell script is **never** executed on Windows;
  - a `SessionStart` exec-form hook launches.
- **`InstallerScriptWindowsTest`** — renders the `:installer-gen` `install.ps1` template and asserts it is **ASCII-only** and **parses** under Windows PowerShell 5.1 (via the PowerShell AST parser). Full ~611 MB end-to-end install is intentionally out of scope here (belongs with #254's polyglot verification).

## Skip behaviour (macOS/Linux)

The suite is **structurally incompatible** with macOS/Linux, so it is gated at the **Gradle task level** — `tasks.test { enabled = OperatingSystem.current().isWindows }` — per the repo rule that the only acceptable skip is a structurally-incompatible suite disabled at the task level. There are **no** runtime `assumeTrue` / `@EnabledOnOs` / `TestAbortedException` skips.

- On macOS/Linux: `:test-integration-windows:test` and `ciWindowsTests` are **skipped**; `compileTestKotlin` still runs, so the tests stay compilation-checked everywhere.
- Verified locally on macOS: module compiles, `:test-integration-windows:test` → `SKIPPED`, `ciWindowsTests` registered.

## CI wiring

- Root `ciWindowsTests` aggregator (`build.gradle.kts`) → `:test-integration-windows:test`.
- TeamCity (separate repo `mcp-steroid-teamcity`): new `WindowsTests` build config (`builds/_18_windows_tests.kt`, registered in `settings.kts`) reusing the shared per-OS Gradle scaffold with `CpuAndOs.Windows_amd64` + `gradleTask = "ciWindowsTests"`. Generated XML confirmed: requires `os.name` starts-with `Windows` + `amd64`, runs `ciWindowsTests` on `%env.JDK_21_0%`.

## Not yet executed on real Windows

Because this host is macOS the suite is skipped here; the actual assertions run on the TeamCity Windows agent. This PR is the mechanism to get that green (or reveal a real behaviour difference, e.g. if exec-form hooks resolve differently from MCP).
