### PR TITLE
Preserve agent-produced patch for evaluation

### DIFF
--- a/test-experiments/src/test/kotlin/com/jonnyzzz/mcpSteroid/integration/arena/ArenaTestRunner.kt
+++ b/test-experiments/src/test/kotlin/com/jonnyzzz/mcpSteroid/integration/arena/ArenaTestRunner.kt
@@ -5,6 +5,7 @@ import com.jonnyzzz.mcpSteroid.testHelper.AiAgentSession
 import com.jonnyzzz.mcpSteroid.testHelper.process.ProcessResult
 import com.jonnyzzz.mcpSteroid.testHelper.docker.ContainerDriver
 import com.jonnyzzz.mcpSteroid.testHelper.git.GitDriver
+import java.io.File
 
 /**
  * Manages the execution of a dpaia arena test case inside a Docker container
@@ -349,6 +350,7 @@ class ArenaTestRunner(
         timeoutSeconds: Long = 1800,
         prewarm: ((projectDir: String) -> Unit)? = null,
         predeployedProjectDir: String? = null,
+        logDir: File? = null,
     ): ArenaTestResult {
         println("[ARENA] ========================================")
         println("[ARENA] Running: ${testCase.instanceId}")
@@ -388,6 +390,8 @@ class ArenaTestRunner(
 
         // Step 5: Evaluate
         val evaluation = evaluate(testCase, agentResult)
+        val diff = git.diff(projectDir)
+        logDir?.resolve("agent-result.patch")?.writeText(diff)
 
         println("[ARENA] ========================================")
         println("[ARENA] Result for ${testCase.instanceId}:")

--- a/test-experiments/src/test/kotlin/com/jonnyzzz/mcpSteroid/integration/arena/DpaiaScenarioBaseTest.kt
+++ b/test-experiments/src/test/kotlin/com/jonnyzzz/mcpSteroid/integration/arena/DpaiaScenarioBaseTest.kt
@@ -135,6 +135,7 @@ abstract class DpaiaScenarioBaseTest {
                 withMcp = withMcp,
                 timeoutSeconds = caseConfig.agentTimeoutSeconds,
                 predeployedProjectDir = ideProjectDir,
+                logDir = session.runDirInContainer
             )
 
             // ── Extract metrics from agent NDJSON ────────────────────────────────

--- a/test-helper/src/main/kotlin/com/jonnyzzz/mcpSteroid/testHelper/git/GitDriver.kt
+++ b/test-helper/src/main/kotlin/com/jonnyzzz/mcpSteroid/testHelper/git/GitDriver.kt
@@ -163,4 +163,25 @@ class GitDriver(
                 .description("git apply patch in $repoDir")
         }.awaitForProcessFinish().assertExitCode(0, "git apply patch")
     }
+
+    /**
+     * Generate a diff of changes in a repository.
+     *
+     * @param repoDir guest path of the repository
+     * @return the diff output as a string in unified diff format, suitable for applyPatch()
+     */
+    fun diff(repoDir: String): String {
+        println("[GIT] Generating diff for $repoDir...")
+        val result = driver.startProcessInContainer {
+            this
+                .args("git", "-C", repoDir, "diff")
+                .timeoutSeconds(30)
+                .quietly()
+                .description("git diff in $repoDir")
+        }.awaitForProcessFinish()
+
+        result.assertExitCode(0, "git diff")
+        return result.stdout
+    }
+
 }

--- a/test-integration/src/main/kotlin/com/jonnyzzz/mcpSteroid/integration/infra/TeamCityServiceMessages.kt
+++ b/test-integration/src/main/kotlin/com/jonnyzzz/mcpSteroid/integration/infra/TeamCityServiceMessages.kt
@@ -89,5 +89,7 @@ object TeamCityServiceMessages {
         // included in the zip too (duplicates the standalone copies) so the
         // zip stays a self-contained offline record of the whole session.
         println("##teamcity[publishArtifacts '${escape("$base/** => $runName.zip")}']")
+        // Agent-produced patch, to be used for evaluation
+        println("##teamcity[publishArtifacts '${escape("$base/agent-result.patch => $runName.patch")}']")
     }
 }


### PR DESCRIPTION
Makes DPAIA tests save the patch produced by the agents, and publish it as a teamcity artifact, so that it can be used to evaluate the agent's work using other tools, instead of being lost when the container is shut down.