### PR TITLE
test(windows): full plugin hook-form matrix, validated on TeamCity + GH windows-latest

### DIFF
--- a/test-integration-windows/CLAUDE.md
+++ b/test-integration-windows/CLAUDE.md
@@ -5,20 +5,34 @@ against the real Windows build of the tools:
 
 | Test | Verifies |
 |---|---|
-| `ClaudeWindowsLaunchTest` | How Claude Code's **Windows** build resolves + launches a plugin stdio MCP `command`: an extensionless `${CLAUDE_PLUGIN_ROOT}/bin/probe` resolves via cross-spawn/PATHEXT to the `.cmd` sibling (script-only launcher, no native binary); a bare name does NOT resolve (plugin `bin/` not on the MCP subprocess PATH); the extensionless Unix script is never run. Live counterpart to jonnyzzz/mcp-steroid#253. |
+| `ClaudeWindowsLaunchTest` | How Claude Code's **Windows** build resolves + launches a plugin stdio MCP `command` (extensionless → `.cmd` via cross-spawn/PATHEXT; bare name doesn't resolve) **and every candidate hook form** (exec x3 + shell x3). Live counterpart to jonnyzzz/mcp-steroid#253. |
 | `InstallerScriptWindowsTest` | The generated `install.ps1` (from `:installer-gen`) is ASCII-only and **parses** under Windows PowerShell 5.1. See #254. |
 
-## Confirmed on a real `windows-latest` run (#253)
+## Confirmed on real Windows — cross-validated on TeamCity **and** GitHub `windows-latest` (#253)
 
