### PR TITLE
Cli hardening

### DIFF
--- a/TODO-mcp-as-cli.md
+++ b/TODO-mcp-as-cli.md
@@ -199,3 +199,51 @@ routing key; `fetch_resource` (bundled, `--project_name`, unknown/empty/bad-sche
 stdin incl. empty + >1 MB; unknown-flag "Did you mean" suggestion; `success_rating` range check;
 `take_screenshot` bad/no window_id; `input press:ESCAPE` + bad window_id; `open_project` nonexistent
 path + already-open-with-backend + `--wait`; `list_projects --json | jq` (no banner leak).
+
+## Round 5 — contract hardening (test-first, `:npx-kt:test` green: 1393 tests)
+
+All 9 findings below are test-pinned (`McpAsCliContractTest`, `CliErrorEnvelopeTest`,
+`McpAsCliParseTest`, `LauncherSelfHealPredicateTest`, `ExecuteCodeCommandTest`,
+`ScreenshotAndOpenProjectCommandTest`) and spot-checked with `devrig-dev` (`jq`-valid envelopes,
+exactly one JSON doc). Contract decisions taken:
+
+- **Exit codes** — added `CliExit.DATA_ERROR=65` (bridge returned unusable data: no image / undecodable
+  base64) and `CliExit.IO_ERROR=74` (genuine write/read failure) alongside the existing OK / TOOL_ERROR
+  (1) / USAGE (64) / UNAVAILABLE (69). BSD sysexits. USAGE stays for fixable input (missing arg,
+  malformed path *string*).
+
+1. **Unified `--json` error contract.** Every failure path emits exactly one
+   `{tool, command, isError:true, data}` envelope on stdout (strict-JSON valid) with a meaningful
+   non-zero exit; no stack traces on stdout, no success-then-fail. The `Main.kt` `runCli` catch-all now
+   also envelopes under `--json` (and rethrows `CancellationException`).
+2. **`execute_code --modal <unknown>`** validated at PARSE (`ExecuteCodeCliCommand`) → rides the
+   parse-error envelope (honors `--json`, exit 64). Removed the stderr-only branch in the runner.
+3. **`open_project --wait --json`** no longer prints an intermediate success envelope. Under `--wait`
+   the poll runs BEFORE any stdout; one FINAL envelope reflects the outcome — ready → success (exit 0),
+   timeout → isError UNAVAILABLE. Transient poll failures still retried; readiness contract unchanged.
+4. **Local path / IO errors normalized** through `renderCliError`: unreadable `--code-file` → IO_ERROR,
+   malformed `--code-file`/`--project_path`/`--out` path string → USAGE, `--out` write failure
+   (directory/permission) → IO_ERROR. No stack traces to `Main`.
+5. **Input single source of truth.** Removed the client-side `InputSequenceParser` rejection — the raw
+   sequence is forwarded verbatim (version-skew safe). The server stack-trace leak is fixed by
+   `sanitizeServerError` (strips JVM frames), applied ONLY to the `input` tool's error result — never
+   `execute_code`, whose trace is the agent's own script.
+6. **`take_screenshot --out` strict contract.** Exit 0 only when the file is actually written; no image
+   → DATA_ERROR, undecodable base64 → DATA_ERROR. Success exposes a STRUCTURED `data.savedOut` absolute
+   path in the `--json` envelope (devrig-owned envelope only — wire `ToolCallResult` untouched, Tenet 5).
+7. **Parse-error command name** via a closed-set subcommand scan (`recoverCommandName` +
+   `DEVRIG_SUBCOMMAND_NAMES`), replacing the `firstOrNull { !startsWith("-") }` heuristic. Covers global
+   flags before/after the subcommand, option values as separate tokens, unknown command, unknown option.
+8. **`execute_feedback --execution_id`** kept for MCP-surface parity (steroid_execute_feedback likewise
+   accepts-but-ignores it; `FeedbackParams` has no field). Help text now states it is contextual only /
+   not forwarded; a glue test pins that it never reaches `FeedbackParams`. No wire change.
+9. **Tenet 3 boundary.** `ensureBinLauncher` on-start self-heal is gated by
+   `DevrigCommand.selfHealsLauncherOnStart()` — the 8 stateless tool facades no longer mutate on-disk
+   launcher/PATH state; lifecycle commands (mcp/install/backend/project/help/version) still do. The
+   launcher integration tests use `devrig version` (lifecycle), so they are unaffected.
+
+### Remaining risks / follow-ups
+- Docker `CliDevrigToolsIntegrationTest` (opt-in, needs a live IDE) not re-run this round — the launcher
+  gating only affects tool facades, which it drives by absolute path, and unit coverage is comprehensive.
+  Re-run before a release if #9 is in scope.
+- `open_project --wait` still uses a bounded sleep-poll loop (not the monitor push stream) — unchanged.

--- a/TODO-mcp-as-cli.md
+++ b/TODO-mcp-as-cli.md
@@ -247,3 +247,80 @@ exactly one JSON doc). Contract decisions taken:
   gating only affects tool facades, which it drives by absolute path, and unit coverage is comprehensive.
   Re-run before a release if #9 is in scope.
 - `open_project --wait` still uses a bounded sleep-poll loop (not the monitor push stream) — unchanged.
+
+## Round 6 — PR #272 review response (plan of record)
+
+Reviewer `jonnyzzz` left `CHANGES_REQUESTED` with 18 inline comments. Agreed scope for this PR:
+**concrete fixes + bounded design fixes + the CORE of the "reuse tool machinery" redesign + issue #266**;
+the FULL schema-driven generation is a deliberate follow-up. Comment → action map:
+
+### Bucket A — concrete fixes (this PR)
+- [ ] **C16** `ToolBackedCommands.kt:79` — drop `Path.of(file!!)`; restructure so `file` is non-null by type.
+- [ ] **C5** `CliToolSupport.kt:133` — `Json { }` block over newlines, no `;`; trim over-detailed comments here + nearby.
+- [ ] **C17** `ToolBackedCommands.kt:102` — confirm `mcpStdin.readBytes()` reads to EOF (it does — `InputStream.readBytes`); document `--code-file=-` (stdin) in the `execute_code` help.
+- [ ] **C4** `CliToolSupport.kt:112` — console image render: save PNG to a temp file under `~/.mcp-steroid/`, print the absolute path (not `[image: …]`).
+
+### Bucket B — bounded design fixes (this PR)
+- [ ] **C6 + C7** `CliToolSupport.kt:217/225` — replace the hand-built `contentDataJson()` with native
+      `@Serializable` serialization of `ToolCallResult`; in `--json`, image `data` is emitted **as-is**
+      (not a byte count). Verify the sealed-`ContentItem` discriminator matches the test-pinned
+      `{type:"text"/"image"/"resource"}` envelope shape.
+- [ ] **C1 + C2** `FetchResourceToolHandler.kt:95/103` — `resolveResourcePayload` / `canonicalResourceEntryPoints`
+      return `Article` (not bare `String`); update call sites (`FetchResourceCommand`, error hints).
+- [ ] **C3** `CliToolSupport.kt:99` — replace the threaded `json: Boolean` with a `Presentation` abstraction
+      (JSON renderer vs console renderer); remove the `if (json) … else …` from the shared render code.
+
+### Bucket C — core of the redesign (this PR; comments C9 + C15)
+- [ ] Project-scoped CLI commands build an `arguments: JsonObject` from their flags and call the
+      **`ToolSpec.call(context)`** directly (same path MCP uses), removing the manual `*Params` rebuild /
+      parallel dispatch in `ToolBackedCommands.kt`. This is literally "map CLI params → tool-call JSON".
+      **Enablers confirmed present:** `McpSession()` has a no-arg ctor (used freely in tests);
+      `devrig mcp` already builds the full `toolRegistry` in-process (`StubMcpSteroidTools.registerAll`);
+      `ToolCallParams(name, arguments)` is all that's needed.
+- [ ] **Design constraint (resolve via TDD):** the bare `registry.callTool` swallows exceptions into a
+      generic `isError` result, which would REGRESS the Round-4/5 exit-code contract (`ProjectRouteNotFound`
+      → USAGE 64 vs bridge failure → UNAVAILABLE 69). So the core = call `tool.call()` and keep the CLI's
+      own exception→`renderCliError` exit-code mapping around it. Do NOT adopt `registry.callTool` verbatim.
+      Keep all ~1393 contract tests green (`McpAsCliContractTest`, `CliErrorEnvelopeTest`, `McpAsCliParseTest`).
+- [ ] CLI-only affordances stay as thin hooks around the call: `--code-file`/`--code-file=-` (stdin) →
+      resolves the `code` arg; `--out` post-processes the screenshot result; `--wait` polls; `--json` +
+      exit codes are the presentation layer (Bucket B/C3).
+
+### Bucket D-inline — comment C10 (this PR)
+- [ ] Add `DevrigPromptsContextHandler.promptsContextFromRoute(route: ProjectRoute): PromptsContext` that
+      hides the leaky `route.route.ide.build` navigation, and route BOTH `buildPromptsContext` (the MCP
+      handler, currently duplicates the chain at `DevrigPromptsContextHandler.kt:12`) AND
+      `FetchResourceCommand.resolvePromptsContext` (`:65`) through it. Inline (not a separate pre-PR).
+
+### #266 — optional `--project_name` via cwd inference (this PR, layered on Bucket C)
+- [ ] Shared "cwd → project_name" resolver over `projectRouting.routes()`: normalize cwd to absolute;
+      pick the route whose `projectPath` is the **longest path-segment-boundary prefix** of cwd
+      (`/foo/bar` must NOT match `/foo/barbaz`); nested projects → most specific wins.
+- [ ] Exactly one match → use silently (optionally note the choice on stderr). Zero or ambiguous →
+      fail fast with an agent-understandable error listing candidates + asking for explicit `--project_name`.
+- [ ] Make `--project_name` optional for `execute_code`, `take_screenshot`, `input`, `execute_feedback`;
+      an explicit value always overrides inference. Inference slots in at the single project_name-resolve
+      point created by Bucket C.
+- [ ] Unit tests: single project, nested, zero matches, ambiguity, cwd == project root. Update each
+      command's `--help`/docs (default behavior + when the name is still required).
+
+### Bucket D-reply — comments C13/C14 (no code here; reply on the PR)
+- [ ] Reply: the `selfHealsLauncherOnStart()` gating (`Main.kt:97`) is **intrinsic** to this PR — the new
+      MCP-as-CLI tool facades must not mutate launcher/PATH state (Tenet 3), and it is pinned by
+      `LauncherSelfHealPredicateTest` (Round-5 #9). Ask which of the "several related issues" to the
+      launcher logic he wants split into a separate PR, rather than extracting the load-bearing gate.
+
+### Deferred to a FOLLOW-UP PR (own design; comments C8, C11, C12)
+- Generate clikt options + per-command help + the command registration from the tool `InputSchemaElement`
+  specs, so a new MCP tool auto-registers as a CLI command. Reviewer himself frames this as
+  "next iteration / next PR". Needs: schema→clikt type adapters, help synopsis (NOT the multi-KB tool
+  description), and re-validating the frozen `--json`/exit-code contract. Open a tracking issue.
+
+### Implementation order (test-first per CLAUDE.md)
+1. Bucket A (independent, low-risk) → green.
+2. Bucket B: C1+C2 (Article) → C6+C7 (native serializer + images) → C3 (Presentation).
+3. Bucket C (core reuse) — riskiest; keep the ~1393 contract tests green throughout.
+4. Bucket D-inline C10 (`promptsContextFromRoute`).
+5. #266 (cwd inference) on top of C + C10 (shares the routing snapshot + the single resolve point).
+6. Bucket D-reply: post PR comments; open the follow-up issue for C8/C11/C12.
+7. Verify: `./gradlew :npx-kt:test` + `:mcp-steroid-server:test` green; `devrig-dev` spot-check.

--- a/TODO-mcp-as-cli.md
+++ b/TODO-mcp-as-cli.md
@@ -1,0 +1,113 @@
+# MCP-as-CLI spike notes (epic #188)
+
+Branch: `spike/mcp-as-cli` (NOT committed — local spike per request).
+Goal: expose the existing `steroid_*` MCP tools as `devrig` shell subcommands, as a thin,
+stateless frontend over the **existing** bridge — no new MCP tools, no duplicated plugin logic.
+
+## What was built
+
+A reusable CLI-tool layer + all 8 epic-#188 subcommands, wired to the same handlers the
+`devrig mcp` stdio proxy uses (`StubMcpSteroidTools` → `Devrig*ToolHandler` → `DevrigToolBridgeClient`).
+
+New/changed files:
+- `mcp-steroid-server/.../server/FetchResourceToolHandler.kt` — extracted `resolveResourcePayload(uri, ctx)`
+  and `canonicalResourceEntryPoints()`; the MCP tool and the CLI now share URI→payload resolution.
+- `npx-kt/.../devrig/CliToolSupport.kt` — shared layer: `ToolCallResult.renderTo(command, json, out)`,
+  `toEnvelopeJson()`, `CliExit` codes, `stderrProgressReporter()`.
+- `npx-kt/.../devrig/FetchResourceCommand.kt` — prompt/fetch_resource (Generic context, no IDE needed).
+- `npx-kt/.../devrig/ToolBackedCommands.kt` — execute_code, execute_feedback, input, take_screenshot,
+  open_project (+ `--wait` poll loop), via `runToolCall { }` helper.
+- `npx-kt/.../devrig/ListWindowsCommand.kt` — list_windows (typed response; own renderer).
+- `npx-kt/.../devrig/Cli.kt` — 9 new clikt subcommands + `DevrigCommand` variants + `runCli` dispatch.
+- `npx-kt/.../devrig/Main.kt`, `DevrigBeacon.kt`, `HelpCommand.kt` — exhaustive-`when` + help + telemetry.
+- Tests: `FetchResourceCommandTest`, `McpAsCliParseTest`, `CliToolSupportTest` (npx-kt).
+
+## What worked well
+
+- **The bridge reuse is genuinely thin.** Every tool-backed command is ~10-20 lines: build the
+  `*Params`, get the handler from `StubMcpSteroidTools`, call it, `renderTo`. No tool logic in the CLI.
+  This is the strongest signal that the direction is right — the CLI is a projection, not a fork.
+- **`resolveResourcePayload` extraction** removed the only real duplication risk (URI resolution) and
+  let `devrig prompt` work **without a running IDE** — verified from the shell against the built binary.
+- **The shared `renderTo`/envelope + `CliExit`** fit all 5 `ToolCallResult`-returning commands cleanly
+  (execute_code, feedback, input, screenshot, open_project). One place decides stdout/stderr routing,
+  exit codes, and `--json`.
+- **Agent-usable errors**: missing args print a runnable example with a real URI (pulled from the
+  generated article classes) and a `→ devrig list_projects` next step. Validated from the shell.
+- **stdout stays clean** for data commands (headliner suppressed via `isMcpAsCliToolCommand()`), so
+  `devrig prompt ... | ...` and `--json | jq` work.
+
+## What felt wrong / rough edges
+
+1. **Three different `--json` shapes.** `renderTo` uses `{tool, command, isError, content}`;
+   `list_projects` (shared with `devrig project`) uses `{tool, projects}`; `list_windows` uses raw
+   `{windows, backgroundTasks}` with no `tool` header. The typed-response listers don't fit the
+   `ToolCallResult` envelope. **Decision needed for the final PR:** either wrap all `--json` output in a
+   common `{tool, command, ...}` header, or accept two families (tool-result vs typed-response) and
+   document it. Leaning toward a common header.
+2. **`<subcommand> --help` shows the global banner, not per-command help.** This is the *existing*
+   devrig behavior (`--help` → `DevrigCommandHelp` → `printHelp`), inherited by the new commands. The
+   global banner now lists each command with a runnable example, so it's serviceable, but true
+   per-command clikt help would be better. Changing it touches shared `DevrigCliktCommand` plumbing —
+   deferred out of the spike.
+3. **`open_project --wait` uses `Thread.sleep` in a `runBlocking` loop.** Works, but it re-creates
+   `StubMcpSteroidTools` each poll and blocks a thread. Fine for a one-shot CLI; would want a proper
+   suspend/backoff loop (and to reuse the discovery push stream the monitor already has) if we invest.
+4. **`runCli` is non-suspend and each command wraps its own `runBlocking(Dispatchers.IO)`** (matching
+   the existing `runProjectCommand`). Consistent, but if the CLI grows it'd be cleaner to make the
+   dispatch suspend end-to-end.
+5. **`list_projects` is an alias to `devrig project`** (reconciliation per #191). Output is identical and
+   exposes `project_name`. Good, but the MCP `ListProjectsResponse` shape (`ListedProject`) and the
+   `devrig project` JSON shape are *near*-identical, not identical — a future unify could pick one.
+
+## Command status
+
+| Command | Parse+validate | Bridge wiring | Unit-tested (no IDE) | Verified vs live IDE |
+|---|---|---|---|---|
+| `prompt` / `fetch_resource` | ✅ | ✅ (Generic + project) | ✅ end-to-end | n/a (bundled, no IDE) ✅ |
+| `list_projects` | ✅ | ✅ (alias → project) | ✅ (no-IDE path) | ⬜ needs IDE |
+| `list_windows` | ✅ | ✅ | ✅ (no-IDE path) | ⬜ needs IDE |
+| `execute_code` | ✅ (file/inline/modal/timeout) | ✅ | ✅ parse + validation | ⬜ needs IDE |
+| `execute_feedback` | ✅ (rating range) | ✅ | ✅ parse + validation | ⬜ needs IDE |
+| `open_project` (+`--wait`) | ✅ | ✅; `--wait` = basic poll | ✅ parse | ⬜ needs IDE |
+| `take_screenshot` (+`--out`) | ✅ | ✅; `--out` writes PNG | ✅ parse | ⬜ needs IDE |
+| `input` | ✅ | ✅ (raw sequence forwarded) | ✅ parse | ⬜ needs IDE |
+
+"Needs IDE" = the bridge call itself is exercised by existing handler tests
+(`DevrigToolBridgeClientTest`, `DevrigListToolHandlersTest`); only the CLI→handler glue for those five
+is not yet covered by an in-process fake-bridge test (see follow-ups).
+
+## Test coverage delivered
+
+`./gradlew :npx-kt:test` and `./gradlew :mcp-steroid-server:test` both green. Covered: command parsing
+for all 8 commands, missing/invalid-arg usage errors with examples, stdout/stderr separation, the
+`--json` envelope, unknown-URI handling, prompt resolution without an IDE, and the render/exit-code
+contract. Not yet covered: CLI→bridge payload mapping via an injected fake bridge for the five
+tool-backed commands (would need `StubMcpSteroidTools` to accept an injectable `DevrigToolBridgeClient`).
+
+## Recommendation for the final PR shape
+
+**One foundational PR + follow-ups**, not a single mega-PR:
+
+- **PR 1 (foundation):** `CliToolSupport` + `resolveResourcePayload` extraction + `prompt`/`fetch_resource`
+  + `list_projects`/`list_windows`. Small, fully testable without an IDE, immediately useful
+  (docs discovery + routing keys). Resolve the `--json` shape decision here (finding #1) so the envelope
+  is locked before the write-commands land.
+- **PR 2:** `execute_code` (highest value) — after making `StubMcpSteroidTools` accept an injectable
+  bridge so the payload mapping gets a fake-bridge unit test. Add one Docker integration smoke test.
+- **PR 3:** `execute_feedback` + the UX/debug trio (`take_screenshot --out`, `input`, `open_project --wait`).
+
+Rationale: the write/IDE-driving commands (PR2/PR3) carry the real risk (need a live IDE to truly
+verify, and `--wait`/`--out` semantics deserve their own review), while PR1 is low-risk and unblocks
+agents that lost their MCP tools in a session. Keeping PR1 IDE-free also keeps its CI fast.
+
+## Follow-ups / open questions
+
+- [ ] Decide the unified `--json` envelope (finding #1) and apply to list_windows/list_projects.
+- [ ] Make `StubMcpSteroidTools` accept an injectable `DevrigToolBridgeClient` → fake-bridge unit tests
+      for execute_code/feedback/input/screenshot/open_project payload mapping.
+- [ ] Per-command `--help` (finding #2) — or explicitly accept the global banner and document it.
+- [ ] `open_project --wait`: reuse the monitor's push stream instead of a sleep-poll loop.
+- [ ] Agent-usable docs: add a `mcp-steroid://` article (or extend the skill) describing the CLI
+      mapping so agents discover `devrig <tool>` the same way they discover the MCP tools.
+- [ ] Consider `devrig execute_code --code-file=-` (read from stdin) for piping snippets.

--- a/TODO-mcp-as-cli.md
+++ b/TODO-mcp-as-cli.md
@@ -101,13 +101,28 @@ Rationale: the write/IDE-driving commands (PR2/PR3) carry the real risk (need a 
 verify, and `--wait`/`--out` semantics deserve their own review), while PR1 is low-risk and unblocks
 agents that lost their MCP tools in a session. Keeping PR1 IDE-free also keeps its CI fast.
 
+## Round 2 — hardening all tools (done)
+
+- [x] **Unified `--json` envelope** `{tool, command, isError, data}` across ALL commands (finding #1
+      resolved). `data` = `{content:[...]}` for tool-results, `{projects:[...]}` / `{windows,backgroundTasks}`
+      for listers. `CliToolSupport.cliEnvelopeJson` is the single writer.
+- [x] **Injectable handlers for testability**: each tool-command takes
+      `tools: McpSteroidTools = StubMcpSteroidTools(this)`; `FakeMcpSteroidTools` + recording handlers
+      drive **glue tests** for execute_code / feedback / input / take_screenshot / open_project, plus
+      list_windows / list_projects (args→`*Params`→render→exit; no IDE). Bridge payload→wire mapping stays
+      covered by `DevrigToolBridgeClientTest`.
+- [x] `execute_code --code-file=-` reads the script from stdin.
+- [x] `take_screenshot --out` creates parent dirs, writes decoded PNG, reports abs path; no-image case noted.
+- [x] `open_project --wait` poll loop is test-friendly (injected `ListWindowsToolHandler`, small
+      attempts/interval), quiet on stdout under `--json`.
+- [x] `list_projects` reconciled: human = `devrig project`; `--json` = unified envelope via the MCP handler.
+
 ## Follow-ups / open questions
 
-- [ ] Decide the unified `--json` envelope (finding #1) and apply to list_windows/list_projects.
-- [ ] Make `StubMcpSteroidTools` accept an injectable `DevrigToolBridgeClient` → fake-bridge unit tests
-      for execute_code/feedback/input/screenshot/open_project payload mapping.
+- [ ] **Docker live-IDE smoke suite** (`CliDevrigToolsIntegrationTest`, opt-in) — the remaining item.
 - [ ] Per-command `--help` (finding #2) — or explicitly accept the global banner and document it.
 - [ ] `open_project --wait`: reuse the monitor's push stream instead of a sleep-poll loop.
 - [ ] Agent-usable docs: add a `mcp-steroid://` article (or extend the skill) describing the CLI
       mapping so agents discover `devrig <tool>` the same way they discover the MCP tools.
-- [ ] Consider `devrig execute_code --code-file=-` (read from stdin) for piping snippets.
+- [ ] Optional client-side `input` sequence validation via `InputSequenceParser` (currently the IDE
+      re-parses the raw sequence).

--- a/TODO-mcp-as-cli.md
+++ b/TODO-mcp-as-cli.md
@@ -117,9 +117,19 @@ agents that lost their MCP tools in a session. Keeping PR1 IDE-free also keeps i
       attempts/interval), quiet on stdout under `--json`.
 - [x] `list_projects` reconciled: human = `devrig project`; `--json` = unified envelope via the MCP handler.
 
+## Round 3 — Docker live-IDE smoke (written; needs Docker to run)
+
+- [x] `CliDevrigToolsIntegrationTest` (`:test-integration`, opt-in — excluded from default runs) drives the
+      deployed `devrig` binary as a plain CLI against a real dockerized IDE: `list_projects --json`
+      (envelope + routing key), `execute_code` (marker printed by the IDE), `fetch_resource --project_name`.
+      **Executed & green** — BUILD SUCCESSFUL, all 3 cases pass end-to-end against a live IDE container
+      (~9 min). Run with: `./gradlew :test-integration:test --tests '*CliDevrigToolsIntegrationTest*'`.
+      Confirmed: the devrig bridge translates the exposed routing key (`demo-project-<hash>` from
+      `list_projects`) to the IDE's internal `project_name` before forwarding — agents only ever use the
+      exposed key.
+
 ## Follow-ups / open questions
 
-- [ ] **Docker live-IDE smoke suite** (`CliDevrigToolsIntegrationTest`, opt-in) — the remaining item.
 - [ ] Per-command `--help` (finding #2) — or explicitly accept the global banner and document it.
 - [ ] `open_project --wait`: reuse the monitor's push stream instead of a sleep-poll loop.
 - [ ] Agent-usable docs: add a `mcp-steroid://` article (or extend the skill) describing the CLI

--- a/TODO-mcp-as-cli.md
+++ b/TODO-mcp-as-cli.md
@@ -131,8 +131,71 @@ agents that lost their MCP tools in a session. Keeping PR1 IDE-free also keeps i
 ## Follow-ups / open questions
 
 - [ ] Per-command `--help` (finding #2) — or explicitly accept the global banner and document it.
+      **Update (Round 4):** `execute_code --help` now returns real per-command help (usage, required
+      options, first-call rules, resource pointers). Confirm the other commands and close this out.
 - [ ] `open_project --wait`: reuse the monitor's push stream instead of a sleep-poll loop.
 - [ ] Agent-usable docs: add a `mcp-steroid://` article (or extend the skill) describing the CLI
       mapping so agents discover `devrig <tool>` the same way they discover the MCP tools.
 - [ ] Optional client-side `input` sequence validation via `InputSequenceParser` (currently the IDE
-      re-parses the raw sequence).
+      re-parses the raw sequence). **Round 4 confirms this is needed** — see the stack-trace leak below.
+
+## Round 4 — Codex edge-case bug hunt (2026-07-07)
+
+Source: `docs/mcp-as-cli/mcp-as-cli-codex-findings.md` — Codex drove `devrig-dev` (`…e6c62445`) against a
+live host IDE, 22 shell probes across all 8 commands. Full reproducers are in that file. Triage:
+
+**Status (2026-07-08): all Round-4 findings below are FIXED** (`:npx-kt`; `./gradlew :npx-kt:test` green,
+spot-checked with `devrig-dev`). Contract decisions taken: (1) relative `--project_path` is **resolved
+against cwd**; (2) every failure — usage/parse AND runtime — **emits the `isError:true` envelope** under
+`--json` (exit codes unchanged: 64 usage, 69 unavailable). New shared writer `renderCliError`
+(`CliToolSupport.kt`) is the single place that routes an error to a stderr line or a `--json` envelope.
+
+### High — correctness / dangerous
+- [x] **`open_project` accepts a relative `--project_path` and resolves it against `/`, not the caller's
+      cwd.** FIXED: `runOpenProjectCommand` now normalizes `Path.of(projectPath).toAbsolutePath()
+      .normalize()` against the caller's cwd before forwarding (and for the `--wait` poll). Pinned by
+      `CliErrorEnvelopeTest."open_project resolves a relative --project_path against cwd"`.
+
+### High — `--json` contract holes (the dominant theme)
+Two distinct classes used to escape the `{tool, command, isError, data}` envelope even with `--json`:
+- [x] **(a) Client-side usage / parse / validation errors → stderr-only, exit 64, no envelope.** FIXED
+      (contract: emit envelope). `parseDevrigCommand` now records the concise message + best-effort
+      command name and whether `--json` was requested (detected from raw tokens, since the exception
+      aborts flag capture); `runCli`'s `DevrigCommandParseError` branch emits the `isError` envelope under
+      `--json`, else prints the full help to stderr — exit stays 64. clikt-internal errors (unknown flag)
+      get their specific "Error:" line lifted into the message. `--code-file` missing/non-regular now
+      throws `CodeArgException` → enveloped. `--timeout`/`--success_rating` type errors ride the same path.
+- [x] **(b) Runtime tool/bridge errors that SHOULD be enveloped but aren't.** FIXED: every pre-render
+      catch (`runToolCall` for execute_code/feedback/input, `runScreenshotCommand`, `runOpenProjectCommand`,
+      list_windows/list_projects) routes through `renderCliError(..., command.json, ...)` →
+      `ProjectRouteNotFoundException` = enveloped USAGE(64), generic failure = enveloped UNAVAILABLE(69).
+      Pinned by `CliErrorEnvelopeTest` (stale project_name + bridge failure + `--out` write failure).
+
+### Medium — error-message quality
+- [x] **`input` validation errors leak full server stack traces.** FIXED: `runInputCommand` validates the
+      sequence client-side with `InputSequenceParser` before dispatch; on failure it returns the concise
+      parser message + accepted-syntax hint via `renderCliError` (no stack, no round-trip). Still forwards
+      the raw sequence on success (IDE stays the parsing source of truth). Verified: envelope text carries
+      no `com.jonnyzzz.mcpSteroid.vision` / stack frames.
+- [x] **`execute_code --timeout <= 0` is not validated client-side.** FIXED: `ExecuteCodeCliCommand`
+      rejects a non-positive `--timeout` with a `UsageError` before dispatching (rides the F2 envelope
+      path under `--json`).
+
+### Medium — `take_screenshot --out` reporting
+- [x] **The `--out` path is under-reported in the envelope.** FIXED: `writeScreenshotOut` returns the
+      written absolute path; `runScreenshotCommand` appends a `Saved --out: <abs>` text item to the
+      rendered result so the real destination appears in both human output and the `--json` envelope
+      `data`. Relative `--out` policy = resolved-against-cwd + reported (the abs path communicates it).
+      Write failures are enveloped (finding b).
+
+### Low — rough edge
+- [x] **`prompt --json` reports `"command": "fetch_resource"`.** FIXED: `DevrigCommandFetchResource`
+      carries `commandName` (set to `prompt` / `fetch_resource` by the respective clikt command);
+      `runFetchResourceCommand` echoes it into `renderTo`. Pinned by two `FetchResourceCommandTest` cases.
+
+### Confirmed OK (no action)
+Per-command `execute_code --help`; `--json` success envelopes; `list_projects`/`list_windows` +
+routing key; `fetch_resource` (bundled, `--project_name`, unknown/empty/bad-scheme URI); `code-file=-`
+stdin incl. empty + >1 MB; unknown-flag "Did you mean" suggestion; `success_rating` range check;
+`take_screenshot` bad/no window_id; `input press:ESCAPE` + bad window_id; `open_project` nonexistent
+path + already-open-with-backend + `--wait`; `list_projects --json | jq` (no banner leak).

--- a/TODO-mcp-as-cli.md
+++ b/TODO-mcp-as-cli.md
@@ -311,10 +311,11 @@ the FULL schema-driven generation is a deliberate follow-up. Comment → action 
       launcher logic he wants split into a separate PR, rather than extracting the load-bearing gate.
 
 ### Deferred to a FOLLOW-UP PR (own design; comments C8, C11, C12)
+- Tracking issue: #284 (`devrig CLI: derive command registration, flags, and help from ToolSpec`).
 - Generate clikt options + per-command help + the command registration from the tool `InputSchemaElement`
   specs, so a new MCP tool auto-registers as a CLI command. Reviewer himself frames this as
   "next iteration / next PR". Needs: schema→clikt type adapters, help synopsis (NOT the multi-KB tool
-  description), and re-validating the frozen `--json`/exit-code contract. Open a tracking issue.
+  description), and re-validating the frozen `--json`/exit-code contract.
 
 ### Implementation order (test-first per CLAUDE.md)
 1. Bucket A (independent, low-risk) → green.

--- a/docs/superpowers/plans/2026-07-15-pr272-review-response.md
+++ b/docs/superpowers/plans/2026-07-15-pr272-review-response.md
@@ -1,0 +1,809 @@
+# PR #272 (cli-hardening) Review Response — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Resolve the 18 review comments on PR #272 plus issue #266 (optional `--project_name`) by de-duplicating the devrig MCP-as-CLI layer against the existing tool machinery, cleaning up presentation, and inferring the project from the cwd — without regressing the frozen `--json`/exit-code contract.
+
+**Architecture:** The devrig CLI exposes each `steroid_*` MCP tool as a subcommand. Today each command re-declares the tool's parameters (clikt options), re-builds the tool's `*Params`, and hand-serializes the result. This plan routes tool calls through the shared `ToolSpec.call(context)` path (the same path `devrig mcp` uses), replaces the hand-built JSON envelope with native `kotlinx.serialization`, introduces a `Presentation` abstraction to replace a threaded `json: Boolean`, and adds a cwd→project resolver over the routing snapshot. The full "generate CLI flags/help from the tool schema" redesign is explicitly a follow-up PR.
+
+**Tech Stack:** Kotlin 2.3.20, kotlinx.serialization, clikt, JUnit 5 (jupiter), Gradle 9.5.1. Module `:npx-kt` (the devrig CLI) and `:mcp-steroid-server` (shared tool handlers/schema).
+
+## Global Constraints
+
+Copied verbatim from `CLAUDE.md` / `ij-plugin/CLAUDE.md`. Every task's requirements implicitly include these.
+
+- Bytecode targets Java 21 (class-file v65); toolchain JDK 25. Do not raise the target.
+- Banned: `internal` visibility modifier — use plain public (no modifier).
+- Banned: `runCatching{}.onFailure{}` — use `try { } catch (e: Exception) { }`.
+- Banned: empty `catch` / `catch (_: Exception) {}` — every catch must rethrow, log via `System.err.println` / `logger.error`, or both.
+- Banned: returning `(value, errorFlag)` pairs from a fallible call — return the value or throw / return null.
+- Banned: `@Suppress("DEPRECATION")` — find the non-deprecated replacement.
+- Banned: hardcoded `mcp-steroid://…` URI literals in production Kotlin — use the generated `XxxPromptArticle().uri` (enforced by `NoHardcodedMcpSteroidUriUsageTest`).
+- Prefer JSON libraries for JSON parsing/manipulation; only static final JSON constants may be hand-written.
+- Tests must show reality. Never remove, disable, or weaken a failing test; fix the underlying issue. **Exception in this plan:** where a reviewer-requested change deliberately alters an observable contract (image rendering), the test that pinned the OLD contract is *rewritten* to pin the NEW contract — that is a contract change, not a weakening.
+- Atomic commits; descriptive messages (what + why). Never mention AI or add AI co-authors.
+- Test scoping: never `./gradlew test` at repo root. Use `./gradlew :npx-kt:test` and `./gradlew :mcp-steroid-server:test`; single test via `--tests '<pattern>'`.
+- Keep the frozen contract green throughout: `McpAsCliContractTest`, `CliErrorEnvelopeTest`, `McpAsCliParseTest`, `ExecuteCodeCommandTest`, `ScreenshotAndOpenProjectCommandTest`, `FeedbackAndInputCommandTest`, `FetchResourceCommandTest`, `ListCommandsTest`, `ExecuteCodeHelpTopicTest`.
+- `timeout`/`gtimeout` are unavailable on this Mac; use the Bash tool's own timeout or Gradle timeouts.
+- Do not push or merge. Commit locally only. The branch is `cli-hardening`.
+
+## File Structure
+
+Module `:npx-kt` — `src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/`
+- `CliToolSupport.kt` — MODIFY. Envelope + render helpers. Introduces `Presentation`; native serialization replaces `contentDataJson()`; console image → temp file.
+- `ToolBackedCommands.kt` — MODIFY. Core reuse: build `arguments: JsonObject` → call `ToolSpec.call()`; project_name inference hook.
+- `FetchResourceCommand.kt` — MODIFY. Use `Article` return type; use `promptsContextFromRoute`.
+- `HelpCommand.kt` — MODIFY. Document `--code-file=-` (stdin); note optional `--project_name`.
+- `Cli.kt` — MODIFY. `--project_name` optional for project-scoped commands; help text.
+- `server/DevrigPromptsContextHandler.kt` — MODIFY. Add `promptsContextFromRoute(route)`; dedupe.
+- `server/DevrigProjectRoutingService.kt` — MODIFY. Add `resolveProjectFromCwd(cwd): ProjectRoute` (or a result type) for #266.
+- `server/CwdProjectResolver.kt` — CREATE (if the resolver is cleaner standalone). Longest-prefix cwd→route.
+
+Module `:mcp-steroid-server` — `src/main/kotlin/com/jonnyzzz/mcpSteroid/server/`
+- `FetchResourceToolHandler.kt` — MODIFY. `resolveResourcePayload` / `canonicalResourceEntryPoints` return article objects.
+
+Tests (`:npx-kt` `src/test/kotlin/...devrig/`, `:mcp-steroid-server` `src/test/kotlin/...server/`)
+- `CliToolSupportTest.kt` — MODIFY (image contract rewrite + presentation).
+- `FetchResourceCommandTest.kt` — MODIFY (article return types).
+- `ToolBackedCommands` glue tests (`CliGlueTestSupport.kt`, `ExecuteCodeCommandTest.kt`, etc.) — kept green; extended for #266.
+- `CwdProjectResolverTest.kt` — CREATE (#266 resolver matrix).
+
+> **Note on ordering:** the plan's task order refines the spec's A/B/C bucket order because the rendering tasks (image, envelope, presentation) are interdependent — they touch the same `CliToolSupport.kt` render path and must land in dependency order.
+
+---
+
+## Task 1: Fix the `!!` in `resolveCodeArg` (comment C16)
+
+**Files:**
+- Modify: `npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/ToolBackedCommands.kt:76-91`
+- Test: `npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/ExecuteCodeCommandTest.kt` (existing, kept green)
+
+**Interfaces:**
+- Consumes: `CodeArgException(message: String, val exit: Int)`, `CliExit.USAGE`.
+- Produces: no signature change to `resolveCodeArg(inline: String?, file: String?): String`.
+
+This is a code-smell fix, not a behavior change: `Cli.kt:471` already rejects both-blank at parse time, so the `file!!` branch is unreachable in practice. Replace the `!!` with an explicit guard that fails cleanly if ever reached.
+
+- [ ] **Step 1: Run the existing execute_code tests to confirm the baseline is green**
+
+Run: `./gradlew :npx-kt:test --tests '*ExecuteCodeCommandTest*'`
+Expected: PASS.
+
+- [ ] **Step 2: Replace the `!!` with a guard**
+
+In `resolveCodeArg`, change:
+
+```kotlin
+    val path = try {
+        Path.of(file!!)
+    } catch (e: InvalidPathException) {
+```
+
+to:
+
+```kotlin
+    val resolvedFile = file
+        ?: throw CodeArgException("provide --code or --code-file", CliExit.USAGE)
+    val path = try {
+        Path.of(resolvedFile)
+    } catch (e: InvalidPathException) {
+```
+
+and update the two later uses of `file` in this function (`Path.of`, and the `InvalidPathException`/`isRegularFile`/`readString` messages) to use `resolvedFile`.
+
+- [ ] **Step 3: Run the tests to confirm still green**
+
+Run: `./gradlew :npx-kt:test --tests '*ExecuteCodeCommandTest*' --tests '*McpAsCliContractTest*'`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/ToolBackedCommands.kt
+git commit -m "refactor(devrig): replace !! in resolveCodeArg with an explicit usage guard"
+```
+
+---
+
+## Task 2: `Json { }` style + trim over-detailed comments (comment C5)
+
+**Files:**
+- Modify: `npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/CliToolSupport.kt:135`
+- Test: `npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/CliToolSupportTest.kt` (kept green)
+
+**Interfaces:**
+- Produces: `CLI_ENVELOPE_JSON` unchanged in behavior (`prettyPrint`, `encodeDefaults`, `explicitNulls=false`).
+
+- [ ] **Step 1: Reformat the `Json { }` block over newlines, no `;`**
+
+Change:
+
+```kotlin
+val CLI_ENVELOPE_JSON: Json = Json { prettyPrint = true; encodeDefaults = true; explicitNulls = false }
+```
+
+to:
+
+```kotlin
+val CLI_ENVELOPE_JSON: Json = Json {
+    prettyPrint = true
+    encodeDefaults = true
+    explicitNulls = false
+}
+```
+
+- [ ] **Step 2: Trim the over-detailed comments**
+
+Shorten the multi-paragraph KDoc on `CLI_ENVELOPE_JSON` and on `renderScreenshotSaved`/`toEnvelopeJson` to one or two lines each (keep the one-line "what + why"; drop the prose the reviewer flagged as too detailed). Do not remove the copyright header.
+
+- [ ] **Step 3: Run tests**
+
+Run: `./gradlew :npx-kt:test --tests '*CliToolSupportTest*'`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/CliToolSupport.kt
+git commit -m "style(devrig): newline the CLI envelope Json block; trim over-detailed comments"
+```
+
+---
+
+## Task 3: Document `--code-file=-` stdin in help (comment C17)
+
+**Files:**
+- Modify: `npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/HelpCommand.kt:26-62` (the `printExecuteCodeHelp` block) and `:119-128` (global banner `execute_code` line)
+- Test: `npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/ExecuteCodeHelpTopicTest.kt`
+
+**Interfaces:**
+- Consumes: nothing new.
+- Produces: help text mentions `--code-file=-` reads the script from stdin.
+
+`readBytes()` on `mcpStdin` (a `java.io.InputStream`) reads to EOF — no partial-read risk for a slow producer; it blocks until the stream closes. This task documents that affordance (it was implemented but undocumented).
+
+- [ ] **Step 1: Add a failing assertion to the help topic test**
+
+In `ExecuteCodeHelpTopicTest.kt`, add:
+
+```kotlin
+    @Test
+    fun `execute_code help documents stdin via code-file dash`() {
+        val out = ByteArrayOutputStream()
+        printExecuteCodeHelp(PrintStream(out))
+        val text = out.toString(Charsets.UTF_8)
+        assertTrue(text.contains("--code-file=-") || text.contains("\"-\""),
+            "expected stdin affordance documented, got:\n$text")
+        assertTrue(text.contains("stdin"), text)
+    }
+```
+
+Match the existing imports/style in that file (add `ByteArrayOutputStream`, `PrintStream`, `assertTrue` if missing).
+
+- [ ] **Step 2: Run it to see it fail**
+
+Run: `./gradlew :npx-kt:test --tests '*ExecuteCodeHelpTopicTest*'`
+Expected: FAIL (the current help lists `--code-file=-` only in the flags block; confirm the assertion actually fails, otherwise the doc already covers it — if so, drop this task).
+
+- [ ] **Step 3: Update the help text**
+
+In `printExecuteCodeHelp`, under `Required:` for `--code-file`, change the line to:
+
+```
+          --code-file      path to a .kts file; pass "-" to read the script from stdin (blocks until EOF)
+```
+
+and in the global banner (`printHelp`), extend the `execute_code` description similarly.
+
+- [ ] **Step 4: Run tests**
+
+Run: `./gradlew :npx-kt:test --tests '*ExecuteCodeHelpTopicTest*'`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/HelpCommand.kt npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/ExecuteCodeHelpTopicTest.kt
+git commit -m "docs(devrig): document --code-file=- stdin affordance in execute_code help"
+```
+
+---
+
+## Task 4: Native serialization for the `--json` envelope content (comments C6 + C7)
+
+**Files:**
+- Modify: `npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/CliToolSupport.kt:205-249` (`toEnvelopeJson`, `contentDataJson`, `decodedByteCount`)
+- Test: `npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/CliToolSupportTest.kt:45-59`
+
+**Interfaces:**
+- Consumes: `ContentItem` (sealed, `@SerialName` "text"/"image"/"resource"), `McpJson` (`classDiscriminator = "type"`), `ToolCallResult`.
+- Produces: `ToolCallResult.contentDataJson(): JsonObject` still exists, but `content` array is built by serializing the `List<ContentItem>` with `McpJson`. Image objects now carry `data` (base64) as-is instead of a `bytes` count. Resource objects serialize to their native `{type:"resource","resource":{...}}` shape.
+
+Background: `McpJson` uses `classDiscriminator = "type"`, and `ContentItem.Text` is `@SerialName("text")`, so serializing content natively yields exactly `{"type":"text","text":"…"}` for text (unchanged) and `{"type":"image","data":"…","mimeType":"…"}` for images (the "keep data as-is" the reviewer asked for). This removes the second hand-written copy of the serialization logic.
+
+- [ ] **Step 1: Rewrite the image envelope test to pin the NEW contract**
+
+Replace `CliToolSupportTest`'s `image renders a byte-count placeholder and the envelope reports bytes` test's **envelope** assertions (lines 55-58) with:
+
+```kotlin
+        val obj = Json.parseToJsonElement(result.toEnvelopeJson("shot")).jsonObject
+        val item = obj["data"]!!.jsonObject["content"]!!.jsonArray.first().jsonObject
+        assertEquals("image", item["type"]!!.jsonPrimitive.content)
+        // C7: image data is carried as-is (base64), not summarized to a byte count.
+        assertEquals(b64, item["data"]!!.jsonPrimitive.content)
+        assertEquals("image/png", item["mimeType"]!!.jsonPrimitive.content)
+```
+
+(The console `[image: …]` assertion on line 53 is handled in Task 6 — leave it for now; this task can temporarily keep the console line asserting the old placeholder. If that makes the test internally inconsistent, split the test into `envelope` and `console` cases here and finish the console half in Task 6.)
+
+- [ ] **Step 2: Run it to see it fail**
+
+Run: `./gradlew :npx-kt:test --tests '*CliToolSupportTest*'`
+Expected: FAIL (current envelope emits `bytes`, not `data`).
+
+- [ ] **Step 3: Replace `contentDataJson()` with native serialization**
+
+Rewrite `contentDataJson()` to serialize the content list via `McpJson`:
+
+```kotlin
+fun ToolCallResult.contentDataJson(): JsonObject = buildJsonObject {
+    put("content", McpJson.encodeToJsonElement(
+        ListSerializer(ContentItem.serializer()), content
+    ))
+}
+```
+
+Add imports: `com.jonnyzzz.mcpSteroid.mcp.McpJson`, `kotlinx.serialization.builtins.ListSerializer`, `kotlinx.serialization.json.put` (JsonElement overload). Delete the now-unused `decodedByteCount()` helper and the `java.util.Base64` import if no longer referenced elsewhere in the file (the console renderer in Task 6 will re-introduce its own decode).
+
+- [ ] **Step 4: Run the full CliToolSupport + contract tests**
+
+Run: `./gradlew :npx-kt:test --tests '*CliToolSupportTest*' --tests '*McpAsCliContractTest*' --tests '*CliErrorEnvelopeTest*' --tests '*ScreenshotAndOpenProjectCommandTest*'`
+Expected: PASS. If a contract test pinned the old `bytes` image shape or the old flattened resource shape, update it to the native shape (this is the intended contract change; record it in the commit message).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/CliToolSupport.kt npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/CliToolSupportTest.kt
+git commit -m "refactor(devrig): serialize --json envelope content natively; keep image data as-is (C6,C7)"
+```
+
+---
+
+## Task 5: `Presentation` abstraction replacing threaded `json: Boolean` (comment C3)
+
+**Files:**
+- Modify: `npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/CliToolSupport.kt` (introduce `Presentation`)
+- Modify call sites: `FetchResourceCommand.kt:48`, `ToolBackedCommands.kt` (all `renderTo`/`renderCliError` calls), `ListProjectsCommand.kt`, `ListWindowsCommand.kt`, `Main.kt:149`, `Cli.kt:761`
+- Test: `npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/CliToolSupportTest.kt`
+
+**Interfaces:**
+- Produces: a sealed `Presentation` with two implementations and a uniform rendering surface, e.g.:
+
+```kotlin
+sealed interface Presentation {
+    fun render(result: ToolCallResult, command: String, out: PrintStream, err: PrintStream): Int
+    fun renderError(command: String, message: String, exit: Int, out: PrintStream, err: PrintStream): Int
+    class Json : Presentation
+    class Console(private val imageDir: () -> Path) : Presentation
+}
+fun presentationFor(json: Boolean, imageDir: () -> Path): Presentation
+```
+
+The exact method set is discovered while migrating call sites; the invariant is **no `if (json)` left in the shared render code** — each branch lives in its `Presentation` implementation. `Console` takes an `imageDir` provider so Task 6 (console image → file) has a home.
+
+- [ ] **Step 1: Baseline green**
+
+Run: `./gradlew :npx-kt:test`
+Expected: PASS.
+
+- [ ] **Step 2: Add a test that both presentations render the same result differently**
+
+In `CliToolSupportTest.kt`:
+
+```kotlin
+    @Test
+    fun `json presentation emits one envelope, console emits plain text`() {
+        val result = ToolCallResult(content = listOf(ContentItem.Text("hi")))
+        val (jo, je) = buffers()
+        Presentation.Json().render(result, "demo", PrintStream(jo), PrintStream(je))
+        val (co, ce) = buffers()
+        Presentation.Console { java.nio.file.Files.createTempDirectory("t") }
+            .render(result, "demo", PrintStream(co), PrintStream(ce))
+
+        assertTrue(jo.text().trim().startsWith("{"), jo.text())
+        assertEquals("hi", co.text().trim())
+    }
+```
+
+- [ ] **Step 3: Run it to see it fail (types don't exist yet)**
+
+Run: `./gradlew :npx-kt:test --tests '*CliToolSupportTest*'`
+Expected: FAIL to compile / unresolved `Presentation`.
+
+- [ ] **Step 4: Introduce `Presentation` and move the branch bodies into it**
+
+Extract the current `if (json) …` bodies of `renderTo` and `renderCliError` into `Presentation.Json` / `Presentation.Console`. Keep `ToolCallResult.renderTo(command, json, out, err)` and `renderCliError(...)` as thin shims that delegate to `presentationFor(json, imageDir)` so existing call sites keep compiling; migrate call sites incrementally in Step 5. The `Json` impl uses `toEnvelopeJson` / `cliEnvelopeJson`; the `Console` impl does the stdout/stderr routing and the per-`ContentItem` `when`.
+
+- [ ] **Step 5: Migrate call sites off the boolean where natural**
+
+For each file in the call-site list, pass/construct the `Presentation` once per command instead of threading `json`. Where a command already has `command.json`, build `presentationFor(command.json, services.homePaths::screenshotTmpDir)` (add that provider in Task 6; for now `{ homePaths.home }`). Keep behavior identical.
+
+- [ ] **Step 6: Run the full suite**
+
+Run: `./gradlew :npx-kt:test`
+Expected: PASS (all ~1393 contract tests included).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/
+git commit -m "refactor(devrig): replace threaded json:Boolean with a Presentation abstraction (C3)"
+```
+
+---
+
+## Task 6: Console image → temp file under `~/.mcp-steroid/` (comment C4)
+
+**Files:**
+- Modify: `npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/CliToolSupport.kt` (`Presentation.Console` image branch)
+- Modify: `npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/HomePaths.kt` (add a tmp dir accessor)
+- Test: `npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/CliToolSupportTest.kt`
+
+**Interfaces:**
+- Consumes: `HomePaths` (resolves `~/.mcp-steroid`).
+- Produces: `HomePaths.screenshotTmpDir(): Path` (creates `~/.mcp-steroid/tmp` if missing); `Presentation.Console` writes decoded PNG bytes to `<tmpDir>/image-<n>.<ext>` and prints the absolute path.
+
+- [ ] **Step 1: Rewrite the console image test to pin the file-path contract**
+
+Replace the console assertion (old line 53) with:
+
+```kotlin
+    @Test
+    fun `console image is written to a temp file and the path is printed`() {
+        val raw = ByteArray(9) { it.toByte() }
+        val b64 = Base64.getEncoder().encodeToString(raw)
+        val result = ToolCallResult(content = listOf(ContentItem.Image(data = b64, mimeType = "image/png")))
+        val tmp = java.nio.file.Files.createTempDirectory("shot")
+        val (out, err) = buffers()
+
+        Presentation.Console { tmp }.render(result, "shot", PrintStream(out), PrintStream(err))
+
+        val printed = out.text().trim()
+        val path = java.nio.file.Path.of(printed.substringAfterLast(' ').ifBlank { printed })
+        assertTrue(java.nio.file.Files.exists(path), "expected a written file, printed: $printed")
+        assertEquals(9, java.nio.file.Files.size(path).toInt())
+        assertEquals("image/png", result.content.filterIsInstance<ContentItem.Image>().first().mimeType)
+    }
+```
+
+- [ ] **Step 2: Run it to see it fail**
+
+Run: `./gradlew :npx-kt:test --tests '*CliToolSupportTest*'`
+Expected: FAIL (console still prints the `[image: …]` placeholder).
+
+- [ ] **Step 3: Add `HomePaths.screenshotTmpDir()`**
+
+In `HomePaths.kt`:
+
+```kotlin
+    fun screenshotTmpDir(): Path {
+        val dir = home.resolve("tmp")
+        Files.createDirectories(dir)
+        return dir
+    }
+```
+
+(Match the file's existing `home: Path` field and imports.)
+
+- [ ] **Step 4: Write the image in `Presentation.Console`**
+
+In the `Console` image branch, decode the base64 and write it:
+
+```kotlin
+is ContentItem.Image -> {
+    val bytes = try {
+        Base64.getDecoder().decode(item.data)
+    } catch (e: IllegalArgumentException) {
+        System.err.println("devrig: image payload was not valid base64 (${e.message})")
+        out.println("[image: ${item.mimeType}, undecodable]")
+        return@forEach   // or the equivalent control flow for your loop shape
+    }
+    val ext = item.mimeType.substringAfterLast('/', "png")
+    val file = imageDir().resolve("image-${index}.$ext")
+    Files.write(file, bytes)
+    out.println("Saved image: ${file.toAbsolutePath()}")
+}
+```
+
+Add imports `java.nio.file.Files`, `java.util.Base64`, `java.nio.file.Path`.
+
+- [ ] **Step 5: Run tests**
+
+Run: `./gradlew :npx-kt:test --tests '*CliToolSupportTest*' --tests '*ScreenshotAndOpenProjectCommandTest*'`
+Expected: PASS. Reconcile any `take_screenshot` contract test that asserted the old placeholder.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/CliToolSupport.kt npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/HomePaths.kt npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/CliToolSupportTest.kt
+git commit -m "feat(devrig): console renders images to a ~/.mcp-steroid/tmp file and prints the path (C4)"
+```
+
+---
+
+## Task 7: `resolveResourcePayload` / `canonicalResourceEntryPoints` return article objects (comments C1 + C2)
+
+**Files:**
+- Modify: `mcp-steroid-server/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/FetchResourceToolHandler.kt:64-110`
+- Modify: `npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/FetchResourceCommand.kt:41-83`
+- Test: `mcp-steroid-server/.../server/` (add/adjust a resolver test), `npx-kt/.../FetchResourceCommandTest.kt:41`
+
+**Interfaces:**
+- Produces: `resolveResourceArticle(uri: String, context: PromptsContext): <Article>?` returning the article object (caller calls `.readPayload(context)`); `canonicalResourceEntryPoints(): List<<Article>>`. `<Article>` = the common supertype of `SkillPromptArticle` etc.
+
+- [ ] **Step 1: Discover the article supertype name**
+
+Run: `grep -rn "class SkillPromptArticle" --include='*.kt' .` and read its `: SuperType`. Use that concrete type in the signatures below (replace `Article` placeholder with the real type, e.g. `MarkdownArticle`). This is a real discovery step — do not invent the name.
+
+- [ ] **Step 2: Add a failing test for the article-returning API**
+
+In `mcp-steroid-server` add a test asserting `resolveResourceArticle(knownUri, PromptsContext.Generic)` returns non-null and its `.uri` equals the requested uri; and `canonicalResourceEntryPoints()` returns a non-empty list whose `.first().uri` is a valid `mcp-steroid://` string.
+
+- [ ] **Step 3: Run it to see it fail**
+
+Run: `./gradlew :mcp-steroid-server:test --tests '*FetchResource*'`
+Expected: FAIL (function/return-type not present).
+
+- [ ] **Step 4: Change the return types**
+
+- `resolveResourcePayload(...): String?` → `resolveResourceArticle(...): <Article>?` returning the matched `article` (drop the `.readPayload` call here).
+- `canonicalResourceEntryPoints(): List<String>` → `List<<Article>>` (return the article instances, not `.uri`).
+- Update `FetchResourceToolHandler.call:70-77` to `val article = resolveResourceArticle(uri, promptsContext) ?: return error; ToolCallResult(content = listOf(ContentItem.Text(article.readPayload(promptsContext))))`.
+- Update `FetchResourceCommand.kt:41` similarly; update the error-hint loop (`:73`) and `canonicalResourceEntryPointOrPlaceholder()` (`:83`) to use `entry.uri`.
+
+- [ ] **Step 5: Update the npx-kt consumer test**
+
+In `FetchResourceCommandTest.kt:41` change `canonicalResourceEntryPoints().first()` → `canonicalResourceEntryPoints().first().uri`.
+
+- [ ] **Step 6: Run both modules' tests**
+
+Run: `./gradlew :mcp-steroid-server:test --tests '*FetchResource*'` then `./gradlew :npx-kt:test --tests '*FetchResourceCommandTest*'`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add mcp-steroid-server/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/FetchResourceToolHandler.kt npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/FetchResourceCommand.kt npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/FetchResourceCommandTest.kt mcp-steroid-server/src/test/
+git commit -m "refactor: fetch-resource resolution returns Article objects, not bare strings (C1,C2)"
+```
+
+---
+
+## Task 8: `promptsContextFromRoute` helper + dedupe (comment C10, inline)
+
+**Files:**
+- Modify: `npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/server/DevrigPromptsContextHandler.kt`
+- Modify: `npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/FetchResourceCommand.kt:65`
+- Test: `npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/server/` (add a small unit test)
+
+**Interfaces:**
+- Produces: `DevrigPromptsContextHandler.Companion.promptsContextFromRoute(route: ProjectRoute): PromptsContext` = `promptsContextFromBuild(route.route.ide.build)`. The `route.route.ide.build` navigation lives ONLY here.
+
+- [ ] **Step 1: Add a failing test**
+
+```kotlin
+    @Test
+    fun `promptsContextFromRoute derives product and baseline from the route build`() {
+        val route = fakeRoute(build = "IU-261.1234")   // build a ProjectRoute with route.ide.build = "IU-261.1234"
+        val ctx = DevrigPromptsContextHandler.promptsContextFromRoute(route)
+        assertEquals("IU", ctx.productCode)
+        assertEquals(261, ctx.baselineVersion)
+    }
+```
+
+Build `fakeRoute` from the real `ProjectRoute`/`DiscoveredIde` constructors (inspect `DiscoveredIde` fields first; reuse any existing test fixture in the `server` test package).
+
+- [ ] **Step 2: Run it to see it fail**
+
+Run: `./gradlew :npx-kt:test --tests '*PromptsContext*'`
+Expected: FAIL (`promptsContextFromRoute` unresolved).
+
+- [ ] **Step 3: Add the helper and dedupe both call sites**
+
+In `DevrigPromptsContextHandler`:
+
+```kotlin
+    companion object {
+        fun promptsContextFromRoute(route: ProjectRoute): PromptsContext =
+            promptsContextFromBuild(route.route.ide.build)
+
+        fun promptsContextFromBuild(build: String): PromptsContext { /* unchanged */ }
+    }
+```
+
+Change `buildPromptsContext` (`:11-12`) to `return promptsContextFromRoute(routing.requireProject(projectName))`, and `FetchResourceCommand.resolvePromptsContext` (`:65`) to `return DevrigPromptsContextHandler.promptsContextFromRoute(route)`.
+
+- [ ] **Step 4: Run tests**
+
+Run: `./gradlew :npx-kt:test --tests '*PromptsContext*' --tests '*FetchResourceCommandTest*'`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/server/DevrigPromptsContextHandler.kt npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/FetchResourceCommand.kt npx-kt/src/test/
+git commit -m "refactor(devrig): add promptsContextFromRoute, hide route.route.ide.build (C10)"
+```
+
+---
+
+## Task 9: Core reuse — call `ToolSpec.call()` instead of rebuilding `*Params` (comments C9 + C15)
+
+**Files:**
+- Modify: `npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/ToolBackedCommands.kt` (all five tool-backed runners)
+- Possibly Create: `npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/server/CliToolDispatch.kt` (a helper that maps CLI args → `arguments: JsonObject`, builds a `ToolCallContext` over a no-arg `McpSession()` + `stderrProgressReporter()`, and calls the tool)
+- Test: existing glue tests (`ExecuteCodeCommandTest`, `FeedbackAndInputCommandTest`, `ScreenshotAndOpenProjectCommandTest`, `CliGlueTestSupport`) kept green
+
+**Interfaces:**
+- Consumes: `McpSession()` (no-arg ctor), `ToolCallParams(name, arguments)`, `ToolCallContext(params, session, progress)`, each `*ToolSpec` (e.g. `ExecuteCodeToolSpec`), `StubMcpSteroidTools` (for handlers), `stderrProgressReporter()`.
+- Produces: a single `suspend fun callToolViaSpec(spec: McpTool, arguments: JsonObject, progress: McpProgressReporter): ToolCallResult` that the runners use in place of the manual `*Params` construction + handler call.
+
+**Design constraint (must hold):** do NOT route through `McpToolRegistry.callTool`, which swallows exceptions into a generic `isError` and would collapse the exit-code contract (`ProjectRouteNotFound` → USAGE 64 vs bridge failure → UNAVAILABLE 69). Call `spec.call(context)` directly and keep the CLI's existing `try/catch → renderCliError(...)` exit-code mapping around it (the `ProjectRouteNotFoundException` / generic-`Exception` branches in `runToolCall`). The observable `--json`/exit-code contract must be byte-for-byte unchanged.
+
+- [ ] **Step 1: Baseline green + capture the current contract**
+
+Run: `./gradlew :npx-kt:test`
+Expected: PASS. These tests are the spec for this refactor — they must stay green with zero edits (behavior-preserving refactor).
+
+- [ ] **Step 2: Add a characterization test that execute_code forwards args as tool JSON**
+
+In `ExecuteCodeCommandTest.kt` (or `CliGlueTestSupport`), add a test that runs `runExecuteCodeCommand` with a `FakeMcpSteroidTools` and asserts the tool received `code`, `task_id`, `reason`, `timeout`, `modal` with the expected values — driving them through the new arguments-JSON path. Model it on the existing glue tests' fake-handler recording.
+
+- [ ] **Step 3: Run it (may pass against current code)**
+
+Run: `./gradlew :npx-kt:test --tests '*ExecuteCodeCommandTest*'`
+Expected: PASS or FAIL depending on whether the assertion matches the current path; either way it locks the arg-mapping contract before the refactor.
+
+- [ ] **Step 4: Introduce `callToolViaSpec` and migrate `execute_code` first**
+
+Add the dispatch helper:
+
+```kotlin
+suspend fun callToolViaSpec(
+    spec: McpTool,
+    arguments: JsonObject,
+    progress: McpProgressReporter,
+): ToolCallResult {
+    val params = ToolCallParams(name = spec.name, arguments = arguments)
+    val context = ToolCallContext(params, McpSession(), progress)
+    return spec.call(context)
+}
+```
+
+Rewrite `runExecuteCodeCommand` to build `arguments` from the CLI flags (`buildJsonObject { put("code", code); put("task_id", command.taskId); put("reason", command.reason); put("timeout", timeout); put("modal", modalWire); put("project_name", projectName) }`), then `callToolViaSpec(ExecuteCodeToolSpec { tools.handler() }, arguments, stderrProgressReporter())`, keeping the existing surrounding `try/catch → renderCliError` for exit codes and the `renderTo` at the end. Remove the hand-built `ExecCodeParams`.
+
+- [ ] **Step 5: Run execute_code tests**
+
+Run: `./gradlew :npx-kt:test --tests '*ExecuteCodeCommandTest*' --tests '*McpAsCliContractTest*' --tests '*CliErrorEnvelopeTest*'`
+Expected: PASS. Investigate any exit-code diff immediately — it means an exception path changed.
+
+- [ ] **Step 6: Migrate the remaining four runners the same way**
+
+Repeat Step 4's pattern for `execute_feedback`, `input`, `take_screenshot`, `open_project` (each builds its own `arguments` object and calls its `*ToolSpec`). Keep `--out` (screenshot post-write) and `--wait` (poll loop) as the existing hooks around the call. Delete the now-dead `*Params` imports.
+
+- [ ] **Step 7: Full suite**
+
+Run: `./gradlew :npx-kt:test`
+Expected: PASS (all contract tests). Then `devrig-dev` spot-check per the memory note (build with `installDist`, run via the `devrig-dev` symlink): `execute_code`, `take_screenshot --json | jq`, a stale `--project_name` (expect USAGE 64), and an unreachable bridge (expect UNAVAILABLE 69).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/
+git commit -m "refactor(devrig): route CLI tool calls through ToolSpec.call(), drop *Params rebuild (C9,C15)"
+```
+
+---
+
+## Task 10: Optional `--project_name` via cwd inference — the resolver (issue #266, part 1)
+
+**Files:**
+- Create: `npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/server/CwdProjectResolver.kt`
+- Create: `npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/server/CwdProjectResolverTest.kt`
+
+**Interfaces:**
+- Consumes: `DevrigProjectRoutingService.routes(): List<ProjectRoute>` (each has `projectPath: String`, `exposedProjectName: String`).
+- Produces:
+
+```kotlin
+sealed interface CwdProjectMatch {
+    data class One(val route: ProjectRoute) : CwdProjectMatch
+    data object None : CwdProjectMatch
+    data class Ambiguous(val candidates: List<ProjectRoute>) : CwdProjectMatch
+}
+fun resolveProjectFromCwd(cwd: Path, routes: List<ProjectRoute>): CwdProjectMatch
+```
+
+Longest path-segment-boundary prefix wins. `/foo/bar` must NOT match a route at `/foo/barbaz`. If several routes tie at the same longest depth → `Ambiguous`.
+
+- [ ] **Step 1: Write the resolver test matrix**
+
+```kotlin
+class CwdProjectResolverTest {
+    private fun route(path: String, name: String) = /* build a ProjectRoute with projectPath=path, exposedProjectName=name */
+
+    @Test fun `single project containing cwd matches`() {
+        val r = route("/home/u/proj", "proj-abc")
+        assertEquals(CwdProjectMatch.One(r), resolveProjectFromCwd(Path.of("/home/u/proj/src"), listOf(r)))
+    }
+    @Test fun `cwd equal to project root matches`() {
+        val r = route("/home/u/proj", "proj-abc")
+        assertEquals(CwdProjectMatch.One(r), resolveProjectFromCwd(Path.of("/home/u/proj"), listOf(r)))
+    }
+    @Test fun `nested projects pick the most specific`() {
+        val outer = route("/home/u/proj", "proj-abc")
+        val inner = route("/home/u/proj/module", "module-def")
+        assertEquals(CwdProjectMatch.One(inner),
+            resolveProjectFromCwd(Path.of("/home/u/proj/module/src"), listOf(outer, inner)))
+    }
+    @Test fun `no containing project yields None`() {
+        val r = route("/home/u/proj", "proj-abc")
+        assertEquals(CwdProjectMatch.None, resolveProjectFromCwd(Path.of("/tmp/elsewhere"), listOf(r)))
+    }
+    @Test fun `sibling prefix does not falsely match`() {
+        val r = route("/home/u/proj", "proj-abc")
+        assertEquals(CwdProjectMatch.None, resolveProjectFromCwd(Path.of("/home/u/projbeta"), listOf(r)))
+    }
+}
+```
+
+Fill `route(...)` from the real `ProjectRoute` constructor (reuse the fixture from Task 8 if shared).
+
+- [ ] **Step 2: Run it to see it fail**
+
+Run: `./gradlew :npx-kt:test --tests '*CwdProjectResolverTest*'`
+Expected: FAIL (unresolved `resolveProjectFromCwd`).
+
+- [ ] **Step 3: Implement the resolver**
+
+```kotlin
+fun resolveProjectFromCwd(cwd: Path, routes: List<ProjectRoute>): CwdProjectMatch {
+    val abs = cwd.toAbsolutePath().normalize()
+    val containing = routes.filter { abs.startsWith(Path.of(it.projectPath).toAbsolutePath().normalize()) }
+    if (containing.isEmpty()) return CwdProjectMatch.None
+    val maxDepth = containing.maxOf { Path.of(it.projectPath).normalize().nameCount }
+    val deepest = containing.filter { Path.of(it.projectPath).normalize().nameCount == maxDepth }
+    return if (deepest.size == 1) CwdProjectMatch.One(deepest.single())
+        else CwdProjectMatch.Ambiguous(deepest)
+}
+```
+
+`Path.startsWith` compares on name boundaries, so the sibling-prefix case is handled correctly.
+
+- [ ] **Step 4: Run tests**
+
+Run: `./gradlew :npx-kt:test --tests '*CwdProjectResolverTest*'`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/server/CwdProjectResolver.kt npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/server/CwdProjectResolverTest.kt
+git commit -m "feat(devrig): cwd->project longest-prefix resolver (#266 part 1)"
+```
+
+---
+
+## Task 11: Wire cwd inference into the project-scoped commands (issue #266, part 2)
+
+**Files:**
+- Modify: `npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/ToolBackedCommands.kt` (the project_name resolve point created in Task 9)
+- Modify: `npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/Cli.kt` (help text for the four commands)
+- Modify: `npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/HelpCommand.kt` (note optional `--project_name`)
+- Test: `npx-kt/.../ExecuteCodeCommandTest.kt`, `FeedbackAndInputCommandTest.kt`, `ScreenshotAndOpenProjectCommandTest.kt`
+
+**Interfaces:**
+- Consumes: `resolveProjectFromCwd`, `CwdProjectMatch`, `DevrigServices` (has `projectRouting`; get cwd from `System.getProperty("user.dir")` — confirm devrig's cwd source, it is the launch dir).
+- Produces: a shared `fun DevrigServices.requireProjectName(explicit: String?): String` that returns `explicit` when non-blank, else infers from cwd, else throws a `CodeArgException`/routes through `renderCliError` with an agent-understandable candidate list.
+
+- [ ] **Step 1: Add failing tests for inference + override + errors**
+
+In `ExecuteCodeCommandTest.kt`:
+
+```kotlin
+    @Test fun `explicit project_name overrides cwd inference`() { /* pass --project_name, assert the tool got it verbatim */ }
+    @Test fun `blank project_name infers the single containing project`() { /* fake routes with one match under cwd, assert inferred name reaches the tool */ }
+    @Test fun `no containing project fails with a candidate-listing usage error`() { /* assert USAGE(64) envelope lists open projects */ }
+```
+
+Use the existing fake-tools harness; inject a `routes()` snapshot and a cwd.
+
+- [ ] **Step 2: Run to see them fail**
+
+Run: `./gradlew :npx-kt:test --tests '*ExecuteCodeCommandTest*'`
+Expected: FAIL.
+
+- [ ] **Step 3: Make `--project_name` optional + add `requireProjectName`**
+
+- In `Cli.kt`, the four commands' `--project_name` options are already `String?` — update their `help` to: "routing key from `devrig list_projects`; omit to infer from the current directory".
+- Add `requireProjectName(explicit)` that maps `CwdProjectMatch.One` → `route.exposedProjectName`; `None`/`Ambiguous` → throw a usage error whose message lists `routes().map { it.exposedProjectName }` and asks for an explicit `--project_name`.
+- At the single project_name resolve point in each of the four runners, call `requireProjectName(command.projectName)` instead of using the raw (previously-required) value.
+
+- [ ] **Step 4: Run tests**
+
+Run: `./gradlew :npx-kt:test --tests '*ExecuteCodeCommandTest*' --tests '*FeedbackAndInputCommandTest*' --tests '*ScreenshotAndOpenProjectCommandTest*' --tests '*McpAsCliContractTest*'`
+Expected: PASS.
+
+- [ ] **Step 5: Update help docs**
+
+Add a line to `printExecuteCodeHelp` and the global banner: `--project_name` is optional; inferred from cwd when omitted; required when run outside any open project or when the directory is inside more than one.
+
+- [ ] **Step 6: Full suite + devrig-dev spot-check**
+
+Run: `./gradlew :npx-kt:test`
+Expected: PASS. Spot-check with `devrig-dev`: `cd` into a known open project and run `execute_code` without `--project_name` (should infer); run from `/tmp` (should list candidates + exit 64).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/ npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/
+git commit -m "feat(devrig): infer --project_name from cwd, explicit overrides (#266 part 2)"
+```
+
+---
+
+## Task 12: PR reply for the self-heal gate + follow-up issue (comments C13/C14, C8/C11/C12)
+
+**Files:** none (GitHub only).
+
+- [ ] **Step 1: Post a reply on the `Main.kt:97` thread**
+
+Explain that `selfHealsLauncherOnStart()` gating is intrinsic to this PR (the new MCP-as-CLI tool facades must not mutate launcher/PATH state — Tenet 3 — and it is pinned by `LauncherSelfHealPredicateTest`, Round-5 #9). Ask which of the "several related issues" to the launcher logic he wants split into a separate PR rather than extracting the load-bearing gate.
+
+```bash
+gh pr comment 272 --body "<reply text>"
+```
+
+(Use a review-thread reply if preferred: `gh api ...pulls/272/comments/<id>/replies`.)
+
+- [ ] **Step 2: Open the follow-up issue for schema-driven generation**
+
+```bash
+gh issue create --title "devrig CLI: generate subcommands/flags/help from MCP ToolSpec" \
+  --body "Follow-up to #272 (comments C8/C11/C12). Derive clikt options, per-command help, and command registration from each tool's InputSchemaElement specs so a new MCP tool auto-registers as a CLI command. Needs: schema->clikt type adapters, a help synopsis (not the multi-KB tool description), and re-validation of the frozen --json/exit-code contract. Epic #188."
+```
+
+- [ ] **Step 3: Note the issue number in `TODO-mcp-as-cli.md`** (Round 6 → "Deferred to a FOLLOW-UP PR"), then commit that doc.
+
+```bash
+git add TODO-mcp-as-cli.md
+git commit -m "docs: record PR #272 review-response plan (Round 6) + follow-up issue ref"
+```
+
+---
+
+## Task 13: Final verification
+
+- [ ] **Step 1: Full module suites green**
+
+Run: `./gradlew :npx-kt:test` then `./gradlew :mcp-steroid-server:test`
+Expected: BUILD SUCCESSFUL, all green (incl. the ~1393-test contract suite).
+
+- [ ] **Step 2: Compile/warning check via IDE MCP**
+
+Per `CLAUDE.md`, verify no new warnings/errors with `steroid_execute_code` (`runInspectionsDirectly` / build) on the changed files.
+
+- [ ] **Step 3: devrig-dev end-to-end spot check**
+
+Build (`./gradlew :npx-kt:installDist`) and drive via the `devrig-dev` symlink: `prompt <uri>`, `execute_code` (inferred + explicit project), `take_screenshot` (file path printed + `--json` data present), a stale project (USAGE 64), an unreachable bridge (UNAVAILABLE 69). Confirm each `--json` output is a single `jq`-valid document.
+
+- [ ] **Step 4: Reply to the remaining review threads**
+
+For each addressed comment, reply on its thread with the commit that resolved it, then re-request review.
+
+## Self-Review Notes
+
+- **Spec coverage:** all 18 comments mapped — C16→T1, C5→T2, C17→T3, C6/C7→T4, C3→T5, C4→T6, C1/C2→T7, C10→T8, C9/C15→T9, #266→T10+T11, C13/C14→T12, C8/C11/C12→T12 (deferred issue). ✅
+- **Contract safety:** T4, T5, T6 rewrite the tests that pinned the OLD image/envelope contract to pin the NEW one (intentional contract change, recorded in commits). T9 is behavior-preserving — its tests must pass unedited. ✅
+- **Type consistency:** `Presentation` (T5) provides the `imageDir` seam T6 needs; `callToolViaSpec` (T9) provides the single project_name resolve point T11 needs; `promptsContextFromRoute` (T8) and `resolveProjectFromCwd` (T10) both consume the routing snapshot. ✅
+- **Discovery steps** (article supertype in T7; `DiscoveredIde`/`ProjectRoute` fixtures in T8/T10) are explicit executable steps, not placeholders. ✅

--- a/mcp-steroid-server/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/FetchResourceToolHandler.kt
+++ b/mcp-steroid-server/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/FetchResourceToolHandler.kt
@@ -18,6 +18,7 @@ import com.jonnyzzz.mcpSteroid.prompts.generated.prompt.DebuggerSkillPromptArtic
 import com.jonnyzzz.mcpSteroid.prompts.generated.prompt.SkillPromptArticle
 import com.jonnyzzz.mcpSteroid.prompts.generated.prompt.TestSkillPromptArticle
 import com.jonnyzzz.mcpSteroid.prompts.generated.skill.CodingWithIntelliJPromptArticle
+import com.jonnyzzz.mcpSteroid.prompts.generated.skill.ExecuteCodeToolDescriptionPromptArticle
 import com.jonnyzzz.mcpSteroid.thisLogger
 
 /**
@@ -106,4 +107,17 @@ fun canonicalResourceEntryPoints(): List<String> = listOf(
     FindDuplicatesPromptArticle().uri,
     InspectAndFixPromptArticle().uri,
     CodingWithIntelliJPromptArticle().uri,
+)
+
+/**
+ * Layered "go deeper" guide URIs for the `devrig execute_code` CLI help — ordered shallow→deep so an
+ * agent can fetch only as far as it needs (`devrig prompt <uri>`). Built from the generated article
+ * classes (no hardcoded `mcp-steroid://` literals), so a renamed/removed article breaks the build.
+ * Each pair is `uri to one-line-what-you-get`.
+ */
+fun executeCodeGuideUris(): List<Pair<String, String>> = listOf(
+    ExecuteCodeToolDescriptionPromptArticle().uri to "full tool guide: decision tree, threading rules, multi-file edits, output rules",
+    CodingWithIntelliJPromptArticle().uri to "IntelliJ API reference: PSI, VFS, refactorings, patterns, examples",
+    TestSkillPromptArticle().uri to "running/inspecting tests via the IDE runner",
+    DebuggerSkillPromptArticle().uri to "breakpoints, debug sessions, threads",
 )

--- a/mcp-steroid-server/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/FetchResourceToolHandler.kt
+++ b/mcp-steroid-server/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/FetchResourceToolHandler.kt
@@ -10,6 +10,7 @@ import com.jonnyzzz.mcpSteroid.mcp.get
 import com.jonnyzzz.mcpSteroid.mcp.param
 import com.jonnyzzz.mcpSteroid.mcp.required
 import com.jonnyzzz.mcpSteroid.mcp.string
+import com.jonnyzzz.mcpSteroid.prompts.PromptsContext
 import com.jonnyzzz.mcpSteroid.prompts.generated.ResourcesIndex
 import com.jonnyzzz.mcpSteroid.prompts.generated.ide.FindDuplicatesPromptArticle
 import com.jonnyzzz.mcpSteroid.prompts.generated.ide.InspectAndFixPromptArticle
@@ -66,15 +67,43 @@ class FetchResourceToolHandler(
         log.info("steroid_fetch_resource: $uri")
 
         val promptsContext = handler().buildPromptsContext(projectName)
-        val article = ResourcesIndex().roots.values
-            .asSequence()
-            .flatMap { it.articles.values.asSequence() }
-            .firstOrNull { it.uri == uri && it.filter.matches(promptsContext) }
+        val payload = resolveResourcePayload(uri, promptsContext)
             ?: return ToolCallResult(
                 content = listOf(ContentItem.Text(text = "ERROR: Resource not found: $uri")),
                 isError = true
             )
 
-        return ToolCallResult(content = listOf(ContentItem.Text(text = article.readPayload(promptsContext))))
+        return ToolCallResult(content = listOf(ContentItem.Text(text = payload)))
     }
 }
+
+/**
+ * Resolves a `mcp-steroid://` resource URI to its rendered Markdown payload for the given
+ * [context], or `null` when no article matches the URI + IDE filter.
+ *
+ * The single source of truth for URI → payload resolution: used by [FetchResourceToolHandler]
+ * (the `steroid_fetch_resource` MCP tool) and by the `devrig fetch_resource` / `devrig prompt`
+ * CLI commands, so both surfaces resolve identically.
+ */
+fun resolveResourcePayload(uri: String, context: PromptsContext): String? {
+    val article = ResourcesIndex().roots.values
+        .asSequence()
+        .flatMap { it.articles.values.asSequence() }
+        .firstOrNull { it.uri == uri && it.filter.matches(context) }
+        ?: return null
+    return article.readPayload(context)
+}
+
+/**
+ * Canonical entry-point URIs to suggest when a fetch misses — built from the generated article
+ * classes (never hardcoded `mcp-steroid://` literals, per NoHardcodedMcpSteroidUriUsageTest).
+ * Reused by CLI error hints so the suggestions stay in sync with the tool description above.
+ */
+fun canonicalResourceEntryPoints(): List<String> = listOf(
+    SkillPromptArticle().uri,
+    TestSkillPromptArticle().uri,
+    DebuggerSkillPromptArticle().uri,
+    FindDuplicatesPromptArticle().uri,
+    InspectAndFixPromptArticle().uri,
+    CodingWithIntelliJPromptArticle().uri,
+)

--- a/mcp-steroid-server/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/FetchResourceToolHandler.kt
+++ b/mcp-steroid-server/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/FetchResourceToolHandler.kt
@@ -10,6 +10,7 @@ import com.jonnyzzz.mcpSteroid.mcp.get
 import com.jonnyzzz.mcpSteroid.mcp.param
 import com.jonnyzzz.mcpSteroid.mcp.required
 import com.jonnyzzz.mcpSteroid.mcp.string
+import com.jonnyzzz.mcpSteroid.prompts.ArticleBase
 import com.jonnyzzz.mcpSteroid.prompts.PromptsContext
 import com.jonnyzzz.mcpSteroid.prompts.generated.ResourcesIndex
 import com.jonnyzzz.mcpSteroid.prompts.generated.ide.FindDuplicatesPromptArticle
@@ -68,45 +69,43 @@ class FetchResourceToolHandler(
         log.info("steroid_fetch_resource: $uri")
 
         val promptsContext = handler().buildPromptsContext(projectName)
-        val payload = resolveResourcePayload(uri, promptsContext)
+        val article = resolveResourceArticle(uri, promptsContext)
             ?: return ToolCallResult(
                 content = listOf(ContentItem.Text(text = "ERROR: Resource not found: $uri")),
                 isError = true
             )
 
-        return ToolCallResult(content = listOf(ContentItem.Text(text = payload)))
+        return ToolCallResult(content = listOf(ContentItem.Text(text = article.readPayload(promptsContext))))
     }
 }
 
 /**
- * Resolves a `mcp-steroid://` resource URI to its rendered Markdown payload for the given
- * [context], or `null` when no article matches the URI + IDE filter.
+ * Resolves a `mcp-steroid://` resource URI to its matching [ArticleBase] for the given [context],
+ * or `null` when no article matches the URI + IDE filter. Callers render the payload themselves via
+ * [ArticleBase.readPayload] — this function hands back the article object, not pre-rendered text.
  *
- * The single source of truth for URI → payload resolution: used by [FetchResourceToolHandler]
+ * The single source of truth for URI → article resolution: used by [FetchResourceToolHandler]
  * (the `steroid_fetch_resource` MCP tool) and by the `devrig fetch_resource` / `devrig prompt`
  * CLI commands, so both surfaces resolve identically.
  */
-fun resolveResourcePayload(uri: String, context: PromptsContext): String? {
-    val article = ResourcesIndex().roots.values
+fun resolveResourceArticle(uri: String, context: PromptsContext): ArticleBase? =
+    ResourcesIndex().roots.values
         .asSequence()
         .flatMap { it.articles.values.asSequence() }
         .firstOrNull { it.uri == uri && it.filter.matches(context) }
-        ?: return null
-    return article.readPayload(context)
-}
 
 /**
- * Canonical entry-point URIs to suggest when a fetch misses — built from the generated article
+ * Canonical entry-point articles to suggest when a fetch misses — built from the generated article
  * classes (never hardcoded `mcp-steroid://` literals, per NoHardcodedMcpSteroidUriUsageTest).
  * Reused by CLI error hints so the suggestions stay in sync with the tool description above.
  */
-fun canonicalResourceEntryPoints(): List<String> = listOf(
-    SkillPromptArticle().uri,
-    TestSkillPromptArticle().uri,
-    DebuggerSkillPromptArticle().uri,
-    FindDuplicatesPromptArticle().uri,
-    InspectAndFixPromptArticle().uri,
-    CodingWithIntelliJPromptArticle().uri,
+fun canonicalResourceEntryPoints(): List<ArticleBase> = listOf(
+    SkillPromptArticle(),
+    TestSkillPromptArticle(),
+    DebuggerSkillPromptArticle(),
+    FindDuplicatesPromptArticle(),
+    InspectAndFixPromptArticle(),
+    CodingWithIntelliJPromptArticle(),
 )
 
 /**

--- a/mcp-steroid-server/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/OpenProjectTool.kt
+++ b/mcp-steroid-server/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/OpenProjectTool.kt
@@ -31,6 +31,7 @@ import kotlinx.serialization.Serializable
  */
 class OpenProjectToolSpec(
     val includeBackendName: Boolean = false,
+    val validateProjectPath: Boolean = true,
     val handler: () -> OpenProjectToolHandler,
 ) : McpToolBase() {
     private val logger = thisLogger()
@@ -88,18 +89,20 @@ class OpenProjectToolSpec(
             return ToolCallResult.errorResult("Invalid project path: $projectPathStr - ${e.message}")
         }
 
-        // Validate that the path exists
-        if (!Files.isDirectory(requestedProjectPath)) {
-            return ToolCallResult.errorResult("Project path is not a directory: $requestedProjectPath")
-        }
-
-        val projectPath = try {
-            withContext(Dispatchers.IO) {
-                requestedProjectPath.toRealPath()
+        val projectPath = if (validateProjectPath) {
+            if (!Files.isDirectory(requestedProjectPath)) {
+                return ToolCallResult.errorResult("Project path is not a directory: $requestedProjectPath")
             }
-        } catch (e: Exception) {
-            logger.warn("Failed to resolve project path: $requestedProjectPath", e)
-            return ToolCallResult.errorResult("Failed to resolve project path: $requestedProjectPath - ${e.message}")
+            try {
+                withContext(Dispatchers.IO) {
+                    requestedProjectPath.toRealPath()
+                }
+            } catch (e: Exception) {
+                logger.warn("Failed to resolve project path: $requestedProjectPath", e)
+                return ToolCallResult.errorResult("Failed to resolve project path: $requestedProjectPath - ${e.message}")
+            }
+        } else {
+            requestedProjectPath
         }
 
         return handler().handleOpenProject(

--- a/mcp-steroid-server/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/VisionInputTool.kt
+++ b/mcp-steroid-server/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/VisionInputTool.kt
@@ -17,7 +17,10 @@ import kotlinx.serialization.Serializable
 /**
  * Handler for the steroid_input MCP tool.
  */
-class VisionInputToolSpec(val handler: () -> VisionInputToolHandler) : McpToolBase() {
+class VisionInputToolSpec(
+    val parseSequence: Boolean = true,
+    val handler: () -> VisionInputToolHandler,
+) : McpToolBase() {
     override val name = "steroid_input"
 
     override val description = """
@@ -66,8 +69,8 @@ class VisionInputToolSpec(val handler: () -> VisionInputToolHandler) : McpToolBa
         val windowId = context[windowId]
         val sequence = context[sequence]
 
-        val parsed = InputSequenceParser().parse(sequence)
-        if (parsed.filterIsInstance<InputStep.Click>().any { it.target is InputTarget.Unsupported }) {
+        val parsed = if (parseSequence) InputSequenceParser().parse(sequence) else emptyList()
+        if (parseSequence && parsed.filterIsInstance<InputStep.Click>().any { it.target is InputTarget.Unsupported }) {
             throw IllegalArgumentException("Unsupported target in sequence. Only screenshot/screen targets are supported.")
         }
 

--- a/mcp-steroid-server/src/test/kotlin/com/jonnyzzz/mcpSteroid/server/FetchResourceResolverTest.kt
+++ b/mcp-steroid-server/src/test/kotlin/com/jonnyzzz/mcpSteroid/server/FetchResourceResolverTest.kt
@@ -1,0 +1,35 @@
+/* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
+package com.jonnyzzz.mcpSteroid.server
+
+import com.jonnyzzz.mcpSteroid.prompts.Generic
+import com.jonnyzzz.mcpSteroid.prompts.PromptsContext
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * Pins that URI -> article resolution returns the article object itself (not a pre-rendered
+ * payload string, not a bare URI string) so callers stay in control of when/how they render it.
+ */
+class FetchResourceResolverTest {
+
+    @Test
+    fun `resolveResourceArticle returns the matched article`() {
+        val knownUri = canonicalResourceEntryPoints().first().uri
+
+        val article = resolveResourceArticle(knownUri, PromptsContext.Generic)
+
+        assertNotNull(article, "expected a matching article for $knownUri")
+        assertEquals(knownUri, article!!.uri)
+    }
+
+    @Test
+    fun `canonicalResourceEntryPoints returns articles with valid mcp-steroid uris`() {
+        val entryPoints = canonicalResourceEntryPoints()
+
+        assertTrue(entryPoints.isNotEmpty(), "expected at least one canonical entry point")
+        val first = entryPoints.first()
+        assertTrue(first.uri.startsWith("mcp-steroid://"), "unexpected uri: ${first.uri}")
+    }
+}

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/Cli.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/Cli.kt
@@ -13,8 +13,36 @@ import com.github.ajalt.clikt.parameters.options.option
 import com.github.ajalt.clikt.parameters.types.double
 import com.github.ajalt.clikt.parameters.types.int
 import com.jonnyzzz.mcpSteroid.aiAgents.AiAgentCli
+import com.jonnyzzz.mcpSteroid.server.ModalMode
 
 const val NO_BACKENDS_DETECTED_MESSAGE: String = "No backends detected."
+
+/**
+ * The closed set of every devrig subcommand token (including nested `backend` verbs and the hidden
+ * `mpc` alias). Used to recover the command name from raw tokens when a [CliktError] aborts parsing
+ * before a variant's flags are captured — reliable precisely because the grammar is subcommand-first
+ * over this fixed set and every global flag is boolean (so an option VALUE never precedes the
+ * subcommand). Kept next to the subcommand registration in [DevrigRootCommand] so the two stay in sync.
+ */
+val DEVRIG_SUBCOMMAND_NAMES: Set<String> = setOf(
+    "mcp", "mpc", "backend", "project", "install",
+    "prompt", "fetch_resource", "execute_code", "list_projects", "list_windows",
+    "open_project", "take_screenshot", "input", "execute_feedback",
+    "help", "version",
+    // nested `backend` verbs
+    "download", "start", "stop", "provision",
+)
+
+/**
+ * Recovers the subcommand name from raw CLI tokens for a parse-error envelope. Prefers the first token
+ * that matches a known subcommand ([DEVRIG_SUBCOMMAND_NAMES]); falls back to the first non-flag token
+ * (covers an unknown command like `devrig frobnicate`), then to `"devrig"`. Deterministic and free of
+ * clikt internals, so it survives clikt version changes.
+ */
+fun recoverCommandName(rawArgs: Array<String>): String =
+    rawArgs.firstOrNull { it in DEVRIG_SUBCOMMAND_NAMES }
+        ?: rawArgs.firstOrNull { !it.startsWith("-") }
+        ?: "devrig"
 
 sealed interface DevrigCommand {
     val debug: Boolean
@@ -210,7 +238,7 @@ fun parseDevrigCommand(rawArgs: Array<String>): DevrigCommand {
         DevrigCommand.DevrigCommandParseError(
             text = formatted ?: message,
             message = message,
-            commandName = rawArgs.firstOrNull { !it.startsWith("-") } ?: "devrig",
+            commandName = recoverCommandName(rawArgs),
             json = rawArgs.any { it == "--json" },
         )
     }
@@ -452,6 +480,15 @@ private class ExecuteCodeCliCommand(
         // Reject a non-positive timeout up front: dispatching with 0/-1 would start the script and then
         // immediately fail with "timed out after 0 seconds" (Codex Round-4 finding).
         timeout?.let { if (it <= 0) throw UsageError("--timeout must be a positive number of seconds (got $it)") }
+        // Validate --modal here so an unknown value rides the parse-error envelope path (honors --json,
+        // exit 64) instead of a stderr-only message from runExecuteCodeCommand (Codex finding #2).
+        modal?.let { wire ->
+            if (ModalMode.entries.none { it.wire == wire }) {
+                throw UsageError(
+                    "invalid --modal '$wire'. Valid: ${ModalMode.entries.joinToString(" | ") { it.wire }}"
+                )
+            }
+        }
         requireArg(taskId, "--task_id", null)
         requireArg(reason, "--reason", null)
         select(DevrigCommand.DevrigCommandExecuteCode(
@@ -571,7 +608,13 @@ private class FeedbackCliCommand(
 ) : DevrigCliktCommand("execute_feedback", selected, parent) {
     private val projectName: String? by option("--project_name", help = "routing key from `devrig list_projects`")
     private val taskId: String? by option("--task_id", help = "the same task_id used for the rated execution")
-    private val executionId: String? by option("--execution_id", help = "execution_id from the rated execute_code result")
+    // Accepted for parity with the steroid_execute_feedback MCP surface, which likewise documents
+    // execution_id but does not forward it (FeedbackParams has no such field). Kept so an agent/script
+    // that passes it is not rejected; the value is contextual only and is intentionally NOT forwarded.
+    private val executionId: String? by option(
+        "--execution_id",
+        help = "accepted for MCP parity; contextual only — currently NOT forwarded (matches steroid_execute_feedback)",
+    )
     private val successRating: Double? by option("--success_rating", help = "0.00 (failure) .. 1.00 (success)").double()
     private val explanation: String? by option("--explanation", help = "what worked, what didn't, what you'll try next")
     private val codeFile: String? by option("--code-file", help = "optional illustrative snippet file")

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/Cli.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/Cli.kt
@@ -758,7 +758,7 @@ fun DevrigServices.runCli(command: DevrigCommand): Int {
                 // `--json` consumers must be able to parse usage/parse failures too — emit the unified
                 // isError envelope; otherwise print the full formatted help to stderr. Exit stays 64.
                 if (command.json) {
-                    renderCliError(command.commandName, command.message, json = true, exit = CliExit.USAGE, out = mcpStdout)
+                    Presentation.Json().renderError(command.commandName, command.message, exit = CliExit.USAGE, out = mcpStdout)
                 } else {
                     System.err.println(command.text)
                     CliExit.USAGE

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/Cli.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/Cli.kt
@@ -456,7 +456,7 @@ private class ExecuteCodeCliCommand(
     selected: SelectedDevrigCommand,
     parent: DevrigCliktCommand,
 ) : DevrigCliktCommand("execute_code", selected, parent) {
-    private val projectName: String? by option("--project_name", help = "routing key from `devrig list_projects`")
+    private val projectName: String? by option("--project_name", help = "routing key from `devrig list_projects`; omit to infer from the current directory")
     private val codeFile: String? by option("--code-file", help = "path to a Kotlin script file (preferred)")
     private val code: String? by option("--code", help = "inline Kotlin suspend body (alternative to --code-file)")
     private val taskId: String? by option("--task_id", help = "groups related calls in audit logs")
@@ -467,7 +467,6 @@ private class ExecuteCodeCliCommand(
     override fun run() {
         val options = options()
         if (options.help) { selectHelpTopic("execute_code"); return }
-        requireArg(projectName, "--project_name", "devrig list_projects")
         if (code.isNullOrBlank() && codeFile.isNullOrBlank()) {
             throw UsageError(
                 "missing code. Pass --code-file=<path> (preferred) or --code=\"...\". Example:\n" +
@@ -550,7 +549,7 @@ private class ScreenshotCliCommand(
     selected: SelectedDevrigCommand,
     parent: DevrigCliktCommand,
 ) : DevrigCliktCommand("take_screenshot", selected, parent) {
-    private val projectName: String? by option("--project_name", help = "routing key from `devrig list_projects`")
+    private val projectName: String? by option("--project_name", help = "routing key from `devrig list_projects`; omit to infer from the current directory")
     private val taskId: String? by option("--task_id", help = "groups related calls in audit logs")
     private val reason: String? by option("--reason", help = "full task description")
     private val windowId: String? by option("--window_id", help = "target window (from `devrig list_windows`)")
@@ -559,7 +558,6 @@ private class ScreenshotCliCommand(
     override fun run() {
         val options = options()
         if (options.help) { select(helpFor(options)); return }
-        requireArg(projectName, "--project_name", "devrig list_projects")
         requireArg(taskId, "--task_id", null)
         requireArg(reason, "--reason", null)
         select(DevrigCommand.DevrigCommandScreenshot(
@@ -574,7 +572,7 @@ private class InputCliCommand(
     selected: SelectedDevrigCommand,
     parent: DevrigCliktCommand,
 ) : DevrigCliktCommand("input", selected, parent) {
-    private val projectName: String? by option("--project_name", help = "routing key from `devrig list_projects`")
+    private val projectName: String? by option("--project_name", help = "routing key from `devrig list_projects`; omit to infer from the current directory")
     private val windowId: String? by option("--window_id", help = "target window (from `devrig list_windows`)")
     private val taskId: String? by option("--task_id", help = "groups related calls in audit logs")
     private val reason: String? by option("--reason", help = "full task description")
@@ -583,7 +581,6 @@ private class InputCliCommand(
     override fun run() {
         val options = options()
         if (options.help) { select(helpFor(options)); return }
-        requireArg(projectName, "--project_name", "devrig list_projects")
         requireArg(windowId, "--window_id", "devrig list_windows")
         requireArg(taskId, "--task_id", null)
         requireArg(reason, "--reason", null)
@@ -606,7 +603,7 @@ private class FeedbackCliCommand(
     selected: SelectedDevrigCommand,
     parent: DevrigCliktCommand,
 ) : DevrigCliktCommand("execute_feedback", selected, parent) {
-    private val projectName: String? by option("--project_name", help = "routing key from `devrig list_projects`")
+    private val projectName: String? by option("--project_name", help = "routing key from `devrig list_projects`; omit to infer from the current directory")
     private val taskId: String? by option("--task_id", help = "the same task_id used for the rated execution")
     // Accepted for parity with the steroid_execute_feedback MCP surface, which likewise documents
     // execution_id but does not forward it (FeedbackParams has no such field). Kept so an agent/script
@@ -623,7 +620,6 @@ private class FeedbackCliCommand(
     override fun run() {
         val options = options()
         if (options.help) { select(helpFor(options)); return }
-        requireArg(projectName, "--project_name", "devrig list_projects")
         requireArg(taskId, "--task_id", null)
         requireArg(explanation, "--explanation", null)
         val rating = successRating

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/Cli.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/Cli.kt
@@ -10,6 +10,8 @@ import com.github.ajalt.clikt.parameters.arguments.argument
 import com.github.ajalt.clikt.parameters.arguments.optional
 import com.github.ajalt.clikt.parameters.options.flag
 import com.github.ajalt.clikt.parameters.options.option
+import com.github.ajalt.clikt.parameters.types.double
+import com.github.ajalt.clikt.parameters.types.int
 import com.jonnyzzz.mcpSteroid.aiAgents.AiAgentCli
 
 const val NO_BACKENDS_DETECTED_MESSAGE: String = "No backends detected."
@@ -76,6 +78,88 @@ sealed interface DevrigCommand {
     data class DevrigCommandInstallDevrig(
         val installScript: String? = null,
         val jdkHome: String? = null,
+        override val debug: Boolean = false,
+        override val json: Boolean = false,
+    ) : DevrigCommand
+
+    // ---- MCP-as-CLI (epic #188): thin frontends over the existing bridge tool handlers ----
+
+    /** `devrig prompt <uri>` / `devrig fetch_resource --uri=...` — steroid_fetch_resource. */
+    data class DevrigCommandFetchResource(
+        val uri: String? = null,
+        val projectName: String? = null,
+        override val debug: Boolean = false,
+        override val json: Boolean = false,
+    ) : DevrigCommand
+
+    /** `devrig execute_code` — steroid_execute_code. Code comes from --code-file (preferred) or --code. */
+    data class DevrigCommandExecuteCode(
+        val projectName: String? = null,
+        val code: String? = null,
+        val codeFile: String? = null,
+        val taskId: String? = null,
+        val reason: String? = null,
+        val modal: String? = null,
+        val timeout: Int? = null,
+        override val debug: Boolean = false,
+        override val json: Boolean = false,
+    ) : DevrigCommand
+
+    /** `devrig list_projects` — steroid_list_projects (reconciled with `devrig project`). */
+    data class DevrigCommandListProjects(
+        override val debug: Boolean = false,
+        override val json: Boolean = false,
+    ) : DevrigCommand
+
+    /** `devrig list_windows` — steroid_list_windows. */
+    data class DevrigCommandListWindows(
+        override val debug: Boolean = false,
+        override val json: Boolean = false,
+    ) : DevrigCommand
+
+    /** `devrig open_project` — steroid_open_project. `--wait` polls until the project is ready. */
+    data class DevrigCommandOpenProject(
+        val projectPath: String? = null,
+        val taskId: String? = null,
+        val reason: String? = null,
+        val trustProject: Boolean = true,
+        val backendName: String? = null,
+        val wait: Boolean = false,
+        override val debug: Boolean = false,
+        override val json: Boolean = false,
+    ) : DevrigCommand
+
+    /** `devrig take_screenshot` — steroid_take_screenshot. `--out` writes the PNG to a file. */
+    data class DevrigCommandScreenshot(
+        val projectName: String? = null,
+        val taskId: String? = null,
+        val reason: String? = null,
+        val windowId: String? = null,
+        val out: String? = null,
+        override val debug: Boolean = false,
+        override val json: Boolean = false,
+    ) : DevrigCommand
+
+    /** `devrig input` — steroid_input. */
+    data class DevrigCommandInput(
+        val projectName: String? = null,
+        val windowId: String? = null,
+        val taskId: String? = null,
+        val reason: String? = null,
+        val sequence: String? = null,
+        override val debug: Boolean = false,
+        override val json: Boolean = false,
+    ) : DevrigCommand
+
+    /** `devrig execute_feedback` — steroid_execute_feedback. Optional code via --code-file / --code. */
+    data class DevrigCommandFeedback(
+        val projectName: String? = null,
+        val taskId: String? = null,
+        val executionId: String? = null,
+        val successRating: Double? = null,
+        val explanation: String? = null,
+        val code: String? = null,
+        val codeFile: String? = null,
         override val debug: Boolean = false,
         override val json: Boolean = false,
     ) : DevrigCommand
@@ -183,6 +267,16 @@ private class DevrigRootCommand(
             backend,
             ProjectCommand(selected, this),
             InstallCommand(selected, this),
+            // MCP-as-CLI (epic #188) — thin frontends over the existing bridge tool handlers.
+            PromptCliCommand(selected, this),
+            FetchResourceCliCommand(selected, this),
+            ExecuteCodeCliCommand(selected, this),
+            ListProjectsCliCommand(selected, this),
+            ListWindowsCliCommand(selected, this),
+            OpenProjectCliCommand(selected, this),
+            ScreenshotCliCommand(selected, this),
+            InputCliCommand(selected, this),
+            FeedbackCliCommand(selected, this),
             HelpCommand(selected, this),
             VersionCommand(selected, this),
         )
@@ -251,6 +345,238 @@ private class InstallCommand(
         select(DevrigCommand.DevrigCommandInstall(target, check = checkFlag, debug = options.debug, json = options.json))
     }
 }
+
+// ============================ MCP-as-CLI subcommands (epic #188) ============================
+//
+// Each command below only PARSES + VALIDATES into a DevrigCommand variant. The actual behavior is
+// dispatched by runCli(...) and reuses the existing bridge tool handlers — the CLI never
+// reimplements tool logic. Required args are validated here (not via clikt `.required()`) so the
+// error messages can carry agent-usable runnable examples.
+
+/** `devrig prompt <uri> [--project_name]` — ergonomic alias for fetch_resource. */
+private class PromptCliCommand(
+    selected: SelectedDevrigCommand,
+    parent: DevrigCliktCommand,
+) : DevrigCliktCommand("prompt", selected, parent) {
+    private val uri by argument("uri").optional()
+    private val projectName: String? by option("--project_name", help = "resolve IDE-specific content for this project (from `devrig list_projects`); omit for generic docs")
+
+    override fun run() {
+        val options = options()
+        if (!options.help && uri.isNullOrBlank()) {
+            throw UsageError("missing <uri>. Example:\n  ${fetchResourceUsageExample()}")
+        }
+        select(DevrigCommand.DevrigCommandFetchResource(
+            uri = uri, projectName = projectName, debug = options.debug, json = options.json,
+        ))
+    }
+}
+
+/** `devrig fetch_resource --uri=<uri> [--project_name]` — canonical steroid_fetch_resource. */
+private class FetchResourceCliCommand(
+    selected: SelectedDevrigCommand,
+    parent: DevrigCliktCommand,
+) : DevrigCliktCommand("fetch_resource", selected, parent) {
+    private val uri: String? by option("--uri", help = "the mcp-steroid:// resource URI to fetch")
+    private val projectName: String? by option("--project_name", help = "resolve IDE-specific content for this project (from `devrig list_projects`); omit for generic docs")
+
+    override fun run() {
+        val options = options()
+        if (!options.help && uri.isNullOrBlank()) {
+            throw UsageError("missing --uri. Example:\n  devrig fetch_resource --uri=${canonicalResourceEntryPointOrPlaceholder()}")
+        }
+        select(DevrigCommand.DevrigCommandFetchResource(
+            uri = uri, projectName = projectName, debug = options.debug, json = options.json,
+        ))
+    }
+}
+
+/** `devrig execute_code` — steroid_execute_code. */
+private class ExecuteCodeCliCommand(
+    selected: SelectedDevrigCommand,
+    parent: DevrigCliktCommand,
+) : DevrigCliktCommand("execute_code", selected, parent) {
+    private val projectName: String? by option("--project_name", help = "routing key from `devrig list_projects`")
+    private val codeFile: String? by option("--code-file", help = "path to a Kotlin script file (preferred)")
+    private val code: String? by option("--code", help = "inline Kotlin suspend body (alternative to --code-file)")
+    private val taskId: String? by option("--task_id", help = "groups related calls in audit logs")
+    private val reason: String? by option("--reason", help = "full task description")
+    private val modal: String? by option("--modal", help = "smart_non_modal (default) | non_modal | unleashed")
+    private val timeout: Int? by option("--timeout", help = "script timeout in seconds (default 600)").int()
+
+    override fun run() {
+        val options = options()
+        if (options.help) { select(helpFor(options)); return }
+        requireArg(projectName, "--project_name", "devrig list_projects")
+        if (code.isNullOrBlank() && codeFile.isNullOrBlank()) {
+            throw UsageError(
+                "missing code. Pass --code-file=<path> (preferred) or --code=\"...\". Example:\n" +
+                    "  devrig execute_code --project_name=\"<key>\" --code-file=repro.kts --task_id=t1 --reason=\"reproduce issue\""
+            )
+        }
+        if (!code.isNullOrBlank() && !codeFile.isNullOrBlank()) {
+            throw UsageError("pass only one of --code / --code-file, not both")
+        }
+        requireArg(taskId, "--task_id", null)
+        requireArg(reason, "--reason", null)
+        select(DevrigCommand.DevrigCommandExecuteCode(
+            projectName = projectName, code = code, codeFile = codeFile, taskId = taskId,
+            reason = reason, modal = modal, timeout = timeout, debug = options.debug, json = options.json,
+        ))
+    }
+}
+
+/** `devrig list_projects [--json]` — steroid_list_projects (shares the `devrig project` render path). */
+private class ListProjectsCliCommand(
+    selected: SelectedDevrigCommand,
+    parent: DevrigCliktCommand,
+) : DevrigCliktCommand("list_projects", selected, parent) {
+    override fun run() {
+        val options = options()
+        select(DevrigCommand.DevrigCommandListProjects(debug = options.debug, json = options.json))
+    }
+}
+
+/** `devrig list_windows [--json]` — steroid_list_windows. */
+private class ListWindowsCliCommand(
+    selected: SelectedDevrigCommand,
+    parent: DevrigCliktCommand,
+) : DevrigCliktCommand("list_windows", selected, parent) {
+    override fun run() {
+        val options = options()
+        select(DevrigCommand.DevrigCommandListWindows(debug = options.debug, json = options.json))
+    }
+}
+
+/** `devrig open_project --project_path=... [--wait]` — steroid_open_project. */
+private class OpenProjectCliCommand(
+    selected: SelectedDevrigCommand,
+    parent: DevrigCliktCommand,
+) : DevrigCliktCommand("open_project", selected, parent) {
+    private val projectPath: String? by option("--project_path", help = "absolute path to the project directory")
+    private val taskId: String? by option("--task_id", help = "groups related calls in audit logs")
+    private val reason: String? by option("--reason", help = "full task description")
+    private val trustProject by option("--trust_project", help = "trust the project (skip trust dialog); default true").flag(default = true)
+    private val backendName: String? by option("--backend_name", help = "target backend when several IDEs are running (from `devrig backend --json`)")
+    private val wait by option("--wait", help = "poll until the project is initialized (no modal, indexing done)").flag()
+
+    override fun run() {
+        val options = options()
+        if (options.help) { select(helpFor(options)); return }
+        requireArg(projectPath, "--project_path", null)
+        requireArg(taskId, "--task_id", null)
+        requireArg(reason, "--reason", null)
+        select(DevrigCommand.DevrigCommandOpenProject(
+            projectPath = projectPath, taskId = taskId, reason = reason, trustProject = trustProject,
+            backendName = backendName, wait = wait, debug = options.debug, json = options.json,
+        ))
+    }
+}
+
+/** `devrig take_screenshot --project_name=... [--out=file.png]` — steroid_take_screenshot. */
+private class ScreenshotCliCommand(
+    selected: SelectedDevrigCommand,
+    parent: DevrigCliktCommand,
+) : DevrigCliktCommand("take_screenshot", selected, parent) {
+    private val projectName: String? by option("--project_name", help = "routing key from `devrig list_projects`")
+    private val taskId: String? by option("--task_id", help = "groups related calls in audit logs")
+    private val reason: String? by option("--reason", help = "full task description")
+    private val windowId: String? by option("--window_id", help = "target window (from `devrig list_windows`)")
+    private val out: String? by option("--out", help = "write the PNG to this file path")
+
+    override fun run() {
+        val options = options()
+        if (options.help) { select(helpFor(options)); return }
+        requireArg(projectName, "--project_name", "devrig list_projects")
+        requireArg(taskId, "--task_id", null)
+        requireArg(reason, "--reason", null)
+        select(DevrigCommand.DevrigCommandScreenshot(
+            projectName = projectName, taskId = taskId, reason = reason, windowId = windowId,
+            out = out, debug = options.debug, json = options.json,
+        ))
+    }
+}
+
+/** `devrig input --project_name=... --window_id=... --sequence=...` — steroid_input. */
+private class InputCliCommand(
+    selected: SelectedDevrigCommand,
+    parent: DevrigCliktCommand,
+) : DevrigCliktCommand("input", selected, parent) {
+    private val projectName: String? by option("--project_name", help = "routing key from `devrig list_projects`")
+    private val windowId: String? by option("--window_id", help = "target window (from `devrig list_windows`)")
+    private val taskId: String? by option("--task_id", help = "groups related calls in audit logs")
+    private val reason: String? by option("--reason", help = "full task description")
+    private val sequence: String? by option("--sequence", help = "input steps, e.g. \"press:CTRL+P, type:Main, delay:200, press:ENTER\"")
+
+    override fun run() {
+        val options = options()
+        if (options.help) { select(helpFor(options)); return }
+        requireArg(projectName, "--project_name", "devrig list_projects")
+        requireArg(windowId, "--window_id", "devrig list_windows")
+        requireArg(taskId, "--task_id", null)
+        requireArg(reason, "--reason", null)
+        if (sequence.isNullOrBlank()) {
+            throw UsageError(
+                "missing --sequence. Example:\n" +
+                    "  devrig input --project_name=\"<key>\" --window_id=\"<win>\" --task_id=t1 --reason=\"...\" \\\n" +
+                    "    --sequence=\"press:CTRL+P, type:Main, delay:200, press:ENTER\""
+            )
+        }
+        select(DevrigCommand.DevrigCommandInput(
+            projectName = projectName, windowId = windowId, taskId = taskId, reason = reason,
+            sequence = sequence, debug = options.debug, json = options.json,
+        ))
+    }
+}
+
+/** `devrig execute_feedback --project_name=... --task_id=... --success_rating=... --explanation=...` */
+private class FeedbackCliCommand(
+    selected: SelectedDevrigCommand,
+    parent: DevrigCliktCommand,
+) : DevrigCliktCommand("execute_feedback", selected, parent) {
+    private val projectName: String? by option("--project_name", help = "routing key from `devrig list_projects`")
+    private val taskId: String? by option("--task_id", help = "the same task_id used for the rated execution")
+    private val executionId: String? by option("--execution_id", help = "execution_id from the rated execute_code result")
+    private val successRating: Double? by option("--success_rating", help = "0.00 (failure) .. 1.00 (success)").double()
+    private val explanation: String? by option("--explanation", help = "what worked, what didn't, what you'll try next")
+    private val codeFile: String? by option("--code-file", help = "optional illustrative snippet file")
+    private val code: String? by option("--code", help = "optional illustrative snippet (inline)")
+
+    override fun run() {
+        val options = options()
+        if (options.help) { select(helpFor(options)); return }
+        requireArg(projectName, "--project_name", "devrig list_projects")
+        requireArg(taskId, "--task_id", null)
+        requireArg(explanation, "--explanation", null)
+        val rating = successRating
+            ?: throw UsageError("missing --success_rating (number 0.00..1.00). Example:\n" +
+                "  devrig execute_feedback --project_name=\"<key>\" --task_id=t1 --success_rating=0.9 --explanation=\"...\"")
+        if (rating !in 0.0..1.0) {
+            throw UsageError("--success_rating=$rating is out of range (must be 0.00..1.00)")
+        }
+        if (!code.isNullOrBlank() && !codeFile.isNullOrBlank()) {
+            throw UsageError("pass only one of --code / --code-file, not both")
+        }
+        select(DevrigCommand.DevrigCommandFeedback(
+            projectName = projectName, taskId = taskId, executionId = executionId,
+            successRating = rating, explanation = explanation, code = code, codeFile = codeFile,
+            debug = options.debug, json = options.json,
+        ))
+    }
+}
+
+/**
+ * Throws an agent-usable [UsageError] when [value] is null/blank. [nextStep] names the command to
+ * run to obtain the value (e.g. `devrig list_projects`) so the error points the agent forward.
+ */
+private fun requireArg(value: String?, flag: String, nextStep: String?) {
+    if (!value.isNullOrBlank()) return
+    val hint = nextStep?.let { " (get it from `$it`)" } ?: ""
+    throw UsageError("missing required $flag$hint")
+}
+
+private fun helpFor(options: GenericOptions): DevrigCommand =
+    DevrigCommand.DevrigCommandHelp(debug = options.debug, json = options.json)
 
 private class HelpCommand(
     selected: SelectedDevrigCommand,
@@ -360,6 +686,18 @@ fun DevrigServices.runCli(command: DevrigCommand): Int {
             is DevrigCommand.DevrigCommandProject -> runProjectCommand(command)
             is DevrigCommand.DevrigCommandInstall -> runInstallCommand(command)
             is DevrigCommand.DevrigCommandInstallDevrig -> runInstallDevrigCommand(command)
+            // MCP-as-CLI (epic #188)
+            is DevrigCommand.DevrigCommandFetchResource -> runFetchResourceCommand(command)
+            is DevrigCommand.DevrigCommandExecuteCode -> runExecuteCodeCommand(command)
+            is DevrigCommand.DevrigCommandListProjects -> runProjectCommand(
+                // list_projects shares the project render path; project_name is exposed in both.
+                DevrigCommand.DevrigCommandProject(debug = command.debug, json = command.json),
+            )
+            is DevrigCommand.DevrigCommandListWindows -> runListWindowsCommand(command)
+            is DevrigCommand.DevrigCommandOpenProject -> runOpenProjectCommand(command)
+            is DevrigCommand.DevrigCommandScreenshot -> runScreenshotCommand(command)
+            is DevrigCommand.DevrigCommandInput -> runInputCommand(command)
+            is DevrigCommand.DevrigCommandFeedback -> runFeedbackCommand(command)
         }
     } catch (e: ManagedBackendLockException) {
         System.err.println(e.message)

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/Cli.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/Cli.kt
@@ -88,6 +88,8 @@ sealed interface DevrigCommand {
     data class DevrigCommandFetchResource(
         val uri: String? = null,
         val projectName: String? = null,
+        /** The alias the user typed ("prompt" or "fetch_resource"); echoed into the `--json` envelope. */
+        val commandName: String = "fetch_resource",
         override val debug: Boolean = false,
         override val json: Boolean = false,
     ) : DevrigCommand
@@ -177,7 +179,12 @@ sealed interface DevrigCommand {
     ) : DevrigCommand
 
     data class DevrigCommandParseError(
+        /** Full formatted help/usage text (printed to stderr in the human, non-`--json` path). */
         val text: String,
+        /** Concise one-line message (used as the `--json` error-envelope payload). */
+        val message: String = text,
+        /** Best-effort subcommand name (first non-flag token) echoed into the `--json` envelope. */
+        val commandName: String = "devrig",
         override val debug: Boolean = false,
         override val json: Boolean = false,
     ) : DevrigCommand
@@ -190,7 +197,22 @@ fun parseDevrigCommand(rawArgs: Array<String>): DevrigCommand {
         root.parse(rawArgs)
         selected.command ?: DevrigCommand.DevrigCommandHelp()
     } catch (e: CliktError) {
-        DevrigCommand.DevrigCommandParseError(root.getFormattedHelp(e) ?: e.message ?: "Invalid arguments")
+        // The exception aborts parsing before the `--json`/command flags are captured on a variant, so
+        // recover both directly from the raw tokens to keep the `--json` error envelope contract intact.
+        val formatted = root.getFormattedHelp(e)
+        // Our own UsageErrors carry a concise `message`; clikt-internal errors (e.g. NoSuchOption) leave it
+        // blank and only put the specifics in the formatted help ("Error: no such option --nope") — lift
+        // that line so the `--json` envelope isn't a useless "Invalid arguments".
+        val message = e.message?.takeIf { it.isNotBlank() }
+            ?: formatted?.lineSequence()?.map { it.trim() }
+                ?.firstOrNull { it.startsWith("Error:") }?.removePrefix("Error:")?.trim()
+            ?: "Invalid arguments"
+        DevrigCommand.DevrigCommandParseError(
+            text = formatted ?: message,
+            message = message,
+            commandName = rawArgs.firstOrNull { !it.startsWith("-") } ?: "devrig",
+            json = rawArgs.any { it == "--json" },
+        )
     }
 }
 
@@ -375,7 +397,8 @@ private class PromptCliCommand(
             throw UsageError("missing <uri>. Example:\n  ${fetchResourceUsageExample()}")
         }
         select(DevrigCommand.DevrigCommandFetchResource(
-            uri = uri, projectName = projectName, debug = options.debug, json = options.json,
+            uri = uri, projectName = projectName, commandName = "prompt",
+            debug = options.debug, json = options.json,
         ))
     }
 }
@@ -394,7 +417,8 @@ private class FetchResourceCliCommand(
             throw UsageError("missing --uri. Example:\n  devrig fetch_resource --uri=${canonicalResourceEntryPointOrPlaceholder()}")
         }
         select(DevrigCommand.DevrigCommandFetchResource(
-            uri = uri, projectName = projectName, debug = options.debug, json = options.json,
+            uri = uri, projectName = projectName, commandName = "fetch_resource",
+            debug = options.debug, json = options.json,
         ))
     }
 }
@@ -425,6 +449,9 @@ private class ExecuteCodeCliCommand(
         if (!code.isNullOrBlank() && !codeFile.isNullOrBlank()) {
             throw UsageError("pass only one of --code / --code-file, not both")
         }
+        // Reject a non-positive timeout up front: dispatching with 0/-1 would start the script and then
+        // immediately fail with "timed out after 0 seconds" (Codex Round-4 finding).
+        timeout?.let { if (it <= 0) throw UsageError("--timeout must be a positive number of seconds (got $it)") }
         requireArg(taskId, "--task_id", null)
         requireArg(reason, "--reason", null)
         select(DevrigCommand.DevrigCommandExecuteCode(
@@ -685,8 +712,14 @@ fun DevrigServices.runCli(command: DevrigCommand): Int {
             is DevrigCommand.DevrigCommandHelp -> printTopicHelp(command.topic, mcpStdout)
             is DevrigCommand.DevrigCommandVersion -> printVersion(mcpStdout)
             is DevrigCommand.DevrigCommandParseError -> {
-                System.err.println(command.text)
-                64
+                // `--json` consumers must be able to parse usage/parse failures too — emit the unified
+                // isError envelope; otherwise print the full formatted help to stderr. Exit stays 64.
+                if (command.json) {
+                    renderCliError(command.commandName, command.message, json = true, exit = CliExit.USAGE, out = mcpStdout)
+                } else {
+                    System.err.println(command.text)
+                    CliExit.USAGE
+                }
             }
             is DevrigCommand.DevrigCommandBackend -> runBackendCommand(command)
             is DevrigCommand.DevrigCommandBackendDownload -> runBackendDownloadCommand(command)

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/Cli.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/Cli.kt
@@ -689,10 +689,7 @@ fun DevrigServices.runCli(command: DevrigCommand): Int {
             // MCP-as-CLI (epic #188)
             is DevrigCommand.DevrigCommandFetchResource -> runFetchResourceCommand(command)
             is DevrigCommand.DevrigCommandExecuteCode -> runExecuteCodeCommand(command)
-            is DevrigCommand.DevrigCommandListProjects -> runProjectCommand(
-                // list_projects shares the project render path; project_name is exposed in both.
-                DevrigCommand.DevrigCommandProject(debug = command.debug, json = command.json),
-            )
+            is DevrigCommand.DevrigCommandListProjects -> runListProjectsCommand(command)
             is DevrigCommand.DevrigCommandListWindows -> runListWindowsCommand(command)
             is DevrigCommand.DevrigCommandOpenProject -> runOpenProjectCommand(command)
             is DevrigCommand.DevrigCommandScreenshot -> runScreenshotCommand(command)

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/Cli.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/Cli.kt
@@ -165,6 +165,8 @@ sealed interface DevrigCommand {
     ) : DevrigCommand
 
     data class DevrigCommandHelp(
+        /** Optional per-command topic (e.g. "execute_code") for layered help; null = the global banner. */
+        val topic: String? = null,
         override val debug: Boolean = false,
         override val json: Boolean = false,
     ) : DevrigCommand
@@ -243,6 +245,12 @@ private abstract class DevrigCliktCommand(
         } else {
             command
         }
+    }
+
+    /** Select layered help for a specific [topic] (bypasses the generic --help→global-banner rule). */
+    protected fun selectHelpTopic(topic: String?) {
+        val options = options()
+        selected.command = DevrigCommand.DevrigCommandHelp(topic = topic, debug = options.debug, json = options.json)
     }
 }
 
@@ -406,7 +414,7 @@ private class ExecuteCodeCliCommand(
 
     override fun run() {
         val options = options()
-        if (options.help) { select(helpFor(options)); return }
+        if (options.help) { selectHelpTopic("execute_code"); return }
         requireArg(projectName, "--project_name", "devrig list_projects")
         if (code.isNullOrBlank() && codeFile.isNullOrBlank()) {
             throw UsageError(
@@ -582,9 +590,11 @@ private class HelpCommand(
     selected: SelectedDevrigCommand,
     parent: DevrigCliktCommand,
 ) : DevrigCliktCommand("help", selected, parent) {
+    // `devrig help` → global banner; `devrig help <topic>` (e.g. execute_code) → layered per-command help.
+    private val topic by argument("topic").optional()
+
     override fun run() {
-        val options = options()
-        select(DevrigCommand.DevrigCommandHelp(debug = options.debug, json = options.json))
+        selectHelpTopic(topic)
     }
 }
 
@@ -672,7 +682,7 @@ fun DevrigServices.runCli(command: DevrigCommand): Int {
     return try {
         when (command) {
             is DevrigCommand.MCP -> error("runCli called with DevrigCommand.MCP")
-            is DevrigCommand.DevrigCommandHelp -> printHelp(mcpStdout)
+            is DevrigCommand.DevrigCommandHelp -> printTopicHelp(command.topic, mcpStdout)
             is DevrigCommand.DevrigCommandVersion -> printVersion(mcpStdout)
             is DevrigCommand.DevrigCommandParseError -> {
                 System.err.println(command.text)

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/CliToolSupport.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/CliToolSupport.kt
@@ -2,10 +2,12 @@
 package com.jonnyzzz.mcpSteroid.devrig
 
 import com.jonnyzzz.mcpSteroid.mcp.ContentItem
+import com.jonnyzzz.mcpSteroid.mcp.McpJson
 import com.jonnyzzz.mcpSteroid.mcp.ToolCallResult
 import com.jonnyzzz.mcpSteroid.server.McpProgressReporter
 import java.io.PrintStream
 import java.util.Base64
+import kotlinx.serialization.builtins.ListSerializer
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.buildJsonObject
@@ -197,40 +199,24 @@ fun cliEnvelopeJson(command: String, isError: Boolean, data: JsonObject): String
     return CLI_ENVELOPE_JSON.encodeToString(JsonObject.serializer(), payload)
 }
 
-/** Envelope for a [ToolCallResult]: `data:{content:[...]}`, with images summarized to prevent bloat. */
+/** Envelope for a [ToolCallResult]: `data:{content:[...]}`, native [ContentItem] serialization. */
 fun ToolCallResult.toEnvelopeJson(command: String): String =
     cliEnvelopeJson(command, isError, contentDataJson())
 
 /**
  * Builds the `data:{content:[...]}` object for a [ToolCallResult] — the same payload
  * [toEnvelopeJson] wraps, but exposed so a command can merge command-specific keys alongside it.
+ *
+ * `content` is [ContentItem]'s own `@Serializable` shape, encoded via [McpJson] (the same
+ * `classDiscriminator = "type"` config the wire protocol uses) — not a hand-built second copy.
+ * Image items therefore carry `data` (base64) as-is, and resource items serialize to their native
+ * `{type:"resource","resource":{...}}` shape (C6, C7).
  */
 fun ToolCallResult.contentDataJson(): JsonObject = buildJsonObject {
-    putJsonArray("content") {
-        for (item in content) {
-            add(buildJsonObject {
-                when (item) {
-                    is ContentItem.Text -> {
-                        put("type", "text")
-                        put("text", item.text)
-                    }
-                    is ContentItem.Image -> {
-                        put("type", "image")
-                        put("mimeType", item.mimeType)
-                        put("bytes", item.decodedByteCount())
-                    }
-                    is ContentItem.Resource -> {
-                        put("type", "resource")
-                        put("uri", item.resource.uri)
-                        item.resource.mimeType?.let { put("mimeType", it) }
-                        item.resource.text?.let { put("text", it) }
-                    }
-                }
-            })
-        }
-    }
+    put("content", McpJson.encodeToJsonElement(ListSerializer(ContentItem.serializer()), content))
 }
 
+/** Used only by the human-readable console renderer ([renderTo]); the `--json` envelope carries `data` as-is. */
 private fun ContentItem.Image.decodedByteCount(): Int =
     try {
         Base64.getDecoder().decode(data).size

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/CliToolSupport.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/CliToolSupport.kt
@@ -1,0 +1,137 @@
+/* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
+package com.jonnyzzz.mcpSteroid.devrig
+
+import com.jonnyzzz.mcpSteroid.mcp.ContentItem
+import com.jonnyzzz.mcpSteroid.mcp.ToolCallResult
+import com.jonnyzzz.mcpSteroid.server.McpProgressReporter
+import java.io.PrintStream
+import java.util.Base64
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.add
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import kotlinx.serialization.json.putJsonArray
+
+/**
+ * Shared support for `devrig` subcommands that are thin frontends over an existing MCP tool.
+ *
+ * This is deliberately a small helper set, NOT a "CLI-from-MCP-schema" generator: it factors out
+ * only the parts every tool-backed command repeats — rendering a [ToolCallResult] to stdout/stderr,
+ * a stable `--json` envelope, meaningful exit codes, and progress plumbing. The tool behavior itself
+ * always lives behind the existing bridge handlers (single source of truth); the CLI never
+ * reimplements it.
+ */
+
+/** Meaningful, stable process exit codes shared by all tool-backed commands. */
+object CliExit {
+    /** Success. */
+    const val OK: Int = 0
+
+    /**
+     * The tool call reached its target but the tool itself reported `isError` (e.g. a script threw,
+     * a resource was missing). Distinct from a usage/infra failure so scripts can tell them apart.
+     */
+    const val TOOL_ERROR: Int = 1
+
+    /** Bad invocation the user can fix: missing/blank required args, unknown project_name, bad file. */
+    const val USAGE: Int = 64
+
+    /** The command could not reach a backend / the bridge failed (no IDE running, connection refused). */
+    const val UNAVAILABLE: Int = 69
+}
+
+/** A [McpProgressReporter] that streams progress to stderr so stdout stays clean for data. */
+fun stderrProgressReporter(err: PrintStream = System.err): McpProgressReporter =
+    object : McpProgressReporter {
+        override fun report(message: String) {
+            err.println(message)
+        }
+    }
+
+/**
+ * Renders a [ToolCallResult] for a CLI command and returns the process exit code.
+ *
+ * Contract (locked by tests, matches the rest of devrig):
+ *  - Non-error text content → **stdout** (so `| jq`, `| less` work).
+ *  - Error content (`isError == true`) → **stderr**; stdout stays empty.
+ *  - `--json` emits a single stable envelope on stdout regardless of success/failure.
+ *
+ * @param command the CLI subcommand name, echoed into the JSON envelope for context.
+ */
+fun ToolCallResult.renderTo(
+    command: String,
+    json: Boolean,
+    out: PrintStream,
+    err: PrintStream = System.err,
+): Int {
+    if (json) {
+        out.println(toEnvelopeJson(command))
+        return if (isError) CliExit.TOOL_ERROR else CliExit.OK
+    }
+
+    val sink = if (isError) err else out
+    for (item in content) {
+        when (item) {
+            is ContentItem.Text -> sink.println(item.text)
+            is ContentItem.Image -> sink.println("[image: ${item.mimeType}, ${item.decodedByteCount()} bytes]")
+            is ContentItem.Resource -> {
+                val res = item.resource
+                sink.println("[resource: ${res.uri}${res.mimeType?.let { " ($it)" } ?: ""}]")
+                res.text?.let { sink.println(it) }
+            }
+        }
+    }
+    return if (isError) CliExit.TOOL_ERROR else CliExit.OK
+}
+
+/**
+ * Stable machine-readable envelope for a tool-backed command's result. Kept intentionally simple
+ * (no MCP-schema echo): `tool` identity, the `command`, the `isError` flag, and the `content` items.
+ * Image blobs are summarized (mimeType + byte count) rather than inlined so stdout stays usable.
+ */
+fun ToolCallResult.toEnvelopeJson(command: String): String {
+    val payload = buildJsonObject {
+        put("tool", buildJsonObject {
+            put("name", "devrig")
+            put("version", DevrigVersionMetadata.getDevrigVersion())
+        })
+        put("command", command)
+        put("isError", isError)
+        putJsonArray("content") {
+            for (item in content) {
+                add(buildJsonObject {
+                    when (item) {
+                        is ContentItem.Text -> {
+                            put("type", "text")
+                            put("text", item.text)
+                        }
+                        is ContentItem.Image -> {
+                            put("type", "image")
+                            put("mimeType", item.mimeType)
+                            put("bytes", item.decodedByteCount())
+                        }
+                        is ContentItem.Resource -> {
+                            put("type", "resource")
+                            put("uri", item.resource.uri)
+                            item.resource.mimeType?.let { put("mimeType", it) }
+                            item.resource.text?.let { put("text", it) }
+                        }
+                    }
+                })
+            }
+        }
+    }
+    return ENVELOPE_JSON.encodeToString(JsonObject.serializer(), payload)
+}
+
+private val ENVELOPE_JSON = Json { prettyPrint = true; encodeDefaults = true; explicitNulls = false }
+
+private fun ContentItem.Image.decodedByteCount(): Int =
+    try {
+        Base64.getDecoder().decode(data).size
+    } catch (e: IllegalArgumentException) {
+        // Not valid base64 — report the raw length rather than failing the whole render.
+        System.err.println("devrig: image payload was not valid base64 (${e.message}); reporting raw length")
+        data.length
+    }

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/CliToolSupport.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/CliToolSupport.kt
@@ -9,10 +9,10 @@ import java.io.PrintStream
 import java.nio.file.Files
 import java.nio.file.Path
 import java.util.Base64
-import kotlinx.serialization.builtins.ListSerializer
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.put
 import kotlinx.serialization.json.putJsonArray
 
@@ -26,39 +26,24 @@ import kotlinx.serialization.json.putJsonArray
  * reimplements it.
  */
 
-/** Meaningful, stable process exit codes shared by all tool-backed commands. */
+/** Stable process exit codes shared by tool-backed commands. */
 object CliExit {
     /** Success. */
     const val OK: Int = 0
 
-    /**
-     * The tool call reached its target but the tool itself reported `isError` (e.g. a script threw,
-     * a resource was missing). Distinct from a usage/infra failure so scripts can tell them apart.
-     */
+    /** The backend returned a [ToolCallResult] with `isError=true`. */
     const val TOOL_ERROR: Int = 1
 
     /** Bad invocation the user can fix: missing/blank required args, unknown project_name, malformed path. */
     const val USAGE: Int = 64
 
-    /**
-     * The command reached its target but the data it produced/received was unusable — e.g. the bridge
-     * returned a screenshot result with no image payload, or an image whose base64 could not be decoded.
-     * Distinct from [USAGE] (a fixable-input mistake) and [UNAVAILABLE] (could not reach a backend), so a
-     * `--json` consumer can tell "your fault" from "no IDE" from "bad data from the IDE".
-     * Value follows BSD sysexits `EX_DATAERR`.
-     */
+    /** The backend returned unusable data, such as an invalid image payload. */
     const val DATA_ERROR: Int = 65
 
     /** The command could not reach a backend / the bridge failed (no IDE running, connection refused). */
     const val UNAVAILABLE: Int = 69
 
-    /**
-     * A genuine filesystem I/O failure the invocation cannot fix by changing an argument — a readable
-     * `--code-file` path that fails mid-read, or an `--out` target that exists as a path string but
-     * cannot be written (a directory, a permission denial). Kept distinct from [USAGE] so a malformed
-     * *path string* (fixable) is not conflated with a real write/read failure. Value follows BSD
-     * sysexits `EX_IOERR`.
-     */
+    /** A filesystem read/write failure. */
     const val IO_ERROR: Int = 74
 }
 
@@ -88,20 +73,7 @@ fun stderrProgressReporter(err: PrintStream = System.err): McpProgressReporter =
         }
     }
 
-/**
- * Renders CLI output for a command as either a `--json` envelope or human-readable console text — the
- * single fork point for that choice. Each implementation owns its own branch body in full (Tenet: no
- * `if (json)` scattered through shared render code); [presentationFor] is the only place that maps the
- * `--json` flag onto a concrete implementation.
- *
- * Contract (locked by tests, matches the rest of devrig):
- *  - [Console]: non-error text content → **stdout** (so `| jq`, `| less` work); error content
- *    (`isError == true`) → **stderr**, stdout stays empty.
- *  - [Json]: a single stable envelope on stdout regardless of success/failure.
- *
- * [Console.imageDir] is a provider (not a value) so each render can resolve a fresh, possibly
- * lazily-created temp directory (C4) — production wires it to [HomePaths.screenshotTmpDir].
- */
+/** Renders tool results as either a JSON envelope or human-readable console output. */
 sealed interface Presentation {
     /** Renders a [ToolCallResult] for [command] and returns the process exit code. */
     fun render(result: ToolCallResult, command: String, out: PrintStream, err: PrintStream = System.err): Int
@@ -112,7 +84,7 @@ sealed interface Presentation {
     /** Renders a successful `take_screenshot` whose image was additionally saved to [savedOut]. */
     fun renderScreenshotSaved(result: ToolCallResult, savedOut: String, out: PrintStream): Int
 
-    /** `--json`: a single stable envelope on stdout, built from [toEnvelopeJson] / [cliEnvelopeJson]. */
+    /** `--json`: one stable envelope on stdout. */
     class Json : Presentation {
         override fun render(result: ToolCallResult, command: String, out: PrintStream, err: PrintStream): Int {
             out.println(result.toEnvelopeJson(command))
@@ -142,12 +114,7 @@ sealed interface Presentation {
         }
     }
 
-    /**
-     * Human-readable console text. Image content (C4) is decoded and written to a file under
-     * [imageDir] — a provider (not a value) so each render resolves a fresh, possibly lazily-created,
-     * temp directory (production wires it to [HomePaths.screenshotTmpDir]) — and the file's absolute
-     * path is printed instead of a byte-count placeholder.
-     */
+    /** Human-readable output; image payloads are materialized under [imageDir]. */
     class Console(private val imageDir: () -> Path) : Presentation {
         override fun render(result: ToolCallResult, command: String, out: PrintStream, err: PrintStream): Int {
             val sink = if (result.isError) err else out
@@ -165,11 +132,6 @@ sealed interface Presentation {
             return if (result.isError) CliExit.TOOL_ERROR else CliExit.OK
         }
 
-        /**
-         * Decodes [item]'s base64 payload and writes it to `<imageDir>/image-<index>.<ext>`, printing the
-         * absolute path to [sink]. Undecodable base64 is logged to stderr (never silently swallowed) and
-         * reported as a clear, non-crashing console line — the render must still complete.
-         */
         private fun renderImage(item: ContentItem.Image, index: Int, sink: PrintStream) {
             val decoded = try {
                 Base64.getDecoder().decode(item.data)
@@ -182,7 +144,7 @@ sealed interface Presentation {
                 return
             }
             val ext = item.mimeType.substringAfterLast('/', "png")
-            val file = imageDir().resolve("image-$index.$ext")
+            val file = Files.createTempFile(imageDir(), "image-$index-", ".$ext")
             Files.write(file, decoded)
             sink.println("Saved image: ${file.toAbsolutePath()}")
         }
@@ -193,9 +155,6 @@ sealed interface Presentation {
         }
 
         override fun renderScreenshotSaved(result: ToolCallResult, savedOut: String, out: PrintStream): Int {
-            // The image was ALREADY written to the explicit --out path by the caller; strip image items
-            // before re-rendering so [renderImage] does not redundantly re-materialize a `<tmpDir>/image-*`
-            // file and print a spurious "Saved image:" line ahead of the "Saved --out:" note.
             val nonImage = result.content.filterNot { it is ContentItem.Image }
             val withNote = ToolCallResult(content = nonImage + ContentItem.Text("Saved --out: $savedOut"))
             return render(withNote, command = "take_screenshot", out = out)
@@ -206,28 +165,6 @@ sealed interface Presentation {
 /** Maps the `--json` flag onto a concrete [Presentation]; the only place the boolean is branched on. */
 fun presentationFor(json: Boolean, imageDir: () -> Path): Presentation =
     if (json) Presentation.Json() else Presentation.Console(imageDir)
-
-/**
- * Fallback [Presentation.Console] image-dir provider for callers with no [DevrigServices] in scope
- * (tests only — no production call site uses the shim below). Resolves the JVM temp dir, never the
- * real `user.home`, so an image-bearing [ToolCallResult] rendered through the shim cannot write into the
- * user's actual home directory.
- */
-private val defaultImageDir: () -> Path = { Path.of(System.getProperty("java.io.tmpdir")) }
-
-/**
- * Renders a [ToolCallResult] for a CLI command and returns the process exit code. Thin shim over
- * [presentationFor] kept for call sites/tests that don't have a [DevrigServices] receiver in scope; new
- * production call sites should build a [Presentation] once per command instead (see [ToolBackedCommands]).
- *
- * @param command the CLI subcommand name, echoed into the JSON envelope for context.
- */
-fun ToolCallResult.renderTo(
-    command: String,
-    json: Boolean,
-    out: PrintStream,
-    err: PrintStream = System.err,
-): Int = presentationFor(json, defaultImageDir).render(this, command, out, err)
 
 /**
  * The unified JSON envelope for all `devrig` CLI commands, shared across tool-backed subcommands.
@@ -255,19 +192,12 @@ fun cliEnvelopeJson(command: String, isError: Boolean, data: JsonObject): String
     return CLI_ENVELOPE_JSON.encodeToString(JsonObject.serializer(), payload)
 }
 
-/** Envelope for a [ToolCallResult]: `data:{content:[...]}`, native [ContentItem] serialization. */
+/** Envelope for a [ToolCallResult]: `data:{content:[...]}`. */
 fun ToolCallResult.toEnvelopeJson(command: String): String =
     cliEnvelopeJson(command, isError, contentDataJson())
 
-/**
- * Builds the `data:{content:[...]}` object for a [ToolCallResult] — the same payload
- * [toEnvelopeJson] wraps, but exposed so a command can merge command-specific keys alongside it.
- *
- * `content` is [ContentItem]'s own `@Serializable` shape, encoded via [McpJson] (the same
- * `classDiscriminator = "type"` config the wire protocol uses) — not a hand-built second copy.
- * Image items therefore carry `data` (base64) as-is, and resource items serialize to their native
- * `{type:"resource","resource":{...}}` shape (C6, C7).
- */
+/** Extracts native serialized `content` for command-specific envelopes. */
 fun ToolCallResult.contentDataJson(): JsonObject = buildJsonObject {
-    put("content", McpJson.encodeToJsonElement(ListSerializer(ContentItem.serializer()), content))
+    val native = McpJson.encodeToJsonElement(ToolCallResult.serializer(), this@contentDataJson).jsonObject
+    put("content", native.getValue("content"))
 }

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/CliToolSupport.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/CliToolSupport.kt
@@ -209,8 +209,8 @@ fun presentationFor(json: Boolean, imageDir: () -> Path): Presentation =
 
 /**
  * Fallback [Presentation.Console] image-dir provider for callers with no [DevrigServices] in scope
- * (tests only — no production call site uses the shims below). Resolves the JVM temp dir, never the
- * real `user.home`, so an image-bearing [ToolCallResult] rendered through a shim cannot write into the
+ * (tests only — no production call site uses the shim below). Resolves the JVM temp dir, never the
+ * real `user.home`, so an image-bearing [ToolCallResult] rendered through the shim cannot write into the
  * user's actual home directory.
  */
 private val defaultImageDir: () -> Path = { Path.of(System.getProperty("java.io.tmpdir")) }
@@ -240,34 +240,6 @@ val CLI_ENVELOPE_JSON: Json = Json {
     encodeDefaults = true
     explicitNulls = false
 }
-
-/**
- * Renders a CLI-level failure (usage/parse, routing, or bridge error) consistently, so a `--json`
- * consumer can parse EVERY failure the same way it parses success:
- *  - `--json` → emits the unified `{tool, command, isError:true, data:{content:[{type,text}]}}` envelope
- *    on [out] (stdout), matching [ToolCallResult.toEnvelopeJson]'s shape.
- *  - otherwise → prints [message] to [err] (stderr), keeping stdout clean.
- *
- * Returns [exit] verbatim so callers keep their meaningful [CliExit] codes (USAGE / UNAVAILABLE / …);
- * the exit code is independent of the `--json` toggle. Thin shim over [presentationFor] kept for call
- * sites/tests without a [DevrigServices] receiver in scope.
- */
-fun renderCliError(
-    command: String,
-    message: String,
-    json: Boolean,
-    exit: Int,
-    out: PrintStream,
-    err: PrintStream = System.err,
-): Int = presentationFor(json, defaultImageDir).renderError(command, message, exit, out, err)
-
-/**
- * Renders a successful `take_screenshot` with a structured `savedOut` path in the JSON envelope.
- * `savedOut` lives in the devrig-owned CLI envelope, not the frozen wire DTO [ToolCallResult] (Tenet 5).
- * Thin shim over [presentationFor] kept for call sites/tests without a [DevrigServices] receiver in scope.
- */
-fun renderScreenshotSaved(result: ToolCallResult, savedOut: String, json: Boolean, out: PrintStream): Int =
-    presentationFor(json, defaultImageDir).renderScreenshotSaved(result, savedOut, out)
 
 /** Wraps a command-specific [data] object in the unified envelope and renders it to a string. */
 fun cliEnvelopeJson(command: String, isError: Boolean, data: JsonObject): String {

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/CliToolSupport.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/CliToolSupport.kt
@@ -121,18 +121,16 @@ fun ToolCallResult.renderTo(
 }
 
 /**
- * The single, unified `--json` envelope shared by EVERY `devrig` MCP-as-CLI command:
+ * The unified JSON envelope for all `devrig` CLI commands, shared across tool-backed subcommands.
  *
- * ```json
- * { "tool": {"name":"devrig","version":"..."}, "command": "<name>", "isError": <bool>, "data": { ... } }
- * ```
- *
- * `data` holds the command-specific payload: `{content:[...]}` for tool-result commands (fetch_resource,
- * execute_code, …), `{projects:[...]}` for list_projects, `{windows,backgroundTasks}` for list_windows.
- * One outer shape keeps agents and tests from special-casing per command. The [Json] instance is shared
- * so encoding stays consistent.
+ * `data` shape is command-specific: `{content:[...]}` for tool-result commands, `{projects:[...]}`
+ * for list_projects, `{windows,backgroundTasks}` for list_windows.
  */
-val CLI_ENVELOPE_JSON: Json = Json { prettyPrint = true; encodeDefaults = true; explicitNulls = false }
+val CLI_ENVELOPE_JSON: Json = Json {
+    prettyPrint = true
+    encodeDefaults = true
+    explicitNulls = false
+}
 
 /**
  * Renders a CLI-level failure (usage/parse, routing, or bridge error) consistently, so a `--json`
@@ -169,11 +167,8 @@ fun renderCliError(
 }
 
 /**
- * Renders a successful `take_screenshot` that wrote a file to `--out`, adding a **structured**
- * `savedOut` (absolute path) key alongside the usual `content` in the `--json` envelope `data`, and a
- * human `Saved --out: <abs>` line otherwise. The structured field lives only in the devrig-owned CLI
- * envelope — the frozen wire DTO ([ToolCallResult]) is untouched (Tenet 5). Always [CliExit.OK]: the
- * caller only reaches this after the file is confirmed written.
+ * Renders a successful `take_screenshot` with a structured `savedOut` path in the JSON envelope.
+ * `savedOut` lives in the devrig-owned CLI envelope, not the frozen wire DTO [ToolCallResult] (Tenet 5).
  */
 fun renderScreenshotSaved(result: ToolCallResult, savedOut: String, json: Boolean, out: PrintStream): Int {
     if (json) {
@@ -202,10 +197,7 @@ fun cliEnvelopeJson(command: String, isError: Boolean, data: JsonObject): String
     return CLI_ENVELOPE_JSON.encodeToString(JsonObject.serializer(), payload)
 }
 
-/**
- * Envelope for a tool-backed command's [ToolCallResult]: `data:{content:[...]}`. Image blobs are
- * summarized (mimeType + byte count) rather than inlined so stdout stays usable.
- */
+/** Envelope for a [ToolCallResult]: `data:{content:[...]}`, with images summarized to prevent bloat. */
 fun ToolCallResult.toEnvelopeJson(command: String): String =
     cliEnvelopeJson(command, isError, contentDataJson())
 

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/CliToolSupport.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/CliToolSupport.kt
@@ -8,7 +8,6 @@ import java.io.PrintStream
 import java.util.Base64
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
-import kotlinx.serialization.json.add
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
 import kotlinx.serialization.json.putJsonArray
@@ -34,12 +33,48 @@ object CliExit {
      */
     const val TOOL_ERROR: Int = 1
 
-    /** Bad invocation the user can fix: missing/blank required args, unknown project_name, bad file. */
+    /** Bad invocation the user can fix: missing/blank required args, unknown project_name, malformed path. */
     const val USAGE: Int = 64
+
+    /**
+     * The command reached its target but the data it produced/received was unusable — e.g. the bridge
+     * returned a screenshot result with no image payload, or an image whose base64 could not be decoded.
+     * Distinct from [USAGE] (a fixable-input mistake) and [UNAVAILABLE] (could not reach a backend), so a
+     * `--json` consumer can tell "your fault" from "no IDE" from "bad data from the IDE".
+     * Value follows BSD sysexits `EX_DATAERR`.
+     */
+    const val DATA_ERROR: Int = 65
 
     /** The command could not reach a backend / the bridge failed (no IDE running, connection refused). */
     const val UNAVAILABLE: Int = 69
+
+    /**
+     * A genuine filesystem I/O failure the invocation cannot fix by changing an argument — a readable
+     * `--code-file` path that fails mid-read, or an `--out` target that exists as a path string but
+     * cannot be written (a directory, a permission denial). Kept distinct from [USAGE] so a malformed
+     * *path string* (fixable) is not conflated with a real write/read failure. Value follows BSD
+     * sysexits `EX_IOERR`.
+     */
+    const val IO_ERROR: Int = 74
 }
+
+/**
+ * Strips Java stack-frame noise (`\tat …` lines and the `... N more` continuations) out of a server
+ * error message so the agent sees the human-readable message, not a leaked JVM trace. Keeps every
+ * non-frame line (including `Caused by:` headers, which carry the actual cause message).
+ *
+ * Scope: apply this ONLY to a tool's error output where a trace is never the agent's own code (e.g.
+ * `input`, whose failures are IDE-side parse errors). Do NOT apply it to `execute_code`, which returns
+ * `stackTraceToString()` of the agent's OWN script on purpose — that trace is the whole point.
+ */
+fun sanitizeServerError(text: String): String =
+    text.lineSequence()
+        .filterNot { line ->
+            val t = line.trimStart()
+            t.startsWith("at ") || t.startsWith("... ") && t.endsWith(" more")
+        }
+        .joinToString("\n")
+        .trim()
 
 /** A [McpProgressReporter] that streams progress to stderr so stdout stays clean for data. */
 fun stderrProgressReporter(err: PrintStream = System.err): McpProgressReporter =
@@ -133,6 +168,26 @@ fun renderCliError(
     return exit
 }
 
+/**
+ * Renders a successful `take_screenshot` that wrote a file to `--out`, adding a **structured**
+ * `savedOut` (absolute path) key alongside the usual `content` in the `--json` envelope `data`, and a
+ * human `Saved --out: <abs>` line otherwise. The structured field lives only in the devrig-owned CLI
+ * envelope — the frozen wire DTO ([ToolCallResult]) is untouched (Tenet 5). Always [CliExit.OK]: the
+ * caller only reaches this after the file is confirmed written.
+ */
+fun renderScreenshotSaved(result: ToolCallResult, savedOut: String, json: Boolean, out: PrintStream): Int {
+    if (json) {
+        val data = buildJsonObject {
+            for ((key, value) in result.contentDataJson()) put(key, value)
+            put("savedOut", savedOut)
+        }
+        out.println(cliEnvelopeJson("take_screenshot", isError = false, data = data))
+        return CliExit.OK
+    }
+    val withNote = ToolCallResult(content = result.content + ContentItem.Text("Saved --out: $savedOut"))
+    return withNote.renderTo(command = "take_screenshot", json = false, out = out)
+}
+
 /** Wraps a command-specific [data] object in the unified envelope and renders it to a string. */
 fun cliEnvelopeJson(command: String, isError: Boolean, data: JsonObject): String {
     val payload = buildJsonObject {
@@ -151,33 +206,37 @@ fun cliEnvelopeJson(command: String, isError: Boolean, data: JsonObject): String
  * Envelope for a tool-backed command's [ToolCallResult]: `data:{content:[...]}`. Image blobs are
  * summarized (mimeType + byte count) rather than inlined so stdout stays usable.
  */
-fun ToolCallResult.toEnvelopeJson(command: String): String {
-    val data = buildJsonObject {
-        putJsonArray("content") {
-            for (item in content) {
-                add(buildJsonObject {
-                    when (item) {
-                        is ContentItem.Text -> {
-                            put("type", "text")
-                            put("text", item.text)
-                        }
-                        is ContentItem.Image -> {
-                            put("type", "image")
-                            put("mimeType", item.mimeType)
-                            put("bytes", item.decodedByteCount())
-                        }
-                        is ContentItem.Resource -> {
-                            put("type", "resource")
-                            put("uri", item.resource.uri)
-                            item.resource.mimeType?.let { put("mimeType", it) }
-                            item.resource.text?.let { put("text", it) }
-                        }
+fun ToolCallResult.toEnvelopeJson(command: String): String =
+    cliEnvelopeJson(command, isError, contentDataJson())
+
+/**
+ * Builds the `data:{content:[...]}` object for a [ToolCallResult] — the same payload
+ * [toEnvelopeJson] wraps, but exposed so a command can merge command-specific keys alongside it.
+ */
+fun ToolCallResult.contentDataJson(): JsonObject = buildJsonObject {
+    putJsonArray("content") {
+        for (item in content) {
+            add(buildJsonObject {
+                when (item) {
+                    is ContentItem.Text -> {
+                        put("type", "text")
+                        put("text", item.text)
                     }
-                })
-            }
+                    is ContentItem.Image -> {
+                        put("type", "image")
+                        put("mimeType", item.mimeType)
+                        put("bytes", item.decodedByteCount())
+                    }
+                    is ContentItem.Resource -> {
+                        put("type", "resource")
+                        put("uri", item.resource.uri)
+                        item.resource.mimeType?.let { put("mimeType", it) }
+                        item.resource.text?.let { put("text", it) }
+                    }
+                }
+            })
         }
     }
-    return cliEnvelopeJson(command, isError, data)
 }
 
 private fun ContentItem.Image.decodedByteCount(): Int =

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/CliToolSupport.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/CliToolSupport.kt
@@ -99,6 +99,40 @@ fun ToolCallResult.renderTo(
  */
 val CLI_ENVELOPE_JSON: Json = Json { prettyPrint = true; encodeDefaults = true; explicitNulls = false }
 
+/**
+ * Renders a CLI-level failure (usage/parse, routing, or bridge error) consistently, so a `--json`
+ * consumer can parse EVERY failure the same way it parses success:
+ *  - `--json` → emits the unified `{tool, command, isError:true, data:{content:[{type,text}]}}` envelope
+ *    on [out] (stdout), matching [ToolCallResult.toEnvelopeJson]'s shape.
+ *  - otherwise → prints [message] to [err] (stderr), keeping stdout clean.
+ *
+ * Returns [exit] verbatim so callers keep their meaningful [CliExit] codes (USAGE / UNAVAILABLE / …);
+ * the exit code is independent of the `--json` toggle.
+ */
+fun renderCliError(
+    command: String,
+    message: String,
+    json: Boolean,
+    exit: Int,
+    out: PrintStream,
+    err: PrintStream = System.err,
+): Int {
+    if (json) {
+        val data = buildJsonObject {
+            putJsonArray("content") {
+                add(buildJsonObject {
+                    put("type", "text")
+                    put("text", message)
+                })
+            }
+        }
+        out.println(cliEnvelopeJson(command, isError = true, data = data))
+    } else {
+        err.println(message)
+    }
+    return exit
+}
+
 /** Wraps a command-specific [data] object in the unified envelope and renders it to a string. */
 fun cliEnvelopeJson(command: String, isError: Boolean, data: JsonObject): String {
     val payload = buildJsonObject {

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/CliToolSupport.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/CliToolSupport.kt
@@ -193,7 +193,11 @@ sealed interface Presentation {
         }
 
         override fun renderScreenshotSaved(result: ToolCallResult, savedOut: String, out: PrintStream): Int {
-            val withNote = ToolCallResult(content = result.content + ContentItem.Text("Saved --out: $savedOut"))
+            // The image was ALREADY written to the explicit --out path by the caller; strip image items
+            // before re-rendering so [renderImage] does not redundantly re-materialize a `<tmpDir>/image-*`
+            // file and print a spurious "Saved image:" line ahead of the "Saved --out:" note.
+            val nonImage = result.content.filterNot { it is ContentItem.Image }
+            val withNote = ToolCallResult(content = nonImage + ContentItem.Text("Saved --out: $savedOut"))
             return render(withNote, command = "take_screenshot", out = out)
         }
     }

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/CliToolSupport.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/CliToolSupport.kt
@@ -6,6 +6,7 @@ import com.jonnyzzz.mcpSteroid.mcp.McpJson
 import com.jonnyzzz.mcpSteroid.mcp.ToolCallResult
 import com.jonnyzzz.mcpSteroid.server.McpProgressReporter
 import java.io.PrintStream
+import java.nio.file.Files
 import java.nio.file.Path
 import java.util.Base64
 import kotlinx.serialization.builtins.ListSerializer
@@ -98,8 +99,8 @@ fun stderrProgressReporter(err: PrintStream = System.err): McpProgressReporter =
  *    (`isError == true`) → **stderr**, stdout stays empty.
  *  - [Json]: a single stable envelope on stdout regardless of success/failure.
  *
- * [Console.imageDir] is a provider (not a value) so a future console image-to-file renderer (Task 6) can
- * resolve a fresh temp directory per render without changing this interface.
+ * [Console.imageDir] is a provider (not a value) so each render can resolve a fresh, possibly
+ * lazily-created temp directory (C4) — production wires it to [HomePaths.screenshotTmpDir].
  */
 sealed interface Presentation {
     /** Renders a [ToolCallResult] for [command] and returns the process exit code. */
@@ -142,16 +143,18 @@ sealed interface Presentation {
     }
 
     /**
-     * Human-readable console text. [imageDir] is unused this task — it exists so Task 6 can plug in a
-     * temp-dir provider for writing console image content to a file instead of a byte-count placeholder.
+     * Human-readable console text. Image content (C4) is decoded and written to a file under
+     * [imageDir] — a provider (not a value) so each render resolves a fresh, possibly lazily-created,
+     * temp directory (production wires it to [HomePaths.screenshotTmpDir]) — and the file's absolute
+     * path is printed instead of a byte-count placeholder.
      */
     class Console(private val imageDir: () -> Path) : Presentation {
         override fun render(result: ToolCallResult, command: String, out: PrintStream, err: PrintStream): Int {
             val sink = if (result.isError) err else out
-            for (item in result.content) {
+            for ((index, item) in result.content.withIndex()) {
                 when (item) {
                     is ContentItem.Text -> sink.println(item.text)
-                    is ContentItem.Image -> sink.println("[image: ${item.mimeType}, ${item.decodedByteCount()} bytes]")
+                    is ContentItem.Image -> renderImage(item, index, sink)
                     is ContentItem.Resource -> {
                         val res = item.resource
                         sink.println("[resource: ${res.uri}${res.mimeType?.let { " ($it)" } ?: ""}]")
@@ -160,6 +163,28 @@ sealed interface Presentation {
                 }
             }
             return if (result.isError) CliExit.TOOL_ERROR else CliExit.OK
+        }
+
+        /**
+         * Decodes [item]'s base64 payload and writes it to `<imageDir>/image-<index>.<ext>`, printing the
+         * absolute path to [sink]. Undecodable base64 is logged to stderr (never silently swallowed) and
+         * reported as a clear, non-crashing console line — the render must still complete.
+         */
+        private fun renderImage(item: ContentItem.Image, index: Int, sink: PrintStream) {
+            val decoded = try {
+                Base64.getDecoder().decode(item.data)
+            } catch (e: IllegalArgumentException) {
+                System.err.println("devrig: image payload was not valid base64 (${e.message})")
+                null
+            }
+            if (decoded == null) {
+                sink.println("[image: ${item.mimeType}, undecodable]")
+                return
+            }
+            val ext = item.mimeType.substringAfterLast('/', "png")
+            val file = imageDir().resolve("image-$index.$ext")
+            Files.write(file, decoded)
+            sink.println("Saved image: ${file.toAbsolutePath()}")
         }
 
         override fun renderError(command: String, message: String, exit: Int, out: PrintStream, err: PrintStream): Int {
@@ -178,8 +203,13 @@ sealed interface Presentation {
 fun presentationFor(json: Boolean, imageDir: () -> Path): Presentation =
     if (json) Presentation.Json() else Presentation.Console(imageDir)
 
-/** Fallback [Presentation.Console] image-dir provider for callers with no [DevrigServices] in scope (tests). */
-private val defaultImageDir: () -> Path = { Path.of(System.getProperty("user.home")) }
+/**
+ * Fallback [Presentation.Console] image-dir provider for callers with no [DevrigServices] in scope
+ * (tests only — no production call site uses the shims below). Resolves the JVM temp dir, never the
+ * real `user.home`, so an image-bearing [ToolCallResult] rendered through a shim cannot write into the
+ * user's actual home directory.
+ */
+private val defaultImageDir: () -> Path = { Path.of(System.getProperty("java.io.tmpdir")) }
 
 /**
  * Renders a [ToolCallResult] for a CLI command and returns the process exit code. Thin shim over
@@ -265,13 +295,3 @@ fun ToolCallResult.toEnvelopeJson(command: String): String =
 fun ToolCallResult.contentDataJson(): JsonObject = buildJsonObject {
     put("content", McpJson.encodeToJsonElement(ListSerializer(ContentItem.serializer()), content))
 }
-
-/** Used only by the human-readable console renderer ([renderTo]); the `--json` envelope carries `data` as-is. */
-private fun ContentItem.Image.decodedByteCount(): Int =
-    try {
-        Base64.getDecoder().decode(data).size
-    } catch (e: IllegalArgumentException) {
-        // Not valid base64 — report the raw length rather than failing the whole render.
-        System.err.println("devrig: image payload was not valid base64 (${e.message}); reporting raw length")
-        data.length
-    }

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/CliToolSupport.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/CliToolSupport.kt
@@ -6,6 +6,7 @@ import com.jonnyzzz.mcpSteroid.mcp.McpJson
 import com.jonnyzzz.mcpSteroid.mcp.ToolCallResult
 import com.jonnyzzz.mcpSteroid.server.McpProgressReporter
 import java.io.PrintStream
+import java.nio.file.Path
 import java.util.Base64
 import kotlinx.serialization.builtins.ListSerializer
 import kotlinx.serialization.json.Json
@@ -87,12 +88,103 @@ fun stderrProgressReporter(err: PrintStream = System.err): McpProgressReporter =
     }
 
 /**
- * Renders a [ToolCallResult] for a CLI command and returns the process exit code.
+ * Renders CLI output for a command as either a `--json` envelope or human-readable console text — the
+ * single fork point for that choice. Each implementation owns its own branch body in full (Tenet: no
+ * `if (json)` scattered through shared render code); [presentationFor] is the only place that maps the
+ * `--json` flag onto a concrete implementation.
  *
  * Contract (locked by tests, matches the rest of devrig):
- *  - Non-error text content → **stdout** (so `| jq`, `| less` work).
- *  - Error content (`isError == true`) → **stderr**; stdout stays empty.
- *  - `--json` emits a single stable envelope on stdout regardless of success/failure.
+ *  - [Console]: non-error text content → **stdout** (so `| jq`, `| less` work); error content
+ *    (`isError == true`) → **stderr**, stdout stays empty.
+ *  - [Json]: a single stable envelope on stdout regardless of success/failure.
+ *
+ * [Console.imageDir] is a provider (not a value) so a future console image-to-file renderer (Task 6) can
+ * resolve a fresh temp directory per render without changing this interface.
+ */
+sealed interface Presentation {
+    /** Renders a [ToolCallResult] for [command] and returns the process exit code. */
+    fun render(result: ToolCallResult, command: String, out: PrintStream, err: PrintStream = System.err): Int
+
+    /** Renders a CLI-level failure (usage/parse, routing, bridge error) for [command]; returns [exit] verbatim. */
+    fun renderError(command: String, message: String, exit: Int, out: PrintStream, err: PrintStream = System.err): Int
+
+    /** Renders a successful `take_screenshot` whose image was additionally saved to [savedOut]. */
+    fun renderScreenshotSaved(result: ToolCallResult, savedOut: String, out: PrintStream): Int
+
+    /** `--json`: a single stable envelope on stdout, built from [toEnvelopeJson] / [cliEnvelopeJson]. */
+    class Json : Presentation {
+        override fun render(result: ToolCallResult, command: String, out: PrintStream, err: PrintStream): Int {
+            out.println(result.toEnvelopeJson(command))
+            return if (result.isError) CliExit.TOOL_ERROR else CliExit.OK
+        }
+
+        override fun renderError(command: String, message: String, exit: Int, out: PrintStream, err: PrintStream): Int {
+            val data = buildJsonObject {
+                putJsonArray("content") {
+                    add(buildJsonObject {
+                        put("type", "text")
+                        put("text", message)
+                    })
+                }
+            }
+            out.println(cliEnvelopeJson(command, isError = true, data = data))
+            return exit
+        }
+
+        override fun renderScreenshotSaved(result: ToolCallResult, savedOut: String, out: PrintStream): Int {
+            val data = buildJsonObject {
+                for ((key, value) in result.contentDataJson()) put(key, value)
+                put("savedOut", savedOut)
+            }
+            out.println(cliEnvelopeJson("take_screenshot", isError = false, data = data))
+            return CliExit.OK
+        }
+    }
+
+    /**
+     * Human-readable console text. [imageDir] is unused this task — it exists so Task 6 can plug in a
+     * temp-dir provider for writing console image content to a file instead of a byte-count placeholder.
+     */
+    class Console(private val imageDir: () -> Path) : Presentation {
+        override fun render(result: ToolCallResult, command: String, out: PrintStream, err: PrintStream): Int {
+            val sink = if (result.isError) err else out
+            for (item in result.content) {
+                when (item) {
+                    is ContentItem.Text -> sink.println(item.text)
+                    is ContentItem.Image -> sink.println("[image: ${item.mimeType}, ${item.decodedByteCount()} bytes]")
+                    is ContentItem.Resource -> {
+                        val res = item.resource
+                        sink.println("[resource: ${res.uri}${res.mimeType?.let { " ($it)" } ?: ""}]")
+                        res.text?.let { sink.println(it) }
+                    }
+                }
+            }
+            return if (result.isError) CliExit.TOOL_ERROR else CliExit.OK
+        }
+
+        override fun renderError(command: String, message: String, exit: Int, out: PrintStream, err: PrintStream): Int {
+            err.println(message)
+            return exit
+        }
+
+        override fun renderScreenshotSaved(result: ToolCallResult, savedOut: String, out: PrintStream): Int {
+            val withNote = ToolCallResult(content = result.content + ContentItem.Text("Saved --out: $savedOut"))
+            return render(withNote, command = "take_screenshot", out = out)
+        }
+    }
+}
+
+/** Maps the `--json` flag onto a concrete [Presentation]; the only place the boolean is branched on. */
+fun presentationFor(json: Boolean, imageDir: () -> Path): Presentation =
+    if (json) Presentation.Json() else Presentation.Console(imageDir)
+
+/** Fallback [Presentation.Console] image-dir provider for callers with no [DevrigServices] in scope (tests). */
+private val defaultImageDir: () -> Path = { Path.of(System.getProperty("user.home")) }
+
+/**
+ * Renders a [ToolCallResult] for a CLI command and returns the process exit code. Thin shim over
+ * [presentationFor] kept for call sites/tests that don't have a [DevrigServices] receiver in scope; new
+ * production call sites should build a [Presentation] once per command instead (see [ToolBackedCommands]).
  *
  * @param command the CLI subcommand name, echoed into the JSON envelope for context.
  */
@@ -101,26 +193,7 @@ fun ToolCallResult.renderTo(
     json: Boolean,
     out: PrintStream,
     err: PrintStream = System.err,
-): Int {
-    if (json) {
-        out.println(toEnvelopeJson(command))
-        return if (isError) CliExit.TOOL_ERROR else CliExit.OK
-    }
-
-    val sink = if (isError) err else out
-    for (item in content) {
-        when (item) {
-            is ContentItem.Text -> sink.println(item.text)
-            is ContentItem.Image -> sink.println("[image: ${item.mimeType}, ${item.decodedByteCount()} bytes]")
-            is ContentItem.Resource -> {
-                val res = item.resource
-                sink.println("[resource: ${res.uri}${res.mimeType?.let { " ($it)" } ?: ""}]")
-                res.text?.let { sink.println(it) }
-            }
-        }
-    }
-    return if (isError) CliExit.TOOL_ERROR else CliExit.OK
-}
+): Int = presentationFor(json, defaultImageDir).render(this, command, out, err)
 
 /**
  * The unified JSON envelope for all `devrig` CLI commands, shared across tool-backed subcommands.
@@ -142,7 +215,8 @@ val CLI_ENVELOPE_JSON: Json = Json {
  *  - otherwise → prints [message] to [err] (stderr), keeping stdout clean.
  *
  * Returns [exit] verbatim so callers keep their meaningful [CliExit] codes (USAGE / UNAVAILABLE / …);
- * the exit code is independent of the `--json` toggle.
+ * the exit code is independent of the `--json` toggle. Thin shim over [presentationFor] kept for call
+ * sites/tests without a [DevrigServices] receiver in scope.
  */
 fun renderCliError(
     command: String,
@@ -151,39 +225,15 @@ fun renderCliError(
     exit: Int,
     out: PrintStream,
     err: PrintStream = System.err,
-): Int {
-    if (json) {
-        val data = buildJsonObject {
-            putJsonArray("content") {
-                add(buildJsonObject {
-                    put("type", "text")
-                    put("text", message)
-                })
-            }
-        }
-        out.println(cliEnvelopeJson(command, isError = true, data = data))
-    } else {
-        err.println(message)
-    }
-    return exit
-}
+): Int = presentationFor(json, defaultImageDir).renderError(command, message, exit, out, err)
 
 /**
  * Renders a successful `take_screenshot` with a structured `savedOut` path in the JSON envelope.
  * `savedOut` lives in the devrig-owned CLI envelope, not the frozen wire DTO [ToolCallResult] (Tenet 5).
+ * Thin shim over [presentationFor] kept for call sites/tests without a [DevrigServices] receiver in scope.
  */
-fun renderScreenshotSaved(result: ToolCallResult, savedOut: String, json: Boolean, out: PrintStream): Int {
-    if (json) {
-        val data = buildJsonObject {
-            for ((key, value) in result.contentDataJson()) put(key, value)
-            put("savedOut", savedOut)
-        }
-        out.println(cliEnvelopeJson("take_screenshot", isError = false, data = data))
-        return CliExit.OK
-    }
-    val withNote = ToolCallResult(content = result.content + ContentItem.Text("Saved --out: $savedOut"))
-    return withNote.renderTo(command = "take_screenshot", json = false, out = out)
-}
+fun renderScreenshotSaved(result: ToolCallResult, savedOut: String, json: Boolean, out: PrintStream): Int =
+    presentationFor(json, defaultImageDir).renderScreenshotSaved(result, savedOut, out)
 
 /** Wraps a command-specific [data] object in the unified envelope and renders it to a string. */
 fun cliEnvelopeJson(command: String, isError: Boolean, data: JsonObject): String {

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/CliToolSupport.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/CliToolSupport.kt
@@ -86,11 +86,21 @@ fun ToolCallResult.renderTo(
 }
 
 /**
- * Stable machine-readable envelope for a tool-backed command's result. Kept intentionally simple
- * (no MCP-schema echo): `tool` identity, the `command`, the `isError` flag, and the `content` items.
- * Image blobs are summarized (mimeType + byte count) rather than inlined so stdout stays usable.
+ * The single, unified `--json` envelope shared by EVERY `devrig` MCP-as-CLI command:
+ *
+ * ```json
+ * { "tool": {"name":"devrig","version":"..."}, "command": "<name>", "isError": <bool>, "data": { ... } }
+ * ```
+ *
+ * `data` holds the command-specific payload: `{content:[...]}` for tool-result commands (fetch_resource,
+ * execute_code, …), `{projects:[...]}` for list_projects, `{windows,backgroundTasks}` for list_windows.
+ * One outer shape keeps agents and tests from special-casing per command. The [Json] instance is shared
+ * so encoding stays consistent.
  */
-fun ToolCallResult.toEnvelopeJson(command: String): String {
+val CLI_ENVELOPE_JSON: Json = Json { prettyPrint = true; encodeDefaults = true; explicitNulls = false }
+
+/** Wraps a command-specific [data] object in the unified envelope and renders it to a string. */
+fun cliEnvelopeJson(command: String, isError: Boolean, data: JsonObject): String {
     val payload = buildJsonObject {
         put("tool", buildJsonObject {
             put("name", "devrig")
@@ -98,6 +108,17 @@ fun ToolCallResult.toEnvelopeJson(command: String): String {
         })
         put("command", command)
         put("isError", isError)
+        put("data", data)
+    }
+    return CLI_ENVELOPE_JSON.encodeToString(JsonObject.serializer(), payload)
+}
+
+/**
+ * Envelope for a tool-backed command's [ToolCallResult]: `data:{content:[...]}`. Image blobs are
+ * summarized (mimeType + byte count) rather than inlined so stdout stays usable.
+ */
+fun ToolCallResult.toEnvelopeJson(command: String): String {
+    val data = buildJsonObject {
         putJsonArray("content") {
             for (item in content) {
                 add(buildJsonObject {
@@ -122,10 +143,8 @@ fun ToolCallResult.toEnvelopeJson(command: String): String {
             }
         }
     }
-    return ENVELOPE_JSON.encodeToString(JsonObject.serializer(), payload)
+    return cliEnvelopeJson(command, isError, data)
 }
-
-private val ENVELOPE_JSON = Json { prettyPrint = true; encodeDefaults = true; explicitNulls = false }
 
 private fun ContentItem.Image.decodedByteCount(): Int =
     try {

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/DevrigBeacon.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/DevrigBeacon.kt
@@ -72,6 +72,14 @@ class DevrigBeacon(
             is DevrigCommand.DevrigCommandProject -> "project"
             is DevrigCommand.DevrigCommandInstall -> "install"
             is DevrigCommand.DevrigCommandInstallDevrig -> "install"
+            is DevrigCommand.DevrigCommandFetchResource -> "fetch_resource"
+            is DevrigCommand.DevrigCommandExecuteCode -> "execute_code"
+            is DevrigCommand.DevrigCommandListProjects -> "list_projects"
+            is DevrigCommand.DevrigCommandListWindows -> "list_windows"
+            is DevrigCommand.DevrigCommandOpenProject -> "open_project"
+            is DevrigCommand.DevrigCommandScreenshot -> "take_screenshot"
+            is DevrigCommand.DevrigCommandInput -> "input"
+            is DevrigCommand.DevrigCommandFeedback -> "execute_feedback"
             is DevrigCommand.DevrigCommandHelp -> null
             is DevrigCommand.DevrigCommandVersion -> null
             is DevrigCommand.DevrigCommandParseError -> null

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/FetchResourceCommand.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/FetchResourceCommand.kt
@@ -1,0 +1,78 @@
+/* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
+package com.jonnyzzz.mcpSteroid.devrig
+
+import com.jonnyzzz.mcpSteroid.devrig.server.DevrigPromptsContextHandler
+import com.jonnyzzz.mcpSteroid.mcp.ContentItem
+import com.jonnyzzz.mcpSteroid.mcp.ToolCallResult
+import com.jonnyzzz.mcpSteroid.mcp.errorResult
+import com.jonnyzzz.mcpSteroid.prompts.Generic
+import com.jonnyzzz.mcpSteroid.prompts.PromptsContext
+import com.jonnyzzz.mcpSteroid.server.canonicalResourceEntryPoints
+import com.jonnyzzz.mcpSteroid.server.resolveResourcePayload
+
+/**
+ * `devrig prompt <uri>` / `devrig fetch_resource --uri=...` — the CLI face of `steroid_fetch_resource`.
+ *
+ * Bundled `mcp-steroid://` articles ship inside the devrig binary, so this resolves **without a
+ * running IDE** using [PromptsContext.Generic]. Passing `--project_name` upgrades to that project's
+ * IDE-specific context via the existing routing + [DevrigPromptsContextHandler] (which needs the IDE
+ * to be discovered). URI → payload resolution is the shared [resolveResourcePayload] — the same code
+ * the MCP tool uses, so both surfaces render identically.
+ */
+fun DevrigServices.runFetchResourceCommand(command: DevrigCommand.DevrigCommandFetchResource): Int {
+    val uri = command.uri
+    if (uri.isNullOrBlank()) {
+        // Defensive: the parser already rejects a blank URI; keep a clean error if reached directly.
+        System.err.println("missing <uri>. Example:\n  ${fetchResourceUsageExample()}")
+        return CliExit.USAGE
+    }
+
+    val context = try {
+        resolvePromptsContext(command.projectName)
+    } catch (e: PromptsContextResolutionException) {
+        System.err.println(e.message)
+        return CliExit.USAGE
+    }
+
+    val payload = resolveResourcePayload(uri, context)
+    val result = if (payload != null) {
+        ToolCallResult(content = listOf(ContentItem.Text(text = payload)))
+    } else {
+        ToolCallResult.errorResult(resourceNotFoundMessage(uri))
+    }
+    return result.renderTo(command = "fetch_resource", json = command.json, out = mcpStdout)
+}
+
+/**
+ * Resolves the [PromptsContext] for a resource fetch. No project → [PromptsContext.Generic] (bundled
+ * docs, no IDE needed). With a project → that project's IDE build → context, reusing the same routing
+ * the other CLI/MCP commands use.
+ */
+private fun DevrigServices.resolvePromptsContext(projectName: String?): PromptsContext {
+    if (projectName.isNullOrBlank()) return PromptsContext.Generic
+    val route = try {
+        projectRouting.requireProject(projectName)
+    } catch (e: IllegalArgumentException) {
+        throw PromptsContextResolutionException(
+            "unknown --project_name '$projectName' (get it from `devrig list_projects`)"
+        )
+    }
+    return DevrigPromptsContextHandler.promptsContextFromBuild(route.route.ide.build)
+}
+
+private class PromptsContextResolutionException(message: String) : RuntimeException(message)
+
+private fun resourceNotFoundMessage(uri: String): String = buildString {
+    append("Resource not found: ").append(uri).append('\n')
+    append("Canonical entry points:\n")
+    for (entry in canonicalResourceEntryPoints()) {
+        append("  devrig prompt ").append(entry).append('\n')
+    }
+}
+
+/** A runnable example for the `prompt` usage error — built from generated article URIs, never a literal. */
+fun fetchResourceUsageExample(): String = "devrig prompt ${canonicalResourceEntryPointOrPlaceholder()}"
+
+/** First canonical entry-point URI, or a bracket placeholder if the article index is somehow empty. */
+fun canonicalResourceEntryPointOrPlaceholder(): String =
+    canonicalResourceEntryPoints().firstOrNull() ?: "<resource-uri>"

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/FetchResourceCommand.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/FetchResourceCommand.kt
@@ -8,7 +8,7 @@ import com.jonnyzzz.mcpSteroid.mcp.errorResult
 import com.jonnyzzz.mcpSteroid.prompts.Generic
 import com.jonnyzzz.mcpSteroid.prompts.PromptsContext
 import com.jonnyzzz.mcpSteroid.server.canonicalResourceEntryPoints
-import com.jonnyzzz.mcpSteroid.server.resolveResourcePayload
+import com.jonnyzzz.mcpSteroid.server.resolveResourceArticle
 
 /**
  * `devrig prompt <uri>` / `devrig fetch_resource --uri=...` — the CLI face of `steroid_fetch_resource`.
@@ -16,7 +16,7 @@ import com.jonnyzzz.mcpSteroid.server.resolveResourcePayload
  * Bundled `mcp-steroid://` articles ship inside the devrig binary, so this resolves **without a
  * running IDE** using [PromptsContext.Generic]. Passing `--project_name` upgrades to that project's
  * IDE-specific context via the existing routing + [DevrigPromptsContextHandler] (which needs the IDE
- * to be discovered). URI → payload resolution is the shared [resolveResourcePayload] — the same code
+ * to be discovered). URI → article resolution is the shared [resolveResourceArticle] — the same code
  * the MCP tool uses, so both surfaces render identically.
  */
 fun DevrigServices.runFetchResourceCommand(command: DevrigCommand.DevrigCommandFetchResource): Int {
@@ -39,9 +39,9 @@ fun DevrigServices.runFetchResourceCommand(command: DevrigCommand.DevrigCommandF
         )
     }
 
-    val payload = resolveResourcePayload(uri, context)
-    val result = if (payload != null) {
-        ToolCallResult(content = listOf(ContentItem.Text(text = payload)))
+    val article = resolveResourceArticle(uri, context)
+    val result = if (article != null) {
+        ToolCallResult(content = listOf(ContentItem.Text(text = article.readPayload(context))))
     } else {
         ToolCallResult.errorResult(resourceNotFoundMessage(uri))
     }
@@ -72,7 +72,7 @@ private fun resourceNotFoundMessage(uri: String): String = buildString {
     append("Resource not found: ").append(uri).append('\n')
     append("Canonical entry points:\n")
     for (entry in canonicalResourceEntryPoints()) {
-        append("  devrig prompt ").append(entry).append('\n')
+        append("  devrig prompt ").append(entry.uri).append('\n')
     }
 }
 
@@ -81,4 +81,4 @@ fun fetchResourceUsageExample(): String = "devrig prompt ${canonicalResourceEntr
 
 /** First canonical entry-point URI, or a bracket placeholder if the article index is somehow empty. */
 fun canonicalResourceEntryPointOrPlaceholder(): String =
-    canonicalResourceEntryPoints().firstOrNull() ?: "<resource-uri>"
+    canonicalResourceEntryPoints().firstOrNull()?.uri ?: "<resource-uri>"

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/FetchResourceCommand.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/FetchResourceCommand.kt
@@ -63,7 +63,7 @@ private fun DevrigServices.resolvePromptsContext(projectName: String?): PromptsC
             "unknown --project_name '$projectName' (get it from `devrig list_projects`)"
         )
     }
-    return DevrigPromptsContextHandler.promptsContextFromBuild(route.route.ide.build)
+    return DevrigPromptsContextHandler.promptsContextFromRoute(route)
 }
 
 private class PromptsContextResolutionException(message: String) : RuntimeException(message)

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/FetchResourceCommand.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/FetchResourceCommand.kt
@@ -20,7 +20,7 @@ import com.jonnyzzz.mcpSteroid.server.resolveResourcePayload
  * the MCP tool uses, so both surfaces render identically.
  */
 fun DevrigServices.runFetchResourceCommand(command: DevrigCommand.DevrigCommandFetchResource): Int {
-    val presentation = presentationFor(command.json) { homePaths.home }
+    val presentation = presentationFor(command.json, homePaths::screenshotTmpDir)
     val uri = command.uri
     if (uri.isNullOrBlank()) {
         // Defensive: the parser already rejects a blank URI; keep a clean error if reached directly.

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/FetchResourceCommand.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/FetchResourceCommand.kt
@@ -20,21 +20,22 @@ import com.jonnyzzz.mcpSteroid.server.resolveResourcePayload
  * the MCP tool uses, so both surfaces render identically.
  */
 fun DevrigServices.runFetchResourceCommand(command: DevrigCommand.DevrigCommandFetchResource): Int {
+    val presentation = presentationFor(command.json) { homePaths.home }
     val uri = command.uri
     if (uri.isNullOrBlank()) {
         // Defensive: the parser already rejects a blank URI; keep a clean error if reached directly.
-        return renderCliError(
+        return presentation.renderError(
             command.commandName, "missing <uri>. Example:\n  ${fetchResourceUsageExample()}",
-            command.json, CliExit.USAGE, mcpStdout,
+            CliExit.USAGE, mcpStdout,
         )
     }
 
     val context = try {
         resolvePromptsContext(command.projectName)
     } catch (e: PromptsContextResolutionException) {
-        return renderCliError(
+        return presentation.renderError(
             command.commandName, e.message ?: "failed to resolve project context",
-            command.json, CliExit.USAGE, mcpStdout,
+            CliExit.USAGE, mcpStdout,
         )
     }
 
@@ -45,7 +46,7 @@ fun DevrigServices.runFetchResourceCommand(command: DevrigCommand.DevrigCommandF
         ToolCallResult.errorResult(resourceNotFoundMessage(uri))
     }
     // Echo the alias the user actually typed ("prompt" vs "fetch_resource") into the `--json` envelope.
-    return result.renderTo(command = command.commandName, json = command.json, out = mcpStdout)
+    return presentation.render(result, command = command.commandName, out = mcpStdout)
 }
 
 /**

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/FetchResourceCommand.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/FetchResourceCommand.kt
@@ -23,15 +23,19 @@ fun DevrigServices.runFetchResourceCommand(command: DevrigCommand.DevrigCommandF
     val uri = command.uri
     if (uri.isNullOrBlank()) {
         // Defensive: the parser already rejects a blank URI; keep a clean error if reached directly.
-        System.err.println("missing <uri>. Example:\n  ${fetchResourceUsageExample()}")
-        return CliExit.USAGE
+        return renderCliError(
+            command.commandName, "missing <uri>. Example:\n  ${fetchResourceUsageExample()}",
+            command.json, CliExit.USAGE, mcpStdout,
+        )
     }
 
     val context = try {
         resolvePromptsContext(command.projectName)
     } catch (e: PromptsContextResolutionException) {
-        System.err.println(e.message)
-        return CliExit.USAGE
+        return renderCliError(
+            command.commandName, e.message ?: "failed to resolve project context",
+            command.json, CliExit.USAGE, mcpStdout,
+        )
     }
 
     val payload = resolveResourcePayload(uri, context)
@@ -40,7 +44,8 @@ fun DevrigServices.runFetchResourceCommand(command: DevrigCommand.DevrigCommandF
     } else {
         ToolCallResult.errorResult(resourceNotFoundMessage(uri))
     }
-    return result.renderTo(command = "fetch_resource", json = command.json, out = mcpStdout)
+    // Echo the alias the user actually typed ("prompt" vs "fetch_resource") into the `--json` envelope.
+    return result.renderTo(command = command.commandName, json = command.json, out = mcpStdout)
 }
 
 /**

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/FetchResourceCommand.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/FetchResourceCommand.kt
@@ -1,23 +1,28 @@
 /* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
 package com.jonnyzzz.mcpSteroid.devrig
 
+import com.jonnyzzz.mcpSteroid.devrig.server.callToolViaSpec
 import com.jonnyzzz.mcpSteroid.devrig.server.DevrigPromptsContextHandler
 import com.jonnyzzz.mcpSteroid.mcp.ContentItem
 import com.jonnyzzz.mcpSteroid.mcp.ToolCallResult
-import com.jonnyzzz.mcpSteroid.mcp.errorResult
 import com.jonnyzzz.mcpSteroid.prompts.Generic
 import com.jonnyzzz.mcpSteroid.prompts.PromptsContext
+import com.jonnyzzz.mcpSteroid.server.FetchResourceToolHandler
+import com.jonnyzzz.mcpSteroid.server.PromptsContextHandler
 import com.jonnyzzz.mcpSteroid.server.canonicalResourceEntryPoints
-import com.jonnyzzz.mcpSteroid.server.resolveResourceArticle
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
 
 /**
  * `devrig prompt <uri>` / `devrig fetch_resource --uri=...` — the CLI face of `steroid_fetch_resource`.
  *
  * Bundled `mcp-steroid://` articles ship inside the devrig binary, so this resolves **without a
  * running IDE** using [PromptsContext.Generic]. Passing `--project_name` upgrades to that project's
- * IDE-specific context via the existing routing + [DevrigPromptsContextHandler] (which needs the IDE
- * to be discovered). URI → article resolution is the shared [resolveResourceArticle] — the same code
- * the MCP tool uses, so both surfaces render identically.
+ * IDE-specific context via the existing routing + [DevrigPromptsContextHandler]. Calls are dispatched
+ * through [FetchResourceToolHandler], the same ToolSpec used by `devrig mcp`.
  */
 fun DevrigServices.runFetchResourceCommand(command: DevrigCommand.DevrigCommandFetchResource): Int {
     val presentation = presentationFor(command.json, homePaths::screenshotTmpDir)
@@ -30,50 +35,57 @@ fun DevrigServices.runFetchResourceCommand(command: DevrigCommand.DevrigCommandF
         )
     }
 
-    val context = try {
-        resolvePromptsContext(command.projectName)
-    } catch (e: PromptsContextResolutionException) {
-        return presentation.renderError(
-            command.commandName, e.message ?: "failed to resolve project context",
-            CliExit.USAGE, mcpStdout,
-        )
-    }
-
-    val article = resolveResourceArticle(uri, context)
-    val result = if (article != null) {
-        ToolCallResult(content = listOf(ContentItem.Text(text = article.readPayload(context))))
+    val projectName = command.projectName?.takeUnless { it.isBlank() }
+    val contextHandler: PromptsContextHandler = if (projectName == null) {
+        FixedPromptsContextHandler(PromptsContext.Generic)
     } else {
-        ToolCallResult.errorResult(resourceNotFoundMessage(uri))
+        DevrigPromptsContextHandler(projectRouting)
     }
-    // Echo the alias the user actually typed ("prompt" vs "fetch_resource") into the `--json` envelope.
-    return presentation.render(result, command = command.commandName, out = mcpStdout)
-}
-
-/**
- * Resolves the [PromptsContext] for a resource fetch. No project → [PromptsContext.Generic] (bundled
- * docs, no IDE needed). With a project → that project's IDE build → context, reusing the same routing
- * the other CLI/MCP commands use.
- */
-private fun DevrigServices.resolvePromptsContext(projectName: String?): PromptsContext {
-    if (projectName.isNullOrBlank()) return PromptsContext.Generic
-    val route = try {
-        projectRouting.requireProject(projectName)
+    val arguments = buildJsonObject {
+        put("uri", uri)
+        put("project_name", projectName ?: GENERIC_PROJECT_NAME)
+    }
+    val result = try {
+        runBlocking(Dispatchers.IO) {
+            callToolViaSpec(
+                FetchResourceToolHandler { contextHandler },
+                arguments,
+                stderrProgressReporter(),
+            )
+        }
     } catch (e: IllegalArgumentException) {
-        throw PromptsContextResolutionException(
-            "unknown --project_name '$projectName' (get it from `devrig list_projects`)"
+        return presentation.renderError(
+            command.commandName,
+            "unknown --project_name '$projectName' (get it from `devrig list_projects`)",
+            CliExit.USAGE,
+            mcpStdout,
+        )
+    } catch (e: CancellationException) {
+        throw e
+    } catch (e: Exception) {
+        return presentation.renderError(
+            command.commandName,
+            "devrig ${command.commandName} failed: ${e.message}",
+            CliExit.UNAVAILABLE,
+            mcpStdout,
         )
     }
-    return DevrigPromptsContextHandler.promptsContextFromRoute(route)
+    val rendered = if (result.isError) result.withResourceEntryPointHints() else result
+    return presentation.render(rendered, command = command.commandName, out = mcpStdout)
 }
 
-private class PromptsContextResolutionException(message: String) : RuntimeException(message)
+private class FixedPromptsContextHandler(private val context: PromptsContext) : PromptsContextHandler {
+    override suspend fun buildPromptsContext(projectName: String): PromptsContext = context
+}
 
-private fun resourceNotFoundMessage(uri: String): String = buildString {
-    append("Resource not found: ").append(uri).append('\n')
-    append("Canonical entry points:\n")
-    for (entry in canonicalResourceEntryPoints()) {
-        append("  devrig prompt ").append(entry.uri).append('\n')
+private fun ToolCallResult.withResourceEntryPointHints(): ToolCallResult {
+    val hints = buildString {
+        append("Canonical entry points:\n")
+        for (entry in canonicalResourceEntryPoints()) {
+            append("  devrig prompt ").append(entry.uri).append('\n')
+        }
     }
+    return copy(content = content + ContentItem.Text(hints))
 }
 
 /** A runnable example for the `prompt` usage error — built from generated article URIs, never a literal. */
@@ -82,3 +94,5 @@ fun fetchResourceUsageExample(): String = "devrig prompt ${canonicalResourceEntr
 /** First canonical entry-point URI, or a bracket placeholder if the article index is somehow empty. */
 fun canonicalResourceEntryPointOrPlaceholder(): String =
     canonicalResourceEntryPoints().firstOrNull()?.uri ?: "<resource-uri>"
+
+private const val GENERIC_PROJECT_NAME = "devrig-cli-generic"

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/HelpCommand.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/HelpCommand.kt
@@ -59,6 +59,40 @@ fun printHelp(out: PrintStream) : Int {
                                          provisioned. With id (for example port-63342),
                                          print manual MCP Steroid plugin install
                                          instructions for that IDE.
+
+        MCP tools as CLI (same tools as the `devrig mcp` server, callable from the shell):
+
+          devrig prompt <uri> [--project_name <key>]
+                                         fetch a mcp-steroid:// guide by URI (steroid_fetch_resource).
+                                         Works without a running IDE for bundled docs; pass
+                                         --project_name for IDE-specific content.
+          devrig fetch_resource --uri=<uri> [--project_name <key>]
+                                         canonical form of `devrig prompt`.
+
+          devrig execute_code --project_name=<key> --code-file=<path> --task_id=<id> --reason=<text>
+                              [--code=<inline>] [--modal=<mode>] [--timeout=<sec>] [--json]
+                                         run a Kotlin script in the IDE (steroid_execute_code).
+
+          devrig list_projects [--json]  list open projects (steroid_list_projects; shares
+                                         output with `devrig project`). Exposes project_name,
+                                         the routing key for the other commands.
+          devrig list_windows  [--json]  list IDE windows + readiness + background tasks
+                                         (steroid_list_windows).
+
+          devrig open_project --project_path=<abs> --task_id=<id> --reason=<text>
+                              [--backend_name=<id>] [--trust_project] [--wait] [--json]
+                                         open a project (steroid_open_project); --wait polls until ready.
+
+          devrig take_screenshot --project_name=<key> --task_id=<id> --reason=<text>
+                              [--window_id=<win>] [--out=<file.png>] [--json]
+                                         capture a screenshot (steroid_take_screenshot).
+          devrig input --project_name=<key> --window_id=<win> --task_id=<id> --reason=<text>
+                              --sequence=<steps> [--json]
+                                         send keyboard/mouse input (steroid_input).
+          devrig execute_feedback --project_name=<key> --task_id=<id> --success_rating=<0..1>
+                              --explanation=<text> [--execution_id=<id>] [--code-file=<path>] [--json]
+                                         rate an execution (steroid_execute_feedback).
+
           devrig --version | -v          print the devrig version and exit
           devrig --help    | -h          print this help and exit
 

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/HelpCommand.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/HelpCommand.kt
@@ -29,17 +29,19 @@ fun printExecuteCodeHelp(out: PrintStream): Int {
         devrig execute_code — run a Kotlin script inside the target IDE (steroid_execute_code).
 
         Usage:
-          devrig execute_code --project_name=<key> (--code-file=<path> | --code=<inline> | --code-file=-)
+          devrig execute_code [--project_name=<key>] (--code-file=<path> | --code=<inline> | --code-file=-)
                               --task_id=<id> --reason=<text> [--modal=<mode>] [--timeout=<sec>] [--json]
 
         Required:
-          --project_name   routing key from `devrig list_projects` (NOT the folder name)
           --code-file      path to a .kts file; pass "-" to read the script from stdin (blocks until EOF)
           --code           inline script (alternative to --code-file)
           --task_id        groups related calls in audit logs
           --reason         full task description
 
         Optional:
+          --project_name   routing key from `devrig list_projects` (NOT the folder name); omit to infer
+                            from the current directory — fails with a candidate list (exit 64) when the
+                            cwd matches zero or more than one open project
           --modal          smart_non_modal (default) | non_modal | unleashed
           --timeout        script timeout in seconds (default 600)
           --json           emit the unified {tool, command, isError, data} envelope
@@ -48,7 +50,8 @@ fun printExecuteCodeHelp(out: PrintStream): Int {
           - the script is a Kotlin SUSPEND body — never use runBlocking
           - PSI reads go in readAction { }, writes in writeAction { }
           - nothing is auto-printed: end with println(...) / printJson(...) to see output
-          - route by project_name (get it from `devrig list_projects`), not the folder name
+          - route by project_name (get it from `devrig list_projects`), not the folder name; omitted
+            --project_name is inferred from the current directory when it uniquely matches one open project
 
         Go deeper — fetch only what you need:
         """.trimIndent() + "\n"
@@ -123,10 +126,12 @@ fun printHelp(out: PrintStream) : Int {
           devrig fetch_resource --uri=<uri> [--project_name <key>]
                                          canonical form of `devrig prompt`.
 
-          devrig execute_code --project_name=<key> --code-file=<path> --task_id=<id> --reason=<text>
+          devrig execute_code [--project_name=<key>] --code-file=<path> --task_id=<id> --reason=<text>
                               [--code=<inline>] [--modal=<mode>] [--timeout=<sec>] [--json]
                                          run a Kotlin script in the IDE (steroid_execute_code).
                                          --code-file=- reads the script from stdin (blocks until EOF).
+                                         --project_name omitted → inferred from the current directory
+                                         (fails with a candidate list, exit 64, if not unique).
 
           devrig list_projects [--json]  list open projects (steroid_list_projects; shares
                                          output with `devrig project`). Exposes project_name,
@@ -138,15 +143,18 @@ fun printHelp(out: PrintStream) : Int {
                               [--backend_name=<id>] [--trust_project] [--wait] [--json]
                                          open a project (steroid_open_project); --wait polls until ready.
 
-          devrig take_screenshot --project_name=<key> --task_id=<id> --reason=<text>
+          devrig take_screenshot [--project_name=<key>] --task_id=<id> --reason=<text>
                               [--window_id=<win>] [--out=<file.png>] [--json]
                                          capture a screenshot (steroid_take_screenshot).
-          devrig input --project_name=<key> --window_id=<win> --task_id=<id> --reason=<text>
+                                         --project_name omitted → inferred from the current directory.
+          devrig input [--project_name=<key>] --window_id=<win> --task_id=<id> --reason=<text>
                               --sequence=<steps> [--json]
                                          send keyboard/mouse input (steroid_input).
-          devrig execute_feedback --project_name=<key> --task_id=<id> --success_rating=<0..1>
+                                         --project_name omitted → inferred from the current directory.
+          devrig execute_feedback [--project_name=<key>] --task_id=<id> --success_rating=<0..1>
                               --explanation=<text> [--execution_id=<id>] [--code-file=<path>] [--json]
                                          rate an execution (steroid_execute_feedback).
+                                         --project_name omitted → inferred from the current directory.
 
           devrig --version | -v          print the devrig version and exit
           devrig --help    | -h          print this help and exit

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/HelpCommand.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/HelpCommand.kt
@@ -34,7 +34,7 @@ fun printExecuteCodeHelp(out: PrintStream): Int {
 
         Required:
           --project_name   routing key from `devrig list_projects` (NOT the folder name)
-          --code-file      path to a .kts file; pass "-" to read the script from stdin
+          --code-file      path to a .kts file; pass "-" to read the script from stdin (blocks until EOF)
           --code           inline script (alternative to --code-file)
           --task_id        groups related calls in audit logs
           --reason         full task description
@@ -126,6 +126,7 @@ fun printHelp(out: PrintStream) : Int {
           devrig execute_code --project_name=<key> --code-file=<path> --task_id=<id> --reason=<text>
                               [--code=<inline>] [--modal=<mode>] [--timeout=<sec>] [--json]
                                          run a Kotlin script in the IDE (steroid_execute_code).
+                                         --code-file=- reads the script from stdin (blocks until EOF).
 
           devrig list_projects [--json]  list open projects (steroid_list_projects; shares
                                          output with `devrig project`). Exposes project_name,

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/HelpCommand.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/HelpCommand.kt
@@ -1,9 +1,63 @@
 package com.jonnyzzz.mcpSteroid.devrig
 
+import com.jonnyzzz.mcpSteroid.server.executeCodeGuideUris
 import java.io.PrintStream
 
 fun printVersion(out: PrintStream) : Int {
     out.println(DevrigVersionMetadata.getDevrigVersion())
+    return 0
+}
+
+/**
+ * Layered help: `devrig help <topic>` / `devrig <cmd> --help`. A [topic] gives a concise per-command
+ * entry that ends with `devrig prompt <uri>` pointers so an agent drills only as deep as it needs;
+ * an unknown/absent topic falls back to the global banner.
+ */
+fun printTopicHelp(topic: String?, out: PrintStream): Int = when (topic) {
+    "execute_code" -> printExecuteCodeHelp(out)
+    else -> printHelp(out)
+}
+
+/**
+ * Concise entry point for `devrig execute_code` — the flags + the must-know rules for a first call,
+ * then a "go deeper" list into the `mcp-steroid://` article graph (fetch with `devrig prompt <uri>`).
+ * Deliberately short: the full reference stays fetch-on-demand, not inlined here.
+ */
+fun printExecuteCodeHelp(out: PrintStream): Int {
+    out.print(
+        """
+        devrig execute_code — run a Kotlin script inside the target IDE (steroid_execute_code).
+
+        Usage:
+          devrig execute_code --project_name=<key> (--code-file=<path> | --code=<inline> | --code-file=-)
+                              --task_id=<id> --reason=<text> [--modal=<mode>] [--timeout=<sec>] [--json]
+
+        Required:
+          --project_name   routing key from `devrig list_projects` (NOT the folder name)
+          --code-file      path to a .kts file; pass "-" to read the script from stdin
+          --code           inline script (alternative to --code-file)
+          --task_id        groups related calls in audit logs
+          --reason         full task description
+
+        Optional:
+          --modal          smart_non_modal (default) | non_modal | unleashed
+          --timeout        script timeout in seconds (default 600)
+          --json           emit the unified {tool, command, isError, data} envelope
+
+        Must know (first call):
+          - the script is a Kotlin SUSPEND body — never use runBlocking
+          - PSI reads go in readAction { }, writes in writeAction { }
+          - nothing is auto-printed: end with println(...) / printJson(...) to see output
+          - route by project_name (get it from `devrig list_projects`), not the folder name
+
+        Go deeper — fetch only what you need:
+        """.trimIndent() + "\n"
+    )
+    for ((uri, blurb) in executeCodeGuideUris()) {
+        out.println("  devrig prompt $uri")
+        out.println("      $blurb")
+    }
+    out.println()
     return 0
 }
 

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/HomePaths.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/HomePaths.kt
@@ -33,6 +33,17 @@ class HomePaths(val home: Path) {
     fun cacheDir(id: String): Path = cachesDir.resolve(id)
     fun pidFile(id: String): Path = stateDir.resolve("$id.pid")
 
+    /**
+     * `~/.mcp-steroid/tmp` — where [Presentation.Console] writes decoded image content it prints a path
+     * to (C4). Created on demand rather than in [mkdirsAll] since not every `devrig` invocation renders
+     * an image.
+     */
+    fun screenshotTmpDir(): Path {
+        val dir = home.resolve("tmp")
+        Files.createDirectories(dir)
+        return dir
+    }
+
     fun mkdirsAll() {
         listOf(logsDir, backendsDir, cachesDir, downloadsDir, stateDir, binDir).forEach { Files.createDirectories(it) }
     }

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/ListProjectsCommand.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/ListProjectsCommand.kt
@@ -36,9 +36,10 @@ fun DevrigServices.runListProjectsCommand(
     } catch (e: CancellationException) {
         throw e
     } catch (e: Exception) {
-        return renderCliError(
+        // command.json is always true past the early return above; the JSON presentation is fixed here.
+        return Presentation.Json().renderError(
             "list_projects", "devrig list_projects failed to reach a backend: ${e.message}",
-            command.json, CliExit.UNAVAILABLE, mcpStdout,
+            CliExit.UNAVAILABLE, mcpStdout,
         )
     }
     mcpStdout.println(listProjectsEnvelopeJson(response))

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/ListProjectsCommand.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/ListProjectsCommand.kt
@@ -1,0 +1,52 @@
+/* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
+package com.jonnyzzz.mcpSteroid.devrig
+
+import com.jonnyzzz.mcpSteroid.devrig.server.StubMcpSteroidTools
+import com.jonnyzzz.mcpSteroid.server.ListProjectsResponse
+import com.jonnyzzz.mcpSteroid.server.ListProjectsToolHandler
+import com.jonnyzzz.mcpSteroid.server.McpSteroidTools
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.jsonObject
+
+/**
+ * `devrig list_projects [--json]` — the CLI face of `steroid_list_projects`, reconciled with the existing
+ * `devrig project` (#191):
+ *  - **human** output reuses `devrig project`'s renderer (so the two never drift);
+ *  - **`--json`** uses the unified envelope ([cliEnvelopeJson]) built from the same
+ *    [ListProjectsToolHandler] the MCP tool uses, exposing `project_name` (the routing key) for the
+ *    other commands.
+ *
+ * `tools` is defaulted so tests can inject a fake routing snapshot.
+ */
+fun DevrigServices.runListProjectsCommand(
+    command: DevrigCommand.DevrigCommandListProjects,
+    tools: McpSteroidTools = StubMcpSteroidTools(this),
+): Int {
+    if (!command.json) {
+        // Human path: identical to `devrig project` (port-scan footer + routing table).
+        return runProjectCommand(DevrigCommand.DevrigCommandProject(debug = command.debug, json = false))
+    }
+
+    val response = try {
+        runBlocking(Dispatchers.IO) {
+            tools.handler<ListProjectsToolHandler>().collectListProjectsResponse()
+        }
+    } catch (e: CancellationException) {
+        throw e
+    } catch (e: Exception) {
+        System.err.println("devrig list_projects failed to reach a backend: ${e.message}")
+        return CliExit.UNAVAILABLE
+    }
+    mcpStdout.println(listProjectsEnvelopeJson(response))
+    return CliExit.OK
+}
+
+/** Wraps the projects response in the unified `{tool, command, isError, data}` envelope. */
+fun listProjectsEnvelopeJson(response: ListProjectsResponse): String {
+    val data = CLI_ENVELOPE_JSON
+        .encodeToJsonElement(ListProjectsResponse.serializer(), response)
+        .jsonObject
+    return cliEnvelopeJson(command = "list_projects", isError = false, data = data)
+}

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/ListProjectsCommand.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/ListProjectsCommand.kt
@@ -36,8 +36,10 @@ fun DevrigServices.runListProjectsCommand(
     } catch (e: CancellationException) {
         throw e
     } catch (e: Exception) {
-        System.err.println("devrig list_projects failed to reach a backend: ${e.message}")
-        return CliExit.UNAVAILABLE
+        return renderCliError(
+            "list_projects", "devrig list_projects failed to reach a backend: ${e.message}",
+            command.json, CliExit.UNAVAILABLE, mcpStdout,
+        )
     }
     mcpStdout.println(listProjectsEnvelopeJson(response))
     return CliExit.OK

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/ListWindowsCommand.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/ListWindowsCommand.kt
@@ -23,6 +23,7 @@ fun DevrigServices.runListWindowsCommand(
     command: DevrigCommand.DevrigCommandListWindows,
     tools: McpSteroidTools = StubMcpSteroidTools(this),
 ): Int {
+    val presentation = presentationFor(command.json) { homePaths.home }
     val response = try {
         runBlocking(Dispatchers.IO) {
             tools.handler<ListWindowsToolHandler>().collectListWindowsResponse()
@@ -30,12 +31,15 @@ fun DevrigServices.runListWindowsCommand(
     } catch (e: CancellationException) {
         throw e
     } catch (e: Exception) {
-        return renderCliError(
+        return presentation.renderError(
             "list_windows", "devrig list_windows failed to reach a backend: ${e.message}",
-            command.json, CliExit.UNAVAILABLE, mcpStdout,
+            CliExit.UNAVAILABLE, mcpStdout,
         )
     }
 
+    // list_windows/list_projects don't route their SUCCESS path through Presentation.render: the payload
+    // is a typed ListWindowsResponse (list_windows_envelope_json), not a ToolCallResult, so each keeps its
+    // own success renderer here; only the shared error envelope goes through `presentation`.
     if (command.json) {
         mcpStdout.println(listWindowsEnvelopeJson(response))
     } else {

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/ListWindowsCommand.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/ListWindowsCommand.kt
@@ -4,25 +4,28 @@ package com.jonnyzzz.mcpSteroid.devrig
 import com.jonnyzzz.mcpSteroid.devrig.server.StubMcpSteroidTools
 import com.jonnyzzz.mcpSteroid.server.ListWindowsResponse
 import com.jonnyzzz.mcpSteroid.server.ListWindowsToolHandler
+import com.jonnyzzz.mcpSteroid.server.McpSteroidTools
 import java.io.PrintStream
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking
-import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonObject
 
 /**
  * `devrig list_windows [--json]` — the CLI face of `steroid_list_windows`.
  *
- * Like `devrig project`, this returns a typed response (not a [com.jonnyzzz.mcpSteroid.mcp.ToolCallResult])
- * so it uses its own renderers rather than the shared `renderTo` envelope. The data comes from the
- * existing [ListWindowsToolHandler] bridge implementation — one source of truth with the MCP tool.
+ * Returns a typed response (not a [com.jonnyzzz.mcpSteroid.mcp.ToolCallResult]) so it has its own human
+ * renderer, but `--json` uses the SAME unified envelope as every other command ([cliEnvelopeJson]). The
+ * data comes from the existing [ListWindowsToolHandler] bridge implementation — one source of truth with
+ * the MCP tool. `tools` is defaulted so tests can inject a fake snapshot.
  */
-fun DevrigServices.runListWindowsCommand(command: DevrigCommand.DevrigCommandListWindows): Int {
+fun DevrigServices.runListWindowsCommand(
+    command: DevrigCommand.DevrigCommandListWindows,
+    tools: McpSteroidTools = StubMcpSteroidTools(this),
+): Int {
     val response = try {
         runBlocking(Dispatchers.IO) {
-            StubMcpSteroidTools(this@runListWindowsCommand)
-                .handler<ListWindowsToolHandler>()
-                .collectListWindowsResponse()
+            tools.handler<ListWindowsToolHandler>().collectListWindowsResponse()
         }
     } catch (e: CancellationException) {
         throw e
@@ -32,17 +35,19 @@ fun DevrigServices.runListWindowsCommand(command: DevrigCommand.DevrigCommandLis
     }
 
     if (command.json) {
-        renderListWindowsJson(response, mcpStdout)
+        mcpStdout.println(listWindowsEnvelopeJson(response))
     } else {
         renderListWindowsText(response, mcpStdout)
     }
     return CliExit.OK
 }
 
-private val LIST_WINDOWS_JSON = Json { prettyPrint = true; encodeDefaults = true; explicitNulls = false }
-
-fun renderListWindowsJson(response: ListWindowsResponse, out: PrintStream) {
-    out.println(LIST_WINDOWS_JSON.encodeToString(ListWindowsResponse.serializer(), response))
+/** Wraps the windows response in the unified `{tool, command, isError, data}` envelope. */
+fun listWindowsEnvelopeJson(response: ListWindowsResponse): String {
+    val data = CLI_ENVELOPE_JSON
+        .encodeToJsonElement(ListWindowsResponse.serializer(), response)
+        .jsonObject
+    return cliEnvelopeJson(command = "list_windows", isError = false, data = data)
 }
 
 fun renderListWindowsText(response: ListWindowsResponse, out: PrintStream) {

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/ListWindowsCommand.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/ListWindowsCommand.kt
@@ -30,8 +30,10 @@ fun DevrigServices.runListWindowsCommand(
     } catch (e: CancellationException) {
         throw e
     } catch (e: Exception) {
-        System.err.println("devrig list_windows failed to reach a backend: ${e.message}")
-        return CliExit.UNAVAILABLE
+        return renderCliError(
+            "list_windows", "devrig list_windows failed to reach a backend: ${e.message}",
+            command.json, CliExit.UNAVAILABLE, mcpStdout,
+        )
     }
 
     if (command.json) {

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/ListWindowsCommand.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/ListWindowsCommand.kt
@@ -1,0 +1,75 @@
+/* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
+package com.jonnyzzz.mcpSteroid.devrig
+
+import com.jonnyzzz.mcpSteroid.devrig.server.StubMcpSteroidTools
+import com.jonnyzzz.mcpSteroid.server.ListWindowsResponse
+import com.jonnyzzz.mcpSteroid.server.ListWindowsToolHandler
+import java.io.PrintStream
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.Json
+
+/**
+ * `devrig list_windows [--json]` — the CLI face of `steroid_list_windows`.
+ *
+ * Like `devrig project`, this returns a typed response (not a [com.jonnyzzz.mcpSteroid.mcp.ToolCallResult])
+ * so it uses its own renderers rather than the shared `renderTo` envelope. The data comes from the
+ * existing [ListWindowsToolHandler] bridge implementation — one source of truth with the MCP tool.
+ */
+fun DevrigServices.runListWindowsCommand(command: DevrigCommand.DevrigCommandListWindows): Int {
+    val response = try {
+        runBlocking(Dispatchers.IO) {
+            StubMcpSteroidTools(this@runListWindowsCommand)
+                .handler<ListWindowsToolHandler>()
+                .collectListWindowsResponse()
+        }
+    } catch (e: CancellationException) {
+        throw e
+    } catch (e: Exception) {
+        System.err.println("devrig list_windows failed to reach a backend: ${e.message}")
+        return CliExit.UNAVAILABLE
+    }
+
+    if (command.json) {
+        renderListWindowsJson(response, mcpStdout)
+    } else {
+        renderListWindowsText(response, mcpStdout)
+    }
+    return CliExit.OK
+}
+
+private val LIST_WINDOWS_JSON = Json { prettyPrint = true; encodeDefaults = true; explicitNulls = false }
+
+fun renderListWindowsJson(response: ListWindowsResponse, out: PrintStream) {
+    out.println(LIST_WINDOWS_JSON.encodeToString(ListWindowsResponse.serializer(), response))
+}
+
+fun renderListWindowsText(response: ListWindowsResponse, out: PrintStream) {
+    if (response.windows.isEmpty() && response.backgroundTasks.isEmpty()) {
+        out.println("No IDE windows detected.")
+        return
+    }
+    out.println("Windows (${response.windows.size}):")
+    for ((index, w) in response.windows.withIndex()) {
+        val flags = buildList {
+            if (w.modalDialogShowing) add("modal")
+            if (w.indexingInProgress == true) add("indexing")
+            if (w.projectInitialized == true) add("initialized")
+            if (w.isActive) add("active")
+        }.joinToString(", ").ifEmpty { "—" }
+        out.println("  [${index + 1}] window_id=${w.windowId}  project_name=${w.projectName ?: "—"}")
+        out.println("        title:   ${w.title ?: "—"}")
+        out.println("        path:    ${w.projectPath ?: "—"}")
+        out.println("        backend: ${w.backendName ?: "—"}")
+        out.println("        state:   $flags")
+    }
+    if (response.backgroundTasks.isNotEmpty()) {
+        out.println()
+        out.println("Background tasks (${response.backgroundTasks.size}):")
+        for (task in response.backgroundTasks) {
+            val pct = task.fraction?.let { " ${(it * 100).toInt()}%" } ?: if (task.isIndeterminate) " (indeterminate)" else ""
+            out.println("  - ${task.title}$pct — ${task.text} (project_name=${task.projectName ?: "—"})")
+        }
+    }
+}

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/ListWindowsCommand.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/ListWindowsCommand.kt
@@ -23,7 +23,7 @@ fun DevrigServices.runListWindowsCommand(
     command: DevrigCommand.DevrigCommandListWindows,
     tools: McpSteroidTools = StubMcpSteroidTools(this),
 ): Int {
-    val presentation = presentationFor(command.json) { homePaths.home }
+    val presentation = presentationFor(command.json, homePaths::screenshotTmpDir)
     val response = try {
         runBlocking(Dispatchers.IO) {
             tools.handler<ListWindowsToolHandler>().collectListWindowsResponse()

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/Main.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/Main.kt
@@ -146,9 +146,9 @@ suspend fun DevrigServices.mainImpl2(
         // consumer never gets an empty stdout on an unexpected failure; otherwise log the trace to
         // stderr (stdout stays clean). Never a stack trace on stdout, never a second stdout document.
         if (command.json) {
-            renderCliError(
+            Presentation.Json().renderError(
                 "devrig", "unexpected error: ${t.message ?: t.javaClass.simpleName}",
-                json = true, exit = 64, out = mcpStdout,
+                exit = 64, out = mcpStdout,
             )
         } else {
             System.err.println("Unexpected error calling $command. ${t.message}")

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/Main.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/Main.kt
@@ -85,12 +85,18 @@ suspend fun DevrigServices.mainImpl2(
     command: DevrigCommand,
     headliner: String,
 ): Int = coroutineScope {
-    // The devrig binary owns ~/.mcp-steroid/bin/devrig: (re)create/update it on EVERY start so it
-    // self-heals and always points at this running install + JDK. Best-effort and stderr-only — never
-    // blocks serving. It writes atomically, so an agent mid-read of the launcher never sees a torn file.
-    // For `devrig mcp` we skip the Windows user-PATH registration (it spawns PowerShell and would delay
-    // the first serve); that runs on interactive/`install` invocations instead.
-    ensureBinLauncher(homePaths, registerWindowsPath = command !is DevrigCommand.MCP)
+    // The devrig binary owns ~/.mcp-steroid/bin/devrig: (re)create/update it on start so it self-heals
+    // and always points at this running install + JDK. Best-effort and stderr-only — never blocks
+    // serving. It writes atomically, so an agent mid-read of the launcher never sees a torn file. For
+    // `devrig mcp` we skip the Windows user-PATH registration (it spawns PowerShell and would delay the
+    // first serve); that runs on interactive/`install` invocations instead.
+    //
+    // Gated on [selfHealsLauncherOnStart]: the MCP-as-CLI tool facades are thin, stateless bridge
+    // forwarders and must NOT mutate on-disk launcher/PATH state (Tenet 3). The self-heal is a
+    // bootstrap/lifecycle concern reserved for `mcp` + the interactive commands.
+    if (command.selfHealsLauncherOnStart()) {
+        ensureBinLauncher(homePaths, registerWindowsPath = command !is DevrigCommand.MCP)
+    }
 
     // For the MCP command, the running McpServerCore becomes available once the
     // stdio server is built; the update check broadcasts its notice over it (in
@@ -133,10 +139,22 @@ suspend fun DevrigServices.mainImpl2(
     }
     try {
         runCli(command)
+    } catch (c: kotlinx.coroutines.CancellationException) {
+        throw c
     } catch (t: Throwable) {
-        System.err.println("Unexpected error calling $command. ${t.message}")
-        t.printStackTrace(System.err)
-        64
+        // Last-resort crash handler. Under --json still emit a single isError envelope so a machine
+        // consumer never gets an empty stdout on an unexpected failure; otherwise log the trace to
+        // stderr (stdout stays clean). Never a stack trace on stdout, never a second stdout document.
+        if (command.json) {
+            renderCliError(
+                "devrig", "unexpected error: ${t.message ?: t.javaClass.simpleName}",
+                json = true, exit = 64, out = mcpStdout,
+            )
+        } else {
+            System.err.println("Unexpected error calling $command. ${t.message}")
+            t.printStackTrace(System.err)
+            64
+        }
     }
 }
 
@@ -182,6 +200,16 @@ private fun DevrigCommand.isMcpAsCliToolCommand(): Boolean = when (this) {
 
 private fun DevrigCommand.printsHeadliner(): Boolean =
     runsTool() && this !is DevrigCommand.MCP && !json && !isMcpAsCliToolCommand()
+
+/**
+ * Whether this command performs the on-start `~/.mcp-steroid/bin` launcher + PATH self-heal
+ * ([ensureBinLauncher]). The self-heal is a bootstrap/lifecycle concern: it runs for the long-lived
+ * `mcp` server and the interactive lifecycle commands (backend / project / install / help / version) —
+ * but NOT for the thin, stateless MCP-as-CLI tool facades ([isMcpAsCliToolCommand]), which must never
+ * mutate on-disk launcher/PATH state just to forward a single bridge call (Tenet 3: devrig is
+ * stateless). Pure and side-effect-free so it is unit-testable across every [DevrigCommand] variant.
+ */
+fun DevrigCommand.selfHealsLauncherOnStart(): Boolean = !isMcpAsCliToolCommand()
 
 suspend fun DevrigServices.mainImplMcp(
     onServerReady: (McpServerCore) -> Unit = {},

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/Main.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/Main.kt
@@ -149,14 +149,39 @@ private fun DevrigCommand.runsTool(): Boolean = when (this) {
     is DevrigCommand.DevrigCommandBackendProvision,
     is DevrigCommand.DevrigCommandProject,
     is DevrigCommand.DevrigCommandInstall,
-    is DevrigCommand.DevrigCommandInstallDevrig -> true
+    is DevrigCommand.DevrigCommandInstallDevrig,
+    is DevrigCommand.DevrigCommandFetchResource,
+    is DevrigCommand.DevrigCommandExecuteCode,
+    is DevrigCommand.DevrigCommandListProjects,
+    is DevrigCommand.DevrigCommandListWindows,
+    is DevrigCommand.DevrigCommandOpenProject,
+    is DevrigCommand.DevrigCommandScreenshot,
+    is DevrigCommand.DevrigCommandInput,
+    is DevrigCommand.DevrigCommandFeedback -> true
     is DevrigCommand.DevrigCommandHelp,
     is DevrigCommand.DevrigCommandVersion,
     is DevrigCommand.DevrigCommandParseError -> false
 }
 
+/**
+ * The MCP-as-CLI tool commands emit data (markdown, JSON, tool output) to stdout that must stay
+ * clean for piping, so they never print the human headliner banner — unlike the interactive
+ * `project` / `backend` / `install` listings.
+ */
+private fun DevrigCommand.isMcpAsCliToolCommand(): Boolean = when (this) {
+    is DevrigCommand.DevrigCommandFetchResource,
+    is DevrigCommand.DevrigCommandExecuteCode,
+    is DevrigCommand.DevrigCommandListProjects,
+    is DevrigCommand.DevrigCommandListWindows,
+    is DevrigCommand.DevrigCommandOpenProject,
+    is DevrigCommand.DevrigCommandScreenshot,
+    is DevrigCommand.DevrigCommandInput,
+    is DevrigCommand.DevrigCommandFeedback -> true
+    else -> false
+}
+
 private fun DevrigCommand.printsHeadliner(): Boolean =
-    runsTool() && this !is DevrigCommand.MCP && !json
+    runsTool() && this !is DevrigCommand.MCP && !json && !isMcpAsCliToolCommand()
 
 suspend fun DevrigServices.mainImplMcp(
     onServerReady: (McpServerCore) -> Unit = {},

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/ToolBackedCommands.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/ToolBackedCommands.kt
@@ -65,9 +65,9 @@ private inline fun DevrigServices.runToolCall(
     return presentation.render(result, command = commandName, out = mcpStdout)
 }
 
-/** Builds this command's [Presentation] once from its `--json` flag; `imageDir` is unused before Task 6. */
+/** Builds this command's [Presentation] once from its `--json` flag; console images go to [HomePaths.screenshotTmpDir]. */
 private fun DevrigServices.presentationFor(json: Boolean): Presentation =
-    presentationFor(json) { homePaths.home }
+    presentationFor(json, homePaths::screenshotTmpDir)
 
 /**
  * Signals a bad `--code-file`. [exit] distinguishes a fixable-input mistake ([CliExit.USAGE] — missing

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/ToolBackedCommands.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/ToolBackedCommands.kt
@@ -13,12 +13,12 @@ import com.jonnyzzz.mcpSteroid.server.ExecuteCodeToolHandler
 import com.jonnyzzz.mcpSteroid.server.ExecuteCodeToolSpec
 import com.jonnyzzz.mcpSteroid.server.ExecuteFeedbackToolHandler
 import com.jonnyzzz.mcpSteroid.server.ExecuteFeedbackToolSpec
-import com.jonnyzzz.mcpSteroid.server.InputParams
 import com.jonnyzzz.mcpSteroid.server.ListWindowsToolHandler
 import com.jonnyzzz.mcpSteroid.server.McpSteroidTools
-import com.jonnyzzz.mcpSteroid.server.OpenProjectParams
 import com.jonnyzzz.mcpSteroid.server.OpenProjectToolHandler
+import com.jonnyzzz.mcpSteroid.server.OpenProjectToolSpec
 import com.jonnyzzz.mcpSteroid.server.VisionInputToolHandler
+import com.jonnyzzz.mcpSteroid.server.VisionInputToolSpec
 import com.jonnyzzz.mcpSteroid.server.VisionScreenshotToolHandler
 import com.jonnyzzz.mcpSteroid.server.VisionScreenshotToolSpec
 import java.io.IOException
@@ -62,6 +62,10 @@ private inline fun DevrigServices.runToolCall(
         )
     } catch (e: CancellationException) {
         throw e
+    } catch (e: IllegalArgumentException) {
+        return presentation.renderError(
+            commandName, "devrig $commandName: ${e.message}", CliExit.USAGE, mcpStdout,
+        )
     } catch (e: Exception) {
         return presentation.renderError(
             commandName, "devrig $commandName failed to reach a backend: ${e.message}",
@@ -164,10 +168,7 @@ fun DevrigServices.runExecuteCodeCommand(
     } catch (e: CodeArgException) {
         return presentation.renderCodeArgFailure("execute_code", e, mcpStdout)
     }
-    // Map the CLI flags → tool-call JSON arguments; ExecuteCodeToolSpec.call() re-parses them into
-    // ExecCodeParams (single source of truth), rather than the CLI rebuilding *Params by hand (C9/C15).
-    // --modal is validated at parse time (ExecuteCodeCliCommand), so a bad value never reaches here; when
-    // omitted the spec applies its own default (SMART_NON_MODAL == ModalMode.DEFAULT), preserving behavior.
+    // ToolSpec owns parameter parsing and defaults; the CLI only maps its flags to JSON.
     val arguments = buildJsonObject {
         put("project_name", projectName)
         put("code", code)
@@ -208,11 +209,7 @@ fun DevrigServices.runFeedbackCommand(
     } catch (e: CodeArgException) {
         return presentation.renderCodeArgFailure("execute_feedback", e, mcpStdout)
     }
-    // Map the CLI flags → tool-call JSON arguments; ExecuteFeedbackToolSpec.call() re-parses them into
-    // FeedbackParams and calls the handler (C9/C15). All required fields (project_name, task_id,
-    // success_rating in range, explanation) are already enforced at parse time (FeedbackCliCommand), so
-    // the spec's equivalent guards never fire — behavior is preserved. execution_id is intentionally NOT
-    // forwarded (parity with the MCP surface). `code` is optional and omitted when absent.
+    // execution_id is accepted by the CLI for compatibility but is not part of FeedbackParams.
     val arguments = buildJsonObject {
         put("project_name", projectName)
         put("task_id", command.taskId!!)
@@ -243,38 +240,21 @@ fun DevrigServices.runInputCommand(
     } catch (e: CodeArgException) {
         return presentation.renderCodeArgFailure("input", e, mcpStdout)
     }
-    // Forward the RAW sequence verbatim — the IDE is the SINGLE source of truth for input syntax. devrig
-    // deliberately does NOT re-parse/validate the sequence: a newer plugin may accept steps this devrig's
-    // parser wouldn't recognize, so client-side rejection would strand a valid call on version skew.
-    val params = InputParams(
-        taskId = command.taskId!!,
-        reason = command.reason!!,
-        windowId = command.windowId!!,
-        sequence = emptyList(),
-        rawSequence = command.sequence,
-    )
-    // The IDE's parse failure is returned as an isError result whose text is a full server stack trace;
-    // sanitize THAT (strip JVM frames) so the agent sees the message, not a leaked trace. Scoped to
-    // input — never execute_code, whose trace is the agent's own script (see sanitizeServerError).
-    val result = try {
-        runBlocking(Dispatchers.IO) {
-            tools.handler<VisionInputToolHandler>().handleInputSequence(projectName, params)
-        }
-    } catch (e: ProjectRouteNotFoundException) {
-        return presentation.renderError(
-            "input", "${e.message} — run `devrig list_projects` to see valid project_name keys",
-            CliExit.USAGE, mcpStdout,
-        )
-    } catch (e: CancellationException) {
-        throw e
-    } catch (e: Exception) {
-        return presentation.renderError(
-            "input", "devrig input failed to reach a backend: ${e.message}",
-            CliExit.UNAVAILABLE, mcpStdout,
-        )
+    val arguments = buildJsonObject {
+        put("project_name", projectName)
+        put("task_id", command.taskId!!)
+        put("reason", command.reason!!)
+        put("window_id", command.windowId!!)
+        put("sequence", command.sequence)
     }
-    val rendered = if (result.isError) result.sanitizeErrorContent() else result
-    return presentation.render(rendered, command = "input", out = mcpStdout)
+    return runToolCall("input", presentation, tools) { t ->
+        val result = callToolViaSpec(
+            VisionInputToolSpec(parseSequence = false) { t.handler<VisionInputToolHandler>() },
+            arguments,
+            stderrProgressReporter(),
+        )
+        if (result.isError) result.sanitizeErrorContent() else result
+    }
 }
 
 /** Returns a copy with every Text content item's stack-frame noise stripped ([sanitizeServerError]). */
@@ -298,9 +278,7 @@ fun DevrigServices.runScreenshotCommand(
     } catch (e: CodeArgException) {
         return presentation.renderCodeArgFailure("take_screenshot", e, mcpStdout)
     }
-    // Map the CLI flags → tool-call JSON arguments; VisionScreenshotToolSpec.call() re-parses them into
-    // ScreenshotParams and calls the handler (C9/C15). window_id is optional and omitted when absent. The
-    // --out post-write below stays a CLI-only affordance around the call.
+    // --out remains a CLI-only post-processing step around the shared ToolSpec call.
     val arguments = buildJsonObject {
         put("project_name", projectName)
         put("task_id", command.taskId!!)
@@ -335,9 +313,7 @@ fun DevrigServices.runScreenshotCommand(
         return presentation.render(result, command = "take_screenshot", out = mcpStdout)
     }
 
-    // --out requested: strict contract (finding #6) — exit 0 ONLY when the file is actually written.
-    // A result with no image, or an undecodable image, is a data error (65), not a silent success; a
-    // malformed --out path string is a usage error (64); a real write failure is an I/O error (74).
+    // With --out, success means an image was decoded and written.
     val image = result.content.filterIsInstance<ContentItem.Image>().firstOrNull()
         ?: return presentation.renderError(
             "take_screenshot",
@@ -393,10 +369,7 @@ fun DevrigServices.runOpenProjectCommand(
     waitIntervalMs: Long = 2000,
 ): Int {
     val presentation = presentationFor(command.json)
-    // Resolve a relative --project_path against the caller's cwd into an absolute path. Previously a
-    // relative path (e.g. `.`) was resolved by the backend against `/`, silently opening the wrong
-    // project — the one genuinely dangerous Round-4 finding. A malformed path STRING is a fixable
-    // usage error (enveloped, not a stack trace propagated to Main).
+    // Resolve relative paths against the caller's cwd before dispatch.
     val absoluteProjectPath = try {
         Path.of(command.projectPath!!).toAbsolutePath().normalize().toString()
     } catch (e: InvalidPathException) {
@@ -405,14 +378,23 @@ fun DevrigServices.runOpenProjectCommand(
             CliExit.USAGE, mcpStdout,
         )
     }
-    val params = OpenProjectParams(
-        projectPath = absoluteProjectPath,
-        trustProject = command.trustProject,
-        backendName = command.backendName,
-    )
+    val arguments = buildJsonObject {
+        put("project_path", absoluteProjectPath)
+        put("task_id", command.taskId!!)
+        put("reason", command.reason!!)
+        put("trust_project", command.trustProject)
+        command.backendName?.let { put("backend_name", it) }
+    }
     val result = try {
         runBlocking(Dispatchers.IO) {
-            tools.handler<OpenProjectToolHandler>().handleOpenProject(params, stderrProgressReporter())
+            callToolViaSpec(
+                OpenProjectToolSpec(
+                    includeBackendName = true,
+                    validateProjectPath = false,
+                ) { tools.handler<OpenProjectToolHandler>() },
+                arguments,
+                stderrProgressReporter(),
+            )
         }
     } catch (e: CancellationException) {
         throw e
@@ -428,10 +410,7 @@ fun DevrigServices.runOpenProjectCommand(
         return presentation.render(result, command = "open_project", out = mcpStdout)
     }
 
-    // --wait: poll list_windows until the freshly-opened project is ready BEFORE emitting any stdout, so
-    // exactly ONE final envelope reflects the command's true outcome. Poll progress + transient poll
-    // failures go to stderr; the readiness contract is unchanged (initialized, not indexing, no modal).
-    // A timeout is a genuine failure — stdout gets a single isError envelope, never a stale success one.
+    // Delay stdout until --wait knows the final outcome, preserving one JSON envelope per invocation.
     val ready = waitForProjectReady(absoluteProjectPath, tools, attempts = waitAttempts, intervalMs = waitIntervalMs)
     if (!ready) {
         return presentation.renderError(

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/ToolBackedCommands.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/ToolBackedCommands.kt
@@ -18,6 +18,7 @@ import com.jonnyzzz.mcpSteroid.server.OpenProjectToolHandler
 import com.jonnyzzz.mcpSteroid.server.ScreenshotParams
 import com.jonnyzzz.mcpSteroid.server.VisionInputToolHandler
 import com.jonnyzzz.mcpSteroid.server.VisionScreenshotToolHandler
+import com.jonnyzzz.mcpSteroid.vision.InputSequenceParser
 import java.nio.file.Files
 import java.nio.file.Path
 import java.util.Base64
@@ -47,24 +48,31 @@ private inline fun DevrigServices.runToolCall(
     val result = try {
         runBlocking(Dispatchers.IO) { block(tools) }
     } catch (e: ProjectRouteNotFoundException) {
-        System.err.println("${e.message} — run `devrig list_projects` to see valid project_name keys")
-        return CliExit.USAGE
+        return renderCliError(
+            commandName,
+            "${e.message} — run `devrig list_projects` to see valid project_name keys",
+            json, CliExit.USAGE, mcpStdout,
+        )
     } catch (e: CancellationException) {
         throw e
     } catch (e: Exception) {
-        System.err.println("devrig $commandName failed to reach a backend: ${e.message}")
-        return CliExit.UNAVAILABLE
+        return renderCliError(
+            commandName, "devrig $commandName failed to reach a backend: ${e.message}",
+            json, CliExit.UNAVAILABLE, mcpStdout,
+        )
     }
     return result.renderTo(command = commandName, json = json, out = mcpStdout)
 }
 
-/** Reads inline `--code` or the `--code-file` path; returns null (after printing) on a bad file. */
-private fun resolveCodeArg(inline: String?, file: String?): String? {
+/** Signals a bad `--code-file` argument (missing / not a regular file) with an agent-usable message. */
+private class CodeArgException(message: String) : RuntimeException(message)
+
+/** Reads inline `--code` or the `--code-file` path; throws [CodeArgException] on a bad file. */
+private fun resolveCodeArg(inline: String?, file: String?): String {
     if (!inline.isNullOrBlank()) return inline
     val path = Path.of(file!!)
     if (!Files.isRegularFile(path)) {
-        System.err.println("--code-file not found or not a regular file: $path")
-        return null
+        throw CodeArgException("--code-file not found or not a regular file: $path")
     }
     return Files.readString(path)
 }
@@ -76,9 +84,13 @@ fun DevrigServices.runExecuteCodeCommand(
     tools: McpSteroidTools = StubMcpSteroidTools(this),
 ): Int {
     // `--code-file=-` reads the script from stdin so agents can pipe a snippet without a temp file.
-    val code = when {
-        command.codeFile == "-" -> mcpStdin.readBytes().decodeToString()
-        else -> resolveCodeArg(command.code, command.codeFile) ?: return CliExit.USAGE
+    val code = try {
+        when {
+            command.codeFile == "-" -> mcpStdin.readBytes().decodeToString()
+            else -> resolveCodeArg(command.code, command.codeFile)
+        }
+    } catch (e: CodeArgException) {
+        return renderCliError("execute_code", e.message!!, command.json, CliExit.USAGE, mcpStdout)
     }
     val modal = command.modal?.let { wire ->
         ModalMode.entries.firstOrNull { it.wire == wire }
@@ -108,10 +120,14 @@ fun DevrigServices.runFeedbackCommand(
     command: DevrigCommand.DevrigCommandFeedback,
     tools: McpSteroidTools = StubMcpSteroidTools(this),
 ): Int {
-    val code: String? = when {
-        !command.code.isNullOrBlank() -> command.code
-        !command.codeFile.isNullOrBlank() -> resolveCodeArg(null, command.codeFile) ?: return CliExit.USAGE
-        else -> null
+    val code: String? = try {
+        when {
+            !command.code.isNullOrBlank() -> command.code
+            !command.codeFile.isNullOrBlank() -> resolveCodeArg(null, command.codeFile)
+            else -> null
+        }
+    } catch (e: CodeArgException) {
+        return renderCliError("execute_feedback", e.message!!, command.json, CliExit.USAGE, mcpStdout)
     }
     val params = FeedbackParams(
         taskId = command.taskId!!,
@@ -130,8 +146,24 @@ fun DevrigServices.runInputCommand(
     command: DevrigCommand.DevrigCommandInput,
     tools: McpSteroidTools = StubMcpSteroidTools(this),
 ): Int {
+    // Validate the sequence client-side so a malformed step fails fast with a concise message + syntax
+    // hint. Previously the raw string round-tripped to the IDE, whose parse failure leaked a full server
+    // stack trace into the (--json) envelope (Codex Round-4 finding). We still forward the RAW string and
+    // an empty parsed list on success — the IDE remains the single source of truth for parsing.
+    command.sequence?.let { seq ->
+        try {
+            InputSequenceParser().parse(seq)
+        } catch (e: IllegalArgumentException) {
+            return renderCliError(
+                "input",
+                "invalid --sequence: ${e.message}\n" +
+                    "Accepted steps: press:KEY[+MODS], type:TEXT, delay:MS, stick:KEY, click:BTN@x,y",
+                command.json, CliExit.USAGE, mcpStdout,
+            )
+        }
+    }
     // The devrig bridge forwards the raw sequence string verbatim (the IDE re-parses it), so we do
-    // not need a client-side parse here; pass an empty parsed list and the raw string.
+    // not need to send the parsed list; pass an empty parsed list and the raw string.
     val params = InputParams(
         taskId = command.taskId!!,
         reason = command.reason!!,
@@ -161,41 +193,58 @@ fun DevrigServices.runScreenshotCommand(
                 .screenshotWindow(command.projectName!!, params, stderrProgressReporter())
         }
     } catch (e: ProjectRouteNotFoundException) {
-        System.err.println("${e.message} — run `devrig list_projects` to see valid project_name keys")
-        return CliExit.USAGE
+        return renderCliError(
+            "take_screenshot",
+            "${e.message} — run `devrig list_projects` to see valid project_name keys",
+            command.json, CliExit.USAGE, mcpStdout,
+        )
     } catch (e: CancellationException) {
         throw e
     } catch (e: Exception) {
-        System.err.println("devrig take_screenshot failed to reach a backend: ${e.message}")
-        return CliExit.UNAVAILABLE
+        return renderCliError(
+            "take_screenshot", "devrig take_screenshot failed to reach a backend: ${e.message}",
+            command.json, CliExit.UNAVAILABLE, mcpStdout,
+        )
     }
 
     // --out: pull the first image out of the result and write the raw PNG bytes to disk.
+    var rendered = result
     if (!command.out.isNullOrBlank() && !result.isError) {
-        val written = writeScreenshotOut(result, command.out)
-        if (!written) return CliExit.USAGE
+        val savedPath = try {
+            writeScreenshotOut(result, command.out)
+        } catch (e: Exception) {
+            return renderCliError(
+                "take_screenshot", "failed to write --out=${command.out}: ${e.message}",
+                command.json, CliExit.USAGE, mcpStdout,
+            )
+        }
+        // Surface the ACTUAL written destination (absolute, cwd-resolved for a relative --out) in the
+        // rendered result so it appears in both the human output and the --json envelope `data`, not
+        // just on stderr (Codex Round-4 finding).
+        if (savedPath != null) {
+            rendered = result.copy(content = result.content + ContentItem.Text("Saved --out: $savedPath"))
+        }
     }
-    return result.renderTo(command = "take_screenshot", json = command.json, out = mcpStdout)
+    return rendered.renderTo(command = "take_screenshot", json = command.json, out = mcpStdout)
 }
 
-/** Decodes the first image in [result] and writes it to [out]; returns false (after printing) on failure. */
-private fun writeScreenshotOut(result: ToolCallResult, out: String): Boolean {
+/**
+ * Decodes the first image in [result] and writes it to [out]. Returns the absolute path written, or
+ * null when the result carried no image (a non-error no-op). Throws on a genuine write failure so the
+ * caller can envelope it.
+ */
+private fun writeScreenshotOut(result: ToolCallResult, out: String): Path? {
     val image = result.content.filterIsInstance<ContentItem.Image>().firstOrNull()
     if (image == null) {
         System.err.println("--out given but the screenshot result carried no image payload")
-        return true // not a usage error — the call succeeded, there was just nothing to save
+        return null // not an error — the call succeeded, there was just nothing to save
     }
-    return try {
-        val bytes = Base64.getDecoder().decode(image.data)
-        val outPath = Path.of(out).toAbsolutePath()
-        outPath.parent?.let { Files.createDirectories(it) }
-        Files.write(outPath, bytes)
-        System.err.println("Saved screenshot (${bytes.size} bytes, ${image.mimeType}) to $outPath")
-        true
-    } catch (e: Exception) {
-        System.err.println("failed to write --out=$out: ${e.message}")
-        false
-    }
+    val bytes = Base64.getDecoder().decode(image.data)
+    val outPath = Path.of(out).toAbsolutePath().normalize()
+    outPath.parent?.let { Files.createDirectories(it) }
+    Files.write(outPath, bytes)
+    System.err.println("Saved screenshot (${bytes.size} bytes, ${image.mimeType}) to $outPath")
+    return outPath
 }
 
 // ----------------------------------- open_project -----------------------------------
@@ -207,8 +256,12 @@ fun DevrigServices.runOpenProjectCommand(
     waitAttempts: Int = 60,
     waitIntervalMs: Long = 2000,
 ): Int {
+    // Resolve a relative --project_path against the caller's cwd into an absolute path. Previously a
+    // relative path (e.g. `.`) was resolved by the backend against `/`, silently opening the wrong
+    // project — the one genuinely dangerous Round-4 finding.
+    val absoluteProjectPath = Path.of(command.projectPath!!).toAbsolutePath().normalize().toString()
     val params = OpenProjectParams(
-        projectPath = command.projectPath!!,
+        projectPath = absoluteProjectPath,
         trustProject = command.trustProject,
         backendName = command.backendName,
     )
@@ -219,8 +272,10 @@ fun DevrigServices.runOpenProjectCommand(
     } catch (e: CancellationException) {
         throw e
     } catch (e: Exception) {
-        System.err.println("devrig open_project failed to reach a backend: ${e.message}")
-        return CliExit.UNAVAILABLE
+        return renderCliError(
+            "open_project", "devrig open_project failed to reach a backend: ${e.message}",
+            command.json, CliExit.UNAVAILABLE, mcpStdout,
+        )
     }
 
     val exit = result.renderTo(command = "open_project", json = command.json, out = mcpStdout)
@@ -228,7 +283,7 @@ fun DevrigServices.runOpenProjectCommand(
 
     // --wait: poll list_windows until the freshly-opened project is ready. Best-effort; all progress
     // goes to stderr so stdout keeps just the open_project result (clean for --json / pipes).
-    val ready = waitForProjectReady(command.projectPath, tools, attempts = waitAttempts, intervalMs = waitIntervalMs)
+    val ready = waitForProjectReady(absoluteProjectPath, tools, attempts = waitAttempts, intervalMs = waitIntervalMs)
     if (!ready) {
         System.err.println("open_project: --wait timed out before the project became ready")
         return CliExit.UNAVAILABLE

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/ToolBackedCommands.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/ToolBackedCommands.kt
@@ -5,12 +5,13 @@ import com.jonnyzzz.mcpSteroid.devrig.server.ProjectRouteNotFoundException
 import com.jonnyzzz.mcpSteroid.devrig.server.StubMcpSteroidTools
 import com.jonnyzzz.mcpSteroid.mcp.ContentItem
 import com.jonnyzzz.mcpSteroid.mcp.ToolCallResult
-import com.jonnyzzz.mcpSteroid.mcp.errorResult
 import com.jonnyzzz.mcpSteroid.server.ExecCodeParams
 import com.jonnyzzz.mcpSteroid.server.ExecuteCodeToolHandler
 import com.jonnyzzz.mcpSteroid.server.ExecuteFeedbackToolHandler
 import com.jonnyzzz.mcpSteroid.server.FeedbackParams
 import com.jonnyzzz.mcpSteroid.server.InputParams
+import com.jonnyzzz.mcpSteroid.server.ListWindowsToolHandler
+import com.jonnyzzz.mcpSteroid.server.McpSteroidTools
 import com.jonnyzzz.mcpSteroid.server.ModalMode
 import com.jonnyzzz.mcpSteroid.server.OpenProjectParams
 import com.jonnyzzz.mcpSteroid.server.OpenProjectToolHandler
@@ -25,17 +26,24 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking
 
 /**
- * Shared execution for `devrig` subcommands that map 1:1 onto a bridge tool handler and return a
- * [ToolCallResult]. The handler is resolved from [StubMcpSteroidTools] — the SAME wiring the
- * `devrig mcp` stdio proxy uses — so the CLI never reimplements tool logic. Routing/bridge failures
- * are turned into meaningful exit codes + agent-usable stderr messages.
+ * `devrig` subcommands that map 1:1 onto a bridge tool handler and return a [ToolCallResult].
+ *
+ * The handlers are resolved from an [McpSteroidTools] — in production [StubMcpSteroidTools], the SAME
+ * wiring the `devrig mcp` stdio proxy uses, so the CLI never reimplements tool logic. Each command takes
+ * `tools` as a defaulted parameter purely so tests can inject a fake and assert the args→`*Params`→render
+ * glue without a live IDE (payload→wire mapping is covered by DevrigToolBridgeClientTest).
+ */
+
+/**
+ * Runs [block] against [tools], turning routing/bridge failures into meaningful exit codes + agent-usable
+ * stderr messages, then renders the [ToolCallResult].
  */
 private inline fun DevrigServices.runToolCall(
     commandName: String,
     json: Boolean,
-    crossinline block: suspend (StubMcpSteroidTools) -> ToolCallResult,
+    tools: McpSteroidTools,
+    crossinline block: suspend (McpSteroidTools) -> ToolCallResult,
 ): Int {
-    val tools = StubMcpSteroidTools(this)
     val result = try {
         runBlocking(Dispatchers.IO) { block(tools) }
     } catch (e: ProjectRouteNotFoundException) {
@@ -63,8 +71,15 @@ private fun resolveCodeArg(inline: String?, file: String?): String? {
 
 // ----------------------------------- execute_code -----------------------------------
 
-fun DevrigServices.runExecuteCodeCommand(command: DevrigCommand.DevrigCommandExecuteCode): Int {
-    val code = resolveCodeArg(command.code, command.codeFile) ?: return CliExit.USAGE
+fun DevrigServices.runExecuteCodeCommand(
+    command: DevrigCommand.DevrigCommandExecuteCode,
+    tools: McpSteroidTools = StubMcpSteroidTools(this),
+): Int {
+    // `--code-file=-` reads the script from stdin so agents can pipe a snippet without a temp file.
+    val code = when {
+        command.codeFile == "-" -> mcpStdin.readBytes().decodeToString()
+        else -> resolveCodeArg(command.code, command.codeFile) ?: return CliExit.USAGE
+    }
     val modal = command.modal?.let { wire ->
         ModalMode.entries.firstOrNull { it.wire == wire }
             ?: run {
@@ -81,15 +96,18 @@ fun DevrigServices.runExecuteCodeCommand(command: DevrigCommand.DevrigCommandExe
         timeout = command.timeout ?: 600,
         modal = modal,
     )
-    return runToolCall("execute_code", command.json) { tools ->
-        tools.handler<ExecuteCodeToolHandler>()
+    return runToolCall("execute_code", command.json, tools) { t ->
+        t.handler<ExecuteCodeToolHandler>()
             .executeCode(command.projectName!!, params, stderrProgressReporter())
     }
 }
 
 // ----------------------------------- execute_feedback -----------------------------------
 
-fun DevrigServices.runFeedbackCommand(command: DevrigCommand.DevrigCommandFeedback): Int {
+fun DevrigServices.runFeedbackCommand(
+    command: DevrigCommand.DevrigCommandFeedback,
+    tools: McpSteroidTools = StubMcpSteroidTools(this),
+): Int {
     val code: String? = when {
         !command.code.isNullOrBlank() -> command.code
         !command.codeFile.isNullOrBlank() -> resolveCodeArg(null, command.codeFile) ?: return CliExit.USAGE
@@ -101,14 +119,17 @@ fun DevrigServices.runFeedbackCommand(command: DevrigCommand.DevrigCommandFeedba
         explanation = command.explanation,
         code = code,
     )
-    return runToolCall("execute_feedback", command.json) { tools ->
-        tools.handler<ExecuteFeedbackToolHandler>().handleFeedback(command.projectName!!, params)
+    return runToolCall("execute_feedback", command.json, tools) { t ->
+        t.handler<ExecuteFeedbackToolHandler>().handleFeedback(command.projectName!!, params)
     }
 }
 
 // ----------------------------------- input -----------------------------------
 
-fun DevrigServices.runInputCommand(command: DevrigCommand.DevrigCommandInput): Int {
+fun DevrigServices.runInputCommand(
+    command: DevrigCommand.DevrigCommandInput,
+    tools: McpSteroidTools = StubMcpSteroidTools(this),
+): Int {
     // The devrig bridge forwards the raw sequence string verbatim (the IDE re-parses it), so we do
     // not need a client-side parse here; pass an empty parsed list and the raw string.
     val params = InputParams(
@@ -118,20 +139,22 @@ fun DevrigServices.runInputCommand(command: DevrigCommand.DevrigCommandInput): I
         sequence = emptyList(),
         rawSequence = command.sequence,
     )
-    return runToolCall("input", command.json) { tools ->
-        tools.handler<VisionInputToolHandler>().handleInputSequence(command.projectName!!, params)
+    return runToolCall("input", command.json, tools) { t ->
+        t.handler<VisionInputToolHandler>().handleInputSequence(command.projectName!!, params)
     }
 }
 
 // ----------------------------------- take_screenshot -----------------------------------
 
-fun DevrigServices.runScreenshotCommand(command: DevrigCommand.DevrigCommandScreenshot): Int {
+fun DevrigServices.runScreenshotCommand(
+    command: DevrigCommand.DevrigCommandScreenshot,
+    tools: McpSteroidTools = StubMcpSteroidTools(this),
+): Int {
     val params = ScreenshotParams(
         taskId = command.taskId!!,
         reason = command.reason!!,
         windowId = command.windowId,
     )
-    val tools = StubMcpSteroidTools(this)
     val result = try {
         runBlocking(Dispatchers.IO) {
             tools.handler<VisionScreenshotToolHandler>()
@@ -149,33 +172,46 @@ fun DevrigServices.runScreenshotCommand(command: DevrigCommand.DevrigCommandScre
 
     // --out: pull the first image out of the result and write the raw PNG bytes to disk.
     if (!command.out.isNullOrBlank() && !result.isError) {
-        val image = result.content.filterIsInstance<ContentItem.Image>().firstOrNull()
-        if (image == null) {
-            System.err.println("--out given but the screenshot result carried no image payload")
-        } else {
-            try {
-                val bytes = Base64.getDecoder().decode(image.data)
-                val outPath = Path.of(command.out)
-                Files.write(outPath, bytes)
-                System.err.println("Saved screenshot (${bytes.size} bytes, ${image.mimeType}) to ${outPath.toAbsolutePath()}")
-            } catch (e: Exception) {
-                System.err.println("failed to write --out=${command.out}: ${e.message}")
-                return CliExit.USAGE
-            }
-        }
+        val written = writeScreenshotOut(result, command.out)
+        if (!written) return CliExit.USAGE
     }
     return result.renderTo(command = "take_screenshot", json = command.json, out = mcpStdout)
 }
 
+/** Decodes the first image in [result] and writes it to [out]; returns false (after printing) on failure. */
+private fun writeScreenshotOut(result: ToolCallResult, out: String): Boolean {
+    val image = result.content.filterIsInstance<ContentItem.Image>().firstOrNull()
+    if (image == null) {
+        System.err.println("--out given but the screenshot result carried no image payload")
+        return true // not a usage error — the call succeeded, there was just nothing to save
+    }
+    return try {
+        val bytes = Base64.getDecoder().decode(image.data)
+        val outPath = Path.of(out).toAbsolutePath()
+        outPath.parent?.let { Files.createDirectories(it) }
+        Files.write(outPath, bytes)
+        System.err.println("Saved screenshot (${bytes.size} bytes, ${image.mimeType}) to $outPath")
+        true
+    } catch (e: Exception) {
+        System.err.println("failed to write --out=$out: ${e.message}")
+        false
+    }
+}
+
 // ----------------------------------- open_project -----------------------------------
 
-fun DevrigServices.runOpenProjectCommand(command: DevrigCommand.DevrigCommandOpenProject): Int {
+fun DevrigServices.runOpenProjectCommand(
+    command: DevrigCommand.DevrigCommandOpenProject,
+    tools: McpSteroidTools = StubMcpSteroidTools(this),
+    // Exposed for tests so the --wait poll loop can run with a fast cadence.
+    waitAttempts: Int = 60,
+    waitIntervalMs: Long = 2000,
+): Int {
     val params = OpenProjectParams(
         projectPath = command.projectPath!!,
         trustProject = command.trustProject,
         backendName = command.backendName,
     )
-    val tools = StubMcpSteroidTools(this)
     val result = try {
         runBlocking(Dispatchers.IO) {
             tools.handler<OpenProjectToolHandler>().handleOpenProject(params, stderrProgressReporter())
@@ -190,9 +226,9 @@ fun DevrigServices.runOpenProjectCommand(command: DevrigCommand.DevrigCommandOpe
     val exit = result.renderTo(command = "open_project", json = command.json, out = mcpStdout)
     if (exit != CliExit.OK || !command.wait) return exit
 
-    // --wait: poll list_windows until the freshly-opened project is ready. Best-effort; progress
-    // goes to stderr so stdout keeps just the open_project result.
-    val ready = waitForProjectReady(command.projectPath)
+    // --wait: poll list_windows until the freshly-opened project is ready. Best-effort; all progress
+    // goes to stderr so stdout keeps just the open_project result (clean for --json / pipes).
+    val ready = waitForProjectReady(command.projectPath, tools, attempts = waitAttempts, intervalMs = waitIntervalMs)
     if (!ready) {
         System.err.println("open_project: --wait timed out before the project became ready")
         return CliExit.UNAVAILABLE
@@ -203,11 +239,12 @@ fun DevrigServices.runOpenProjectCommand(command: DevrigCommand.DevrigCommandOpe
 
 /**
  * Polls `list_windows` until a window for [projectPath] is initialized, not indexing, and has no
- * modal dialog — or the timeout elapses. Returns true when ready. Kept simple for the spike: fixed
- * cadence, bounded attempts, all diagnostics on stderr.
+ * modal dialog — or the timeout elapses. Returns true when ready. Fixed cadence, bounded attempts,
+ * all diagnostics on stderr.
  */
 private fun DevrigServices.waitForProjectReady(
     projectPath: String,
+    tools: McpSteroidTools,
     attempts: Int = 60,
     intervalMs: Long = 2000,
 ): Boolean {
@@ -219,9 +256,7 @@ private fun DevrigServices.waitForProjectReady(
     repeat(attempts) { attempt ->
         val response = try {
             runBlocking(Dispatchers.IO) {
-                StubMcpSteroidTools(this@waitForProjectReady)
-                    .handler<com.jonnyzzz.mcpSteroid.server.ListWindowsToolHandler>()
-                    .collectListWindowsResponse()
+                tools.handler<ListWindowsToolHandler>().collectListWindowsResponse()
             }
         } catch (e: CancellationException) {
             throw e

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/ToolBackedCommands.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/ToolBackedCommands.kt
@@ -18,8 +18,9 @@ import com.jonnyzzz.mcpSteroid.server.OpenProjectToolHandler
 import com.jonnyzzz.mcpSteroid.server.ScreenshotParams
 import com.jonnyzzz.mcpSteroid.server.VisionInputToolHandler
 import com.jonnyzzz.mcpSteroid.server.VisionScreenshotToolHandler
-import com.jonnyzzz.mcpSteroid.vision.InputSequenceParser
+import java.io.IOException
 import java.nio.file.Files
+import java.nio.file.InvalidPathException
 import java.nio.file.Path
 import java.util.Base64
 import kotlinx.coroutines.CancellationException
@@ -64,17 +65,29 @@ private inline fun DevrigServices.runToolCall(
     return result.renderTo(command = commandName, json = json, out = mcpStdout)
 }
 
-/** Signals a bad `--code-file` argument (missing / not a regular file) with an agent-usable message. */
-private class CodeArgException(message: String) : RuntimeException(message)
+/**
+ * Signals a bad `--code-file`. [exit] distinguishes a fixable-input mistake ([CliExit.USAGE] — missing
+ * file, non-regular file, malformed path string) from a genuine read failure ([CliExit.IO_ERROR] — the
+ * path resolves and is a regular file but reading it throws, e.g. a permission denial).
+ */
+private class CodeArgException(message: String, val exit: Int) : RuntimeException(message)
 
-/** Reads inline `--code` or the `--code-file` path; throws [CodeArgException] on a bad file. */
+/** Reads inline `--code` or the `--code-file` path; throws [CodeArgException] on a bad/unreadable file. */
 private fun resolveCodeArg(inline: String?, file: String?): String {
     if (!inline.isNullOrBlank()) return inline
-    val path = Path.of(file!!)
-    if (!Files.isRegularFile(path)) {
-        throw CodeArgException("--code-file not found or not a regular file: $path")
+    val path = try {
+        Path.of(file!!)
+    } catch (e: InvalidPathException) {
+        throw CodeArgException("--code-file is not a valid path: $file (${e.reason})", CliExit.USAGE)
     }
-    return Files.readString(path)
+    if (!Files.isRegularFile(path)) {
+        throw CodeArgException("--code-file not found or not a regular file: $path", CliExit.USAGE)
+    }
+    return try {
+        Files.readString(path)
+    } catch (e: IOException) {
+        throw CodeArgException("--code-file could not be read: $path (${e.message})", CliExit.IO_ERROR)
+    }
 }
 
 // ----------------------------------- execute_code -----------------------------------
@@ -90,17 +103,12 @@ fun DevrigServices.runExecuteCodeCommand(
             else -> resolveCodeArg(command.code, command.codeFile)
         }
     } catch (e: CodeArgException) {
-        return renderCliError("execute_code", e.message!!, command.json, CliExit.USAGE, mcpStdout)
+        return renderCliError("execute_code", e.message!!, command.json, e.exit, mcpStdout)
     }
-    val modal = command.modal?.let { wire ->
-        ModalMode.entries.firstOrNull { it.wire == wire }
-            ?: run {
-                System.err.println(
-                    "invalid --modal '$wire'. Valid: ${ModalMode.entries.joinToString(" | ") { it.wire }}"
-                )
-                return CliExit.USAGE
-            }
-    } ?: ModalMode.DEFAULT
+    // --modal is validated at parse time (ExecuteCodeCliCommand), so a bad value never reaches here; the
+    // firstOrNull mapping is a defensive lookup that falls back to the default rather than failing.
+    val modal = command.modal?.let { wire -> ModalMode.entries.firstOrNull { it.wire == wire } }
+        ?: ModalMode.DEFAULT
     val params = ExecCodeParams(
         taskId = command.taskId!!,
         code = code,
@@ -127,7 +135,7 @@ fun DevrigServices.runFeedbackCommand(
             else -> null
         }
     } catch (e: CodeArgException) {
-        return renderCliError("execute_feedback", e.message!!, command.json, CliExit.USAGE, mcpStdout)
+        return renderCliError("execute_feedback", e.message!!, command.json, e.exit, mcpStdout)
     }
     val params = FeedbackParams(
         taskId = command.taskId!!,
@@ -146,24 +154,9 @@ fun DevrigServices.runInputCommand(
     command: DevrigCommand.DevrigCommandInput,
     tools: McpSteroidTools = StubMcpSteroidTools(this),
 ): Int {
-    // Validate the sequence client-side so a malformed step fails fast with a concise message + syntax
-    // hint. Previously the raw string round-tripped to the IDE, whose parse failure leaked a full server
-    // stack trace into the (--json) envelope (Codex Round-4 finding). We still forward the RAW string and
-    // an empty parsed list on success — the IDE remains the single source of truth for parsing.
-    command.sequence?.let { seq ->
-        try {
-            InputSequenceParser().parse(seq)
-        } catch (e: IllegalArgumentException) {
-            return renderCliError(
-                "input",
-                "invalid --sequence: ${e.message}\n" +
-                    "Accepted steps: press:KEY[+MODS], type:TEXT, delay:MS, stick:KEY, click:BTN@x,y",
-                command.json, CliExit.USAGE, mcpStdout,
-            )
-        }
-    }
-    // The devrig bridge forwards the raw sequence string verbatim (the IDE re-parses it), so we do
-    // not need to send the parsed list; pass an empty parsed list and the raw string.
+    // Forward the RAW sequence verbatim — the IDE is the SINGLE source of truth for input syntax. devrig
+    // deliberately does NOT re-parse/validate the sequence: a newer plugin may accept steps this devrig's
+    // parser wouldn't recognize, so client-side rejection would strand a valid call on version skew.
     val params = InputParams(
         taskId = command.taskId!!,
         reason = command.reason!!,
@@ -171,10 +164,36 @@ fun DevrigServices.runInputCommand(
         sequence = emptyList(),
         rawSequence = command.sequence,
     )
-    return runToolCall("input", command.json, tools) { t ->
-        t.handler<VisionInputToolHandler>().handleInputSequence(command.projectName!!, params)
+    // The IDE's parse failure is returned as an isError result whose text is a full server stack trace;
+    // sanitize THAT (strip JVM frames) so the agent sees the message, not a leaked trace. Scoped to
+    // input — never execute_code, whose trace is the agent's own script (see sanitizeServerError).
+    val result = try {
+        runBlocking(Dispatchers.IO) {
+            tools.handler<VisionInputToolHandler>().handleInputSequence(command.projectName!!, params)
+        }
+    } catch (e: ProjectRouteNotFoundException) {
+        return renderCliError(
+            "input", "${e.message} — run `devrig list_projects` to see valid project_name keys",
+            command.json, CliExit.USAGE, mcpStdout,
+        )
+    } catch (e: CancellationException) {
+        throw e
+    } catch (e: Exception) {
+        return renderCliError(
+            "input", "devrig input failed to reach a backend: ${e.message}",
+            command.json, CliExit.UNAVAILABLE, mcpStdout,
+        )
     }
+    val rendered = if (result.isError) result.sanitizeErrorContent() else result
+    return rendered.renderTo(command = "input", json = command.json, out = mcpStdout)
 }
+
+/** Returns a copy with every Text content item's stack-frame noise stripped ([sanitizeServerError]). */
+private fun ToolCallResult.sanitizeErrorContent(): ToolCallResult = copy(
+    content = content.map { item ->
+        if (item is ContentItem.Text) ContentItem.Text(sanitizeServerError(item.text)) else item
+    },
+)
 
 // ----------------------------------- take_screenshot -----------------------------------
 
@@ -207,43 +226,56 @@ fun DevrigServices.runScreenshotCommand(
         )
     }
 
-    // --out: pull the first image out of the result and write the raw PNG bytes to disk.
-    var rendered = result
-    if (!command.out.isNullOrBlank() && !result.isError) {
-        val savedPath = try {
-            writeScreenshotOut(result, command.out)
-        } catch (e: Exception) {
-            return renderCliError(
-                "take_screenshot", "failed to write --out=${command.out}: ${e.message}",
-                command.json, CliExit.USAGE, mcpStdout,
-            )
-        }
-        // Surface the ACTUAL written destination (absolute, cwd-resolved for a relative --out) in the
-        // rendered result so it appears in both the human output and the --json envelope `data`, not
-        // just on stderr (Codex Round-4 finding).
-        if (savedPath != null) {
-            rendered = result.copy(content = result.content + ContentItem.Text("Saved --out: $savedPath"))
-        }
+    // A tool-level error (bad window_id, etc.) or a request with no --out: render the single result.
+    if (result.isError || command.out.isNullOrBlank()) {
+        return result.renderTo(command = "take_screenshot", json = command.json, out = mcpStdout)
     }
-    return rendered.renderTo(command = "take_screenshot", json = command.json, out = mcpStdout)
+
+    // --out requested: strict contract (finding #6) — exit 0 ONLY when the file is actually written.
+    // A result with no image, or an undecodable image, is a data error (65), not a silent success; a
+    // malformed --out path string is a usage error (64); a real write failure is an I/O error (74).
+    val image = result.content.filterIsInstance<ContentItem.Image>().firstOrNull()
+        ?: return renderCliError(
+            "take_screenshot",
+            "--out=${command.out} requested but the screenshot result carried no image to save",
+            command.json, CliExit.DATA_ERROR, mcpStdout,
+        )
+    val bytes = try {
+        Base64.getDecoder().decode(image.data)
+    } catch (e: IllegalArgumentException) {
+        return renderCliError(
+            "take_screenshot",
+            "--out=${command.out}: the screenshot image payload was not valid base64 (${e.message})",
+            command.json, CliExit.DATA_ERROR, mcpStdout,
+        )
+    }
+    val savedPath = try {
+        writeScreenshotOut(command.out, bytes, image.mimeType)
+    } catch (e: InvalidPathException) {
+        return renderCliError(
+            "take_screenshot", "invalid --out path: ${command.out} (${e.reason})",
+            command.json, CliExit.USAGE, mcpStdout,
+        )
+    } catch (e: IOException) {
+        return renderCliError(
+            "take_screenshot", "failed to write --out=${command.out}: ${e.message}",
+            command.json, CliExit.IO_ERROR, mcpStdout,
+        )
+    }
+    return renderScreenshotSaved(result, savedPath.toString(), command.json, mcpStdout)
 }
 
 /**
- * Decodes the first image in [result] and writes it to [out]. Returns the absolute path written, or
- * null when the result carried no image (a non-error no-op). Throws on a genuine write failure so the
- * caller can envelope it.
+ * Writes the decoded PNG [bytes] to [out] (relative paths resolve against cwd), creating parent
+ * directories. Returns the absolute path written. Throws [InvalidPathException] for a malformed path
+ * string and [IOException] for a genuine write failure (a directory target, a permission denial) so the
+ * caller can envelope each with the right exit code.
  */
-private fun writeScreenshotOut(result: ToolCallResult, out: String): Path? {
-    val image = result.content.filterIsInstance<ContentItem.Image>().firstOrNull()
-    if (image == null) {
-        System.err.println("--out given but the screenshot result carried no image payload")
-        return null // not an error — the call succeeded, there was just nothing to save
-    }
-    val bytes = Base64.getDecoder().decode(image.data)
+private fun writeScreenshotOut(out: String, bytes: ByteArray, mimeType: String): Path {
     val outPath = Path.of(out).toAbsolutePath().normalize()
     outPath.parent?.let { Files.createDirectories(it) }
     Files.write(outPath, bytes)
-    System.err.println("Saved screenshot (${bytes.size} bytes, ${image.mimeType}) to $outPath")
+    System.err.println("Saved screenshot (${bytes.size} bytes, $mimeType) to $outPath")
     return outPath
 }
 
@@ -258,8 +290,16 @@ fun DevrigServices.runOpenProjectCommand(
 ): Int {
     // Resolve a relative --project_path against the caller's cwd into an absolute path. Previously a
     // relative path (e.g. `.`) was resolved by the backend against `/`, silently opening the wrong
-    // project — the one genuinely dangerous Round-4 finding.
-    val absoluteProjectPath = Path.of(command.projectPath!!).toAbsolutePath().normalize().toString()
+    // project — the one genuinely dangerous Round-4 finding. A malformed path STRING is a fixable
+    // usage error (enveloped, not a stack trace propagated to Main).
+    val absoluteProjectPath = try {
+        Path.of(command.projectPath!!).toAbsolutePath().normalize().toString()
+    } catch (e: InvalidPathException) {
+        return renderCliError(
+            "open_project", "invalid --project_path: ${command.projectPath} (${e.reason})",
+            command.json, CliExit.USAGE, mcpStdout,
+        )
+    }
     val params = OpenProjectParams(
         projectPath = absoluteProjectPath,
         trustProject = command.trustProject,
@@ -278,18 +318,27 @@ fun DevrigServices.runOpenProjectCommand(
         )
     }
 
-    val exit = result.renderTo(command = "open_project", json = command.json, out = mcpStdout)
-    if (exit != CliExit.OK || !command.wait) return exit
+    // Without --wait, or when the open itself already errored, render that single result now.
+    if (!command.wait || result.isError) {
+        return result.renderTo(command = "open_project", json = command.json, out = mcpStdout)
+    }
 
-    // --wait: poll list_windows until the freshly-opened project is ready. Best-effort; all progress
-    // goes to stderr so stdout keeps just the open_project result (clean for --json / pipes).
+    // --wait: poll list_windows until the freshly-opened project is ready BEFORE emitting any stdout, so
+    // exactly ONE final envelope reflects the command's true outcome. Poll progress + transient poll
+    // failures go to stderr; the readiness contract is unchanged (initialized, not indexing, no modal).
+    // A timeout is a genuine failure — stdout gets a single isError envelope, never a stale success one.
     val ready = waitForProjectReady(absoluteProjectPath, tools, attempts = waitAttempts, intervalMs = waitIntervalMs)
     if (!ready) {
-        System.err.println("open_project: --wait timed out before the project became ready")
-        return CliExit.UNAVAILABLE
+        return renderCliError(
+            "open_project",
+            "open_project --wait timed out before the project became ready: $absoluteProjectPath",
+            command.json, CliExit.UNAVAILABLE, mcpStdout,
+        )
     }
-    System.err.println("open_project: project is initialized and ready")
-    return CliExit.OK
+    val readyResult = result.copy(
+        content = result.content + ContentItem.Text("open_project: project is initialized and ready"),
+    )
+    return readyResult.renderTo(command = "open_project", json = command.json, out = mcpStdout)
 }
 
 /**
@@ -297,7 +346,7 @@ fun DevrigServices.runOpenProjectCommand(
  * modal dialog — or the timeout elapses. Returns true when ready. Fixed cadence, bounded attempts,
  * all diagnostics on stderr.
  */
-private fun DevrigServices.waitForProjectReady(
+private fun waitForProjectReady(
     projectPath: String,
     tools: McpSteroidTools,
     attempts: Int = 60,

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/ToolBackedCommands.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/ToolBackedCommands.kt
@@ -1,9 +1,12 @@
 /* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
 package com.jonnyzzz.mcpSteroid.devrig
 
+import com.jonnyzzz.mcpSteroid.devrig.server.CwdProjectMatch
+import com.jonnyzzz.mcpSteroid.devrig.server.ProjectRoute
 import com.jonnyzzz.mcpSteroid.devrig.server.ProjectRouteNotFoundException
 import com.jonnyzzz.mcpSteroid.devrig.server.StubMcpSteroidTools
 import com.jonnyzzz.mcpSteroid.devrig.server.callToolViaSpec
+import com.jonnyzzz.mcpSteroid.devrig.server.resolveProjectFromCwd
 import com.jonnyzzz.mcpSteroid.mcp.ContentItem
 import com.jonnyzzz.mcpSteroid.mcp.ToolCallResult
 import com.jonnyzzz.mcpSteroid.server.ExecuteCodeToolHandler
@@ -19,6 +22,7 @@ import com.jonnyzzz.mcpSteroid.server.VisionInputToolHandler
 import com.jonnyzzz.mcpSteroid.server.VisionScreenshotToolHandler
 import com.jonnyzzz.mcpSteroid.server.VisionScreenshotToolSpec
 import java.io.IOException
+import java.io.PrintStream
 import java.nio.file.Files
 import java.nio.file.InvalidPathException
 import java.nio.file.Path
@@ -98,13 +102,59 @@ private fun resolveCodeArg(inline: String?, file: String?): String {
     }
 }
 
+/** Renders a [CodeArgException] (bad --code-file, missing/ambiguous --project_name, …) via [presentation]. */
+private fun Presentation.renderCodeArgFailure(command: String, e: CodeArgException, out: PrintStream): Int =
+    renderError(command, e.message!!, e.exit, out)
+
+/**
+ * Effective `--project_name` for the four project-scoped commands (issue #266): [explicit] wins outright
+ * when non-blank; otherwise infers from [cwd] via [resolveProjectFromCwd] against [routes]. Throws
+ * [CodeArgException] ([CliExit.USAGE]) when inference finds no single containing project — [routes]'
+ * exposed names are listed so the agent knows what to pass explicitly instead of guessing.
+ *
+ * [cwd] and [routes] are parameters (not read from [DevrigServices] directly) purely so tests can drive
+ * inference deterministically without a live IDE; production call sites default them to the real launch
+ * directory (`user.dir`) and [DevrigServices.projectRouting].
+ */
+private fun requireProjectName(explicit: String?, cwd: Path, routes: List<ProjectRoute>): String {
+    if (!explicit.isNullOrBlank()) return explicit
+    return when (val match = resolveProjectFromCwd(cwd, routes)) {
+        is CwdProjectMatch.One -> {
+            System.err.println(
+                "devrig: --project_name omitted; inferred '${match.route.exposedProjectName}' from cwd ($cwd)",
+            )
+            match.route.exposedProjectName
+        }
+        is CwdProjectMatch.None, is CwdProjectMatch.Ambiguous -> {
+            val candidates = routes.map { it.exposedProjectName }
+            val listing = if (candidates.isEmpty()) {
+                "no projects are currently open"
+            } else {
+                "open projects: ${candidates.joinToString(", ")}"
+            }
+            throw CodeArgException(
+                "missing --project_name: the current directory ($cwd) does not uniquely match one open " +
+                    "project ($listing). Pass --project_name explicitly (get it from `devrig list_projects`).",
+                CliExit.USAGE,
+            )
+        }
+    }
+}
+
 // ----------------------------------- execute_code -----------------------------------
 
 fun DevrigServices.runExecuteCodeCommand(
     command: DevrigCommand.DevrigCommandExecuteCode,
     tools: McpSteroidTools = StubMcpSteroidTools(this),
+    cwd: Path = Path.of(System.getProperty("user.dir")),
+    routes: List<ProjectRoute> = projectRouting.routes(),
 ): Int {
     val presentation = presentationFor(command.json)
+    val projectName = try {
+        requireProjectName(command.projectName, cwd, routes)
+    } catch (e: CodeArgException) {
+        return presentation.renderCodeArgFailure("execute_code", e, mcpStdout)
+    }
     // `--code-file=-` reads the script from stdin so agents can pipe a snippet without a temp file.
     val code = try {
         when {
@@ -112,14 +162,14 @@ fun DevrigServices.runExecuteCodeCommand(
             else -> resolveCodeArg(command.code, command.codeFile)
         }
     } catch (e: CodeArgException) {
-        return presentation.renderError("execute_code", e.message!!, e.exit, mcpStdout)
+        return presentation.renderCodeArgFailure("execute_code", e, mcpStdout)
     }
     // Map the CLI flags → tool-call JSON arguments; ExecuteCodeToolSpec.call() re-parses them into
     // ExecCodeParams (single source of truth), rather than the CLI rebuilding *Params by hand (C9/C15).
     // --modal is validated at parse time (ExecuteCodeCliCommand), so a bad value never reaches here; when
     // omitted the spec applies its own default (SMART_NON_MODAL == ModalMode.DEFAULT), preserving behavior.
     val arguments = buildJsonObject {
-        put("project_name", command.projectName!!)
+        put("project_name", projectName)
         put("code", code)
         put("task_id", command.taskId!!)
         put("reason", command.reason!!)
@@ -140,8 +190,15 @@ fun DevrigServices.runExecuteCodeCommand(
 fun DevrigServices.runFeedbackCommand(
     command: DevrigCommand.DevrigCommandFeedback,
     tools: McpSteroidTools = StubMcpSteroidTools(this),
+    cwd: Path = Path.of(System.getProperty("user.dir")),
+    routes: List<ProjectRoute> = projectRouting.routes(),
 ): Int {
     val presentation = presentationFor(command.json)
+    val projectName = try {
+        requireProjectName(command.projectName, cwd, routes)
+    } catch (e: CodeArgException) {
+        return presentation.renderCodeArgFailure("execute_feedback", e, mcpStdout)
+    }
     val code: String? = try {
         when {
             !command.code.isNullOrBlank() -> command.code
@@ -149,7 +206,7 @@ fun DevrigServices.runFeedbackCommand(
             else -> null
         }
     } catch (e: CodeArgException) {
-        return presentation.renderError("execute_feedback", e.message!!, e.exit, mcpStdout)
+        return presentation.renderCodeArgFailure("execute_feedback", e, mcpStdout)
     }
     // Map the CLI flags → tool-call JSON arguments; ExecuteFeedbackToolSpec.call() re-parses them into
     // FeedbackParams and calls the handler (C9/C15). All required fields (project_name, task_id,
@@ -157,7 +214,7 @@ fun DevrigServices.runFeedbackCommand(
     // the spec's equivalent guards never fire — behavior is preserved. execution_id is intentionally NOT
     // forwarded (parity with the MCP surface). `code` is optional and omitted when absent.
     val arguments = buildJsonObject {
-        put("project_name", command.projectName!!)
+        put("project_name", projectName)
         put("task_id", command.taskId!!)
         put("success_rating", command.successRating!!)
         command.explanation?.let { put("explanation", it) }
@@ -177,8 +234,15 @@ fun DevrigServices.runFeedbackCommand(
 fun DevrigServices.runInputCommand(
     command: DevrigCommand.DevrigCommandInput,
     tools: McpSteroidTools = StubMcpSteroidTools(this),
+    cwd: Path = Path.of(System.getProperty("user.dir")),
+    routes: List<ProjectRoute> = projectRouting.routes(),
 ): Int {
     val presentation = presentationFor(command.json)
+    val projectName = try {
+        requireProjectName(command.projectName, cwd, routes)
+    } catch (e: CodeArgException) {
+        return presentation.renderCodeArgFailure("input", e, mcpStdout)
+    }
     // Forward the RAW sequence verbatim — the IDE is the SINGLE source of truth for input syntax. devrig
     // deliberately does NOT re-parse/validate the sequence: a newer plugin may accept steps this devrig's
     // parser wouldn't recognize, so client-side rejection would strand a valid call on version skew.
@@ -194,7 +258,7 @@ fun DevrigServices.runInputCommand(
     // input — never execute_code, whose trace is the agent's own script (see sanitizeServerError).
     val result = try {
         runBlocking(Dispatchers.IO) {
-            tools.handler<VisionInputToolHandler>().handleInputSequence(command.projectName!!, params)
+            tools.handler<VisionInputToolHandler>().handleInputSequence(projectName, params)
         }
     } catch (e: ProjectRouteNotFoundException) {
         return presentation.renderError(
@@ -225,13 +289,20 @@ private fun ToolCallResult.sanitizeErrorContent(): ToolCallResult = copy(
 fun DevrigServices.runScreenshotCommand(
     command: DevrigCommand.DevrigCommandScreenshot,
     tools: McpSteroidTools = StubMcpSteroidTools(this),
+    cwd: Path = Path.of(System.getProperty("user.dir")),
+    routes: List<ProjectRoute> = projectRouting.routes(),
 ): Int {
     val presentation = presentationFor(command.json)
+    val projectName = try {
+        requireProjectName(command.projectName, cwd, routes)
+    } catch (e: CodeArgException) {
+        return presentation.renderCodeArgFailure("take_screenshot", e, mcpStdout)
+    }
     // Map the CLI flags → tool-call JSON arguments; VisionScreenshotToolSpec.call() re-parses them into
     // ScreenshotParams and calls the handler (C9/C15). window_id is optional and omitted when absent. The
     // --out post-write below stays a CLI-only affordance around the call.
     val arguments = buildJsonObject {
-        put("project_name", command.projectName!!)
+        put("project_name", projectName)
         put("task_id", command.taskId!!)
         put("reason", command.reason!!)
         command.windowId?.let { put("window_id", it) }

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/ToolBackedCommands.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/ToolBackedCommands.kt
@@ -38,32 +38,36 @@ import kotlinx.coroutines.runBlocking
 
 /**
  * Runs [block] against [tools], turning routing/bridge failures into meaningful exit codes + agent-usable
- * stderr messages, then renders the [ToolCallResult].
+ * stderr messages, then renders the [ToolCallResult] through [presentation].
  */
 private inline fun DevrigServices.runToolCall(
     commandName: String,
-    json: Boolean,
+    presentation: Presentation,
     tools: McpSteroidTools,
     crossinline block: suspend (McpSteroidTools) -> ToolCallResult,
 ): Int {
     val result = try {
         runBlocking(Dispatchers.IO) { block(tools) }
     } catch (e: ProjectRouteNotFoundException) {
-        return renderCliError(
+        return presentation.renderError(
             commandName,
             "${e.message} — run `devrig list_projects` to see valid project_name keys",
-            json, CliExit.USAGE, mcpStdout,
+            CliExit.USAGE, mcpStdout,
         )
     } catch (e: CancellationException) {
         throw e
     } catch (e: Exception) {
-        return renderCliError(
+        return presentation.renderError(
             commandName, "devrig $commandName failed to reach a backend: ${e.message}",
-            json, CliExit.UNAVAILABLE, mcpStdout,
+            CliExit.UNAVAILABLE, mcpStdout,
         )
     }
-    return result.renderTo(command = commandName, json = json, out = mcpStdout)
+    return presentation.render(result, command = commandName, out = mcpStdout)
 }
+
+/** Builds this command's [Presentation] once from its `--json` flag; `imageDir` is unused before Task 6. */
+private fun DevrigServices.presentationFor(json: Boolean): Presentation =
+    presentationFor(json) { homePaths.home }
 
 /**
  * Signals a bad `--code-file`. [exit] distinguishes a fixable-input mistake ([CliExit.USAGE] — missing
@@ -98,6 +102,7 @@ fun DevrigServices.runExecuteCodeCommand(
     command: DevrigCommand.DevrigCommandExecuteCode,
     tools: McpSteroidTools = StubMcpSteroidTools(this),
 ): Int {
+    val presentation = presentationFor(command.json)
     // `--code-file=-` reads the script from stdin so agents can pipe a snippet without a temp file.
     val code = try {
         when {
@@ -105,7 +110,7 @@ fun DevrigServices.runExecuteCodeCommand(
             else -> resolveCodeArg(command.code, command.codeFile)
         }
     } catch (e: CodeArgException) {
-        return renderCliError("execute_code", e.message!!, command.json, e.exit, mcpStdout)
+        return presentation.renderError("execute_code", e.message!!, e.exit, mcpStdout)
     }
     // --modal is validated at parse time (ExecuteCodeCliCommand), so a bad value never reaches here; the
     // firstOrNull mapping is a defensive lookup that falls back to the default rather than failing.
@@ -118,7 +123,7 @@ fun DevrigServices.runExecuteCodeCommand(
         timeout = command.timeout ?: 600,
         modal = modal,
     )
-    return runToolCall("execute_code", command.json, tools) { t ->
+    return runToolCall("execute_code", presentation, tools) { t ->
         t.handler<ExecuteCodeToolHandler>()
             .executeCode(command.projectName!!, params, stderrProgressReporter())
     }
@@ -130,6 +135,7 @@ fun DevrigServices.runFeedbackCommand(
     command: DevrigCommand.DevrigCommandFeedback,
     tools: McpSteroidTools = StubMcpSteroidTools(this),
 ): Int {
+    val presentation = presentationFor(command.json)
     val code: String? = try {
         when {
             !command.code.isNullOrBlank() -> command.code
@@ -137,7 +143,7 @@ fun DevrigServices.runFeedbackCommand(
             else -> null
         }
     } catch (e: CodeArgException) {
-        return renderCliError("execute_feedback", e.message!!, command.json, e.exit, mcpStdout)
+        return presentation.renderError("execute_feedback", e.message!!, e.exit, mcpStdout)
     }
     val params = FeedbackParams(
         taskId = command.taskId!!,
@@ -145,7 +151,7 @@ fun DevrigServices.runFeedbackCommand(
         explanation = command.explanation,
         code = code,
     )
-    return runToolCall("execute_feedback", command.json, tools) { t ->
+    return runToolCall("execute_feedback", presentation, tools) { t ->
         t.handler<ExecuteFeedbackToolHandler>().handleFeedback(command.projectName!!, params)
     }
 }
@@ -156,6 +162,7 @@ fun DevrigServices.runInputCommand(
     command: DevrigCommand.DevrigCommandInput,
     tools: McpSteroidTools = StubMcpSteroidTools(this),
 ): Int {
+    val presentation = presentationFor(command.json)
     // Forward the RAW sequence verbatim — the IDE is the SINGLE source of truth for input syntax. devrig
     // deliberately does NOT re-parse/validate the sequence: a newer plugin may accept steps this devrig's
     // parser wouldn't recognize, so client-side rejection would strand a valid call on version skew.
@@ -174,20 +181,20 @@ fun DevrigServices.runInputCommand(
             tools.handler<VisionInputToolHandler>().handleInputSequence(command.projectName!!, params)
         }
     } catch (e: ProjectRouteNotFoundException) {
-        return renderCliError(
+        return presentation.renderError(
             "input", "${e.message} — run `devrig list_projects` to see valid project_name keys",
-            command.json, CliExit.USAGE, mcpStdout,
+            CliExit.USAGE, mcpStdout,
         )
     } catch (e: CancellationException) {
         throw e
     } catch (e: Exception) {
-        return renderCliError(
+        return presentation.renderError(
             "input", "devrig input failed to reach a backend: ${e.message}",
-            command.json, CliExit.UNAVAILABLE, mcpStdout,
+            CliExit.UNAVAILABLE, mcpStdout,
         )
     }
     val rendered = if (result.isError) result.sanitizeErrorContent() else result
-    return rendered.renderTo(command = "input", json = command.json, out = mcpStdout)
+    return presentation.render(rendered, command = "input", out = mcpStdout)
 }
 
 /** Returns a copy with every Text content item's stack-frame noise stripped ([sanitizeServerError]). */
@@ -203,6 +210,7 @@ fun DevrigServices.runScreenshotCommand(
     command: DevrigCommand.DevrigCommandScreenshot,
     tools: McpSteroidTools = StubMcpSteroidTools(this),
 ): Int {
+    val presentation = presentationFor(command.json)
     val params = ScreenshotParams(
         taskId = command.taskId!!,
         reason = command.reason!!,
@@ -214,57 +222,57 @@ fun DevrigServices.runScreenshotCommand(
                 .screenshotWindow(command.projectName!!, params, stderrProgressReporter())
         }
     } catch (e: ProjectRouteNotFoundException) {
-        return renderCliError(
+        return presentation.renderError(
             "take_screenshot",
             "${e.message} — run `devrig list_projects` to see valid project_name keys",
-            command.json, CliExit.USAGE, mcpStdout,
+            CliExit.USAGE, mcpStdout,
         )
     } catch (e: CancellationException) {
         throw e
     } catch (e: Exception) {
-        return renderCliError(
+        return presentation.renderError(
             "take_screenshot", "devrig take_screenshot failed to reach a backend: ${e.message}",
-            command.json, CliExit.UNAVAILABLE, mcpStdout,
+            CliExit.UNAVAILABLE, mcpStdout,
         )
     }
 
     // A tool-level error (bad window_id, etc.) or a request with no --out: render the single result.
     if (result.isError || command.out.isNullOrBlank()) {
-        return result.renderTo(command = "take_screenshot", json = command.json, out = mcpStdout)
+        return presentation.render(result, command = "take_screenshot", out = mcpStdout)
     }
 
     // --out requested: strict contract (finding #6) — exit 0 ONLY when the file is actually written.
     // A result with no image, or an undecodable image, is a data error (65), not a silent success; a
     // malformed --out path string is a usage error (64); a real write failure is an I/O error (74).
     val image = result.content.filterIsInstance<ContentItem.Image>().firstOrNull()
-        ?: return renderCliError(
+        ?: return presentation.renderError(
             "take_screenshot",
             "--out=${command.out} requested but the screenshot result carried no image to save",
-            command.json, CliExit.DATA_ERROR, mcpStdout,
+            CliExit.DATA_ERROR, mcpStdout,
         )
     val bytes = try {
         Base64.getDecoder().decode(image.data)
     } catch (e: IllegalArgumentException) {
-        return renderCliError(
+        return presentation.renderError(
             "take_screenshot",
             "--out=${command.out}: the screenshot image payload was not valid base64 (${e.message})",
-            command.json, CliExit.DATA_ERROR, mcpStdout,
+            CliExit.DATA_ERROR, mcpStdout,
         )
     }
     val savedPath = try {
         writeScreenshotOut(command.out, bytes, image.mimeType)
     } catch (e: InvalidPathException) {
-        return renderCliError(
+        return presentation.renderError(
             "take_screenshot", "invalid --out path: ${command.out} (${e.reason})",
-            command.json, CliExit.USAGE, mcpStdout,
+            CliExit.USAGE, mcpStdout,
         )
     } catch (e: IOException) {
-        return renderCliError(
+        return presentation.renderError(
             "take_screenshot", "failed to write --out=${command.out}: ${e.message}",
-            command.json, CliExit.IO_ERROR, mcpStdout,
+            CliExit.IO_ERROR, mcpStdout,
         )
     }
-    return renderScreenshotSaved(result, savedPath.toString(), command.json, mcpStdout)
+    return presentation.renderScreenshotSaved(result, savedPath.toString(), mcpStdout)
 }
 
 /**
@@ -290,6 +298,7 @@ fun DevrigServices.runOpenProjectCommand(
     waitAttempts: Int = 60,
     waitIntervalMs: Long = 2000,
 ): Int {
+    val presentation = presentationFor(command.json)
     // Resolve a relative --project_path against the caller's cwd into an absolute path. Previously a
     // relative path (e.g. `.`) was resolved by the backend against `/`, silently opening the wrong
     // project — the one genuinely dangerous Round-4 finding. A malformed path STRING is a fixable
@@ -297,9 +306,9 @@ fun DevrigServices.runOpenProjectCommand(
     val absoluteProjectPath = try {
         Path.of(command.projectPath!!).toAbsolutePath().normalize().toString()
     } catch (e: InvalidPathException) {
-        return renderCliError(
+        return presentation.renderError(
             "open_project", "invalid --project_path: ${command.projectPath} (${e.reason})",
-            command.json, CliExit.USAGE, mcpStdout,
+            CliExit.USAGE, mcpStdout,
         )
     }
     val params = OpenProjectParams(
@@ -314,15 +323,15 @@ fun DevrigServices.runOpenProjectCommand(
     } catch (e: CancellationException) {
         throw e
     } catch (e: Exception) {
-        return renderCliError(
+        return presentation.renderError(
             "open_project", "devrig open_project failed to reach a backend: ${e.message}",
-            command.json, CliExit.UNAVAILABLE, mcpStdout,
+            CliExit.UNAVAILABLE, mcpStdout,
         )
     }
 
     // Without --wait, or when the open itself already errored, render that single result now.
     if (!command.wait || result.isError) {
-        return result.renderTo(command = "open_project", json = command.json, out = mcpStdout)
+        return presentation.render(result, command = "open_project", out = mcpStdout)
     }
 
     // --wait: poll list_windows until the freshly-opened project is ready BEFORE emitting any stdout, so
@@ -331,16 +340,16 @@ fun DevrigServices.runOpenProjectCommand(
     // A timeout is a genuine failure — stdout gets a single isError envelope, never a stale success one.
     val ready = waitForProjectReady(absoluteProjectPath, tools, attempts = waitAttempts, intervalMs = waitIntervalMs)
     if (!ready) {
-        return renderCliError(
+        return presentation.renderError(
             "open_project",
             "open_project --wait timed out before the project became ready: $absoluteProjectPath",
-            command.json, CliExit.UNAVAILABLE, mcpStdout,
+            CliExit.UNAVAILABLE, mcpStdout,
         )
     }
     val readyResult = result.copy(
         content = result.content + ContentItem.Text("open_project: project is initialized and ready"),
     )
-    return readyResult.renderTo(command = "open_project", json = command.json, out = mcpStdout)
+    return presentation.render(readyResult, command = "open_project", out = mcpStdout)
 }
 
 /**

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/ToolBackedCommands.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/ToolBackedCommands.kt
@@ -75,10 +75,12 @@ private class CodeArgException(message: String, val exit: Int) : RuntimeExceptio
 /** Reads inline `--code` or the `--code-file` path; throws [CodeArgException] on a bad/unreadable file. */
 private fun resolveCodeArg(inline: String?, file: String?): String {
     if (!inline.isNullOrBlank()) return inline
+    val resolvedFile = file
+        ?: throw CodeArgException("provide --code or --code-file", CliExit.USAGE)
     val path = try {
-        Path.of(file!!)
+        Path.of(resolvedFile)
     } catch (e: InvalidPathException) {
-        throw CodeArgException("--code-file is not a valid path: $file (${e.reason})", CliExit.USAGE)
+        throw CodeArgException("--code-file is not a valid path: $resolvedFile (${e.reason})", CliExit.USAGE)
     }
     if (!Files.isRegularFile(path)) {
         throw CodeArgException("--code-file not found or not a regular file: $path", CliExit.USAGE)

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/ToolBackedCommands.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/ToolBackedCommands.kt
@@ -3,21 +3,21 @@ package com.jonnyzzz.mcpSteroid.devrig
 
 import com.jonnyzzz.mcpSteroid.devrig.server.ProjectRouteNotFoundException
 import com.jonnyzzz.mcpSteroid.devrig.server.StubMcpSteroidTools
+import com.jonnyzzz.mcpSteroid.devrig.server.callToolViaSpec
 import com.jonnyzzz.mcpSteroid.mcp.ContentItem
 import com.jonnyzzz.mcpSteroid.mcp.ToolCallResult
-import com.jonnyzzz.mcpSteroid.server.ExecCodeParams
 import com.jonnyzzz.mcpSteroid.server.ExecuteCodeToolHandler
+import com.jonnyzzz.mcpSteroid.server.ExecuteCodeToolSpec
 import com.jonnyzzz.mcpSteroid.server.ExecuteFeedbackToolHandler
-import com.jonnyzzz.mcpSteroid.server.FeedbackParams
+import com.jonnyzzz.mcpSteroid.server.ExecuteFeedbackToolSpec
 import com.jonnyzzz.mcpSteroid.server.InputParams
 import com.jonnyzzz.mcpSteroid.server.ListWindowsToolHandler
 import com.jonnyzzz.mcpSteroid.server.McpSteroidTools
-import com.jonnyzzz.mcpSteroid.server.ModalMode
 import com.jonnyzzz.mcpSteroid.server.OpenProjectParams
 import com.jonnyzzz.mcpSteroid.server.OpenProjectToolHandler
-import com.jonnyzzz.mcpSteroid.server.ScreenshotParams
 import com.jonnyzzz.mcpSteroid.server.VisionInputToolHandler
 import com.jonnyzzz.mcpSteroid.server.VisionScreenshotToolHandler
+import com.jonnyzzz.mcpSteroid.server.VisionScreenshotToolSpec
 import java.io.IOException
 import java.nio.file.Files
 import java.nio.file.InvalidPathException
@@ -26,6 +26,8 @@ import java.util.Base64
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
 
 /**
  * `devrig` subcommands that map 1:1 onto a bridge tool handler and return a [ToolCallResult].
@@ -112,20 +114,24 @@ fun DevrigServices.runExecuteCodeCommand(
     } catch (e: CodeArgException) {
         return presentation.renderError("execute_code", e.message!!, e.exit, mcpStdout)
     }
-    // --modal is validated at parse time (ExecuteCodeCliCommand), so a bad value never reaches here; the
-    // firstOrNull mapping is a defensive lookup that falls back to the default rather than failing.
-    val modal = command.modal?.let { wire -> ModalMode.entries.firstOrNull { it.wire == wire } }
-        ?: ModalMode.DEFAULT
-    val params = ExecCodeParams(
-        taskId = command.taskId!!,
-        code = code,
-        reason = command.reason!!,
-        timeout = command.timeout ?: 600,
-        modal = modal,
-    )
+    // Map the CLI flags → tool-call JSON arguments; ExecuteCodeToolSpec.call() re-parses them into
+    // ExecCodeParams (single source of truth), rather than the CLI rebuilding *Params by hand (C9/C15).
+    // --modal is validated at parse time (ExecuteCodeCliCommand), so a bad value never reaches here; when
+    // omitted the spec applies its own default (SMART_NON_MODAL == ModalMode.DEFAULT), preserving behavior.
+    val arguments = buildJsonObject {
+        put("project_name", command.projectName!!)
+        put("code", code)
+        put("task_id", command.taskId!!)
+        put("reason", command.reason!!)
+        put("timeout", command.timeout ?: 600)
+        command.modal?.let { put("modal", it) }
+    }
     return runToolCall("execute_code", presentation, tools) { t ->
-        t.handler<ExecuteCodeToolHandler>()
-            .executeCode(command.projectName!!, params, stderrProgressReporter())
+        callToolViaSpec(
+            ExecuteCodeToolSpec { t.handler<ExecuteCodeToolHandler>() },
+            arguments,
+            stderrProgressReporter(),
+        )
     }
 }
 
@@ -145,14 +151,24 @@ fun DevrigServices.runFeedbackCommand(
     } catch (e: CodeArgException) {
         return presentation.renderError("execute_feedback", e.message!!, e.exit, mcpStdout)
     }
-    val params = FeedbackParams(
-        taskId = command.taskId!!,
-        successRating = command.successRating!!,
-        explanation = command.explanation,
-        code = code,
-    )
+    // Map the CLI flags → tool-call JSON arguments; ExecuteFeedbackToolSpec.call() re-parses them into
+    // FeedbackParams and calls the handler (C9/C15). All required fields (project_name, task_id,
+    // success_rating in range, explanation) are already enforced at parse time (FeedbackCliCommand), so
+    // the spec's equivalent guards never fire — behavior is preserved. execution_id is intentionally NOT
+    // forwarded (parity with the MCP surface). `code` is optional and omitted when absent.
+    val arguments = buildJsonObject {
+        put("project_name", command.projectName!!)
+        put("task_id", command.taskId!!)
+        put("success_rating", command.successRating!!)
+        command.explanation?.let { put("explanation", it) }
+        code?.let { put("code", it) }
+    }
     return runToolCall("execute_feedback", presentation, tools) { t ->
-        t.handler<ExecuteFeedbackToolHandler>().handleFeedback(command.projectName!!, params)
+        callToolViaSpec(
+            ExecuteFeedbackToolSpec { t.handler<ExecuteFeedbackToolHandler>() },
+            arguments,
+            stderrProgressReporter(),
+        )
     }
 }
 
@@ -211,15 +227,22 @@ fun DevrigServices.runScreenshotCommand(
     tools: McpSteroidTools = StubMcpSteroidTools(this),
 ): Int {
     val presentation = presentationFor(command.json)
-    val params = ScreenshotParams(
-        taskId = command.taskId!!,
-        reason = command.reason!!,
-        windowId = command.windowId,
-    )
+    // Map the CLI flags → tool-call JSON arguments; VisionScreenshotToolSpec.call() re-parses them into
+    // ScreenshotParams and calls the handler (C9/C15). window_id is optional and omitted when absent. The
+    // --out post-write below stays a CLI-only affordance around the call.
+    val arguments = buildJsonObject {
+        put("project_name", command.projectName!!)
+        put("task_id", command.taskId!!)
+        put("reason", command.reason!!)
+        command.windowId?.let { put("window_id", it) }
+    }
     val result = try {
         runBlocking(Dispatchers.IO) {
-            tools.handler<VisionScreenshotToolHandler>()
-                .screenshotWindow(command.projectName!!, params, stderrProgressReporter())
+            callToolViaSpec(
+                VisionScreenshotToolSpec { tools.handler<VisionScreenshotToolHandler>() },
+                arguments,
+                stderrProgressReporter(),
+            )
         }
     } catch (e: ProjectRouteNotFoundException) {
         return presentation.renderError(

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/ToolBackedCommands.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/ToolBackedCommands.kt
@@ -1,0 +1,247 @@
+/* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
+package com.jonnyzzz.mcpSteroid.devrig
+
+import com.jonnyzzz.mcpSteroid.devrig.server.ProjectRouteNotFoundException
+import com.jonnyzzz.mcpSteroid.devrig.server.StubMcpSteroidTools
+import com.jonnyzzz.mcpSteroid.mcp.ContentItem
+import com.jonnyzzz.mcpSteroid.mcp.ToolCallResult
+import com.jonnyzzz.mcpSteroid.mcp.errorResult
+import com.jonnyzzz.mcpSteroid.server.ExecCodeParams
+import com.jonnyzzz.mcpSteroid.server.ExecuteCodeToolHandler
+import com.jonnyzzz.mcpSteroid.server.ExecuteFeedbackToolHandler
+import com.jonnyzzz.mcpSteroid.server.FeedbackParams
+import com.jonnyzzz.mcpSteroid.server.InputParams
+import com.jonnyzzz.mcpSteroid.server.ModalMode
+import com.jonnyzzz.mcpSteroid.server.OpenProjectParams
+import com.jonnyzzz.mcpSteroid.server.OpenProjectToolHandler
+import com.jonnyzzz.mcpSteroid.server.ScreenshotParams
+import com.jonnyzzz.mcpSteroid.server.VisionInputToolHandler
+import com.jonnyzzz.mcpSteroid.server.VisionScreenshotToolHandler
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.Base64
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runBlocking
+
+/**
+ * Shared execution for `devrig` subcommands that map 1:1 onto a bridge tool handler and return a
+ * [ToolCallResult]. The handler is resolved from [StubMcpSteroidTools] — the SAME wiring the
+ * `devrig mcp` stdio proxy uses — so the CLI never reimplements tool logic. Routing/bridge failures
+ * are turned into meaningful exit codes + agent-usable stderr messages.
+ */
+private inline fun DevrigServices.runToolCall(
+    commandName: String,
+    json: Boolean,
+    crossinline block: suspend (StubMcpSteroidTools) -> ToolCallResult,
+): Int {
+    val tools = StubMcpSteroidTools(this)
+    val result = try {
+        runBlocking(Dispatchers.IO) { block(tools) }
+    } catch (e: ProjectRouteNotFoundException) {
+        System.err.println("${e.message} — run `devrig list_projects` to see valid project_name keys")
+        return CliExit.USAGE
+    } catch (e: CancellationException) {
+        throw e
+    } catch (e: Exception) {
+        System.err.println("devrig $commandName failed to reach a backend: ${e.message}")
+        return CliExit.UNAVAILABLE
+    }
+    return result.renderTo(command = commandName, json = json, out = mcpStdout)
+}
+
+/** Reads inline `--code` or the `--code-file` path; returns null (after printing) on a bad file. */
+private fun resolveCodeArg(inline: String?, file: String?): String? {
+    if (!inline.isNullOrBlank()) return inline
+    val path = Path.of(file!!)
+    if (!Files.isRegularFile(path)) {
+        System.err.println("--code-file not found or not a regular file: $path")
+        return null
+    }
+    return Files.readString(path)
+}
+
+// ----------------------------------- execute_code -----------------------------------
+
+fun DevrigServices.runExecuteCodeCommand(command: DevrigCommand.DevrigCommandExecuteCode): Int {
+    val code = resolveCodeArg(command.code, command.codeFile) ?: return CliExit.USAGE
+    val modal = command.modal?.let { wire ->
+        ModalMode.entries.firstOrNull { it.wire == wire }
+            ?: run {
+                System.err.println(
+                    "invalid --modal '$wire'. Valid: ${ModalMode.entries.joinToString(" | ") { it.wire }}"
+                )
+                return CliExit.USAGE
+            }
+    } ?: ModalMode.DEFAULT
+    val params = ExecCodeParams(
+        taskId = command.taskId!!,
+        code = code,
+        reason = command.reason!!,
+        timeout = command.timeout ?: 600,
+        modal = modal,
+    )
+    return runToolCall("execute_code", command.json) { tools ->
+        tools.handler<ExecuteCodeToolHandler>()
+            .executeCode(command.projectName!!, params, stderrProgressReporter())
+    }
+}
+
+// ----------------------------------- execute_feedback -----------------------------------
+
+fun DevrigServices.runFeedbackCommand(command: DevrigCommand.DevrigCommandFeedback): Int {
+    val code: String? = when {
+        !command.code.isNullOrBlank() -> command.code
+        !command.codeFile.isNullOrBlank() -> resolveCodeArg(null, command.codeFile) ?: return CliExit.USAGE
+        else -> null
+    }
+    val params = FeedbackParams(
+        taskId = command.taskId!!,
+        successRating = command.successRating!!,
+        explanation = command.explanation,
+        code = code,
+    )
+    return runToolCall("execute_feedback", command.json) { tools ->
+        tools.handler<ExecuteFeedbackToolHandler>().handleFeedback(command.projectName!!, params)
+    }
+}
+
+// ----------------------------------- input -----------------------------------
+
+fun DevrigServices.runInputCommand(command: DevrigCommand.DevrigCommandInput): Int {
+    // The devrig bridge forwards the raw sequence string verbatim (the IDE re-parses it), so we do
+    // not need a client-side parse here; pass an empty parsed list and the raw string.
+    val params = InputParams(
+        taskId = command.taskId!!,
+        reason = command.reason!!,
+        windowId = command.windowId!!,
+        sequence = emptyList(),
+        rawSequence = command.sequence,
+    )
+    return runToolCall("input", command.json) { tools ->
+        tools.handler<VisionInputToolHandler>().handleInputSequence(command.projectName!!, params)
+    }
+}
+
+// ----------------------------------- take_screenshot -----------------------------------
+
+fun DevrigServices.runScreenshotCommand(command: DevrigCommand.DevrigCommandScreenshot): Int {
+    val params = ScreenshotParams(
+        taskId = command.taskId!!,
+        reason = command.reason!!,
+        windowId = command.windowId,
+    )
+    val tools = StubMcpSteroidTools(this)
+    val result = try {
+        runBlocking(Dispatchers.IO) {
+            tools.handler<VisionScreenshotToolHandler>()
+                .screenshotWindow(command.projectName!!, params, stderrProgressReporter())
+        }
+    } catch (e: ProjectRouteNotFoundException) {
+        System.err.println("${e.message} — run `devrig list_projects` to see valid project_name keys")
+        return CliExit.USAGE
+    } catch (e: CancellationException) {
+        throw e
+    } catch (e: Exception) {
+        System.err.println("devrig take_screenshot failed to reach a backend: ${e.message}")
+        return CliExit.UNAVAILABLE
+    }
+
+    // --out: pull the first image out of the result and write the raw PNG bytes to disk.
+    if (!command.out.isNullOrBlank() && !result.isError) {
+        val image = result.content.filterIsInstance<ContentItem.Image>().firstOrNull()
+        if (image == null) {
+            System.err.println("--out given but the screenshot result carried no image payload")
+        } else {
+            try {
+                val bytes = Base64.getDecoder().decode(image.data)
+                val outPath = Path.of(command.out)
+                Files.write(outPath, bytes)
+                System.err.println("Saved screenshot (${bytes.size} bytes, ${image.mimeType}) to ${outPath.toAbsolutePath()}")
+            } catch (e: Exception) {
+                System.err.println("failed to write --out=${command.out}: ${e.message}")
+                return CliExit.USAGE
+            }
+        }
+    }
+    return result.renderTo(command = "take_screenshot", json = command.json, out = mcpStdout)
+}
+
+// ----------------------------------- open_project -----------------------------------
+
+fun DevrigServices.runOpenProjectCommand(command: DevrigCommand.DevrigCommandOpenProject): Int {
+    val params = OpenProjectParams(
+        projectPath = command.projectPath!!,
+        trustProject = command.trustProject,
+        backendName = command.backendName,
+    )
+    val tools = StubMcpSteroidTools(this)
+    val result = try {
+        runBlocking(Dispatchers.IO) {
+            tools.handler<OpenProjectToolHandler>().handleOpenProject(params, stderrProgressReporter())
+        }
+    } catch (e: CancellationException) {
+        throw e
+    } catch (e: Exception) {
+        System.err.println("devrig open_project failed to reach a backend: ${e.message}")
+        return CliExit.UNAVAILABLE
+    }
+
+    val exit = result.renderTo(command = "open_project", json = command.json, out = mcpStdout)
+    if (exit != CliExit.OK || !command.wait) return exit
+
+    // --wait: poll list_windows until the freshly-opened project is ready. Best-effort; progress
+    // goes to stderr so stdout keeps just the open_project result.
+    val ready = waitForProjectReady(command.projectPath)
+    if (!ready) {
+        System.err.println("open_project: --wait timed out before the project became ready")
+        return CliExit.UNAVAILABLE
+    }
+    System.err.println("open_project: project is initialized and ready")
+    return CliExit.OK
+}
+
+/**
+ * Polls `list_windows` until a window for [projectPath] is initialized, not indexing, and has no
+ * modal dialog — or the timeout elapses. Returns true when ready. Kept simple for the spike: fixed
+ * cadence, bounded attempts, all diagnostics on stderr.
+ */
+private fun DevrigServices.waitForProjectReady(
+    projectPath: String,
+    attempts: Int = 60,
+    intervalMs: Long = 2000,
+): Boolean {
+    val target = try {
+        Path.of(projectPath).toRealPath().toString()
+    } catch (e: Exception) {
+        projectPath
+    }
+    repeat(attempts) { attempt ->
+        val response = try {
+            runBlocking(Dispatchers.IO) {
+                StubMcpSteroidTools(this@waitForProjectReady)
+                    .handler<com.jonnyzzz.mcpSteroid.server.ListWindowsToolHandler>()
+                    .collectListWindowsResponse()
+            }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            System.err.println("open_project --wait: poll ${attempt + 1} failed: ${e.message}")
+            null
+        }
+        val window = response?.windows?.firstOrNull { w ->
+            val wp = w.projectPath ?: return@firstOrNull false
+            wp == projectPath || wp == target
+        }
+        if (window != null &&
+            window.projectInitialized == true &&
+            window.indexingInProgress != true &&
+            !window.modalDialogShowing
+        ) {
+            return true
+        }
+        System.err.println("open_project --wait: not ready yet (poll ${attempt + 1}/$attempts)")
+        Thread.sleep(intervalMs)
+    }
+    return false
+}

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/server/CliToolDispatch.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/server/CliToolDispatch.kt
@@ -19,7 +19,7 @@ import kotlinx.serialization.json.JsonObject
  * `McpToolRegistry.callTool`. The registry catches every exception into a generic `isError` result,
  * which would collapse the CLI's frozen exit-code contract (`ProjectRouteNotFoundException` → USAGE 64,
  * a bridge failure → UNAVAILABLE 69, …). Calling `spec.call()` directly lets those exceptions propagate
- * so the caller's existing `try/catch → renderCliError(...)` mapping assigns the right [com.jonnyzzz.mcpSteroid.devrig.CliExit]
+ * so the caller's existing `try/catch → presentation.renderError(...)` mapping assigns the right [com.jonnyzzz.mcpSteroid.devrig.CliExit]
  * code. The spec is constructed with the SAME handler wiring the proxy uses (e.g.
  * `ExecuteCodeToolSpec { tools.handler<ExecuteCodeToolHandler>() }`), so it reaches the real devrig
  * handler.

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/server/CliToolDispatch.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/server/CliToolDispatch.kt
@@ -1,0 +1,38 @@
+/* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
+package com.jonnyzzz.mcpSteroid.devrig.server
+
+import com.jonnyzzz.mcpSteroid.mcp.McpSession
+import com.jonnyzzz.mcpSteroid.mcp.McpTool
+import com.jonnyzzz.mcpSteroid.mcp.ToolCallContext
+import com.jonnyzzz.mcpSteroid.mcp.ToolCallParams
+import com.jonnyzzz.mcpSteroid.mcp.ToolCallResult
+import com.jonnyzzz.mcpSteroid.server.McpProgressReporter
+import kotlinx.serialization.json.JsonObject
+
+/**
+ * Dispatches a CLI tool-backed command through the SAME `*ToolSpec.call()` path the `devrig mcp` stdio
+ * proxy uses, instead of the CLI hand-building each tool's `*Params` and calling a specific handler
+ * method (reviewer comments C9 + C15). The CLI's job shrinks to "map CLI flags → tool-call JSON
+ * [arguments]"; the spec owns arg parsing and the handler invocation — one source of truth.
+ *
+ * Design constraint (must hold): this calls [McpTool.call] DIRECTLY, NOT through
+ * `McpToolRegistry.callTool`. The registry catches every exception into a generic `isError` result,
+ * which would collapse the CLI's frozen exit-code contract (`ProjectRouteNotFoundException` → USAGE 64,
+ * a bridge failure → UNAVAILABLE 69, …). Calling `spec.call()` directly lets those exceptions propagate
+ * so the caller's existing `try/catch → renderCliError(...)` mapping assigns the right [com.jonnyzzz.mcpSteroid.devrig.CliExit]
+ * code. The spec is constructed with the SAME handler wiring the proxy uses (e.g.
+ * `ExecuteCodeToolSpec { tools.handler<ExecuteCodeToolHandler>() }`), so it reaches the real devrig
+ * handler.
+ *
+ * The [McpSession] is a fresh no-arg session (no SSE/sampling is used from the CLI); [progress] is the
+ * CLI's stderr progress reporter so tool progress stays off stdout.
+ */
+suspend fun callToolViaSpec(
+    spec: McpTool,
+    arguments: JsonObject,
+    progress: McpProgressReporter,
+): ToolCallResult {
+    val params = ToolCallParams(name = spec.name, arguments = arguments)
+    val context = ToolCallContext(params, McpSession(), progress)
+    return spec.call(context)
+}

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/server/CwdProjectResolver.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/server/CwdProjectResolver.kt
@@ -1,0 +1,38 @@
+/* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
+package com.jonnyzzz.mcpSteroid.devrig.server
+
+import java.nio.file.Path
+
+/**
+ * Result of resolving the current working directory against the known [ProjectRoute]s.
+ */
+sealed interface CwdProjectMatch {
+    /** Exactly one route contains the cwd, and it is the most specific (deepest) such route. */
+    data class One(val route: ProjectRoute) : CwdProjectMatch
+
+    /** No known route's [ProjectRoute.projectPath] contains the cwd. */
+    data object None : CwdProjectMatch
+
+    /** Two or more routes contain the cwd and tie at the same (deepest) path depth. */
+    data class Ambiguous(val candidates: List<ProjectRoute>) : CwdProjectMatch
+}
+
+/**
+ * Picks the [ProjectRoute] whose [ProjectRoute.projectPath] is the longest path-segment-boundary
+ * prefix of [cwd]. Matching is on whole name components (via [Path.startsWith]), not raw string
+ * prefixes, so a sibling directory like `/home/u/projbeta` never matches a route at `/home/u/proj`.
+ *
+ * Pure function: [cwd] is a parameter, never read from the environment here.
+ */
+fun resolveProjectFromCwd(cwd: Path, routes: List<ProjectRoute>): CwdProjectMatch {
+    val absoluteCwd = cwd.toAbsolutePath().normalize()
+    val containing = routes.filter { route ->
+        absoluteCwd.startsWith(Path.of(route.projectPath).toAbsolutePath().normalize())
+    }
+    if (containing.isEmpty()) return CwdProjectMatch.None
+
+    val maxDepth = containing.maxOf { Path.of(it.projectPath).toAbsolutePath().normalize().nameCount }
+    val deepest = containing.filter { Path.of(it.projectPath).toAbsolutePath().normalize().nameCount == maxDepth }
+
+    return if (deepest.size == 1) CwdProjectMatch.One(deepest.single()) else CwdProjectMatch.Ambiguous(deepest)
+}

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/server/DevrigPromptsContextHandler.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/server/DevrigPromptsContextHandler.kt
@@ -8,11 +8,14 @@ class DevrigPromptsContextHandler(
     private val routing: DevrigProjectRoutingService,
 ) : PromptsContextHandler {
     override suspend fun buildPromptsContext(projectName: String): PromptsContext {
-        val route = routing.requireProject(projectName)
-        return promptsContextFromBuild(route.route.ide.build)
+        return promptsContextFromRoute(routing.requireProject(projectName))
     }
 
     companion object {
+        /** The only place [ProjectRoute.route]`.ide.build` is navigated to derive a [PromptsContext]. */
+        fun promptsContextFromRoute(route: ProjectRoute): PromptsContext =
+            promptsContextFromBuild(route.route.ide.build)
+
         fun promptsContextFromBuild(build: String): PromptsContext {
             val dash = build.indexOf('-')
             if (dash <= 0 || dash == build.lastIndex) return PromptsContext.Generic

--- a/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/CliErrorEnvelopeTest.kt
+++ b/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/CliErrorEnvelopeTest.kt
@@ -6,6 +6,10 @@ import com.jonnyzzz.mcpSteroid.mcp.ContentItem
 import com.jonnyzzz.mcpSteroid.mcp.ToolCallResult
 import com.jonnyzzz.mcpSteroid.server.ExecCodeParams
 import com.jonnyzzz.mcpSteroid.server.ExecuteCodeToolHandler
+import com.jonnyzzz.mcpSteroid.server.ExecuteFeedbackToolHandler
+import com.jonnyzzz.mcpSteroid.server.ListWindowsResponse
+import com.jonnyzzz.mcpSteroid.server.ListWindowsToolHandler
+import com.jonnyzzz.mcpSteroid.server.ListedWindow
 import com.jonnyzzz.mcpSteroid.server.McpProgressReporter
 import com.jonnyzzz.mcpSteroid.server.OpenProjectToolHandler
 import com.jonnyzzz.mcpSteroid.server.VisionInputToolHandler
@@ -104,6 +108,9 @@ class CliErrorEnvelopeTest {
 
     @Test
     fun `--out success surfaces the written absolute path in the --json envelope`() {
+        // Desired contract (#6): the saved destination is a STRUCTURED `data.savedOut` field (an absolute
+        // path), not a human string buried in the content array. Supersedes the Round-4 "Saved --out:"
+        // content-text approach.
         val outFile = home.resolve("shots/ok.png")
         val cmd = DevrigCommand.DevrigCommandScreenshot(
             projectName = "k", taskId = "t", reason = "r", out = outFile.toString(), json = true,
@@ -113,38 +120,200 @@ class CliErrorEnvelopeTest {
         }
         assertEquals(CliExit.OK, run.exit)
         assertFalse(envIsError(run), run.stdout)
-        assertTrue(envContentText(run).contains(outFile.toAbsolutePath().normalize().toString()), run.stdout)
+        val savedOut = run.envelope()["data"]!!.jsonObject["savedOut"]!!.jsonPrimitive.content
+        assertEquals(outFile.toAbsolutePath().normalize().toString(), savedOut)
     }
 
     @Test
-    fun `--out write failure under --json is an enveloped error`() {
-        // Point --out at the home DIRECTORY: Files.write on a directory fails, exercising the write path.
+    fun `--out write failure under --json is an enveloped IO error`() {
+        // Point --out at the home DIRECTORY: Files.write on a directory fails. A genuine write failure is
+        // an I/O error (74), not a usage error (64) — the path string was fine, the write was not (#4/#6).
         val cmd = DevrigCommand.DevrigCommandScreenshot(
             projectName = "k", taskId = "t", reason = "r", out = home.toString(), json = true,
         )
         val run = runCliCommand(homePaths()) {
             runScreenshotCommand(cmd, fakeTools(VisionScreenshotToolHandler::class.java to RecordingScreenshot(imageResult())))
         }
-        assertEquals(CliExit.USAGE, run.exit)
+        assertEquals(CliExit.IO_ERROR, run.exit)
         assertTrue(envIsError(run), run.stdout)
         assertTrue(envContentText(run).contains("failed to write --out"), run.stdout)
     }
 
-    // ------------------------------ finding: input stack-trace leak ------------------------------
+    @Test
+    fun `--out requested but no image is a data error, never a silent success`() {
+        val cmd = DevrigCommand.DevrigCommandScreenshot(
+            projectName = "k", taskId = "t", reason = "r", out = home.resolve("x.png").toString(), json = true,
+        )
+        val noImage = ToolCallResult(content = listOf(ContentItem.Text("screenshot taken, tree saved")))
+        val run = runCliCommand(homePaths()) {
+            runScreenshotCommand(cmd, fakeTools(VisionScreenshotToolHandler::class.java to RecordingScreenshot(noImage)))
+        }
+        assertEquals(CliExit.DATA_ERROR, run.exit)
+        assertTrue(envIsError(run), run.stdout)
+        assertTrue(envContentText(run).contains("no image to save"), run.stdout)
+    }
 
     @Test
-    fun `invalid --sequence fails client-side with a concise enveloped message and no stack trace`() {
+    fun `--out with an undecodable image payload is a data error`() {
+        val cmd = DevrigCommand.DevrigCommandScreenshot(
+            projectName = "k", taskId = "t", reason = "r", out = home.resolve("x.png").toString(), json = true,
+        )
+        val bad = ToolCallResult(content = listOf(ContentItem.Image(data = "!!!not base64!!!", mimeType = "image/png")))
+        val run = runCliCommand(homePaths()) {
+            runScreenshotCommand(cmd, fakeTools(VisionScreenshotToolHandler::class.java to RecordingScreenshot(bad)))
+        }
+        assertEquals(CliExit.DATA_ERROR, run.exit)
+        assertTrue(envIsError(run), run.stdout)
+        assertTrue(envContentText(run).contains("not valid base64"), run.stdout)
+    }
+
+    // ------------------------------ #5: input raw forwarding + no stack-trace leak ------------------------------
+
+    @Test
+    fun `input forwards an unrecognized step verbatim (version skew, no client-side rejection)`() {
+        // A step this devrig's parser would not recognize must still be forwarded raw — a newer plugin
+        // may support it. devrig is NOT a second source of truth for input syntax.
+        val rec = RecordingInput()
         val cmd = DevrigCommand.DevrigCommandInput(
-            projectName = "k", windowId = "w", taskId = "t", reason = "r", sequence = "not-json", json = true,
+            projectName = "k", windowId = "w", taskId = "t", reason = "r", sequence = "warp:9000", json = true,
         )
         val run = runCliCommand(homePaths()) {
-            runInputCommand(cmd, fakeTools(VisionInputToolHandler::class.java to RecordingInput()))
+            runInputCommand(cmd, fakeTools(VisionInputToolHandler::class.java to rec))
         }
-        assertEquals(CliExit.USAGE, run.exit)
+        assertEquals(CliExit.OK, run.exit)
+        assertEquals("warp:9000", rec.params!!.rawSequence)
+    }
+
+    @Test
+    fun `input normalizes a server stack-trace error (message kept, frames stripped)`() {
+        val serverError = ToolCallResult(
+            content = listOf(ContentItem.Text(
+                "ERROR: Unknown input step 'warp:9000'\n" +
+                    "\tat com.jonnyzzz.mcpSteroid.vision.InputSequenceParser.parse(InputSequenceParser.kt:42)\n" +
+                    "\tat com.jonnyzzz.mcpSteroid.server.VisionInputTool.call(VisionInputTool.kt:88)\n" +
+                    "\t... 12 more",
+            )),
+            isError = true,
+        )
+        val cmd = DevrigCommand.DevrigCommandInput(
+            projectName = "k", windowId = "w", taskId = "t", reason = "r", sequence = "warp:9000", json = true,
+        )
+        val run = runCliCommand(homePaths()) {
+            runInputCommand(cmd, fakeTools(VisionInputToolHandler::class.java to RecordingInput(serverError)))
+        }
+        assertEquals(CliExit.TOOL_ERROR, run.exit)
         assertTrue(envIsError(run), run.stdout)
-        assertTrue(envContentText(run).contains("invalid --sequence"), run.stdout)
-        assertFalse(run.stdout.contains("\tat "), "no stack frames in stdout: ${run.stdout}")
-        assertFalse(run.stdout.contains("com.jonnyzzz.mcpSteroid.vision"), "no server internals leaked: ${run.stdout}")
+        assertTrue(envContentText(run).contains("Unknown input step 'warp:9000'"), run.stdout)
+        assertFalse(run.stdout.contains("\\tat "), "no stack frames in stdout: ${run.stdout}")
+        assertFalse(run.stdout.contains("InputSequenceParser"), "no server internals leaked: ${run.stdout}")
+        assertFalse(run.stdout.contains("... 12 more"), "no frame continuations: ${run.stdout}")
+    }
+
+    // ------------------------------ #8: execution_id is accepted but never forwarded ------------------------------
+
+    @Test
+    fun `execute_feedback does not forward --execution_id into FeedbackParams`() {
+        val rec = RecordingFeedback()
+        val cmd = DevrigCommand.DevrigCommandFeedback(
+            projectName = "k", taskId = "t", executionId = "e-42", successRating = 0.5, explanation = "x",
+        )
+        val run = runCliCommand(homePaths()) {
+            runFeedbackCommand(cmd, fakeTools(ExecuteFeedbackToolHandler::class.java to rec))
+        }
+        assertEquals(CliExit.OK, run.exit)
+        // FeedbackParams has no execution_id field; the value is contextual only (matches the MCP tool).
+        assertEquals("t", rec.params!!.taskId)
+        assertEquals(0.5, rec.params!!.successRating)
+    }
+
+    // ------------------------------ #3: open_project --wait single final envelope ------------------------------
+
+    private fun readyWindow(path: String) = ListWindowsResponse(
+        windows = listOf(ListedWindow(
+            projectName = "k", projectPath = path, title = "t", isActive = true, isVisible = true,
+            bounds = null, windowId = "w",
+            modalDialogShowing = false, indexingInProgress = false, projectInitialized = true,
+        )),
+        backgroundTasks = emptyList(),
+    )
+
+    private fun notReadyWindow(path: String) = ListWindowsResponse(
+        windows = listOf(ListedWindow(
+            projectName = "k", projectPath = path, title = "t", isActive = true, isVisible = true,
+            bounds = null, windowId = "w",
+            modalDialogShowing = false, indexingInProgress = true, projectInitialized = false,
+        )),
+        backgroundTasks = emptyList(),
+    )
+
+    @Test
+    fun `open_project --wait ready emits a single success envelope`() {
+        val path = home.resolve("proj").toAbsolutePath().normalize().toString()
+        val cmd = DevrigCommand.DevrigCommandOpenProject(projectPath = path, taskId = "t", reason = "r", wait = true, json = true)
+        val run = runCliCommand(homePaths()) {
+            runOpenProjectCommand(
+                cmd,
+                fakeTools(
+                    OpenProjectToolHandler::class.java to RecordingOpenProject(),
+                    ListWindowsToolHandler::class.java to SequencedListWindows(listOf(notReadyWindow(path), readyWindow(path))),
+                ),
+                waitAttempts = 5, waitIntervalMs = 1,
+            )
+        }
+        assertEquals(CliExit.OK, run.exit)
+        assertFalse(envIsError(run), run.stdout)
+        assertOneJsonDocument(run.stdout)
+        assertTrue(envContentText(run).contains("initialized and ready"), run.stdout)
+    }
+
+    @Test
+    fun `open_project --wait timeout emits a single isError envelope, never a stale success`() {
+        val path = home.resolve("proj").toAbsolutePath().normalize().toString()
+        val cmd = DevrigCommand.DevrigCommandOpenProject(projectPath = path, taskId = "t", reason = "r", wait = true, json = true)
+        val run = runCliCommand(homePaths()) {
+            runOpenProjectCommand(
+                cmd,
+                fakeTools(
+                    OpenProjectToolHandler::class.java to RecordingOpenProject(),
+                    ListWindowsToolHandler::class.java to SequencedListWindows(listOf(notReadyWindow(path))),
+                ),
+                waitAttempts = 3, waitIntervalMs = 1,
+            )
+        }
+        assertEquals(CliExit.UNAVAILABLE, run.exit)
+        assertTrue(envIsError(run), run.stdout)
+        assertOneJsonDocument(run.stdout)
+        assertTrue(envContentText(run).contains("timed out"), run.stdout)
+    }
+
+    @Test
+    fun `open_project --wait tolerates a transient poll failure then succeeds`() {
+        val path = home.resolve("proj").toAbsolutePath().normalize().toString()
+        val cmd = DevrigCommand.DevrigCommandOpenProject(projectPath = path, taskId = "t", reason = "r", wait = true, json = true)
+        val run = runCliCommand(homePaths()) {
+            runOpenProjectCommand(
+                cmd,
+                fakeTools(
+                    OpenProjectToolHandler::class.java to RecordingOpenProject(),
+                    ListWindowsToolHandler::class.java to FlakyListWindows(failFirst = 1, then = readyWindow(path)),
+                ),
+                waitAttempts = 5, waitIntervalMs = 1,
+            )
+        }
+        assertEquals(CliExit.OK, run.exit)
+        assertFalse(envIsError(run), run.stdout)
+        assertOneJsonDocument(run.stdout)
+    }
+
+    /**
+     * Asserts [stdout] is exactly ONE JSON envelope. [Json.parseToJsonElement] reads a single element
+     * and requires EOF, so a second document (or any trailing token) makes it throw — that is the
+     * "exactly one JSON document in stdout" contract.
+     */
+    private fun assertOneJsonDocument(stdout: String) {
+        assertFalse(stdout.contains("}\n{"), "more than one JSON document in stdout: $stdout")
+        val obj = Json.parseToJsonElement(stdout.trim()).jsonObject
+        assertTrue(obj.containsKey("tool") && obj.containsKey("command"), "one envelope object: $stdout")
     }
 
     // ------------------------------ finding (dangerous): open_project relative path ------------------------------

--- a/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/CliErrorEnvelopeTest.kt
+++ b/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/CliErrorEnvelopeTest.kt
@@ -1,0 +1,164 @@
+/* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
+package com.jonnyzzz.mcpSteroid.devrig
+
+import com.jonnyzzz.mcpSteroid.devrig.server.ProjectRouteNotFoundException
+import com.jonnyzzz.mcpSteroid.mcp.ContentItem
+import com.jonnyzzz.mcpSteroid.mcp.ToolCallResult
+import com.jonnyzzz.mcpSteroid.server.ExecCodeParams
+import com.jonnyzzz.mcpSteroid.server.ExecuteCodeToolHandler
+import com.jonnyzzz.mcpSteroid.server.McpProgressReporter
+import com.jonnyzzz.mcpSteroid.server.OpenProjectToolHandler
+import com.jonnyzzz.mcpSteroid.server.VisionInputToolHandler
+import com.jonnyzzz.mcpSteroid.server.VisionScreenshotToolHandler
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.booleanOrNull
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Path
+import java.util.Base64
+
+/**
+ * Pins the Round-4 hardening: under `--json`, EVERY failure (client-side usage, routing, bridge) emits
+ * the unified `{tool, command, isError:true, data}` envelope; errors never leak server stack traces; a
+ * relative `open_project` path resolves against cwd; and `take_screenshot --out` surfaces the written
+ * absolute path in the envelope.
+ */
+class CliErrorEnvelopeTest {
+
+    @TempDir lateinit var home: Path
+    private fun homePaths() = HomePaths(home).also { it.mkdirsAll() }
+
+    private fun CliRun.envelope() = Json.parseToJsonElement(stdout).jsonObject
+    private fun envIsError(run: CliRun) = run.envelope()["isError"]!!.jsonPrimitive.booleanOrNull == true
+    private fun envCommand(run: CliRun) = run.envelope()["command"]!!.jsonPrimitive.content
+    private fun envContentText(run: CliRun): String =
+        run.envelope()["data"]!!.jsonObject["content"]!!.jsonArray
+            .joinToString("\n") { it.jsonObject["text"]?.jsonPrimitive?.content ?: "" }
+
+    // ------------------------------ finding (a): usage/parse errors under --json ------------------------------
+
+    @Test
+    fun `parse error under --json emits an isError envelope with exit 64`() {
+        val run = runCliCommand(homePaths()) { runCli(parseDevrigCommand(arrayOf("execute_code", "--json"))) }
+        assertEquals(CliExit.USAGE, run.exit)
+        assertTrue(envIsError(run), run.stdout)
+        assertEquals("execute_code", envCommand(run))
+    }
+
+    @Test
+    fun `unknown flag under --json emits an isError envelope`() {
+        val run = runCliCommand(homePaths()) { runCli(parseDevrigCommand(arrayOf("list_projects", "--json", "--nope"))) }
+        assertEquals(CliExit.USAGE, run.exit)
+        assertTrue(envIsError(run), run.stdout)
+        // The specific clikt error is lifted into the envelope, not a useless "Invalid arguments".
+        assertTrue(envContentText(run).contains("no such option"), run.stdout)
+    }
+
+    // ------------------------------ finding (b): runtime bridge/routing errors under --json ------------------------------
+
+    private fun throwingExecuteCode(ex: Throwable) = object : ExecuteCodeToolHandler {
+        override suspend fun executeCode(
+            projectName: String,
+            execCodeParams: ExecCodeParams,
+            callProgress: McpProgressReporter,
+        ): ToolCallResult = throw ex
+    }
+
+    @Test
+    fun `stale project_name under --json is an enveloped usage error`() {
+        val cmd = DevrigCommand.DevrigCommandExecuteCode(
+            projectName = "stale", code = "x", taskId = "t", reason = "r", json = true,
+        )
+        val run = runCliCommand(homePaths()) {
+            runExecuteCodeCommand(cmd, fakeTools(ExecuteCodeToolHandler::class.java to throwingExecuteCode(ProjectRouteNotFoundException("stale"))))
+        }
+        assertEquals(CliExit.USAGE, run.exit)
+        assertTrue(envIsError(run), run.stdout)
+        assertTrue(envContentText(run).contains("list_projects"), run.stdout)
+    }
+
+    @Test
+    fun `bridge failure under --json is an enveloped unavailable error`() {
+        val cmd = DevrigCommand.DevrigCommandExecuteCode(
+            projectName = "k", code = "x", taskId = "t", reason = "r", json = true,
+        )
+        val run = runCliCommand(homePaths()) {
+            runExecuteCodeCommand(cmd, fakeTools(ExecuteCodeToolHandler::class.java to throwingExecuteCode(RuntimeException("connection refused"))))
+        }
+        assertEquals(CliExit.UNAVAILABLE, run.exit)
+        assertTrue(envIsError(run), run.stdout)
+    }
+
+    // ------------------------------ take_screenshot --out (findings b + --out reporting) ------------------------------
+
+    private fun imageResult(): ToolCallResult {
+        val b64 = Base64.getEncoder().encodeToString(ByteArray(8) { it.toByte() })
+        return ToolCallResult(content = listOf(ContentItem.Image(data = b64, mimeType = "image/png")))
+    }
+
+    @Test
+    fun `--out success surfaces the written absolute path in the --json envelope`() {
+        val outFile = home.resolve("shots/ok.png")
+        val cmd = DevrigCommand.DevrigCommandScreenshot(
+            projectName = "k", taskId = "t", reason = "r", out = outFile.toString(), json = true,
+        )
+        val run = runCliCommand(homePaths()) {
+            runScreenshotCommand(cmd, fakeTools(VisionScreenshotToolHandler::class.java to RecordingScreenshot(imageResult())))
+        }
+        assertEquals(CliExit.OK, run.exit)
+        assertFalse(envIsError(run), run.stdout)
+        assertTrue(envContentText(run).contains(outFile.toAbsolutePath().normalize().toString()), run.stdout)
+    }
+
+    @Test
+    fun `--out write failure under --json is an enveloped error`() {
+        // Point --out at the home DIRECTORY: Files.write on a directory fails, exercising the write path.
+        val cmd = DevrigCommand.DevrigCommandScreenshot(
+            projectName = "k", taskId = "t", reason = "r", out = home.toString(), json = true,
+        )
+        val run = runCliCommand(homePaths()) {
+            runScreenshotCommand(cmd, fakeTools(VisionScreenshotToolHandler::class.java to RecordingScreenshot(imageResult())))
+        }
+        assertEquals(CliExit.USAGE, run.exit)
+        assertTrue(envIsError(run), run.stdout)
+        assertTrue(envContentText(run).contains("failed to write --out"), run.stdout)
+    }
+
+    // ------------------------------ finding: input stack-trace leak ------------------------------
+
+    @Test
+    fun `invalid --sequence fails client-side with a concise enveloped message and no stack trace`() {
+        val cmd = DevrigCommand.DevrigCommandInput(
+            projectName = "k", windowId = "w", taskId = "t", reason = "r", sequence = "not-json", json = true,
+        )
+        val run = runCliCommand(homePaths()) {
+            runInputCommand(cmd, fakeTools(VisionInputToolHandler::class.java to RecordingInput()))
+        }
+        assertEquals(CliExit.USAGE, run.exit)
+        assertTrue(envIsError(run), run.stdout)
+        assertTrue(envContentText(run).contains("invalid --sequence"), run.stdout)
+        assertFalse(run.stdout.contains("\tat "), "no stack frames in stdout: ${run.stdout}")
+        assertFalse(run.stdout.contains("com.jonnyzzz.mcpSteroid.vision"), "no server internals leaked: ${run.stdout}")
+    }
+
+    // ------------------------------ finding (dangerous): open_project relative path ------------------------------
+
+    @Test
+    fun `open_project resolves a relative --project_path against cwd`() {
+        val rec = RecordingOpenProject()
+        val cmd = DevrigCommand.DevrigCommandOpenProject(projectPath = ".", taskId = "t", reason = "r")
+        val run = runCliCommand(homePaths()) {
+            runOpenProjectCommand(cmd, fakeTools(OpenProjectToolHandler::class.java to rec))
+        }
+        assertEquals(CliExit.OK, run.exit)
+        val expected = Path.of(".").toAbsolutePath().normalize().toString()
+        assertEquals(expected, rec.params!!.projectPath)
+        assertFalse(rec.params!!.projectPath == "." || rec.params!!.projectPath == "/", "must not forward a relative/root path")
+    }
+}

--- a/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/CliGlueTestSupport.kt
+++ b/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/CliGlueTestSupport.kt
@@ -75,6 +75,35 @@ fun fakeTools(vararg pairs: Pair<Class<*>, Any>): FakeMcpSteroidTools =
 fun okResult(text: String = "ok"): ToolCallResult =
     ToolCallResult(content = listOf(ContentItem.Text(text)))
 
+fun toolErrorResult(text: String = "boom"): ToolCallResult =
+    ToolCallResult(content = listOf(ContentItem.Text(text)), isError = true)
+
+// ---------------------------- throwing fakes (routing / bridge failures) ----------------------------
+
+class ThrowingExecuteCode(private val ex: Throwable) : ExecuteCodeToolHandler {
+    override suspend fun executeCode(projectName: String, execCodeParams: ExecCodeParams, callProgress: McpProgressReporter): ToolCallResult = throw ex
+}
+
+class ThrowingFeedback(private val ex: Throwable) : ExecuteFeedbackToolHandler {
+    override suspend fun handleFeedback(projectName: String, params: FeedbackParams): ToolCallResult = throw ex
+}
+
+class ThrowingInput(private val ex: Throwable) : VisionInputToolHandler {
+    override suspend fun handleInputSequence(projectName: String, inputParams: InputParams): ToolCallResult = throw ex
+}
+
+class ThrowingScreenshot(private val ex: Throwable) : VisionScreenshotToolHandler {
+    override suspend fun screenshotWindow(projectName: String, screenshotParams: ScreenshotParams, mcpProgressReporter: McpProgressReporter): ToolCallResult = throw ex
+}
+
+class ThrowingOpenProject(private val ex: Throwable) : OpenProjectToolHandler {
+    override suspend fun handleOpenProject(openProjectParams: OpenProjectParams, callProgress: McpProgressReporter): ToolCallResult = throw ex
+}
+
+class ThrowingListWindows(private val ex: Throwable) : ListWindowsToolHandler {
+    override suspend fun collectListWindowsResponse(): ListWindowsResponse = throw ex
+}
+
 // ---------------------------- recording fake handlers ----------------------------
 
 class RecordingExecuteCode(private val result: ToolCallResult = okResult()) : ExecuteCodeToolHandler {
@@ -143,5 +172,18 @@ class SequencedListWindows(private val responses: List<ListWindowsResponse>) : L
         val idx = minOf(calls, responses.lastIndex)
         calls++
         return responses[idx]
+    }
+}
+
+/**
+ * Throws on the first [failFirst] poll(s) (a transient bridge failure the --wait loop must tolerate),
+ * then returns [then] on every subsequent poll.
+ */
+class FlakyListWindows(private val failFirst: Int, private val then: ListWindowsResponse) : ListWindowsToolHandler {
+    var calls: Int = 0
+    override suspend fun collectListWindowsResponse(): ListWindowsResponse {
+        val current = calls++
+        if (current < failFirst) throw RuntimeException("transient poll failure #$current")
+        return then
     }
 }

--- a/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/CliGlueTestSupport.kt
+++ b/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/CliGlueTestSupport.kt
@@ -1,6 +1,11 @@
 /* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
 package com.jonnyzzz.mcpSteroid.devrig
 
+import com.jonnyzzz.mcpSteroid.IdeInfo
+import com.jonnyzzz.mcpSteroid.PluginInfo
+import com.jonnyzzz.mcpSteroid.devrig.monitor.DiscoveredIde
+import com.jonnyzzz.mcpSteroid.devrig.monitor.IdeProjectState
+import com.jonnyzzz.mcpSteroid.devrig.server.ProjectRoute
 import com.jonnyzzz.mcpSteroid.mcp.ContentItem
 import com.jonnyzzz.mcpSteroid.mcp.ToolCallResult
 import com.jonnyzzz.mcpSteroid.server.ExecCodeParams
@@ -71,6 +76,25 @@ class FakeMcpSteroidTools(private val handlers: Map<Class<*>, Any>) : McpSteroid
 
 fun fakeTools(vararg pairs: Pair<Class<*>, Any>): FakeMcpSteroidTools =
     FakeMcpSteroidTools(pairs.toMap())
+
+/**
+ * A [ProjectRoute] fixture for cwd-inference tests (issue #266): only [path] and [name] are meaningful
+ * (drive `resolveProjectFromCwd` matching + the exposed routing key); the [DiscoveredIde]/[IdeProjectState]
+ * fields are placeholder values, mirroring `CwdProjectResolverTest`'s `route(path, name)` helper.
+ */
+fun fakeRoute(path: String, name: String): ProjectRoute = ProjectRoute(
+    route = DiscoveredIde(
+        backendName = "backend-$name",
+        pid = 1L,
+        rpcBaseUrl = "http://127.0.0.1:4343/mcp",
+        bridgeHeaders = emptyMap(),
+        ide = IdeInfo("IntelliJ IDEA", "2026.1", "IU-261.1"),
+        plugin = PluginInfo("com.jonnyzzz.mcp-steroid", "MCP Steroid", "0.0.0-test"),
+    ),
+    projectInfo = IdeProjectState(name, path),
+    exposedProjectName = name,
+    projectPath = path,
+)
 
 fun okResult(text: String = "ok"): ToolCallResult =
     ToolCallResult(content = listOf(ContentItem.Text(text)))

--- a/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/CliGlueTestSupport.kt
+++ b/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/CliGlueTestSupport.kt
@@ -1,0 +1,147 @@
+/* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
+package com.jonnyzzz.mcpSteroid.devrig
+
+import com.jonnyzzz.mcpSteroid.mcp.ContentItem
+import com.jonnyzzz.mcpSteroid.mcp.ToolCallResult
+import com.jonnyzzz.mcpSteroid.server.ExecCodeParams
+import com.jonnyzzz.mcpSteroid.server.ExecuteCodeToolHandler
+import com.jonnyzzz.mcpSteroid.server.ExecuteFeedbackToolHandler
+import com.jonnyzzz.mcpSteroid.server.FeedbackParams
+import com.jonnyzzz.mcpSteroid.server.InputParams
+import com.jonnyzzz.mcpSteroid.server.ListWindowsResponse
+import com.jonnyzzz.mcpSteroid.server.ListWindowsToolHandler
+import com.jonnyzzz.mcpSteroid.server.McpProgressReporter
+import com.jonnyzzz.mcpSteroid.server.McpSteroidTools
+import com.jonnyzzz.mcpSteroid.server.OpenProjectParams
+import com.jonnyzzz.mcpSteroid.server.OpenProjectToolHandler
+import com.jonnyzzz.mcpSteroid.server.ScreenshotParams
+import com.jonnyzzz.mcpSteroid.server.VisionInputToolHandler
+import com.jonnyzzz.mcpSteroid.server.VisionScreenshotToolHandler
+import com.jonnyzzz.mcpSteroid.testHelper.CloseableStackHost
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.io.PrintStream
+
+/**
+ * Shared harness for the MCP-as-CLI *glue* tests: they exercise the CLI command functions with a fake
+ * [McpSteroidTools] so we assert the args→`*Params`→render→exit-code wiring WITHOUT a live IDE. The
+ * payload→wire mapping of the real handlers is covered separately by `DevrigToolBridgeClientTest`.
+ */
+
+/** Captured result of running one CLI command against buffers. */
+data class CliRun(val exit: Int, val stdout: String, val stderr: String)
+
+/**
+ * Runs [invoke] with a [DevrigServices] whose stdout is a buffer and with `System.err` redirected to a
+ * buffer, returning both plus the exit code. [stdin] feeds `--code-file=-` style stdin reads.
+ */
+fun runCliCommand(
+    homePaths: HomePaths,
+    stdin: ByteArray = ByteArray(0),
+    invoke: DevrigServices.() -> Int,
+): CliRun {
+    val outBuf = ByteArrayOutputStream()
+    val errBuf = ByteArrayOutputStream()
+    val originalErr = System.err
+    System.setErr(PrintStream(errBuf, true, Charsets.UTF_8))
+    val lifetime = CloseableStackHost()
+    val exit = try {
+        DevrigServices(
+            lifetime = lifetime,
+            homePaths = homePaths,
+            mcpStdin = ByteArrayInputStream(stdin),
+            mcpStdout = PrintStream(outBuf, true, Charsets.UTF_8),
+        ).invoke()
+    } finally {
+        lifetime.closeAllStacks()
+        System.setErr(originalErr)
+    }
+    return CliRun(
+        exit = exit,
+        stdout = outBuf.toString(Charsets.UTF_8).replace("\r\n", "\n"),
+        stderr = errBuf.toString(Charsets.UTF_8).replace("\r\n", "\n"),
+    )
+}
+
+/** An [McpSteroidTools] that returns the handlers it was given, keyed by their interface type. */
+class FakeMcpSteroidTools(private val handlers: Map<Class<*>, Any>) : McpSteroidTools() {
+    override fun <T> handler(type: Class<T>): T =
+        type.cast(handlers[type] ?: error("FakeMcpSteroidTools: no handler wired for ${type.name}"))
+}
+
+fun fakeTools(vararg pairs: Pair<Class<*>, Any>): FakeMcpSteroidTools =
+    FakeMcpSteroidTools(pairs.toMap())
+
+fun okResult(text: String = "ok"): ToolCallResult =
+    ToolCallResult(content = listOf(ContentItem.Text(text)))
+
+// ---------------------------- recording fake handlers ----------------------------
+
+class RecordingExecuteCode(private val result: ToolCallResult = okResult()) : ExecuteCodeToolHandler {
+    var projectName: String? = null
+    var params: ExecCodeParams? = null
+    override suspend fun executeCode(
+        projectName: String,
+        execCodeParams: ExecCodeParams,
+        callProgress: McpProgressReporter,
+    ): ToolCallResult {
+        this.projectName = projectName
+        this.params = execCodeParams
+        return result
+    }
+}
+
+class RecordingFeedback(private val result: ToolCallResult = okResult()) : ExecuteFeedbackToolHandler {
+    var projectName: String? = null
+    var params: FeedbackParams? = null
+    override suspend fun handleFeedback(projectName: String, params: FeedbackParams): ToolCallResult {
+        this.projectName = projectName
+        this.params = params
+        return result
+    }
+}
+
+class RecordingInput(private val result: ToolCallResult = okResult()) : VisionInputToolHandler {
+    var projectName: String? = null
+    var params: InputParams? = null
+    override suspend fun handleInputSequence(projectName: String, inputParams: InputParams): ToolCallResult {
+        this.projectName = projectName
+        this.params = inputParams
+        return result
+    }
+}
+
+class RecordingScreenshot(private val result: ToolCallResult) : VisionScreenshotToolHandler {
+    var projectName: String? = null
+    var params: ScreenshotParams? = null
+    override suspend fun screenshotWindow(
+        projectName: String,
+        screenshotParams: ScreenshotParams,
+        mcpProgressReporter: McpProgressReporter,
+    ): ToolCallResult {
+        this.projectName = projectName
+        this.params = screenshotParams
+        return result
+    }
+}
+
+class RecordingOpenProject(private val result: ToolCallResult = okResult()) : OpenProjectToolHandler {
+    var params: OpenProjectParams? = null
+    override suspend fun handleOpenProject(
+        openProjectParams: OpenProjectParams,
+        callProgress: McpProgressReporter,
+    ): ToolCallResult {
+        this.params = openProjectParams
+        return result
+    }
+}
+
+/** Returns the queued responses in order (last one repeats) — for the open_project --wait poll loop. */
+class SequencedListWindows(private val responses: List<ListWindowsResponse>) : ListWindowsToolHandler {
+    var calls: Int = 0
+    override suspend fun collectListWindowsResponse(): ListWindowsResponse {
+        val idx = minOf(calls, responses.lastIndex)
+        calls++
+        return responses[idx]
+    }
+}

--- a/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/CliToolSupportTest.kt
+++ b/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/CliToolSupportTest.kt
@@ -1,0 +1,69 @@
+/* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
+package com.jonnyzzz.mcpSteroid.devrig
+
+import com.jonnyzzz.mcpSteroid.mcp.ContentItem
+import com.jonnyzzz.mcpSteroid.mcp.ToolCallResult
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.booleanOrNull
+import kotlinx.serialization.json.int
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.io.ByteArrayOutputStream
+import java.io.PrintStream
+import java.util.Base64
+
+/** Pins the shared [renderTo] / [toEnvelopeJson] contract reused by every tool-backed command. */
+class CliToolSupportTest {
+
+    private fun buffers() = ByteArrayOutputStream() to ByteArrayOutputStream()
+    private fun ByteArrayOutputStream.text() = toString(Charsets.UTF_8).replace("\r\n", "\n")
+
+    @Test
+    fun `success text goes to stdout with exit OK`() {
+        val (out, err) = buffers()
+        val result = ToolCallResult(content = listOf(ContentItem.Text("hello world")))
+        val exit = result.renderTo("demo", json = false, out = PrintStream(out), err = PrintStream(err))
+        assertEquals(CliExit.OK, exit)
+        assertEquals("hello world", out.text().trim())
+        assertEquals("", err.text())
+    }
+
+    @Test
+    fun `error content goes to stderr and stdout stays clean`() {
+        val (out, err) = buffers()
+        val result = ToolCallResult(content = listOf(ContentItem.Text("ERROR: boom")), isError = true)
+        val exit = result.renderTo("demo", json = false, out = PrintStream(out), err = PrintStream(err))
+        assertEquals(CliExit.TOOL_ERROR, exit)
+        assertEquals("", out.text())
+        assertTrue(err.text().contains("boom"))
+    }
+
+    @Test
+    fun `image renders a byte-count placeholder and the envelope reports bytes`() {
+        val (out, err) = buffers()
+        val raw = ByteArray(9) { it.toByte() }
+        val b64 = Base64.getEncoder().encodeToString(raw)
+        val result = ToolCallResult(content = listOf(ContentItem.Image(data = b64, mimeType = "image/png")))
+
+        result.renderTo("shot", json = false, out = PrintStream(out), err = PrintStream(err))
+        assertTrue(out.text().contains("[image: image/png, 9 bytes]"), out.text())
+
+        val obj = Json.parseToJsonElement(result.toEnvelopeJson("shot")).jsonObject
+        val item = obj["content"]!!.jsonArray.first().jsonObject
+        assertEquals("image", item["type"]!!.jsonPrimitive.content)
+        assertEquals(9, item["bytes"]!!.jsonPrimitive.int)
+    }
+
+    @Test
+    fun `json envelope carries tool identity, command and isError`() {
+        val result = ToolCallResult(content = listOf(ContentItem.Text("x")), isError = false)
+        val obj = Json.parseToJsonElement(result.toEnvelopeJson("execute_code")).jsonObject
+        assertEquals("devrig", obj["tool"]!!.jsonObject["name"]!!.jsonPrimitive.content)
+        assertEquals("execute_code", obj["command"]!!.jsonPrimitive.content)
+        assertEquals(false, obj["isError"]!!.jsonPrimitive.booleanOrNull)
+    }
+}

--- a/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/CliToolSupportTest.kt
+++ b/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/CliToolSupportTest.kt
@@ -15,17 +15,18 @@ import java.io.ByteArrayOutputStream
 import java.io.PrintStream
 import java.util.Base64
 
-/** Pins the shared [renderTo] / [toEnvelopeJson] contract reused by every tool-backed command. */
+/** Pins the shared [Presentation] / [toEnvelopeJson] contract reused by every tool-backed command. */
 class CliToolSupportTest {
 
     private fun buffers() = ByteArrayOutputStream() to ByteArrayOutputStream()
     private fun ByteArrayOutputStream.text() = toString(Charsets.UTF_8).replace("\r\n", "\n")
+    private fun console() = Presentation.Console { java.nio.file.Files.createTempDirectory("cli-render") }
 
     @Test
     fun `success text goes to stdout with exit OK`() {
         val (out, err) = buffers()
         val result = ToolCallResult(content = listOf(ContentItem.Text("hello world")))
-        val exit = result.renderTo("demo", json = false, out = PrintStream(out), err = PrintStream(err))
+        val exit = console().render(result, "demo", PrintStream(out), PrintStream(err))
         assertEquals(CliExit.OK, exit)
         assertEquals("hello world", out.text().trim())
         assertEquals("", err.text())
@@ -35,7 +36,7 @@ class CliToolSupportTest {
     fun `error content goes to stderr and stdout stays clean`() {
         val (out, err) = buffers()
         val result = ToolCallResult(content = listOf(ContentItem.Text("ERROR: boom")), isError = true)
-        val exit = result.renderTo("demo", json = false, out = PrintStream(out), err = PrintStream(err))
+        val exit = console().render(result, "demo", PrintStream(out), PrintStream(err))
         assertEquals(CliExit.TOOL_ERROR, exit)
         assertEquals("", out.text())
         assertTrue(err.text().contains("boom"))

--- a/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/CliToolSupportTest.kt
+++ b/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/CliToolSupportTest.kt
@@ -5,7 +5,6 @@ import com.jonnyzzz.mcpSteroid.mcp.ContentItem
 import com.jonnyzzz.mcpSteroid.mcp.ToolCallResult
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.booleanOrNull
-import kotlinx.serialization.json.int
 import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
@@ -43,19 +42,22 @@ class CliToolSupportTest {
     }
 
     @Test
-    fun `image renders a byte-count placeholder and the envelope reports bytes`() {
+    fun `image renders a byte-count placeholder on console and carries data as-is in the envelope`() {
         val (out, err) = buffers()
         val raw = ByteArray(9) { it.toByte() }
         val b64 = Base64.getEncoder().encodeToString(raw)
         val result = ToolCallResult(content = listOf(ContentItem.Image(data = b64, mimeType = "image/png")))
 
+        // Console rendering is untouched by this task (Task 6 replaces it with a temp-file write).
         result.renderTo("shot", json = false, out = PrintStream(out), err = PrintStream(err))
         assertTrue(out.text().contains("[image: image/png, 9 bytes]"), out.text())
 
         val obj = Json.parseToJsonElement(result.toEnvelopeJson("shot")).jsonObject
         val item = obj["data"]!!.jsonObject["content"]!!.jsonArray.first().jsonObject
         assertEquals("image", item["type"]!!.jsonPrimitive.content)
-        assertEquals(9, item["bytes"]!!.jsonPrimitive.int)
+        // C7: image data is carried as-is (base64), not summarized to a byte count.
+        assertEquals(b64, item["data"]!!.jsonPrimitive.content)
+        assertEquals("image/png", item["mimeType"]!!.jsonPrimitive.content)
     }
 
     @Test

--- a/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/CliToolSupportTest.kt
+++ b/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/CliToolSupportTest.kt
@@ -42,15 +42,10 @@ class CliToolSupportTest {
     }
 
     @Test
-    fun `image renders a byte-count placeholder on console and carries data as-is in the envelope`() {
-        val (out, err) = buffers()
+    fun `image data is carried as-is in the json envelope`() {
         val raw = ByteArray(9) { it.toByte() }
         val b64 = Base64.getEncoder().encodeToString(raw)
         val result = ToolCallResult(content = listOf(ContentItem.Image(data = b64, mimeType = "image/png")))
-
-        // Console rendering is untouched by this task (Task 6 replaces it with a temp-file write).
-        result.renderTo("shot", json = false, out = PrintStream(out), err = PrintStream(err))
-        assertTrue(out.text().contains("[image: image/png, 9 bytes]"), out.text())
 
         val obj = Json.parseToJsonElement(result.toEnvelopeJson("shot")).jsonObject
         val item = obj["data"]!!.jsonObject["content"]!!.jsonArray.first().jsonObject
@@ -58,6 +53,44 @@ class CliToolSupportTest {
         // C7: image data is carried as-is (base64), not summarized to a byte count.
         assertEquals(b64, item["data"]!!.jsonPrimitive.content)
         assertEquals("image/png", item["mimeType"]!!.jsonPrimitive.content)
+    }
+
+    @Test
+    fun `console image is written to a temp file and the path is printed`() {
+        val raw = ByteArray(9) { it.toByte() }
+        val b64 = Base64.getEncoder().encodeToString(raw)
+        val result = ToolCallResult(content = listOf(ContentItem.Image(data = b64, mimeType = "image/png")))
+        val tmp = java.nio.file.Files.createTempDirectory("shot")
+        val (out, err) = buffers()
+
+        Presentation.Console { tmp }.render(result, "shot", PrintStream(out), PrintStream(err))
+
+        val printed = out.text().trim()
+        val path = java.nio.file.Path.of(printed.substringAfterLast(' ').ifBlank { printed })
+        assertTrue(java.nio.file.Files.exists(path), "expected a written file, printed: $printed")
+        assertEquals(9, java.nio.file.Files.size(path).toInt())
+        assertEquals("image/png", result.content.filterIsInstance<ContentItem.Image>().first().mimeType)
+    }
+
+    @Test
+    fun `console image with undecodable base64 logs to stderr and prints a clear line, never crashes`() {
+        val result = ToolCallResult(content = listOf(ContentItem.Image(data = "!!!not base64!!!", mimeType = "image/png")))
+        val tmp = java.nio.file.Files.createTempDirectory("shot")
+        val (out, err) = buffers()
+
+        // The undecodable-base64 log line goes to the real System.err (not the `err` render param — same
+        // logging contract the old decodedByteCount() used), so redirect it to observe it.
+        val originalErr = System.err
+        System.setErr(PrintStream(err))
+        val exit = try {
+            Presentation.Console { tmp }.render(result, "shot", PrintStream(out), PrintStream(err))
+        } finally {
+            System.setErr(originalErr)
+        }
+
+        assertEquals(CliExit.OK, exit)
+        assertTrue(out.text().contains("undecodable"), out.text())
+        assertTrue(err.text().contains("not valid base64"), err.text())
     }
 
     @Test

--- a/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/CliToolSupportTest.kt
+++ b/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/CliToolSupportTest.kt
@@ -68,4 +68,17 @@ class CliToolSupportTest {
         assertEquals("execute_code", obj["command"]!!.jsonPrimitive.content)
         assertEquals(false, obj["isError"]!!.jsonPrimitive.booleanOrNull)
     }
+
+    @Test
+    fun `json presentation emits one envelope, console emits plain text`() {
+        val result = ToolCallResult(content = listOf(ContentItem.Text("hi")))
+        val (jo, je) = buffers()
+        Presentation.Json().render(result, "demo", PrintStream(jo), PrintStream(je))
+        val (co, ce) = buffers()
+        Presentation.Console { java.nio.file.Files.createTempDirectory("t") }
+            .render(result, "demo", PrintStream(co), PrintStream(ce))
+
+        assertTrue(jo.text().trim().startsWith("{"), jo.text())
+        assertEquals("hi", co.text().trim())
+    }
 }

--- a/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/CliToolSupportTest.kt
+++ b/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/CliToolSupportTest.kt
@@ -53,7 +53,7 @@ class CliToolSupportTest {
         assertTrue(out.text().contains("[image: image/png, 9 bytes]"), out.text())
 
         val obj = Json.parseToJsonElement(result.toEnvelopeJson("shot")).jsonObject
-        val item = obj["content"]!!.jsonArray.first().jsonObject
+        val item = obj["data"]!!.jsonObject["content"]!!.jsonArray.first().jsonObject
         assertEquals("image", item["type"]!!.jsonPrimitive.content)
         assertEquals(9, item["bytes"]!!.jsonPrimitive.int)
     }

--- a/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/ExecuteCodeCommandTest.kt
+++ b/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/ExecuteCodeCommandTest.kt
@@ -130,4 +130,100 @@ class ExecuteCodeCommandTest {
         assertEquals("", run.stdout)
         assertTrue(run.stderr.contains("boom"), run.stderr)
     }
+
+    // ------------------------- --project_name cwd inference (issue #266 part 2) -------------------------
+
+    @Test
+    fun `explicit project_name overrides cwd inference`() {
+        // A route DOES contain the cwd, but --project_name was passed explicitly — the explicit value must
+        // win outright, never silently redirected to whatever the cwd happens to resolve to.
+        val rec = RecordingExecuteCode()
+        val cmd = DevrigCommand.DevrigCommandExecuteCode(
+            projectName = "explicit-key", code = "x", taskId = "t", reason = "r",
+        )
+        val cwd = Path.of("/home/u/proj")
+        val run = runCliCommand(homePaths()) {
+            runExecuteCodeCommand(
+                cmd, fakeTools(ExecuteCodeToolHandler::class.java to rec),
+                cwd = cwd, routes = listOf(fakeRoute("/home/u/proj", "cwd-inferred-key")),
+            )
+        }
+        assertEquals(CliExit.OK, run.exit)
+        assertEquals("explicit-key", rec.projectName)
+    }
+
+    @Test
+    fun `blank project_name infers the single containing project`() {
+        val rec = RecordingExecuteCode()
+        val cmd = DevrigCommand.DevrigCommandExecuteCode(
+            projectName = null, code = "x", taskId = "t", reason = "r",
+        )
+        val cwd = Path.of("/home/u/proj/src")
+        val run = runCliCommand(homePaths()) {
+            runExecuteCodeCommand(
+                cmd, fakeTools(ExecuteCodeToolHandler::class.java to rec),
+                cwd = cwd, routes = listOf(fakeRoute("/home/u/proj", "proj-abc")),
+            )
+        }
+        assertEquals(CliExit.OK, run.exit)
+        assertEquals("proj-abc", rec.projectName)
+    }
+
+    @Test
+    fun `no containing project fails with a candidate-listing usage error`() {
+        val rec = RecordingExecuteCode()
+        val cmd = DevrigCommand.DevrigCommandExecuteCode(
+            projectName = null, code = "x", taskId = "t", reason = "r",
+        )
+        val cwd = Path.of("/tmp/elsewhere")
+        val run = runCliCommand(homePaths()) {
+            runExecuteCodeCommand(
+                cmd, fakeTools(ExecuteCodeToolHandler::class.java to rec),
+                cwd = cwd, routes = listOf(fakeRoute("/home/u/proj", "proj-abc")),
+            )
+        }
+        assertEquals(CliExit.USAGE, run.exit)
+        assertEquals("", run.stdout)
+        assertTrue(run.stderr.contains("proj-abc"), run.stderr)
+        assertTrue(run.stderr.contains("--project_name"), run.stderr)
+        assertTrue(rec.projectName == null, "handler must never be invoked on a usage error")
+    }
+
+    @Test
+    fun `ambiguous cwd match fails with a candidate-listing usage error`() {
+        val rec = RecordingExecuteCode()
+        val cmd = DevrigCommand.DevrigCommandExecuteCode(
+            projectName = "  ", code = "x", taskId = "t", reason = "r",
+        )
+        val cwd = Path.of("/home/u/proj/src")
+        val run = runCliCommand(homePaths()) {
+            runExecuteCodeCommand(
+                cmd, fakeTools(ExecuteCodeToolHandler::class.java to rec),
+                cwd = cwd,
+                routes = listOf(fakeRoute("/home/u/proj", "proj-abc"), fakeRoute("/home/u/proj", "proj-xyz")),
+            )
+        }
+        assertEquals(CliExit.USAGE, run.exit)
+        assertTrue(run.stderr.contains("proj-abc"), run.stderr)
+        assertTrue(run.stderr.contains("proj-xyz"), run.stderr)
+    }
+
+    @Test
+    fun `no containing project with --json emits the unified error envelope`() {
+        // The usage error must ride the SAME --json envelope as any other CodeArgException, not a
+        // stderr-only path — assert the JSON stdout carries isError + the USAGE-shaped message.
+        val rec = RecordingExecuteCode()
+        val cmd = DevrigCommand.DevrigCommandExecuteCode(
+            projectName = null, code = "x", taskId = "t", reason = "r", json = true,
+        )
+        val run = runCliCommand(homePaths()) {
+            runExecuteCodeCommand(
+                cmd, fakeTools(ExecuteCodeToolHandler::class.java to rec),
+                cwd = Path.of("/tmp/elsewhere"), routes = listOf(fakeRoute("/home/u/proj", "proj-abc")),
+            )
+        }
+        assertEquals(CliExit.USAGE, run.exit)
+        assertTrue(run.stdout.contains("\"isError\":true") || run.stdout.contains("\"isError\": true"), run.stdout)
+        assertTrue(run.stdout.contains("proj-abc"), run.stdout)
+    }
 }

--- a/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/ExecuteCodeCommandTest.kt
+++ b/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/ExecuteCodeCommandTest.kt
@@ -50,15 +50,15 @@ class ExecuteCodeCommandTest {
     }
 
     @Test
-    fun `invalid modal is a usage error, handler not called`() {
-        val rec = RecordingExecuteCode()
-        val cmd = DevrigCommand.DevrigCommandExecuteCode(
-            projectName = "k", code = "x", taskId = "t", reason = "r", modal = "bogus",
-        )
-        val run = runCliCommand(homePaths()) { runExecuteCodeCommand(cmd, fakeTools(ExecuteCodeToolHandler::class.java to rec)) }
-        assertEquals(CliExit.USAGE, run.exit)
-        assertTrue(run.stderr.contains("invalid --modal"), run.stderr)
-        assertEquals(null, rec.params, "handler must not be called on a usage error")
+    fun `invalid modal is rejected at parse, handler never reached`() {
+        // #2: --modal is validated at PARSE now (not inside runExecuteCodeCommand), so a bad value becomes
+        // a DevrigCommandParseError that rides the unified --json envelope path — the execute_code handler
+        // is never reached. This supersedes the old stderr-only, --json-ignoring behavior.
+        val parsed = parseDevrigCommand(arrayOf(
+            "execute_code", "--project_name=k", "--code=x", "--task_id=t", "--reason=r", "--modal=bogus",
+        ))
+        assertTrue(parsed is DevrigCommand.DevrigCommandParseError, "expected parse error, got $parsed")
+        assertTrue((parsed as DevrigCommand.DevrigCommandParseError).message.contains("invalid --modal"), parsed.message)
     }
 
     @Test

--- a/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/ExecuteCodeCommandTest.kt
+++ b/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/ExecuteCodeCommandTest.kt
@@ -38,6 +38,29 @@ class ExecuteCodeCommandTest {
     }
 
     @Test
+    fun `all CLI flags reach the tool as the exact ExecCodeParams the spec builds`() {
+        // Characterization (Task 9): the CLI now maps its flags to an `arguments` JsonObject and calls
+        // ExecuteCodeToolSpec.call(), which re-parses that JSON into ExecCodeParams. This locks that every
+        // flag — code, task_id, reason, timeout, modal — round-trips through the arguments JSON and arrives
+        // at the handler unchanged, so the spec-dispatch path preserves the args-mapping contract.
+        val rec = RecordingExecuteCode()
+        val cmd = DevrigCommand.DevrigCommandExecuteCode(
+            projectName = "proj-key", code = "println(42)", taskId = "task-9", reason = "characterize",
+            modal = "non_modal", timeout = 321,
+        )
+        val run = runCliCommand(homePaths()) {
+            runExecuteCodeCommand(cmd, fakeTools(ExecuteCodeToolHandler::class.java to rec))
+        }
+        assertEquals(CliExit.OK, run.exit)
+        assertEquals("proj-key", rec.projectName)
+        assertEquals("println(42)", rec.params!!.code)
+        assertEquals("task-9", rec.params!!.taskId)
+        assertEquals("characterize", rec.params!!.reason)
+        assertEquals(321, rec.params!!.timeout)
+        assertEquals(ModalMode.NON_MODAL, rec.params!!.modal)
+    }
+
+    @Test
     fun `modal and timeout flags are reflected`() {
         val rec = RecordingExecuteCode()
         val cmd = DevrigCommand.DevrigCommandExecuteCode(

--- a/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/ExecuteCodeCommandTest.kt
+++ b/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/ExecuteCodeCommandTest.kt
@@ -1,0 +1,110 @@
+/* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
+package com.jonnyzzz.mcpSteroid.devrig
+
+import com.jonnyzzz.mcpSteroid.mcp.ToolCallResult
+import com.jonnyzzz.mcpSteroid.mcp.errorResult
+import com.jonnyzzz.mcpSteroid.server.ExecuteCodeToolHandler
+import com.jonnyzzz.mcpSteroid.server.ModalMode
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Files
+import java.nio.file.Path
+
+/** Glue test for `devrig execute_code`: CLI args → ExecCodeParams → render/exit, via a fake handler. */
+class ExecuteCodeCommandTest {
+
+    @TempDir lateinit var home: Path
+    private fun homePaths() = HomePaths(home).also { it.mkdirsAll() }
+
+    @Test
+    fun `inline code maps to ExecCodeParams with defaults`() {
+        val rec = RecordingExecuteCode()
+        val cmd = DevrigCommand.DevrigCommandExecuteCode(
+            projectName = "proj-key", code = "println(1)", taskId = "t1", reason = "why",
+        )
+        val run = runCliCommand(homePaths()) {
+            runExecuteCodeCommand(cmd, fakeTools(ExecuteCodeToolHandler::class.java to rec))
+        }
+        assertEquals(CliExit.OK, run.exit)
+        assertEquals("proj-key", rec.projectName)
+        assertEquals("println(1)", rec.params!!.code)
+        assertEquals("t1", rec.params!!.taskId)
+        assertEquals("why", rec.params!!.reason)
+        assertEquals(600, rec.params!!.timeout, "default timeout")
+        assertEquals(ModalMode.DEFAULT, rec.params!!.modal)
+        assertEquals("ok", run.stdout.trim())
+    }
+
+    @Test
+    fun `modal and timeout flags are reflected`() {
+        val rec = RecordingExecuteCode()
+        val cmd = DevrigCommand.DevrigCommandExecuteCode(
+            projectName = "k", code = "x", taskId = "t", reason = "r",
+            modal = "unleashed", timeout = 120,
+        )
+        runCliCommand(homePaths()) { runExecuteCodeCommand(cmd, fakeTools(ExecuteCodeToolHandler::class.java to rec)) }
+        assertEquals(ModalMode.UNLEASHED, rec.params!!.modal)
+        assertEquals(120, rec.params!!.timeout)
+    }
+
+    @Test
+    fun `invalid modal is a usage error, handler not called`() {
+        val rec = RecordingExecuteCode()
+        val cmd = DevrigCommand.DevrigCommandExecuteCode(
+            projectName = "k", code = "x", taskId = "t", reason = "r", modal = "bogus",
+        )
+        val run = runCliCommand(homePaths()) { runExecuteCodeCommand(cmd, fakeTools(ExecuteCodeToolHandler::class.java to rec)) }
+        assertEquals(CliExit.USAGE, run.exit)
+        assertTrue(run.stderr.contains("invalid --modal"), run.stderr)
+        assertEquals(null, rec.params, "handler must not be called on a usage error")
+    }
+
+    @Test
+    fun `code-file dash reads the script from stdin`() {
+        val rec = RecordingExecuteCode()
+        val cmd = DevrigCommand.DevrigCommandExecuteCode(
+            projectName = "k", codeFile = "-", taskId = "t", reason = "r",
+        )
+        runCliCommand(homePaths(), stdin = "val x = 42".toByteArray()) {
+            runExecuteCodeCommand(cmd, fakeTools(ExecuteCodeToolHandler::class.java to rec))
+        }
+        assertEquals("val x = 42", rec.params!!.code)
+    }
+
+    @Test
+    fun `code-file path is read from disk`() {
+        val script = home.resolve("snippet.kts")
+        Files.writeString(script, "println(\"hi\")")
+        val rec = RecordingExecuteCode()
+        val cmd = DevrigCommand.DevrigCommandExecuteCode(
+            projectName = "k", codeFile = script.toString(), taskId = "t", reason = "r",
+        )
+        runCliCommand(homePaths()) { runExecuteCodeCommand(cmd, fakeTools(ExecuteCodeToolHandler::class.java to rec)) }
+        assertEquals("println(\"hi\")", rec.params!!.code)
+    }
+
+    @Test
+    fun `missing code-file is a usage error`() {
+        val rec = RecordingExecuteCode()
+        val cmd = DevrigCommand.DevrigCommandExecuteCode(
+            projectName = "k", codeFile = home.resolve("nope.kts").toString(), taskId = "t", reason = "r",
+        )
+        val run = runCliCommand(homePaths()) { runExecuteCodeCommand(cmd, fakeTools(ExecuteCodeToolHandler::class.java to rec)) }
+        assertEquals(CliExit.USAGE, run.exit)
+        assertTrue(run.stderr.contains("--code-file not found"), run.stderr)
+    }
+
+    @Test
+    fun `tool error routes to stderr and TOOL_ERROR exit, clean stdout`() {
+        val rec = RecordingExecuteCode(result = ToolCallResult.errorResult("boom"))
+        val cmd = DevrigCommand.DevrigCommandExecuteCode(
+            projectName = "k", code = "x", taskId = "t", reason = "r",
+        )
+        val run = runCliCommand(homePaths()) { runExecuteCodeCommand(cmd, fakeTools(ExecuteCodeToolHandler::class.java to rec)) }
+        assertEquals(CliExit.TOOL_ERROR, run.exit)
+        assertEquals("", run.stdout)
+        assertTrue(run.stderr.contains("boom"), run.stderr)
+    }
+}

--- a/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/ExecuteCodeHelpTopicTest.kt
+++ b/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/ExecuteCodeHelpTopicTest.kt
@@ -69,4 +69,17 @@ class ExecuteCodeHelpTopicTest {
         assertNotEquals(render("execute_code"), global)
         assertEquals(global, render("no-such-command"), "unknown topic must fall back to the global help")
     }
+
+    @Test
+    fun `execute_code help documents stdin via code-file dash`() {
+        val out = ByteArrayOutputStream()
+        printExecuteCodeHelp(PrintStream(out))
+        val text = out.toString(Charsets.UTF_8)
+        assertTrue(text.contains("--code-file=-") || text.contains("\"-\""),
+            "expected stdin affordance documented, got:\n$text")
+        assertTrue(text.contains("stdin"), text)
+        // C17: readBytes() reads to EOF (blocks until the stream closes) — no partial-read risk
+        // for a slow producer. The help must say so.
+        assertTrue(text.contains("EOF"), "expected the blocks-until-EOF note documented, got:\n$text")
+    }
 }

--- a/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/ExecuteCodeHelpTopicTest.kt
+++ b/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/ExecuteCodeHelpTopicTest.kt
@@ -1,0 +1,72 @@
+/* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
+package com.jonnyzzz.mcpSteroid.devrig
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.io.ByteArrayOutputStream
+import java.io.PrintStream
+
+/**
+ * Layered CLI help for `execute_code`: `devrig help execute_code` / `devrig execute_code --help` give a
+ * concise entry that points deeper via `devrig prompt <uri>` — not the full 6k-token tool description.
+ */
+class ExecuteCodeHelpTopicTest {
+
+    private fun render(topic: String?): String {
+        val buf = ByteArrayOutputStream()
+        printTopicHelp(topic, PrintStream(buf, true, Charsets.UTF_8))
+        return buf.toString(Charsets.UTF_8).replace("\r\n", "\n")
+    }
+
+    // ------------------------------ parsing ------------------------------
+
+    @Test
+    fun `help execute_code parses to a topic-scoped help`() {
+        val command = parseDevrigCommand(arrayOf("help", "execute_code"))
+        assertTrue(command is DevrigCommand.DevrigCommandHelp)
+        assertEquals("execute_code", (command as DevrigCommand.DevrigCommandHelp).topic)
+    }
+
+    @Test
+    fun `execute_code --help routes to the execute_code topic, not the missing-args error`() {
+        val command = parseDevrigCommand(arrayOf("execute_code", "--help"))
+        assertTrue(command is DevrigCommand.DevrigCommandHelp, "got $command")
+        assertEquals("execute_code", (command as DevrigCommand.DevrigCommandHelp).topic)
+    }
+
+    @Test
+    fun `bare help has no topic (global banner)`() {
+        val command = parseDevrigCommand(arrayOf("help"))
+        assertTrue(command is DevrigCommand.DevrigCommandHelp)
+        assertNull((command as DevrigCommand.DevrigCommandHelp).topic)
+    }
+
+    // ------------------------------ rendering ------------------------------
+
+    @Test
+    fun `execute_code help shows flags, must-know rules and drill-down prompts`() {
+        val text = render("execute_code")
+        assertTrue(text.contains("--project_name"), text)
+        assertTrue(text.contains("--code-file"), text)
+        assertTrue(text.contains("--timeout") && text.contains("600"), text)
+        assertTrue(text.contains("runBlocking"), "must-know rule missing: $text")
+        assertTrue(text.contains("devrig prompt mcp-steroid://"), "drill-down pointers missing: $text")
+    }
+
+    @Test
+    fun `topic help is a concise entry, not the full tool description`() {
+        val topicHelp = render("execute_code")
+        // The full execute_code tool description is ~27k chars; the layered entry must stay small.
+        assertTrue(topicHelp.length < 3000, "topic help should be concise, was ${topicHelp.length} chars")
+    }
+
+    @Test
+    fun `unknown or absent topic falls back to the global banner`() {
+        val global = render(null)
+        assertNotEquals(render("execute_code"), global)
+        assertEquals(global, render("no-such-command"), "unknown topic must fall back to the global help")
+    }
+}

--- a/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/FeedbackAndInputCommandTest.kt
+++ b/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/FeedbackAndInputCommandTest.kt
@@ -44,7 +44,7 @@ class FeedbackAndInputCommandTest {
     }
 
     @Test
-    fun `input forwards the raw sequence verbatim and leaves parsing to the IDE`() {
+    fun `input forwards the raw sequence verbatim for plugin version skew`() {
         val rec = RecordingInput()
         val cmd = DevrigCommand.DevrigCommandInput(
             projectName = "k", windowId = "win-1", taskId = "t", reason = "r",
@@ -55,7 +55,7 @@ class FeedbackAndInputCommandTest {
         assertEquals("k", rec.projectName)
         assertEquals("win-1", rec.params!!.windowId)
         assertEquals("press:CTRL+P, type:Main, delay:200, press:ENTER", rec.params!!.rawSequence)
-        assertTrue(rec.params!!.sequence.isEmpty(), "the CLI does not pre-parse; the IDE re-parses rawSequence")
+        assertTrue(rec.params!!.sequence.isEmpty(), "the plugin parses rawSequence using its own version")
     }
 
     // ------------------------- --project_name cwd inference (issue #266 part 2) -------------------------

--- a/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/FeedbackAndInputCommandTest.kt
+++ b/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/FeedbackAndInputCommandTest.kt
@@ -1,0 +1,60 @@
+/* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
+package com.jonnyzzz.mcpSteroid.devrig
+
+import com.jonnyzzz.mcpSteroid.server.ExecuteFeedbackToolHandler
+import com.jonnyzzz.mcpSteroid.server.VisionInputToolHandler
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Files
+import java.nio.file.Path
+
+/** Glue tests for `devrig execute_feedback` and `devrig input`. */
+class FeedbackAndInputCommandTest {
+
+    @TempDir lateinit var home: Path
+    private fun homePaths() = HomePaths(home).also { it.mkdirsAll() }
+
+    @Test
+    fun `feedback maps rating, explanation and inline code`() {
+        val rec = RecordingFeedback()
+        val cmd = DevrigCommand.DevrigCommandFeedback(
+            projectName = "k", taskId = "t1", successRating = 0.75, explanation = "worked", code = "val x = 1",
+        )
+        val run = runCliCommand(homePaths()) { runFeedbackCommand(cmd, fakeTools(ExecuteFeedbackToolHandler::class.java to rec)) }
+        assertEquals(CliExit.OK, run.exit)
+        assertEquals("k", rec.projectName)
+        assertEquals("t1", rec.params!!.taskId)
+        assertEquals(0.75, rec.params!!.successRating)
+        assertEquals("worked", rec.params!!.explanation)
+        assertEquals("val x = 1", rec.params!!.code)
+    }
+
+    @Test
+    fun `feedback reads --code-file`() {
+        val snippet = home.resolve("s.kts")
+        Files.writeString(snippet, "// illustrative")
+        val rec = RecordingFeedback()
+        val cmd = DevrigCommand.DevrigCommandFeedback(
+            projectName = "k", taskId = "t", successRating = 1.0, explanation = "e", codeFile = snippet.toString(),
+        )
+        runCliCommand(homePaths()) { runFeedbackCommand(cmd, fakeTools(ExecuteFeedbackToolHandler::class.java to rec)) }
+        assertEquals("// illustrative", rec.params!!.code)
+    }
+
+    @Test
+    fun `input forwards the raw sequence verbatim and leaves parsing to the IDE`() {
+        val rec = RecordingInput()
+        val cmd = DevrigCommand.DevrigCommandInput(
+            projectName = "k", windowId = "win-1", taskId = "t", reason = "r",
+            sequence = "press:CTRL+P, type:Main, delay:200, press:ENTER",
+        )
+        val run = runCliCommand(homePaths()) { runInputCommand(cmd, fakeTools(VisionInputToolHandler::class.java to rec)) }
+        assertEquals(CliExit.OK, run.exit)
+        assertEquals("k", rec.projectName)
+        assertEquals("win-1", rec.params!!.windowId)
+        assertEquals("press:CTRL+P, type:Main, delay:200, press:ENTER", rec.params!!.rawSequence)
+        assertTrue(rec.params!!.sequence.isEmpty(), "the CLI does not pre-parse; the IDE re-parses rawSequence")
+    }
+}

--- a/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/FeedbackAndInputCommandTest.kt
+++ b/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/FeedbackAndInputCommandTest.kt
@@ -57,4 +57,104 @@ class FeedbackAndInputCommandTest {
         assertEquals("press:CTRL+P, type:Main, delay:200, press:ENTER", rec.params!!.rawSequence)
         assertTrue(rec.params!!.sequence.isEmpty(), "the CLI does not pre-parse; the IDE re-parses rawSequence")
     }
+
+    // ------------------------- --project_name cwd inference (issue #266 part 2) -------------------------
+
+    @Test
+    fun `feedback explicit project_name overrides cwd inference`() {
+        val rec = RecordingFeedback()
+        val cmd = DevrigCommand.DevrigCommandFeedback(
+            projectName = "explicit-key", taskId = "t", successRating = 1.0, explanation = "e",
+        )
+        val run = runCliCommand(homePaths()) {
+            runFeedbackCommand(
+                cmd, fakeTools(ExecuteFeedbackToolHandler::class.java to rec),
+                cwd = Path.of("/home/u/proj"), routes = listOf(fakeRoute("/home/u/proj", "cwd-key")),
+            )
+        }
+        assertEquals(CliExit.OK, run.exit)
+        assertEquals("explicit-key", rec.projectName)
+    }
+
+    @Test
+    fun `feedback blank project_name infers the single containing project`() {
+        val rec = RecordingFeedback()
+        val cmd = DevrigCommand.DevrigCommandFeedback(
+            projectName = null, taskId = "t", successRating = 1.0, explanation = "e",
+        )
+        val run = runCliCommand(homePaths()) {
+            runFeedbackCommand(
+                cmd, fakeTools(ExecuteFeedbackToolHandler::class.java to rec),
+                cwd = Path.of("/home/u/proj/src"), routes = listOf(fakeRoute("/home/u/proj", "proj-abc")),
+            )
+        }
+        assertEquals(CliExit.OK, run.exit)
+        assertEquals("proj-abc", rec.projectName)
+    }
+
+    @Test
+    fun `feedback no containing project fails with a candidate-listing usage error`() {
+        val rec = RecordingFeedback()
+        val cmd = DevrigCommand.DevrigCommandFeedback(
+            projectName = null, taskId = "t", successRating = 1.0, explanation = "e",
+        )
+        val run = runCliCommand(homePaths()) {
+            runFeedbackCommand(
+                cmd, fakeTools(ExecuteFeedbackToolHandler::class.java to rec),
+                cwd = Path.of("/tmp/elsewhere"), routes = listOf(fakeRoute("/home/u/proj", "proj-abc")),
+            )
+        }
+        assertEquals(CliExit.USAGE, run.exit)
+        assertTrue(run.stderr.contains("proj-abc"), run.stderr)
+        assertTrue(rec.projectName == null, "handler must never be invoked on a usage error")
+    }
+
+    @Test
+    fun `input explicit project_name overrides cwd inference`() {
+        val rec = RecordingInput()
+        val cmd = DevrigCommand.DevrigCommandInput(
+            projectName = "explicit-key", windowId = "win-1", taskId = "t", reason = "r", sequence = "press:ENTER",
+        )
+        val run = runCliCommand(homePaths()) {
+            runInputCommand(
+                cmd, fakeTools(VisionInputToolHandler::class.java to rec),
+                cwd = Path.of("/home/u/proj"), routes = listOf(fakeRoute("/home/u/proj", "cwd-key")),
+            )
+        }
+        assertEquals(CliExit.OK, run.exit)
+        assertEquals("explicit-key", rec.projectName)
+    }
+
+    @Test
+    fun `input blank project_name infers the single containing project`() {
+        val rec = RecordingInput()
+        val cmd = DevrigCommand.DevrigCommandInput(
+            projectName = null, windowId = "win-1", taskId = "t", reason = "r", sequence = "press:ENTER",
+        )
+        val run = runCliCommand(homePaths()) {
+            runInputCommand(
+                cmd, fakeTools(VisionInputToolHandler::class.java to rec),
+                cwd = Path.of("/home/u/proj/src"), routes = listOf(fakeRoute("/home/u/proj", "proj-abc")),
+            )
+        }
+        assertEquals(CliExit.OK, run.exit)
+        assertEquals("proj-abc", rec.projectName)
+    }
+
+    @Test
+    fun `input no containing project fails with a candidate-listing usage error`() {
+        val rec = RecordingInput()
+        val cmd = DevrigCommand.DevrigCommandInput(
+            projectName = null, windowId = "win-1", taskId = "t", reason = "r", sequence = "press:ENTER",
+        )
+        val run = runCliCommand(homePaths()) {
+            runInputCommand(
+                cmd, fakeTools(VisionInputToolHandler::class.java to rec),
+                cwd = Path.of("/tmp/elsewhere"), routes = listOf(fakeRoute("/home/u/proj", "proj-abc")),
+            )
+        }
+        assertEquals(CliExit.USAGE, run.exit)
+        assertTrue(run.stderr.contains("proj-abc"), run.stderr)
+        assertTrue(rec.projectName == null, "handler must never be invoked on a usage error")
+    }
 }

--- a/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/FetchResourceCommandTest.kt
+++ b/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/FetchResourceCommandTest.kt
@@ -1,0 +1,132 @@
+/* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
+package com.jonnyzzz.mcpSteroid.devrig
+
+import com.jonnyzzz.mcpSteroid.server.canonicalResourceEntryPoints
+import com.jonnyzzz.mcpSteroid.testHelper.CloseableStackHost
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.booleanOrNull
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.io.PrintStream
+import java.nio.file.Path
+
+/**
+ * End-to-end coverage for `devrig fetch_resource` / `devrig prompt` WITHOUT a running IDE: bundled
+ * `mcp-steroid://` articles resolve from the devrig binary using [com.jonnyzzz.mcpSteroid.prompts.PromptsContext.Generic].
+ *
+ * Pins the CLI contract: data → stdout, errors → stderr, `--json` → a stable envelope, unknown URI →
+ * non-zero exit + entry-point hints on stderr.
+ */
+class FetchResourceCommandTest {
+
+    private lateinit var originalErr: PrintStream
+    private lateinit var errBuf: ByteArrayOutputStream
+    private lateinit var homePaths: HomePaths
+
+    @TempDir
+    lateinit var testHome: Path
+
+    /** A URI guaranteed to exist in the bundled article index (as a plain string — no prompts import). */
+    private val knownUri: String get() = canonicalResourceEntryPoints().first()
+
+    @BeforeEach
+    fun setUp() {
+        homePaths = HomePaths(testHome).also { it.mkdirsAll() }
+        originalErr = System.err
+        errBuf = ByteArrayOutputStream()
+        System.setErr(PrintStream(errBuf, true, Charsets.UTF_8))
+    }
+
+    @AfterEach
+    fun tearDown() {
+        System.setErr(originalErr)
+    }
+
+    private fun stderr(): String = errBuf.toString(Charsets.UTF_8).replace("\r\n", "\n")
+
+    private data class Run(val exit: Int, val stdout: String)
+
+    private fun run(command: DevrigCommand): Run {
+        val outBuf = ByteArrayOutputStream()
+        val lifetime = CloseableStackHost()
+        val exit = try {
+            runBlocking {
+                DevrigServices(
+                    lifetime = lifetime,
+                    homePaths = homePaths,
+                    mcpStdin = ByteArrayInputStream(ByteArray(0)),
+                    mcpStdout = PrintStream(outBuf, true, Charsets.UTF_8),
+                ).runCli(command)
+            }
+        } finally {
+            lifetime.closeAllStacks()
+        }
+        return Run(exit, outBuf.toString(Charsets.UTF_8).replace("\r\n", "\n"))
+    }
+
+    @Test
+    fun `known uri prints markdown to stdout, nothing to stderr, exit 0`() {
+        val result = run(DevrigCommand.DevrigCommandFetchResource(uri = knownUri))
+        assertEquals(0, result.exit)
+        assertTrue(result.stdout.isNotBlank(), "expected markdown payload on stdout")
+        assertEquals("", stderr(), "stdout-only for success; stderr must stay clean")
+    }
+
+    @Test
+    fun `known uri with --json emits a parseable envelope`() {
+        val result = run(DevrigCommand.DevrigCommandFetchResource(uri = knownUri, json = true))
+        assertEquals(0, result.exit)
+        val obj = Json.parseToJsonElement(result.stdout).jsonObject
+        assertEquals("devrig", obj["tool"]!!.jsonObject["name"]!!.jsonPrimitive.content)
+        assertEquals("fetch_resource", obj["command"]!!.jsonPrimitive.content)
+        assertEquals(false, obj["isError"]!!.jsonPrimitive.booleanOrNull)
+        val content = obj["content"]!!.jsonArray
+        assertTrue(content.isNotEmpty(), "envelope must carry the resolved content")
+        assertEquals("text", content.first().jsonObject["type"]!!.jsonPrimitive.content)
+    }
+
+    @Test
+    fun `unknown uri fails with entry-point hints on stderr, clean stdout`() {
+        val result = run(DevrigCommand.DevrigCommandFetchResource(uri = "mcp-steroid://does/not/exist"))
+        assertEquals(CliExit.TOOL_ERROR, result.exit)
+        assertEquals("", result.stdout, "stdout must stay clean on error")
+        val err = stderr()
+        assertTrue(err.contains("Resource not found"), "error must name the failure: $err")
+        assertTrue(err.contains("devrig prompt "), "error must suggest runnable entry points: $err")
+    }
+
+    @Test
+    fun `unknown uri with --json still routes exit code and JSON envelope`() {
+        val result = run(DevrigCommand.DevrigCommandFetchResource(uri = "mcp-steroid://nope", json = true))
+        assertEquals(CliExit.TOOL_ERROR, result.exit)
+        val obj = Json.parseToJsonElement(result.stdout).jsonObject
+        assertTrue(obj["isError"]!!.jsonPrimitive.booleanOrNull == true)
+    }
+
+    @Test
+    fun `blank uri reaching the handler yields a usage exit`() {
+        val result = run(DevrigCommand.DevrigCommandFetchResource(uri = ""))
+        assertEquals(CliExit.USAGE, result.exit)
+        assertEquals("", result.stdout)
+        assertTrue(stderr().contains("missing <uri>"))
+    }
+
+    @Test
+    fun `unknown project_name is a usage error pointing at list_projects`() {
+        val result = run(DevrigCommand.DevrigCommandFetchResource(uri = knownUri, projectName = "no-such-project"))
+        assertEquals(CliExit.USAGE, result.exit)
+        assertFalse(result.stdout.contains("```"), "must not print a payload when routing failed")
+        assertTrue(stderr().contains("list_projects"), "should point the agent at devrig list_projects")
+    }
+}

--- a/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/FetchResourceCommandTest.kt
+++ b/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/FetchResourceCommandTest.kt
@@ -38,7 +38,7 @@ class FetchResourceCommandTest {
     lateinit var testHome: Path
 
     /** A URI guaranteed to exist in the bundled article index (as a plain string — no prompts import). */
-    private val knownUri: String get() = canonicalResourceEntryPoints().first()
+    private val knownUri: String get() = canonicalResourceEntryPoints().first().uri
 
     @BeforeEach
     fun setUp() {

--- a/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/FetchResourceCommandTest.kt
+++ b/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/FetchResourceCommandTest.kt
@@ -91,7 +91,7 @@ class FetchResourceCommandTest {
         assertEquals("devrig", obj["tool"]!!.jsonObject["name"]!!.jsonPrimitive.content)
         assertEquals("fetch_resource", obj["command"]!!.jsonPrimitive.content)
         assertEquals(false, obj["isError"]!!.jsonPrimitive.booleanOrNull)
-        val content = obj["content"]!!.jsonArray
+        val content = obj["data"]!!.jsonObject["content"]!!.jsonArray
         assertTrue(content.isNotEmpty(), "envelope must carry the resolved content")
         assertEquals("text", content.first().jsonObject["type"]!!.jsonPrimitive.content)
     }

--- a/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/FetchResourceCommandTest.kt
+++ b/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/FetchResourceCommandTest.kt
@@ -97,6 +97,22 @@ class FetchResourceCommandTest {
     }
 
     @Test
+    fun `prompt alias reports command prompt in the --json envelope, not fetch_resource`() {
+        val result = run(DevrigCommand.DevrigCommandFetchResource(uri = knownUri, commandName = "prompt", json = true))
+        assertEquals(0, result.exit)
+        val obj = Json.parseToJsonElement(result.stdout).jsonObject
+        assertEquals("prompt", obj["command"]!!.jsonPrimitive.content)
+    }
+
+    @Test
+    fun `fetch_resource alias reports command fetch_resource in the --json envelope`() {
+        val result = run(DevrigCommand.DevrigCommandFetchResource(uri = knownUri, commandName = "fetch_resource", json = true))
+        assertEquals(0, result.exit)
+        val obj = Json.parseToJsonElement(result.stdout).jsonObject
+        assertEquals("fetch_resource", obj["command"]!!.jsonPrimitive.content)
+    }
+
+    @Test
     fun `unknown uri fails with entry-point hints on stderr, clean stdout`() {
         val result = run(DevrigCommand.DevrigCommandFetchResource(uri = "mcp-steroid://does/not/exist"))
         assertEquals(CliExit.TOOL_ERROR, result.exit)

--- a/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/LauncherSelfHealPredicateTest.kt
+++ b/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/LauncherSelfHealPredicateTest.kt
@@ -1,0 +1,55 @@
+/* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
+package com.jonnyzzz.mcpSteroid.devrig
+
+import com.jonnyzzz.mcpSteroid.aiAgents.AiAgentCli
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * Pins the Tenet-3 boundary (#9): the thin, stateless MCP-as-CLI tool facades must NOT perform the
+ * on-start `~/.mcp-steroid/bin` launcher + PATH self-heal (a persistent on-disk side effect), while the
+ * lifecycle commands (mcp / install / backend / project / help / version) still do.
+ */
+class LauncherSelfHealPredicateTest {
+
+    private val toolFacades: List<DevrigCommand> = listOf(
+        DevrigCommand.DevrigCommandFetchResource(uri = "mcp-steroid://x"),
+        DevrigCommand.DevrigCommandExecuteCode(projectName = "k", code = "x", taskId = "t", reason = "r"),
+        DevrigCommand.DevrigCommandListProjects(),
+        DevrigCommand.DevrigCommandListWindows(),
+        DevrigCommand.DevrigCommandOpenProject(projectPath = "/p", taskId = "t", reason = "r"),
+        DevrigCommand.DevrigCommandScreenshot(projectName = "k", taskId = "t", reason = "r"),
+        DevrigCommand.DevrigCommandInput(projectName = "k", windowId = "w", taskId = "t", reason = "r", sequence = "press:ESCAPE"),
+        DevrigCommand.DevrigCommandFeedback(projectName = "k", taskId = "t", successRating = 0.5, explanation = "x"),
+    )
+
+    private val lifecycleCommands: List<DevrigCommand> = listOf(
+        DevrigCommand.MCP(),
+        DevrigCommand.DevrigCommandBackend(),
+        DevrigCommand.DevrigCommandBackendDownload(),
+        DevrigCommand.DevrigCommandBackendStart(),
+        DevrigCommand.DevrigCommandBackendStop(),
+        DevrigCommand.DevrigCommandBackendProvision(),
+        DevrigCommand.DevrigCommandProject(),
+        DevrigCommand.DevrigCommandInstall(AiAgentCli.CLAUDE),
+        DevrigCommand.DevrigCommandInstallDevrig(),
+        DevrigCommand.DevrigCommandHelp(),
+        DevrigCommand.DevrigCommandVersion(),
+        DevrigCommand.DevrigCommandParseError(text = "oops"),
+    )
+
+    @Test
+    fun `tool facades never self-heal the launcher`() {
+        for (command in toolFacades) {
+            assertFalse(command.selfHealsLauncherOnStart(), "$command must not self-heal (Tenet 3)")
+        }
+    }
+
+    @Test
+    fun `lifecycle commands still self-heal the launcher`() {
+        for (command in lifecycleCommands) {
+            assertTrue(command.selfHealsLauncherOnStart(), "$command must keep the bootstrap self-heal")
+        }
+    }
+}

--- a/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/ListCommandsTest.kt
+++ b/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/ListCommandsTest.kt
@@ -1,0 +1,101 @@
+/* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
+package com.jonnyzzz.mcpSteroid.devrig
+
+import com.jonnyzzz.mcpSteroid.server.ListProjectsResponse
+import com.jonnyzzz.mcpSteroid.server.ListProjectsToolHandler
+import com.jonnyzzz.mcpSteroid.server.ListWindowsResponse
+import com.jonnyzzz.mcpSteroid.server.ListWindowsToolHandler
+import com.jonnyzzz.mcpSteroid.server.ListedProject
+import com.jonnyzzz.mcpSteroid.server.ListedWindow
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Path
+
+/** Glue tests for `devrig list_windows` and `devrig list_projects` — the unified envelope + human render. */
+class ListCommandsTest {
+
+    @TempDir lateinit var home: Path
+    private fun homePaths() = HomePaths(home).also { it.mkdirsAll() }
+
+    private class FakeListProjects(val resp: ListProjectsResponse) : ListProjectsToolHandler {
+        override suspend fun collectListProjectsResponse() = resp
+    }
+
+    private fun window() = ListedWindow(
+        projectName = "app-key", projectPath = "/p/app", title = "app", isActive = true, isVisible = true,
+        bounds = null, windowId = "win-1", modalDialogShowing = false, indexingInProgress = false,
+        projectInitialized = true, backendName = "iu-abc",
+    )
+
+    // ------------------------------ list_windows ------------------------------
+
+    @Test
+    fun `list_windows --json uses the unified envelope`() {
+        val windows = SequencedListWindows(listOf(ListWindowsResponse(listOf(window()), emptyList())))
+        val run = runCliCommand(homePaths()) {
+            runListWindowsCommand(
+                DevrigCommand.DevrigCommandListWindows(json = true),
+                fakeTools(ListWindowsToolHandler::class.java to windows),
+            )
+        }
+        assertEquals(CliExit.OK, run.exit)
+        val obj = Json.parseToJsonElement(run.stdout).jsonObject
+        assertEquals("devrig", obj["tool"]!!.jsonObject["name"]!!.jsonPrimitive.content)
+        assertEquals("list_windows", obj["command"]!!.jsonPrimitive.content)
+        val wins = obj["data"]!!.jsonObject["windows"]!!.jsonArray
+        assertEquals("win-1", wins.first().jsonObject["windowId"]!!.jsonPrimitive.content)
+    }
+
+    @Test
+    fun `list_windows human output lists window_id and state`() {
+        val windows = SequencedListWindows(listOf(ListWindowsResponse(listOf(window()), emptyList())))
+        val run = runCliCommand(homePaths()) {
+            runListWindowsCommand(
+                DevrigCommand.DevrigCommandListWindows(json = false),
+                fakeTools(ListWindowsToolHandler::class.java to windows),
+            )
+        }
+        assertEquals(CliExit.OK, run.exit)
+        assertTrue(run.stdout.contains("window_id=win-1"), run.stdout)
+        assertTrue(run.stdout.contains("initialized"), run.stdout)
+    }
+
+    // ------------------------------ list_projects ------------------------------
+
+    @Test
+    fun `list_projects --json envelope exposes project_name`() {
+        val fake = FakeListProjects(ListProjectsResponse(listOf(
+            ListedProject(projectName = "app-9fk2", name = "app", path = "/p/app", backendName = "iu-abc"),
+        )))
+        val run = runCliCommand(homePaths()) {
+            runListProjectsCommand(
+                DevrigCommand.DevrigCommandListProjects(json = true),
+                fakeTools(ListProjectsToolHandler::class.java to fake),
+            )
+        }
+        assertEquals(CliExit.OK, run.exit)
+        val obj = Json.parseToJsonElement(run.stdout).jsonObject
+        assertEquals("list_projects", obj["command"]!!.jsonPrimitive.content)
+        val projects = obj["data"]!!.jsonObject["projects"]!!.jsonArray
+        val p = projects.first().jsonObject
+        assertEquals("app-9fk2", p["project_name"]!!.jsonPrimitive.content)
+        assertEquals("app", p["name"]!!.jsonPrimitive.content)
+        assertEquals("/p/app", p["path"]!!.jsonPrimitive.content)
+    }
+
+    @Test
+    fun `list_projects human path runs without an IDE`() {
+        // No fake needed: the human path delegates to `devrig project` (real routing, empty here).
+        val run = runCliCommand(homePaths()) {
+            runListProjectsCommand(DevrigCommand.DevrigCommandListProjects(json = false))
+        }
+        assertEquals(CliExit.OK, run.exit)
+        assertTrue(run.stdout.isNotBlank(), "human path should print a listing/empty message")
+    }
+}

--- a/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/McpAsCliContractTest.kt
+++ b/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/McpAsCliContractTest.kt
@@ -1,0 +1,248 @@
+/* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
+package com.jonnyzzz.mcpSteroid.devrig
+
+import com.jonnyzzz.mcpSteroid.devrig.server.ProjectRouteNotFoundException
+import com.jonnyzzz.mcpSteroid.server.ExecuteCodeToolHandler
+import com.jonnyzzz.mcpSteroid.server.ExecuteFeedbackToolHandler
+import com.jonnyzzz.mcpSteroid.server.ListWindowsToolHandler
+import com.jonnyzzz.mcpSteroid.server.OpenProjectToolHandler
+import com.jonnyzzz.mcpSteroid.server.VisionInputToolHandler
+import com.jonnyzzz.mcpSteroid.server.VisionScreenshotToolHandler
+import kotlinx.coroutines.CancellationException
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.boolean
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Files
+import java.nio.file.Path
+
+/**
+ * Cross-command contract sweep for the MCP-as-CLI tool commands (epic #188). Runs each command against
+ * fake tool handlers (no IDE) and pins the invariants the whole surface must share:
+ *  - success and tool error;
+ *  - routing error (stale project_name) and bridge/runtime error;
+ *  - human vs `--json` mode, exact exit code, stdout/stderr separation;
+ *  - exactly ONE JSON document on stdout under `--json`;
+ *  - CancellationException propagation, null exception messages, extreme stdin, path normalization.
+ *
+ * Per-command specifics (screenshot `--out`, open_project `--wait`, input normalization) live in
+ * [CliErrorEnvelopeTest]; this class covers the shared contract and the long-tail edge cases.
+ */
+class McpAsCliContractTest {
+
+    @TempDir lateinit var home: Path
+    private fun homePaths() = HomePaths(home).also { it.mkdirsAll() }
+
+    // Project-scoped commands (routing can fail with ProjectRouteNotFoundException).
+    private fun execCmd(json: Boolean) =
+        DevrigCommand.DevrigCommandExecuteCode(projectName = "k", code = "x", taskId = "t", reason = "r", json = json)
+    private fun feedbackCmd(json: Boolean) =
+        DevrigCommand.DevrigCommandFeedback(projectName = "k", taskId = "t", successRating = 0.5, explanation = "x", json = json)
+    private fun inputCmd(json: Boolean) =
+        DevrigCommand.DevrigCommandInput(projectName = "k", windowId = "w", taskId = "t", reason = "r", sequence = "press:ESCAPE", json = json)
+    private fun screenshotCmd(json: Boolean) =
+        DevrigCommand.DevrigCommandScreenshot(projectName = "k", taskId = "t", reason = "r", json = json)
+
+    // ---- shared assertions ----
+
+    /** Under `--json`: exactly one envelope on stdout, with the expected `isError` + exit. */
+    private fun assertEnvelope(run: CliRun, expectedExit: Int, expectError: Boolean) {
+        assertEquals(expectedExit, run.exit, "stderr=${run.stderr}\nstdout=${run.stdout}")
+        // Exactly ONE JSON document: `}\n{` only appears between two top-level pretty-printed objects.
+        assertFalse(run.stdout.contains("}\n{"), "more than one JSON document in stdout: ${run.stdout}")
+        val obj = Json.parseToJsonElement(run.stdout.trim()).jsonObject
+        assertTrue(obj.containsKey("tool") && obj.containsKey("command"), "unified envelope: ${run.stdout}")
+        assertEquals(expectError, obj["isError"]!!.jsonPrimitive.boolean, "isError mismatch: ${run.stdout}")
+    }
+
+    /** Human mode error: stdout stays clean, the message goes to stderr, exit is the expected code. */
+    private fun assertHumanErrorOnStderr(run: CliRun, expectedExit: Int) {
+        assertEquals(expectedExit, run.exit)
+        assertTrue(run.stdout.isBlank(), "stdout must stay clean on a human-mode error: '${run.stdout}'")
+        assertTrue(run.stderr.isNotBlank(), "human-mode error must reach stderr")
+    }
+
+    // ------------------------------ routing error → enveloped USAGE ------------------------------
+
+    @Test
+    fun `stale project_name is an enveloped usage error for every project-scoped tool`() {
+        val ex = { ProjectRouteNotFoundException("k") }
+        assertEnvelope(runCliCommand(homePaths()) {
+            runExecuteCodeCommand(execCmd(true), fakeTools(ExecuteCodeToolHandler::class.java to ThrowingExecuteCode(ex())))
+        }, CliExit.USAGE, expectError = true)
+        assertEnvelope(runCliCommand(homePaths()) {
+            runFeedbackCommand(feedbackCmd(true), fakeTools(ExecuteFeedbackToolHandler::class.java to ThrowingFeedback(ex())))
+        }, CliExit.USAGE, expectError = true)
+        assertEnvelope(runCliCommand(homePaths()) {
+            runInputCommand(inputCmd(true), fakeTools(VisionInputToolHandler::class.java to ThrowingInput(ex())))
+        }, CliExit.USAGE, expectError = true)
+        assertEnvelope(runCliCommand(homePaths()) {
+            runScreenshotCommand(screenshotCmd(true), fakeTools(VisionScreenshotToolHandler::class.java to ThrowingScreenshot(ex())))
+        }, CliExit.USAGE, expectError = true)
+    }
+
+    // ------------------------------ bridge/runtime error → enveloped UNAVAILABLE ------------------------------
+
+    @Test
+    fun `bridge failure is an enveloped unavailable error for every tool`() {
+        val ex = { RuntimeException("connection refused") }
+        assertEnvelope(runCliCommand(homePaths()) {
+            runExecuteCodeCommand(execCmd(true), fakeTools(ExecuteCodeToolHandler::class.java to ThrowingExecuteCode(ex())))
+        }, CliExit.UNAVAILABLE, expectError = true)
+        assertEnvelope(runCliCommand(homePaths()) {
+            runFeedbackCommand(feedbackCmd(true), fakeTools(ExecuteFeedbackToolHandler::class.java to ThrowingFeedback(ex())))
+        }, CliExit.UNAVAILABLE, expectError = true)
+        assertEnvelope(runCliCommand(homePaths()) {
+            runInputCommand(inputCmd(true), fakeTools(VisionInputToolHandler::class.java to ThrowingInput(ex())))
+        }, CliExit.UNAVAILABLE, expectError = true)
+        assertEnvelope(runCliCommand(homePaths()) {
+            runScreenshotCommand(screenshotCmd(true), fakeTools(VisionScreenshotToolHandler::class.java to ThrowingScreenshot(ex())))
+        }, CliExit.UNAVAILABLE, expectError = true)
+        assertEnvelope(runCliCommand(homePaths()) {
+            runOpenProjectCommand(
+                DevrigCommand.DevrigCommandOpenProject(projectPath = "/p", taskId = "t", reason = "r", json = true),
+                fakeTools(OpenProjectToolHandler::class.java to ThrowingOpenProject(ex())),
+            )
+        }, CliExit.UNAVAILABLE, expectError = true)
+        assertEnvelope(runCliCommand(homePaths()) {
+            runListWindowsCommand(
+                DevrigCommand.DevrigCommandListWindows(json = true),
+                fakeTools(ListWindowsToolHandler::class.java to ThrowingListWindows(ex())),
+            )
+        }, CliExit.UNAVAILABLE, expectError = true)
+    }
+
+    // ------------------------------ tool error (isError result) → TOOL_ERROR ------------------------------
+
+    @Test
+    fun `a tool-reported error is enveloped in json and goes to stderr in human mode`() {
+        val jsonRun = runCliCommand(homePaths()) {
+            runExecuteCodeCommand(execCmd(true), fakeTools(ExecuteCodeToolHandler::class.java to RecordingExecuteCode(toolErrorResult("script threw"))))
+        }
+        assertEnvelope(jsonRun, CliExit.TOOL_ERROR, expectError = true)
+
+        val humanRun = runCliCommand(homePaths()) {
+            runExecuteCodeCommand(execCmd(false), fakeTools(ExecuteCodeToolHandler::class.java to RecordingExecuteCode(toolErrorResult("script threw"))))
+        }
+        assertHumanErrorOnStderr(humanRun, CliExit.TOOL_ERROR)
+        assertTrue(humanRun.stderr.contains("script threw"))
+    }
+
+    // ------------------------------ success: human vs json separation ------------------------------
+
+    @Test
+    fun `success emits one envelope in json and clean content on stdout in human mode`() {
+        val jsonRun = runCliCommand(homePaths()) {
+            runExecuteCodeCommand(execCmd(true), fakeTools(ExecuteCodeToolHandler::class.java to RecordingExecuteCode(okResult("done"))))
+        }
+        assertEnvelope(jsonRun, CliExit.OK, expectError = false)
+
+        val humanRun = runCliCommand(homePaths()) {
+            runExecuteCodeCommand(execCmd(false), fakeTools(ExecuteCodeToolHandler::class.java to RecordingExecuteCode(okResult("done"))))
+        }
+        assertEquals(CliExit.OK, humanRun.exit)
+        assertTrue(humanRun.stdout.contains("done"))
+        assertFalse(humanRun.stdout.contains("\"isError\""), "human mode must not print a JSON envelope")
+    }
+
+    // ------------------------------ CancellationException propagates ------------------------------
+
+    @Test
+    fun `cancellation propagates and is never swallowed as a bridge error`() {
+        assertThrows(CancellationException::class.java) {
+            runCliCommand(homePaths()) {
+                runExecuteCodeCommand(execCmd(true), fakeTools(ExecuteCodeToolHandler::class.java to ThrowingExecuteCode(CancellationException("cancelled"))))
+            }
+        }
+    }
+
+    // ------------------------------ null exception message ------------------------------
+
+    @Test
+    fun `a bridge exception with a null message still produces a valid envelope`() {
+        val run = runCliCommand(homePaths()) {
+            runExecuteCodeCommand(execCmd(true), fakeTools(ExecuteCodeToolHandler::class.java to ThrowingExecuteCode(RuntimeException())))
+        }
+        assertEnvelope(run, CliExit.UNAVAILABLE, expectError = true)
+    }
+
+    // ------------------------------ NaN / Infinity success_rating ------------------------------
+
+    @Test
+    fun `NaN and Infinity success_rating are rejected at parse`() {
+        for (bad in listOf("NaN", "Infinity", "-Infinity")) {
+            val cmd = parseDevrigCommand(arrayOf("execute_feedback", "--project_name=k", "--task_id=t", "--success_rating=$bad", "--explanation=x"))
+            assertTrue(cmd is DevrigCommand.DevrigCommandParseError, "success_rating=$bad must be a parse error, got $cmd")
+        }
+    }
+
+    // ------------------------------ extreme stdin for --code-file=- ------------------------------
+
+    @Test
+    fun `execute_code reads empty stdin without error`() {
+        val rec = RecordingExecuteCode()
+        val run = runCliCommand(homePaths(), stdin = ByteArray(0)) {
+            runExecuteCodeCommand(
+                DevrigCommand.DevrigCommandExecuteCode(projectName = "k", codeFile = "-", taskId = "t", reason = "r"),
+                fakeTools(ExecuteCodeToolHandler::class.java to rec),
+            )
+        }
+        assertEquals(CliExit.OK, run.exit)
+        assertEquals("", rec.params!!.code)
+    }
+
+    @Test
+    fun `execute_code reads over 1 MiB from stdin`() {
+        val big = "x".repeat(1_100_000)
+        val rec = RecordingExecuteCode()
+        val run = runCliCommand(homePaths(), stdin = big.toByteArray()) {
+            runExecuteCodeCommand(
+                DevrigCommand.DevrigCommandExecuteCode(projectName = "k", codeFile = "-", taskId = "t", reason = "r"),
+                fakeTools(ExecuteCodeToolHandler::class.java to rec),
+            )
+        }
+        assertEquals(CliExit.OK, run.exit)
+        assertEquals(big.length, rec.params!!.code.length)
+    }
+
+    // ------------------------------ path normalization: relative + symlink ------------------------------
+
+    @Test
+    fun `open_project normalizes a relative path with dot-dot against cwd`() {
+        val rec = RecordingOpenProject()
+        val run = runCliCommand(homePaths()) {
+            runOpenProjectCommand(
+                DevrigCommand.DevrigCommandOpenProject(projectPath = "a/../b", taskId = "t", reason = "r"),
+                fakeTools(OpenProjectToolHandler::class.java to rec),
+            )
+        }
+        assertEquals(CliExit.OK, run.exit)
+        val expected = Path.of("a/../b").toAbsolutePath().normalize().toString()
+        assertEquals(expected, rec.params!!.projectPath)
+        assertFalse(rec.params!!.projectPath.contains(".."), "dot-dot must be normalized away")
+    }
+
+    @Test
+    fun `open_project preserves a symlinked project path (does not resolve the link)`() {
+        val target = Files.createDirectories(home.resolve("real-project"))
+        val link = home.resolve("linked-project")
+        Files.createSymbolicLink(link, target)
+        val rec = RecordingOpenProject()
+        val run = runCliCommand(homePaths()) {
+            runOpenProjectCommand(
+                DevrigCommand.DevrigCommandOpenProject(projectPath = link.toString(), taskId = "t", reason = "r"),
+                fakeTools(OpenProjectToolHandler::class.java to rec),
+            )
+        }
+        assertEquals(CliExit.OK, run.exit)
+        // The user's chosen (symlink) path is honored verbatim after absolute+normalize — not resolved to
+        // the link target, which would silently open a different-looking project than the user asked for.
+        assertEquals(link.toAbsolutePath().normalize().toString(), rec.params!!.projectPath)
+    }
+}

--- a/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/McpAsCliParseTest.kt
+++ b/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/McpAsCliParseTest.kt
@@ -76,10 +76,15 @@ class McpAsCliParseTest {
     }
 
     @Test
-    fun `execute_code without project_name points at list_projects`() {
-        val err = parseError("execute_code", "--code-file=x.kts", "--task_id=t", "--reason=r")
-        assertTrue(err.text.contains("--project_name"), err.text)
-        assertTrue(err.text.contains("list_projects"), err.text)
+    fun `execute_code without project_name parses successfully, resolved later from cwd (#266 p2)`() {
+        // --project_name is optional at parse time (issue #266): a missing value is no longer a parse
+        // error here — it is resolved against the current directory at runtime by requireProjectName in
+        // runExecuteCodeCommand, which fails with a candidate-listing USAGE error (see
+        // ExecuteCodeCommandTest's cwd-inference tests) only when the cwd doesn't uniquely match one open
+        // project. Parsing must succeed and leave projectName null so that resolution point runs.
+        val command = parse("execute_code", "--code-file=x.kts", "--task_id=t", "--reason=r")
+        assertTrue(command is DevrigCommand.DevrigCommandExecuteCode, "expected a parsed command, got $command")
+        assertNull((command as DevrigCommand.DevrigCommandExecuteCode).projectName)
     }
 
     @Test

--- a/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/McpAsCliParseTest.kt
+++ b/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/McpAsCliParseTest.kt
@@ -94,6 +94,15 @@ class McpAsCliParseTest {
         assertTrue(err.text.contains("only one of"), err.text)
     }
 
+    @Test
+    fun `execute_code rejects a non-positive timeout`() {
+        for (bad in listOf("0", "-1")) {
+            val err = parseError("execute_code", "--project_name=k", "--code=x", "--task_id=t", "--reason=r", "--timeout=$bad")
+            assertTrue(err.text.contains("timeout"), err.text)
+            assertTrue(err.text.contains("positive"), err.text)
+        }
+    }
+
     // ------------------------------ listings ------------------------------
 
     @Test

--- a/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/McpAsCliParseTest.kt
+++ b/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/McpAsCliParseTest.kt
@@ -1,0 +1,171 @@
+/* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
+package com.jonnyzzz.mcpSteroid.devrig
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * Pins how the MCP-as-CLI subcommands (epic #188) parse into [DevrigCommand] variants, and that
+ * missing required arguments produce agent-usable parse errors with runnable examples.
+ */
+class McpAsCliParseTest {
+
+    private fun parse(vararg args: String): DevrigCommand = parseDevrigCommand(arrayOf(*args))
+
+    private fun parseError(vararg args: String): DevrigCommand.DevrigCommandParseError {
+        val command = parse(*args)
+        assertTrue(command is DevrigCommand.DevrigCommandParseError, "expected parse error, got $command")
+        return command as DevrigCommand.DevrigCommandParseError
+    }
+
+    // ------------------------------ prompt / fetch_resource ------------------------------
+
+    @Test
+    fun `prompt takes a positional uri`() {
+        val command = parse("prompt", "mcp-steroid://x/y")
+        assertTrue(command is DevrigCommand.DevrigCommandFetchResource)
+        command as DevrigCommand.DevrigCommandFetchResource
+        assertEquals("mcp-steroid://x/y", command.uri)
+        assertNull(command.projectName)
+    }
+
+    @Test
+    fun `prompt without uri is a parse error with a runnable example`() {
+        val err = parseError("prompt")
+        assertTrue(err.text.contains("missing <uri>"), err.text)
+        assertTrue(err.text.contains("devrig prompt "), "must show a runnable example: ${err.text}")
+    }
+
+    @Test
+    fun `fetch_resource maps --uri and --project_name`() {
+        val command = parse("fetch_resource", "--uri=mcp-steroid://a", "--project_name=proj-1")
+        assertTrue(command is DevrigCommand.DevrigCommandFetchResource)
+        command as DevrigCommand.DevrigCommandFetchResource
+        assertEquals("mcp-steroid://a", command.uri)
+        assertEquals("proj-1", command.projectName)
+    }
+
+    @Test
+    fun `fetch_resource without --uri is a parse error`() {
+        assertTrue(parseError("fetch_resource").text.contains("--uri"))
+    }
+
+    // ------------------------------ execute_code ------------------------------
+
+    @Test
+    fun `execute_code maps all flags`() {
+        val command = parse(
+            "execute_code",
+            "--project_name=key-1",
+            "--code-file=repro.kts",
+            "--task_id=t1",
+            "--reason=repro",
+            "--modal=unleashed",
+            "--timeout=120",
+        )
+        assertTrue(command is DevrigCommand.DevrigCommandExecuteCode)
+        command as DevrigCommand.DevrigCommandExecuteCode
+        assertEquals("key-1", command.projectName)
+        assertEquals("repro.kts", command.codeFile)
+        assertEquals("t1", command.taskId)
+        assertEquals("repro", command.reason)
+        assertEquals("unleashed", command.modal)
+        assertEquals(120, command.timeout)
+    }
+
+    @Test
+    fun `execute_code without project_name points at list_projects`() {
+        val err = parseError("execute_code", "--code-file=x.kts", "--task_id=t", "--reason=r")
+        assertTrue(err.text.contains("--project_name"), err.text)
+        assertTrue(err.text.contains("list_projects"), err.text)
+    }
+
+    @Test
+    fun `execute_code without code shows a code-file example`() {
+        val err = parseError("execute_code", "--project_name=k", "--task_id=t", "--reason=r")
+        assertTrue(err.text.contains("--code-file"), err.text)
+    }
+
+    @Test
+    fun `execute_code rejects both code and code-file`() {
+        val err = parseError("execute_code", "--project_name=k", "--task_id=t", "--reason=r", "--code=x", "--code-file=y")
+        assertTrue(err.text.contains("only one of"), err.text)
+    }
+
+    // ------------------------------ listings ------------------------------
+
+    @Test
+    fun `list_projects and list_windows parse with --json`() {
+        assertTrue(parse("list_projects", "--json") is DevrigCommand.DevrigCommandListProjects)
+        assertTrue((parse("list_projects", "--json") as DevrigCommand.DevrigCommandListProjects).json)
+        assertTrue(parse("list_windows") is DevrigCommand.DevrigCommandListWindows)
+    }
+
+    // ------------------------------ open_project ------------------------------
+
+    @Test
+    fun `open_project maps path and --wait`() {
+        val command = parse("open_project", "--project_path=/abs/p", "--task_id=t", "--reason=r", "--wait")
+        assertTrue(command is DevrigCommand.DevrigCommandOpenProject)
+        command as DevrigCommand.DevrigCommandOpenProject
+        assertEquals("/abs/p", command.projectPath)
+        assertTrue(command.wait)
+        assertTrue(command.trustProject, "trust_project defaults to true")
+    }
+
+    @Test
+    fun `open_project without project_path is a parse error`() {
+        assertTrue(parseError("open_project", "--task_id=t", "--reason=r").text.contains("--project_path"))
+    }
+
+    // ------------------------------ take_screenshot / input ------------------------------
+
+    @Test
+    fun `take_screenshot maps --out and --window_id`() {
+        val command = parse("take_screenshot", "--project_name=k", "--task_id=t", "--reason=r", "--window_id=w1", "--out=shot.png")
+        assertTrue(command is DevrigCommand.DevrigCommandScreenshot)
+        command as DevrigCommand.DevrigCommandScreenshot
+        assertEquals("w1", command.windowId)
+        assertEquals("shot.png", command.out)
+    }
+
+    @Test
+    fun `input requires a sequence and window_id`() {
+        assertTrue(parseError("input", "--project_name=k", "--task_id=t", "--reason=r").text.contains("--window_id"))
+        val missingSeq = parseError("input", "--project_name=k", "--window_id=w", "--task_id=t", "--reason=r")
+        assertTrue(missingSeq.text.contains("--sequence"), missingSeq.text)
+    }
+
+    // ------------------------------ execute_feedback ------------------------------
+
+    @Test
+    fun `execute_feedback maps rating and explanation`() {
+        val command = parse(
+            "execute_feedback",
+            "--project_name=k",
+            "--task_id=t",
+            "--success_rating=0.9",
+            "--explanation=good",
+            "--execution_id=e1",
+        )
+        assertTrue(command is DevrigCommand.DevrigCommandFeedback)
+        command as DevrigCommand.DevrigCommandFeedback
+        assertEquals(0.9, command.successRating)
+        assertEquals("good", command.explanation)
+        assertEquals("e1", command.executionId)
+    }
+
+    @Test
+    fun `execute_feedback rejects out-of-range rating`() {
+        val err = parseError("execute_feedback", "--project_name=k", "--task_id=t", "--success_rating=2.0", "--explanation=x")
+        assertTrue(err.text.contains("out of range"), err.text)
+    }
+
+    @Test
+    fun `execute_feedback without rating shows an example`() {
+        val err = parseError("execute_feedback", "--project_name=k", "--task_id=t", "--explanation=x")
+        assertTrue(err.text.contains("--success_rating"), err.text)
+    }
+}

--- a/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/McpAsCliParseTest.kt
+++ b/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/McpAsCliParseTest.kt
@@ -177,4 +177,67 @@ class McpAsCliParseTest {
         val err = parseError("execute_feedback", "--project_name=k", "--task_id=t", "--explanation=x")
         assertTrue(err.text.contains("--success_rating"), err.text)
     }
+
+    @Test
+    fun `execute_feedback still accepts --execution_id (MCP parity, contextual only)`() {
+        // #8: the flag is kept for parity with steroid_execute_feedback; it parses onto the command but
+        // FeedbackParams has no such field, so it is never forwarded (asserted in the glue tests).
+        val command = parse("execute_feedback", "--project_name=k", "--task_id=t", "--success_rating=0.5",
+            "--explanation=x", "--execution_id=e-42") as DevrigCommand.DevrigCommandFeedback
+        assertEquals("e-42", command.executionId)
+    }
+
+    // ------------------------------ #2: --modal validation at parse ------------------------------
+
+    @Test
+    fun `execute_code rejects an unknown --modal value at parse`() {
+        val err = parseError("execute_code", "--project_name=k", "--code=x", "--task_id=t", "--reason=r", "--modal=bogus")
+        assertTrue(err.text.contains("invalid --modal"), err.text)
+        assertTrue(err.text.contains("smart_non_modal"), "lists valid values: ${err.text}")
+    }
+
+    @Test
+    fun `execute_code accepts each valid --modal value`() {
+        for (wire in listOf("smart_non_modal", "non_modal", "unleashed")) {
+            val command = parse("execute_code", "--project_name=k", "--code=x", "--task_id=t", "--reason=r", "--modal=$wire")
+            assertTrue(command is DevrigCommand.DevrigCommandExecuteCode, "modal=$wire should parse: $command")
+        }
+    }
+
+    // ------------------------------ #7: reliable parse-error command name ------------------------------
+
+    @Test
+    fun `parse error recovers the command name with a global flag before the subcommand`() {
+        assertEquals("execute_code", parseError("--json", "execute_code").commandName)
+    }
+
+    @Test
+    fun `parse error recovers the command name with a global flag after the subcommand`() {
+        assertEquals("execute_code", parseError("execute_code", "--json").commandName)
+    }
+
+    @Test
+    fun `parse error recovers the command name when an option value is a separate token`() {
+        // `--project_name mykey` (space-separated); the value token must not be mistaken for the command.
+        assertEquals("execute_code", parseError("execute_code", "--project_name", "mykey").commandName)
+    }
+
+    @Test
+    fun `parse error echoes an unknown command name`() {
+        assertEquals("frobnicate", parseError("frobnicate").commandName)
+    }
+
+    @Test
+    fun `parse error on an unknown option keeps the subcommand name`() {
+        val err = parseError("list_projects", "--nope")
+        assertEquals("list_projects", err.commandName)
+        assertTrue(err.message.contains("no such option"), err.message)
+    }
+
+    @Test
+    fun `recoverCommandName is deterministic over flags, values, unknowns`() {
+        assertEquals("execute_code", recoverCommandName(arrayOf("--debug", "execute_code", "--project_name", "input")))
+        assertEquals("backend", recoverCommandName(arrayOf("backend", "download", "id1")))
+        assertEquals("devrig", recoverCommandName(arrayOf("--json")))
+    }
 }

--- a/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/ScreenshotAndOpenProjectCommandTest.kt
+++ b/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/ScreenshotAndOpenProjectCommandTest.kt
@@ -89,6 +89,57 @@ class ScreenshotAndOpenProjectCommandTest {
         assertFalse(Files.exists(home.resolve("y.png")))
     }
 
+    // ------------------- --project_name cwd inference (issue #266 part 2) -------------------
+
+    @Test
+    fun `screenshot explicit project_name overrides cwd inference`() {
+        val rec = RecordingScreenshot(ToolCallResult(content = listOf(ContentItem.Text("ok"))))
+        val cmd = DevrigCommand.DevrigCommandScreenshot(
+            projectName = "explicit-key", taskId = "t", reason = "r",
+        )
+        val run = runCliCommand(homePaths()) {
+            runScreenshotCommand(
+                cmd, fakeTools(VisionScreenshotToolHandler::class.java to rec),
+                cwd = Path.of("/home/u/proj"), routes = listOf(fakeRoute("/home/u/proj", "cwd-key")),
+            )
+        }
+        assertEquals(CliExit.OK, run.exit)
+        assertEquals("explicit-key", rec.projectName)
+    }
+
+    @Test
+    fun `screenshot blank project_name infers the single containing project`() {
+        val rec = RecordingScreenshot(ToolCallResult(content = listOf(ContentItem.Text("ok"))))
+        val cmd = DevrigCommand.DevrigCommandScreenshot(
+            projectName = null, taskId = "t", reason = "r",
+        )
+        val run = runCliCommand(homePaths()) {
+            runScreenshotCommand(
+                cmd, fakeTools(VisionScreenshotToolHandler::class.java to rec),
+                cwd = Path.of("/home/u/proj/src"), routes = listOf(fakeRoute("/home/u/proj", "proj-abc")),
+            )
+        }
+        assertEquals(CliExit.OK, run.exit)
+        assertEquals("proj-abc", rec.projectName)
+    }
+
+    @Test
+    fun `screenshot no containing project fails with a candidate-listing usage error`() {
+        val rec = RecordingScreenshot(ToolCallResult(content = listOf(ContentItem.Text("ok"))))
+        val cmd = DevrigCommand.DevrigCommandScreenshot(
+            projectName = null, taskId = "t", reason = "r",
+        )
+        val run = runCliCommand(homePaths()) {
+            runScreenshotCommand(
+                cmd, fakeTools(VisionScreenshotToolHandler::class.java to rec),
+                cwd = Path.of("/tmp/elsewhere"), routes = listOf(fakeRoute("/home/u/proj", "proj-abc")),
+            )
+        }
+        assertEquals(CliExit.USAGE, run.exit)
+        assertTrue(run.stderr.contains("proj-abc"), run.stderr)
+        assertTrue(rec.projectName == null, "handler must never be invoked on a usage error")
+    }
+
     // ------------------------------ open_project ------------------------------
 
     private fun readyWindow(path: String) = ListedWindow(

--- a/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/ScreenshotAndOpenProjectCommandTest.kt
+++ b/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/ScreenshotAndOpenProjectCommandTest.kt
@@ -1,0 +1,126 @@
+/* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
+package com.jonnyzzz.mcpSteroid.devrig
+
+import com.jonnyzzz.mcpSteroid.mcp.ContentItem
+import com.jonnyzzz.mcpSteroid.mcp.ToolCallResult
+import com.jonnyzzz.mcpSteroid.server.ListWindowsResponse
+import com.jonnyzzz.mcpSteroid.server.ListWindowsToolHandler
+import com.jonnyzzz.mcpSteroid.server.ListedWindow
+import com.jonnyzzz.mcpSteroid.server.OpenProjectToolHandler
+import com.jonnyzzz.mcpSteroid.server.VisionScreenshotToolHandler
+import org.junit.jupiter.api.Assertions.assertArrayEquals
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.Base64
+
+class ScreenshotAndOpenProjectCommandTest {
+
+    @TempDir lateinit var home: Path
+    private fun homePaths() = HomePaths(home).also { it.mkdirsAll() }
+
+    // ------------------------------ take_screenshot ------------------------------
+
+    @Test
+    fun `--out writes decoded PNG bytes and notes the path on stderr`() {
+        val raw = ByteArray(16) { it.toByte() }
+        val b64 = Base64.getEncoder().encodeToString(raw)
+        val rec = RecordingScreenshot(
+            ToolCallResult(content = listOf(ContentItem.Image(data = b64, mimeType = "image/png"))),
+        )
+        val outFile = home.resolve("shots/x.png") // parent dir does not exist yet
+        val cmd = DevrigCommand.DevrigCommandScreenshot(
+            projectName = "k", taskId = "t", reason = "r", out = outFile.toString(),
+        )
+        val run = runCliCommand(homePaths()) { runScreenshotCommand(cmd, fakeTools(VisionScreenshotToolHandler::class.java to rec)) }
+        assertEquals(CliExit.OK, run.exit)
+        assertTrue(Files.exists(outFile), "parent dirs must be created and file written")
+        assertArrayEquals(raw, Files.readAllBytes(outFile))
+        assertTrue(run.stderr.contains(outFile.toAbsolutePath().toString()), run.stderr)
+    }
+
+    @Test
+    fun `--out with no image in result notes it but still succeeds`() {
+        val rec = RecordingScreenshot(ToolCallResult(content = listOf(ContentItem.Text("no image here"))))
+        val cmd = DevrigCommand.DevrigCommandScreenshot(
+            projectName = "k", taskId = "t", reason = "r", out = home.resolve("y.png").toString(),
+        )
+        val run = runCliCommand(homePaths()) { runScreenshotCommand(cmd, fakeTools(VisionScreenshotToolHandler::class.java to rec)) }
+        assertEquals(CliExit.OK, run.exit)
+        assertTrue(run.stderr.contains("no image payload"), run.stderr)
+        assertFalse(Files.exists(home.resolve("y.png")))
+    }
+
+    // ------------------------------ open_project ------------------------------
+
+    private fun readyWindow(path: String) = ListedWindow(
+        projectName = "k", projectPath = path, title = null, isActive = false, isVisible = true,
+        bounds = null, windowId = "w", modalDialogShowing = false, indexingInProgress = false,
+        projectInitialized = true,
+    )
+
+    private fun notReadyWindow(path: String) = readyWindow(path).copy(projectInitialized = false)
+
+    @Test
+    fun `without --wait open_project returns immediately and does not poll windows`() {
+        val open = RecordingOpenProject()
+        val windows = SequencedListWindows(listOf(ListWindowsResponse(emptyList(), emptyList())))
+        val cmd = DevrigCommand.DevrigCommandOpenProject(
+            projectPath = home.toString(), taskId = "t", reason = "r", wait = false,
+        )
+        val run = runCliCommand(homePaths()) {
+            runOpenProjectCommand(cmd, fakeTools(
+                OpenProjectToolHandler::class.java to open,
+                ListWindowsToolHandler::class.java to windows,
+            ))
+        }
+        assertEquals(CliExit.OK, run.exit)
+        assertEquals(home.toString(), open.params!!.projectPath)
+        assertEquals(0, windows.calls, "no --wait means no polling")
+    }
+
+    @Test
+    fun `--wait polls until the project is initialized`() {
+        val open = RecordingOpenProject()
+        val path = home.toString()
+        val windows = SequencedListWindows(listOf(
+            ListWindowsResponse(listOf(notReadyWindow(path)), emptyList()),
+            ListWindowsResponse(listOf(readyWindow(path)), emptyList()),
+        ))
+        val cmd = DevrigCommand.DevrigCommandOpenProject(
+            projectPath = path, taskId = "t", reason = "r", wait = true,
+        )
+        val run = runCliCommand(homePaths()) {
+            runOpenProjectCommand(cmd, fakeTools(
+                OpenProjectToolHandler::class.java to open,
+                ListWindowsToolHandler::class.java to windows,
+            ), waitAttempts = 5, waitIntervalMs = 10)
+        }
+        assertEquals(CliExit.OK, run.exit)
+        assertTrue(windows.calls >= 2, "should poll again after not-ready (was ${windows.calls})")
+        assertTrue(run.stderr.contains("ready"), run.stderr)
+    }
+
+    @Test
+    fun `--wait times out to UNAVAILABLE when never ready`() {
+        val open = RecordingOpenProject()
+        val path = home.toString()
+        val windows = SequencedListWindows(listOf(ListWindowsResponse(listOf(notReadyWindow(path)), emptyList())))
+        val cmd = DevrigCommand.DevrigCommandOpenProject(
+            projectPath = path, taskId = "t", reason = "r", wait = true,
+        )
+        val run = runCliCommand(homePaths()) {
+            runOpenProjectCommand(cmd, fakeTools(
+                OpenProjectToolHandler::class.java to open,
+                ListWindowsToolHandler::class.java to windows,
+            ), waitAttempts = 2, waitIntervalMs = 5)
+        }
+        assertEquals(CliExit.UNAVAILABLE, run.exit)
+        assertEquals(2, windows.calls)
+        assertTrue(run.stderr.contains("timed out"), run.stderr)
+    }
+}

--- a/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/ScreenshotAndOpenProjectCommandTest.kt
+++ b/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/ScreenshotAndOpenProjectCommandTest.kt
@@ -44,14 +44,17 @@ class ScreenshotAndOpenProjectCommandTest {
     }
 
     @Test
-    fun `--out with no image in result notes it but still succeeds`() {
+    fun `--out with no image in result is a data error, not a silent success`() {
+        // #6: requesting a file via --out means exit 0 requires a file to actually be written. A result
+        // with no image cannot satisfy that, so it is a DATA_ERROR — the old "note it but succeed"
+        // behavior masked a failed request.
         val rec = RecordingScreenshot(ToolCallResult(content = listOf(ContentItem.Text("no image here"))))
         val cmd = DevrigCommand.DevrigCommandScreenshot(
             projectName = "k", taskId = "t", reason = "r", out = home.resolve("y.png").toString(),
         )
         val run = runCliCommand(homePaths()) { runScreenshotCommand(cmd, fakeTools(VisionScreenshotToolHandler::class.java to rec)) }
-        assertEquals(CliExit.OK, run.exit)
-        assertTrue(run.stderr.contains("no image payload"), run.stderr)
+        assertEquals(CliExit.DATA_ERROR, run.exit)
+        assertTrue(run.stderr.contains("no image to save"), run.stderr)
         assertFalse(Files.exists(home.resolve("y.png")))
     }
 

--- a/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/ScreenshotAndOpenProjectCommandTest.kt
+++ b/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/ScreenshotAndOpenProjectCommandTest.kt
@@ -44,6 +44,37 @@ class ScreenshotAndOpenProjectCommandTest {
     }
 
     @Test
+    fun `console --out writes only the out file, never a redundant tmp image or a Saved image line`() {
+        // Regression: with the console image branch now writing files, renderScreenshotSaved must NOT
+        // re-materialize the already-saved image into ~/.mcp-steroid/tmp — the --out path is the only
+        // file the user asked for. It must print "Saved --out:", never "Saved image:".
+        val raw = ByteArray(16) { it.toByte() }
+        val b64 = Base64.getEncoder().encodeToString(raw)
+        val rec = RecordingScreenshot(
+            ToolCallResult(content = listOf(ContentItem.Image(data = b64, mimeType = "image/png"))),
+        )
+        val outFile = home.resolve("shots/only.png")
+        val hp = homePaths()
+        val cmd = DevrigCommand.DevrigCommandScreenshot(
+            projectName = "k", taskId = "t", reason = "r", out = outFile.toString(),
+        )
+        val run = runCliCommand(hp) { runScreenshotCommand(cmd, fakeTools(VisionScreenshotToolHandler::class.java to rec)) }
+        assertEquals(CliExit.OK, run.exit)
+        assertTrue(Files.exists(outFile), "the --out file must be written")
+        assertArrayEquals(raw, Files.readAllBytes(outFile))
+        // No redundant tmp copy: the tmp dir must contain no `image-*` file (may not exist at all).
+        val tmpDir = home.resolve("tmp")
+        val tmpImages = if (Files.isDirectory(tmpDir)) {
+            Files.list(tmpDir).use { s -> s.filter { it.fileName.toString().startsWith("image-") }.toList() }
+        } else {
+            emptyList()
+        }
+        assertTrue(tmpImages.isEmpty(), "console --out must not create a redundant tmp image, found: $tmpImages")
+        assertFalse(run.stdout.contains("Saved image:"), run.stdout)
+        assertTrue(run.stdout.contains("Saved --out:"), run.stdout)
+    }
+
+    @Test
     fun `--out with no image in result is a data error, not a silent success`() {
         // #6: requesting a file via --out means exit 0 requires a file to actually be written. A result
         // with no image cannot satisfy that, so it is a DATA_ERROR — the old "note it but succeed"

--- a/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/server/CwdProjectResolverTest.kt
+++ b/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/server/CwdProjectResolverTest.kt
@@ -1,0 +1,69 @@
+/* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
+package com.jonnyzzz.mcpSteroid.devrig.server
+
+import com.jonnyzzz.mcpSteroid.IdeInfo
+import com.jonnyzzz.mcpSteroid.PluginInfo
+import com.jonnyzzz.mcpSteroid.devrig.monitor.DiscoveredIde
+import com.jonnyzzz.mcpSteroid.devrig.monitor.IdeProjectState
+import java.nio.file.Path
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class CwdProjectResolverTest {
+
+    private fun route(path: String, name: String): ProjectRoute = ProjectRoute(
+        route = DiscoveredIde(
+            backendName = "backend-$name",
+            pid = 1L,
+            rpcBaseUrl = "http://127.0.0.1:4343/mcp",
+            bridgeHeaders = emptyMap(),
+            ide = IdeInfo("IntelliJ IDEA", "2026.1", "IU-261.1"),
+            plugin = PluginInfo("com.jonnyzzz.mcp-steroid", "MCP Steroid", "0.0.0-test"),
+        ),
+        projectInfo = IdeProjectState(name, path),
+        exposedProjectName = name,
+        projectPath = path,
+    )
+
+    @Test
+    fun `single project containing cwd matches`() {
+        val r = route("/home/u/proj", "proj-abc")
+        assertEquals(CwdProjectMatch.One(r), resolveProjectFromCwd(Path.of("/home/u/proj/src"), listOf(r)))
+    }
+
+    @Test
+    fun `cwd equal to project root matches`() {
+        val r = route("/home/u/proj", "proj-abc")
+        assertEquals(CwdProjectMatch.One(r), resolveProjectFromCwd(Path.of("/home/u/proj"), listOf(r)))
+    }
+
+    @Test
+    fun `nested projects pick the most specific`() {
+        val outer = route("/home/u/proj", "proj-abc")
+        val inner = route("/home/u/proj/module", "module-def")
+        assertEquals(
+            CwdProjectMatch.One(inner),
+            resolveProjectFromCwd(Path.of("/home/u/proj/module/src"), listOf(outer, inner)),
+        )
+    }
+
+    @Test
+    fun `no containing project yields None`() {
+        val r = route("/home/u/proj", "proj-abc")
+        assertEquals(CwdProjectMatch.None, resolveProjectFromCwd(Path.of("/tmp/elsewhere"), listOf(r)))
+    }
+
+    @Test
+    fun `sibling prefix does not falsely match`() {
+        val r = route("/home/u/proj", "proj-abc")
+        assertEquals(CwdProjectMatch.None, resolveProjectFromCwd(Path.of("/home/u/projbeta"), listOf(r)))
+    }
+
+    @Test
+    fun `two routes at the identical path tie and yield Ambiguous`() {
+        val a = route("/home/u/proj", "proj-abc")
+        val b = route("/home/u/proj", "proj-xyz")
+        val result = resolveProjectFromCwd(Path.of("/home/u/proj/src"), listOf(a, b))
+        assertEquals(CwdProjectMatch.Ambiguous(listOf(a, b)), result)
+    }
+}

--- a/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/server/DevrigProjectRoutingServiceTest.kt
+++ b/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/server/DevrigProjectRoutingServiceTest.kt
@@ -141,6 +141,24 @@ class DevrigProjectRoutingServiceTest {
     }
 
     @Test
+    fun `promptsContextFromRoute derives product and baseline from the route build`() {
+        val projectHome = Files.createDirectories(tempDir.resolve("project"))
+        val routing = routingService(
+            state(
+                pid = 42,
+                projects = listOf(IdeProjectState("mcp-steroid", projectHome.toString())),
+                build = "IU-261.1234",
+            ),
+        )
+        val route = routing.routes().single()
+
+        val context = DevrigPromptsContextHandler.promptsContextFromRoute(route)
+
+        assertEquals("IU", context.productCode)
+        assertEquals(261, context.baselineVersion)
+    }
+
+    @Test
     fun `prompt context for a stale project name surfaces the route-not-found error`() = runTest {
         assertFailsWith<ProjectRouteNotFoundException> {
             DevrigPromptsContextHandler(routingService()).buildPromptsContext("missing-project-abcdefgh")

--- a/test-integration/src/test/kotlin/com/jonnyzzz/mcpSteroid/integration/tests/CliDevrigToolsIntegrationTest.kt
+++ b/test-integration/src/test/kotlin/com/jonnyzzz/mcpSteroid/integration/tests/CliDevrigToolsIntegrationTest.kt
@@ -1,0 +1,128 @@
+/* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
+package com.jonnyzzz.mcpSteroid.integration.tests
+
+import com.jonnyzzz.mcpSteroid.integration.infra.AiMode
+import com.jonnyzzz.mcpSteroid.integration.infra.DevrigSteroidDriver
+import com.jonnyzzz.mcpSteroid.integration.infra.IntelliJContainer
+import com.jonnyzzz.mcpSteroid.integration.infra.IntelliJContainerOpts
+import com.jonnyzzz.mcpSteroid.integration.infra.create
+import com.jonnyzzz.mcpSteroid.integration.infra.waitForProjectReady
+import com.jonnyzzz.mcpSteroid.testHelper.CloseableStackHost
+import com.jonnyzzz.mcpSteroid.testHelper.docker.startProcessInContainer
+import com.jonnyzzz.mcpSteroid.testHelper.process.ProcessResult
+import com.jonnyzzz.mcpSteroid.testHelper.process.assertExitCode
+import java.util.concurrent.TimeUnit
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Timeout
+
+/**
+ * Live-IDE smoke for the MCP-as-CLI subcommands (epic #188): drives the deployed `devrig` binary as a
+ * plain shell CLI against a real dockerized IDE and asserts the tools work end-to-end — the same bridge
+ * `devrig mpc` uses, just invoked as `devrig <tool>`.
+ *
+ * OPT-IN: this lives in `:test-integration` (Docker + a full IDE container), which is excluded from the
+ * default `:npx-kt:test` / root `test` runs. Invoke explicitly:
+ * `./gradlew :test-integration:test --tests '*CliDevrigToolsIntegrationTest*'`.
+ */
+class CliDevrigToolsIntegrationTest {
+
+    @Test
+    @Timeout(value = 20, unit = TimeUnit.MINUTES)
+    fun listProjectsJsonExposesRoutingKey() {
+        val projectName = waitForCliProjectName()
+        val out = devrig("list_projects", "--json").assertExitCode(0) { "list_projects --json\nstdout=$stdout" }.stdout
+        val envelope = json.parseToJsonElement(out).jsonObject
+        assertEquals("list_projects", envelope["command"]!!.jsonPrimitive.content)
+        val projects = envelope["data"]!!.jsonObject["projects"]!!.jsonArray
+        val found = projects.map { it.jsonObject["project_name"]!!.jsonPrimitive.content }
+        assertTrue(projectName in found, "discovered project_name $projectName must appear in $found")
+    }
+
+    @Test
+    @Timeout(value = 20, unit = TimeUnit.MINUTES)
+    fun executeCodeRunsInTheRunningIde() {
+        val projectName = waitForCliProjectName()
+        val marker = "DEVRIG_CLI_EXEC_OK"
+        val result = devrig(
+            "execute_code",
+            "--project_name=$projectName",
+            "--task_id=cli-smoke-exec",
+            "--reason=verify devrig CLI routes execute_code to the running IDE",
+            "--code=println(\"$marker\")",
+        ).assertExitCode(0) { "execute_code\nstdout=$stdout\nstderr=$stderr" }
+        assertTrue(result.stdout.contains(marker), "execute_code stdout must contain $marker\n${result.stdout}")
+    }
+
+    @Test
+    @Timeout(value = 20, unit = TimeUnit.MINUTES)
+    fun fetchResourceReturnsGuideForTheProject() {
+        val projectName = waitForCliProjectName()
+        // A bundled article that always exists; project_name upgrades to IDE-specific rendering.
+        val out = devrig(
+            "fetch_resource",
+            "--uri=mcp-steroid://prompt/skill",
+            "--project_name=$projectName",
+        ).assertExitCode(0) { "fetch_resource\nstdout=$stdout" }.stdout
+        assertTrue(out.isNotBlank(), "fetch_resource must print the guide markdown")
+        assertTrue(out.contains("MCP Steroid") || out.contains("IntelliJ"), "unexpected guide content:\n${out.take(300)}")
+    }
+
+    // ------------------------------------------------------------------------------------------------
+
+    /** Runs `devrig <args>` in the container and returns the finished process (stdout + exitCode). */
+    private fun devrig(vararg args: String, timeoutSeconds: Long = 180): ProcessResult =
+        session.scope.startProcessInContainer {
+            args(listOf(launcher) + args)
+                .timeoutSeconds(timeoutSeconds)
+                .description("devrig ${args.joinToString(" ")}")
+        }.awaitForProcessFinish()
+
+    /** Polls `devrig list_projects --json` (each call re-runs discovery) until the IDE project appears. */
+    private fun waitForCliProjectName(): String {
+        repeat(80) {
+            val result = devrig("list_projects", "--json")
+            if (result.exitCode == 0) {
+                val projects = json.parseToJsonElement(result.stdout)
+                    .jsonObject["data"]?.jsonObject?.get("projects")?.jsonArray
+                val first = projects?.firstOrNull()?.jsonObject?.get("project_name")?.jsonPrimitive?.content
+                if (first != null) return first
+            }
+            Thread.sleep(250)
+        }
+        error("Timed out waiting for `devrig list_projects` to discover the running IDE\n${session.diagnosticsSummary()}")
+    }
+
+    companion object {
+        private val json = Json { ignoreUnknownKeys = true }
+        private val lifetime by lazy { CloseableStackHost(CliDevrigToolsIntegrationTest::class.java.simpleName) }
+        private val session by lazy {
+            IntelliJContainer.create(lifetime, IntelliJContainerOpts(
+                consoleTitle = "devrig CLI tools smoke",
+                aiMode = AiMode.NONE,
+            )).waitForProjectReady()
+        }
+        private val launcher: String by lazy {
+            DevrigSteroidDriver.deploy(session.scope, session.mcpSteroid).devrigCommand.command
+        }
+
+        @BeforeAll
+        @JvmStatic
+        fun beforeAll() {
+            session.toString()
+        }
+
+        @AfterAll
+        @JvmStatic
+        fun cleanup() {
+            lifetime.closeAllStacks()
+        }
+    }
+}


### PR DESCRIPTION
every mcp tool now is available as devrig command, layered help execute_code
tests: contract, parse, error-envelope, Docker smoke test