-- ✅ **Script-only launcher works**: the extensionless MCP `command` resolves to `probe.cmd` and runs
-  via `cmd.exe` (cross-spawn/PATHEXT). No native binary needed for the MCP server.
-- ✅ **Bare command name is dead** (plugin `bin/` not on the MCP subprocess PATH) and the extensionless
-  **Unix** script is never executed on Windows.
-- ⚠️ **Plugin hooks do NOT run in `claude -p` on Windows** — neither an extensionless nor an explicit
-  `.cmd` SessionStart hook fired, while the same headless `-p` + no-login flow DOES run them on Linux.
-  This is a Claude-Code headless-Windows platform trait, not a launcher property, so the hook is
-  **recorded for diagnostics but not asserted** (a `-p`-based harness can't validly observe it). Real
-  plugin hooks on Windows need separate, non-`-p` verification.
+Probe log format: `LAUNCHED tag=<tag> via=<cmd|sh|shell|script>`.
+
+**MCP stdio (script-only, zero deps):**
+- ✅ extensionless `${CLAUDE_PLUGIN_ROOT}/bin/<stem>` resolves to `<stem>.cmd` via cross-spawn/PATHEXT
+  (`via=cmd`); the extensionless Unix script is NOT run on Windows.
+- ✅ bare command name does NOT resolve (plugin `bin/` isn't on the MCP subprocess PATH).
+
+**Hooks — the full matrix (corrects the earlier "hooks don't run on Windows" claim: they DO):**
+
+| Hook form | Fires on Windows? |
+|---|:-:|
+| exec-form, extensionless path | ❌ (direct spawn, not runnable) |
+| exec-form, `.cmd` path | ❌ (direct spawn can't launch a `.cmd`) |
+| exec-form, `cmd /c <.cmd>` | ✅ (`cmd.exe` is a real exe) |
+| shell-form, default (Git Bash) inline cmd | ✅ |
+| shell-form, `"shell":"powershell"` | ✅ |
+| **shell-form → `#!/bin/sh` script (the devrig hook form)** | ✅ (runs via Git Bash) |
+
+**Key:** devrig's shipped hooks (`check-devrig`, `devrig-progress`, `devrig-recover`) are shell-form
+`sh` scripts → they **work on Windows via Git Bash**. The one dependency is **Git Bash on Windows**
+(default hook shell for `sh`); absent it, an `sh` hook fails (and PowerShell can't run it). MCP has no
+such dependency. Exec-form hooks are only viable for scripts via the `cmd /c` wrapper — prefer
+shell-form.
 
 ## Why the whole suite is gated at the Gradle task level
 

--- a/test-integration-windows/src/test/kotlin/com/jonnyzzz/mcpSteroid/windows/ClaudeWindowsLaunchTest.kt
+++ b/test-integration-windows/src/test/kotlin/com/jonnyzzz/mcpSteroid/windows/ClaudeWindowsLaunchTest.kt
@@ -20,34 +20,29 @@ import kotlin.io.path.writeText
 
 /**
  * Verifies — on a real Windows agent, against the real Windows build of Claude Code — HOW Claude
- * resolves and launches a plugin's stdio MCP `command`. This is the live counterpart to the static
- * analysis + Docker/Linux findings in jonnyzzz/mcp-steroid#253.
+ * resolves and launches a plugin's stdio MCP `command` **and its hooks**. Live counterpart to the
+ * static analysis + Docker/Linux findings in jonnyzzz/mcp-steroid#253.
  *
- * The suite is Windows-only and is gated OFF on macOS/Linux at the Gradle task level
- * (`test-integration-windows/build.gradle.kts` → `tasks.test { enabled = isWindows }`), per the repo
- * rule that the only acceptable skip is a structurally-incompatible suite disabled at the task level.
- * There is deliberately NO runtime `assumeTrue` / `@EnabledOnOs` skip here.
+ * Goal: pin the **tested, script-only** way to call the installed devrig from a plugin (MCP + hooks),
+ * with minimal dependencies. So this exercises EVERY candidate hook form and records which fire.
  *
- * What it proves (script-only launcher design, no native binary):
- *  - An **extensionless** MCP `command` (`${CLAUDE_PLUGIN_ROOT}/bin/probe`) is resolved by Claude's
- *    bundled cross-spawn via PATHEXT to the sibling `probe.cmd` and run through `cmd.exe` — so a pure
- *    `.cmd` script can serve as the launcher. (Tag `mcp-fullpath`.)
- *  - A **bare** command name (`probe`) does NOT resolve — the plugin `bin/` is not on the MCP
- *    subprocess PATH (Option B is dead; matches the Linux finding). (Tag `mcp-bare` must be absent.)
- *  - The extensionless Unix `probe` shell script is NEVER executed on Windows (cross-spawn skips the
- *    exact no-extension name and only tries PATHEXT candidates). (Tag `UNIX-*` must be absent.)
+ * Windows-only; gated OFF on macOS/Linux at the Gradle task level (build.gradle.kts →
+ * `tasks.test { enabled = isWindows }`). No runtime `assumeTrue`/`@EnabledOnOs` skips.
  *
- * Hooks are recorded for diagnostics but NOT asserted — the real Windows runs showed `claude -p` does
- * not run plugin hooks on Windows at all (a headless-Windows platform trait, not a launcher property);
- * see the diagnostic test's KDoc below.
- *
- * No API key is needed: Claude spawns plugin MCP servers during session init, before the `-p` turn
- * fails auth. The probe just appends a line to `%USERPROFILE%\portable-probe.log` and exits.
+ * The probe writes one line per launch to `%USERPROFILE%\portable-probe.log`:
+ *   `LAUNCHED tag=<tag> via=<cmd|sh|shell|script>`
+ * so each entry says both WHAT launched (the tag) and THROUGH WHAT (a `.cmd`, an `sh` script, an inline
+ * shell command, or a script path). No API key needed — MCP servers + hooks spawn during session init,
+ * before the `-p` turn fails auth.
  */
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class ClaudeWindowsLaunchTest {
 
     private lateinit var logLines: List<String>
+
+    // Match the tag exactly up to the trailing " via=" so a tag that is a PREFIX of another (e.g.
+    // hook-exec-cmd vs hook-exec-cmdc) doesn't false-match. Log format: "LAUNCHED tag=<tag> via=<x>".
+    private fun fired(tag: String) = logLines.any { it.contains("tag=$tag ") }
 
     @BeforeAll
     fun runClaudeOnceAndCaptureProbeLog() {
@@ -57,13 +52,10 @@ class ClaudeWindowsLaunchTest {
         val claudeExe = downloadWindowsClaude(cacheDir)
         val pluginDir = writeProbePlugin(cacheDir.resolve("probe-plugin"))
 
-        // Isolated fake home so (a) the probe log is easy to find and (b) Claude has no real auth/config.
         val fakeHome = Files.createTempDirectory(cacheDir, "home").toAbsolutePath()
         val logFile = fakeHome.resolve("portable-probe.log")
         Files.deleteIfExists(logFile)
 
-        // Drive Claude through the repo's shared process-runner util (RunProcessRequest → ProcessRunner):
-        // consistent [claude-win] logging, timeout + destroyForcibly, captured stdout/stderr.
         val result = RunProcessRequest(
             args = listOf(
                 claudeExe.absolutePathString(),
@@ -71,13 +63,10 @@ class ClaudeWindowsLaunchTest {
                 "-p", "reply with OK",
             ),
         )
-            // Override only HOME/USERPROFILE (isolated fake home) — ProcessRunner inherits the rest of
-            // the environment (PATH, SystemRoot, …) which Claude needs.
             .withEnvironment(mapOf("USERPROFILE" to fakeHome.toString(), "HOME" to fakeHome.toString()))
-            // Claude fails auth quickly, but MCP servers + hooks spawn during init first. Bound it anyway.
             .withTimeout(Duration.ofMinutes(3))
             .withLogPrefix("claude-win")
-            .withDescription("claude --plugin-dir <probe> -p (Windows launch probe)")
+            .withDescription("claude --plugin-dir <probe> -p (Windows launch + hook matrix)")
             .startProcess()
             .awaitForProcessFinish()
 
@@ -86,48 +75,73 @@ class ClaudeWindowsLaunchTest {
         println("[probe] portable-probe.log:\n${if (logLines.isEmpty()) "(empty / not created)" else logLines.joinToString("\n")}")
     }
 
+    // ---- MCP server (stdio) ------------------------------------------------------------------------
+
     @Test
-    fun `extensionless MCP command resolves to the cmd sibling (script-only launcher)`() {
-        assertTrue(logLines.isNotEmpty()) {
-            "probe log is empty — Claude never spawned the MCP server. See claude-stderr.txt in the cache dir."
+    fun `MCP - extensionless command resolves to the cmd sibling (script-only launcher)`() {
+        assertTrue(logLines.isNotEmpty()) { "probe log empty — Claude never spawned the MCP server." }
+        assertTrue(logLines.any { it.contains("tag=mcp-fullpath via=cmd") }) {
+            "Extensionless MCP command \${CLAUDE_PLUGIN_ROOT}/bin/probe should resolve to probe.cmd via " +
+                "cross-spawn/PATHEXT. Log:\n${logLines.joinToString("\n")}"
         }
-        assertTrue(logLines.any { it.contains("mcp-fullpath") }) {
-            "Expected the extensionless MCP command \${CLAUDE_PLUGIN_ROOT}/bin/probe to resolve to probe.cmd " +
-                "and run (tag=mcp-fullpath). Log:\n${logLines.joinToString("\n")}"
-        }
-        assertTrue(logLines.none { it.contains("UNIX-SHOULD-NOT-RUN") }) {
-            "The extensionless Unix shell script bin/probe was executed on Windows — cross-spawn should " +
-                "skip the exact no-extension name and only try PATHEXT candidates. Log:\n${logLines.joinToString("\n")}"
+        assertTrue(logLines.none { it.contains("tag=mcp-fullpath via=sh") }) {
+            "The extensionless Unix shell script ran on Windows — cross-spawn should only try PATHEXT " +
+                "candidates. Log:\n${logLines.joinToString("\n")}"
         }
     }
 
     @Test
-    fun `bare command name does not resolve (plugin bin not on MCP subprocess PATH)`() {
-        assertTrue(logLines.none { it.contains("mcp-bare") }) {
-            "The bare command name 'probe' resolved and launched — this would mean the plugin bin/ IS on " +
-                "the MCP subprocess PATH on Windows, contradicting the Linux finding. Log:\n${logLines.joinToString("\n")}"
+    fun `MCP - bare command name does not resolve (plugin bin not on subprocess PATH)`() {
+        assertTrue(!fired("mcp-bare")) {
+            "Bare 'probe' resolved — plugin bin/ must not be on the MCP subprocess PATH. Log:\n${logLines.joinToString("\n")}"
         }
     }
 
-    /**
-     * Hooks are NOT asserted here. The probe registers two SessionStart hook forms (extensionless +
-     * explicit `.cmd`) and the [runClaudeOnceAndCaptureProbeLog] setup prints the full probe log, so
-     * whether a hook fired is visible in CI output for diagnostics. But we do not fail the build on it:
-     * the real Windows runs (jonnyzzz/mcp-steroid#253) established that **`claude -p` does not execute
-     * plugin hooks on Windows at all** (neither form fired, while MCP servers did) — the same headless
-     * `-p` + no-login flow DOES run them on Linux. That is a Claude-Code headless-Windows platform trait,
-     * not a property of the plugin launcher, and it is not observable through a `-p`-based harness. The
-     * launcher behaviour we CAN and DO assert is MCP-server resolution above.
-     */
+    // ---- Hook matrix: every candidate form, one test each ------------------------------------------
+
     @Test
-    fun `hooks fired are recorded for diagnostics (not asserted - see kdoc)`() {
-        val hookLines = logLines.filter { it.contains("hook-") }
-        println("[probe] SessionStart hook lines observed on this host: ${if (hookLines.isEmpty()) "(none)" else hookLines}")
+    fun `hook exec-form extensionless does NOT launch on Windows`() {
+        // Exec form spawns "command" directly as one executable; an extensionless path isn't runnable.
+        assertTrue(!fired("hook-exec-extensionless")) { hookLog() }
     }
 
-    // --- helpers -------------------------------------------------------------------------------------
+    @Test
+    fun `hook exec-form dot-cmd does NOT launch on Windows`() {
+        // Exec form can't spawn a .cmd directly (no shell, not cross-spawn).
+        assertTrue(!fired("hook-exec-cmd")) { hookLog() }
+    }
 
-    /** Download the official win32-x64 Claude Code binary (latest), cached by version. */
+    @Test
+    fun `hook exec-form via cmd slash c launches`() {
+        // cmd.exe IS a real executable, so exec form can spawn it; it then runs the .cmd. Windows-only
+        // (breaks on Unix — no cmd.exe), but a valid Windows exec-form workaround.
+        assertTrue(fired("hook-exec-cmdc")) { hookLog() }
+    }
+
+    @Test
+    fun `hook shell-form default (Git Bash) launches`() {
+        // No "args" => Claude runs the command string through a shell (Git Bash by default on Windows).
+        assertTrue(fired("hook-shell-default")) { hookLog() }
+    }
+
+    @Test
+    fun `hook shell-form powershell launches`() {
+        // No "args" + "shell":"powershell" => PowerShell (always present on Windows) runs the command.
+        assertTrue(fired("hook-shell-powershell")) { hookLog() }
+    }
+
+    @Test
+    fun `hook shell-form pointing at an sh script (the devrig hook pattern) launches`() {
+        // devrig's own hooks are shell-form paths to #!/bin/sh scripts (no args). On Windows that runs
+        // via Git Bash. This is THE test for whether devrig's shipped hooks work on Windows.
+        assertTrue(fired("hook-devrig-pattern")) { hookLog() }
+    }
+
+    private fun hookLog() =
+        "Hook launch outcome differs from expectation. Full probe log:\n${logLines.joinToString("\n")}"
+
+    // ---- helpers -----------------------------------------------------------------------------------
+
     private fun downloadWindowsClaude(cacheDir: Path): Path {
         val base = "https://downloads.claude.ai/claude-code-releases"
         val http = HttpClient.newHttpClient()
@@ -135,24 +149,16 @@ class ClaudeWindowsLaunchTest {
             HttpRequest.newBuilder(URI.create("$base/latest")).GET().build(),
             HttpResponse.BodyHandlers.ofString(),
         ).body().trim()
-        require(version.matches(Regex("""\d+\.\d+\.\d+"""))) { "Unexpected latest version from $base/latest: '$version'" }
-
+        require(version.matches(Regex("""\d+\.\d+\.\d+"""))) { "Unexpected latest version: '$version'" }
         val exe = cacheDir.resolve("claude-$version-win32-x64.exe")
         if (Files.exists(exe) && Files.size(exe) > 50_000_000) return exe
-
         val url = "$base/$version/win32-x64/claude.exe"
         Files.deleteIfExists(exe)
-        http.send(
-            HttpRequest.newBuilder(URI.create(url)).GET().build(),
-            HttpResponse.BodyHandlers.ofFile(exe),
-        )
-        require(Files.exists(exe) && Files.size(exe) > 50_000_000) {
-            "Downloaded claude.exe looks wrong (size=${runCatching { Files.size(exe) }.getOrDefault(-1)}) from $url"
-        }
+        http.send(HttpRequest.newBuilder(URI.create(url)).GET().build(), HttpResponse.BodyHandlers.ofFile(exe))
+        require(Files.exists(exe) && Files.size(exe) > 50_000_000) { "Bad claude.exe from $url" }
         return exe
     }
 
-    /** Write a throwaway plugin whose "servers"/hooks are the launch probe. Returns the plugin dir. */
     private fun writeProbePlugin(root: Path): Path {
         root.resolve(".claude-plugin").createDirectories()
         root.resolve("hooks").createDirectories()
@@ -161,7 +167,7 @@ class ClaudeWindowsLaunchTest {
         root.resolve(".claude-plugin/plugin.json").writeText(
             """{ "name": "windows-probe", "description": "launch probe", "version": "0.0.1", "author": {"name":"probe"} }""",
         )
-        // Two MCP servers: extensionless full path (script-only resolution) + bare name (PATH resolution).
+        // MCP: extensionless full path (script-only resolution) + bare name (PATH resolution).
         root.resolve(".mcp.json").writeText(
             """
             {
@@ -172,38 +178,43 @@ class ClaudeWindowsLaunchTest {
             }
             """.trimIndent(),
         )
-        // SessionStart hooks in BOTH forms so the log tells us which resolves on Windows: an extensionless
-        // command (like MCP) and an explicit `.cmd`. On Linux both fire; on Windows the first run showed
-        // only the explicit form is reliable.
+        // Every candidate hook form, tagged so the probe log records which fire. See the per-form tests.
         root.resolve("hooks/hooks.json").writeText(
             """
             {
               "hooks": {
                 "SessionStart": [ { "hooks": [
-                  { "type": "command", "command": "${'$'}{CLAUDE_PLUGIN_ROOT}/bin/probe", "args": ["hook-extensionless"] },
-                  { "type": "command", "command": "${'$'}{CLAUDE_PLUGIN_ROOT}/bin/probe.cmd", "args": ["hook-cmd"] }
+                  { "type": "command", "command": "${'$'}{CLAUDE_PLUGIN_ROOT}/bin/probe", "args": ["hook-exec-extensionless"] },
+                  { "type": "command", "command": "${'$'}{CLAUDE_PLUGIN_ROOT}/bin/probe.cmd", "args": ["hook-exec-cmd"] },
+                  { "type": "command", "command": "cmd", "args": ["/c", "${'$'}{CLAUDE_PLUGIN_ROOT}\\bin\\probe.cmd", "hook-exec-cmdc"] },
+                  { "type": "command", "command": "printf 'LAUNCHED tag=hook-shell-default via=shell\\n' >> \"${'$'}HOME/portable-probe.log\"" },
+                  { "type": "command", "command": "& \"${'$'}{CLAUDE_PLUGIN_ROOT}\\bin\\probe.cmd\" hook-shell-powershell", "shell": "powershell" },
+                  { "type": "command", "command": "${'$'}{CLAUDE_PLUGIN_ROOT}/bin/devrig-style-hook" }
                 ] } ]
               }
             }
             """.trimIndent(),
         )
-        // The Windows probe: a pure batch script that records how it was launched, then exits.
-        // (No JSON-RPC handshake — the launch + log line is what we assert; Claude marking the server
-        //  "failed" afterwards is irrelevant.) `%~1` strips the surrounding quotes that cross-spawn's
-        // cmd.exe wrapping adds to the argument, so the tag logs clean (e.g. `tag=mcp-fullpath`).
+        // Windows probe (batch): logs tag + via=cmd. `%~1` strips cross-spawn's argument quoting.
         root.resolve("bin/probe.cmd").writeText(
             "@echo off\r\n" +
                 "set \"TAG=%~1\"\r\n" +
-                ">>\"%USERPROFILE%\\portable-probe.log\" echo LAUNCHED tag=%TAG% root=%CLAUDE_PLUGIN_ROOT%\r\n" +
+                ">>\"%USERPROFILE%\\portable-probe.log\" echo LAUNCHED tag=%TAG% via=cmd\r\n" +
                 "exit /b 0\r\n",
         )
-        // Negative control: the extensionless Unix shell script. On Windows, cross-spawn must NOT run
-        // this (it resolves probe -> probe.cmd via PATHEXT). If it ever fires we see the UNIX tag.
+        // Unix probe (sh): logs tag + via=sh. Negative control for MCP on Windows (must NOT run there).
         root.resolve("bin/probe").writeText(
             "#!/bin/sh\n" +
-                "echo \"LAUNCHED tag=UNIX-SHOULD-NOT-RUN arg=\$1\" >> \"\$HOME/portable-probe.log\"\n",
+                "echo \"LAUNCHED tag=\$1 via=sh\" >> \"\$HOME/portable-probe.log\"\n",
         )
         root.resolve("bin/probe").toFile().setExecutable(true)
+        // The devrig-style hook: a #!/bin/sh script referenced shell-form (no args) — exactly how
+        // check-devrig / devrig-progress / devrig-recover are written.
+        root.resolve("bin/devrig-style-hook").writeText(
+            "#!/bin/sh\n" +
+                "echo \"LAUNCHED tag=hook-devrig-pattern via=script\" >> \"\$HOME/portable-probe.log\"\n",
+        )
+        root.resolve("bin/devrig-style-hook").toFile().setExecutable(true)
         return root
     }
 }


### PR DESCRIPTION
Expands `ClaudeWindowsLaunchTest` (the `test-integration-windows` probe) to exercise **every candidate plugin hook form** on a real Windows agent and pin which fire. Answers the last open question from #253 and **corrects** the earlier "hooks don't run in `-p` on Windows" conclusion.

## Confirmed hook matrix (identical on both CI)
| Hook form | Fires on Windows |
|---|:-:|
| exec-form, extensionless path | ❌ |
| exec-form, `.cmd` path | ❌ |
| exec-form, `cmd /c <.cmd>` | ✅ |
| shell-form, default (Git Bash) | ✅ |
| shell-form, `"shell":"powershell"` | ✅ |
| **shell-form → `#!/bin/sh` script (the devrig hook form)** | ✅ (via Git Bash) |

Plus MCP: extensionless → `.cmd` (`via=cmd`, cross-spawn/PATHEXT); bare name doesn't resolve.

**Key result:** devrig's shipped hooks (`check-devrig`, `devrig-progress`, `devrig-recover`) are shell-form `sh` scripts → **they work on Windows via Git Bash**. The single dependency is Git Bash on Windows; MCP has none.

## Validated on both CI (as required)
- **TeamCity** `WindowsTests` branch build **#999549337** — SUCCESS, 11 passed.
- **GitHub `windows-latest`** run **#29077305946** — SUCCESS.
The probe matrices are identical across AWS-Windows (TC) and `windows-latest` (GH).

## Notes
- Corrects the misdiagnosis: hooks *do* run in `-p` on Windows; exec-form just can't spawn a `.cmd`/extensionless (no shell, not cross-spawn), which is what the first probe used.
- Fixes a tag prefix-collision in the assertion helper (`hook-exec-cmd` ⊂ `hook-exec-cmdc`).
- Suite stays Windows-only (task-level `enabled = isWindows`); compiles + skips off-Windows.
