### PR TITLE
install.ps1: fix Windows PowerShell 5.1 arch detect + progress (fix #273 #274)

### DIFF
--- a/.github/workflows/installer-ps1-verify.yml
+++ b/.github/workflows/installer-ps1-verify.yml
@@ -1,0 +1,73 @@
+# Cross-OS validation for the generated installers (install.sh / install.ps1). Runs on EVERY branch
+# push so a template edit that would break the `curl | sh` / `irm | iex` bootstrap on a real OS is
+# caught before it lands — this is the check that would have caught jonnyzzz/mcp-steroid#273/#274.
+# (TeamCity is the internal home for the same suites; this GH lane keeps the public fork covered too.)
+#
+# Two lanes:
+#   * ubuntu-latest → :installer-gen:installerIntegrationTest (Linux Docker + pwsh 7.x)
+#   * windows-latest → :test-integration-agent-launch:test (Windows PowerShell 5.1 + pwsh)
+#
+# The Windows lane runs InstallerPs1ExecutionTest end-to-end under powershell.exe (the default shell
+# on Windows 10/11). Neither lane sets DEVRIG_OS / DEVRIG_CPU: both exercise the full auto-detect path.
+name: Installer PS1 Verify
+
+on:
+  push:
+    branches: ['**']
+  workflow_dispatch:
+
+concurrency:
+  # One run per ref; a newer push cancels the in-flight outdated run.
+  group: installer-ps1-verify-${{ github.ref }}
+  cancel-in-progress: true
+
+# Opt JavaScript actions onto Node 24 to match the repo's other workflows.
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
+jobs:
+  linux-docker:
+    name: linux-docker (pwsh 7.x)
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with: { distribution: temurin, java-version: '25' }
+      - name: Run :installer-gen:installerIntegrationTest (sh + pwsh Docker)
+        shell: bash
+        run: ./gradlew :installer-gen:installerIntegrationTest --info --stacktrace
+      - name: Upload reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: reports-linux-docker
+          path: installer-gen/build/reports/**
+          if-no-files-found: warn
+
+  windows-native:
+    name: windows-native (PS 5.1 + pwsh)
+    runs-on: windows-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with: { distribution: temurin, java-version: '25' }
+      # Run the WHOLE task — no --tests scoping. Every test starts regardless of any single failure
+      # (JUnit runs them all; --continue keeps the Gradle run going past a failed task), so the
+      # install.ps1 tests this PR adds (InstallerPs1ExecutionTest + InstallerScriptTest) always
+      # execute and land in the uploaded report. The one intermittently-red case is
+      # ClaudeAgentLaunchTest.`hook-devrig-pattern - fires on both`: a timing race in the test's
+      # probe-log capture (the slow sh-script hook can lose the race against Claude's fast auth-fail
+      # exit) — tracked in jonnyzzz/mcp-steroid#283 and fixed there. NOT hidden here, and NOT gating
+      # this install.ps1 fix.
+      - name: Run :test-integration-agent-launch:test (native powershell.exe + pwsh)
+        shell: bash
+        run: ./gradlew :test-integration-agent-launch:test --continue --info --stacktrace
+      - name: Upload reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: reports-windows-native
+          path: test-integration-agent-launch/build/reports/**
+          if-no-files-found: warn

--- a/.github/workflows/installer-ps1-verify.yml
+++ b/.github/workflows/installer-ps1-verify.yml
@@ -53,17 +53,18 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4
         with: { distribution: temurin, java-version: '25' }
-      # Run the WHOLE task — no --tests scoping. Every test starts regardless of any single failure
-      # (JUnit runs them all; --continue keeps the Gradle run going past a failed task), so the
-      # install.ps1 tests this PR adds (InstallerPs1ExecutionTest + InstallerScriptTest) always
+      # Run the WHOLE suite — no --tests scoping. `test` is the cross-OS ClaudeAgentLaunchTest +
+      # InstallerScriptTest; `windowsPs1Test` is the Windows-gated native-powershell.exe end-to-end
+      # (InstallerPs1ExecutionTest). Every test starts regardless of any single failure (JUnit runs them
+      # all; --continue keeps the Gradle run going past a failed task), so the install.ps1 tests always
       # execute and land in the uploaded report. The one intermittently-red case is
       # ClaudeAgentLaunchTest.`hook-devrig-pattern - fires on both`: a timing race in the test's
       # probe-log capture (the slow sh-script hook can lose the race against Claude's fast auth-fail
       # exit) — tracked in jonnyzzz/mcp-steroid#283 and fixed there. NOT hidden here, and NOT gating
       # this install.ps1 fix.
-      - name: Run :test-integration-agent-launch:test (native powershell.exe + pwsh)
+      - name: Run install.ps1 suites (native powershell.exe + pwsh)
         shell: bash
-        run: ./gradlew :test-integration-agent-launch:test --continue --info --stacktrace
+        run: ./gradlew :test-integration-agent-launch:test :test-integration-agent-launch:windowsPs1Test --continue --info --stacktrace
       - name: Upload reports
         if: always()
         uses: actions/upload-artifact@v4

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -416,8 +416,12 @@ val ciIntegrationTests by tasks.registering {
  */
 val ciAgentLaunchTests by tasks.registering {
     group = "ci"
-    description = "Run the cross-OS agent-launch behaviour tests: :test-integration-agent-launch:test."
+    description = "Run the cross-OS agent-launch behaviour tests: :test-integration-agent-launch (test + windowsPs1Test)."
     dependsOn(":test-integration-agent-launch:test")
+    // windowsPs1Test is the Windows-gated native-powershell.exe lane (InstallerPs1ExecutionTest), split out
+    // of `test` so it uses a task-level OS gate instead of a runtime skip. It is `enabled = isWindows`, so
+    // it runs on the Windows TC agent and is a no-op on the Linux one — both drive this aggregator.
+    dependsOn(":test-integration-agent-launch:windowsPs1Test")
 }
 
 /**

--- a/installer-gen/src/installerIntegrationTest/kotlin/com/jonnyzzz/mcpSteroid/installer/tests/InstallerBootstrapFixtures.kt
+++ b/installer-gen/src/installerIntegrationTest/kotlin/com/jonnyzzz/mcpSteroid/installer/tests/InstallerBootstrapFixtures.kt
@@ -1,0 +1,116 @@
+/* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
+package com.jonnyzzz.mcpSteroid.installer.tests
+
+import java.io.File
+import java.io.FileOutputStream
+import java.io.OutputStream
+import java.security.MessageDigest
+import java.util.zip.GZIPOutputStream
+
+/**
+ * Shared fixtures for the two installer-bootstrap Docker tests (POSIX `install.sh` in
+ * [InstallerBootstrapTest] and PowerShell `install.ps1` in [InstallerBootstrapPs1Test]). Kept
+ * script-agnostic on purpose: the fake JDK tar.gz + tempdir/sha256/permissions helpers are identical
+ * between the two lanes; per-test-class specifics (container images, log prefix, devrig zip shape)
+ * stay local to each test.
+ */
+
+/** Nginx side-car serving the fixture zip/tar.gz over real HTTP to the install container. */
+const val NGINX_IMAGE = "nginx:alpine"
+
+/** HOME with a space catches quoting bugs in the installer scripts + downstream launcher wrappers. */
+const val INSTALLER_HOME_DIR = "/home/tester one"
+
+/** Constant baked into the generated scripts + into the content-addressed dir names the tests probe. */
+const val INSTALLER_TEST_VERSION = "0.0.0-test"
+
+fun sha256(file: File): String {
+    val md = MessageDigest.getInstance("SHA-256")
+    file.inputStream().use { ins ->
+        val buf = ByteArray(64 * 1024)
+        while (true) {
+            val n = ins.read(buf)
+            if (n < 0) break
+            md.update(buf, 0, n)
+        }
+    }
+    return md.digest().joinToString("") { "%02x".format(it) }
+}
+
+fun makeWorldReadable(dir: File) {
+    dir.walkTopDown().forEach {
+        it.setReadable(true, false)
+        if (it.isDirectory) it.setExecutable(true, false)
+    }
+    dir.setExecutable(true, false)
+}
+
+fun createInstallerWorkDir(prefix: String): File {
+    val d = File.createTempFile(prefix, "").let { it.delete(); File(it.absolutePath + "-dir") }
+    d.mkdirs()
+    return d
+}
+
+/**
+ * Fake JDK tar.gz used by BOTH lanes: top dir `jdk/` (matches `javaHome="jdk"` baked into the
+ * synthetic model), with an executable `bin/java` sh stub — enough that both install.sh's `-x
+ * bin/java` check and install.ps1's `bin/java` fallback (see the pwsh-on-Linux branch in the
+ * template) pass.
+ */
+fun buildFakeJdkTarGz(target: File) {
+    val javaStub = "#!/bin/sh\necho 'java-stub 25'\nexit 0\n".toByteArray()
+    GZIPOutputStream(FileOutputStream(target)).use { gz ->
+        TarWriter(gz).use { tar ->
+            tar.putDir("jdk/")
+            tar.putDir("jdk/bin/")
+            tar.putFile("jdk/bin/java", javaStub, mode = 0b111_101_101) // rwxr-xr-x
+        }
+    }
+}
+
+/**
+ * Minimal POSIX (ustar) tar writer — the JDK has no built-in tar. Enough for a few small files with
+ * stored unix permission bits so the unpacked `bin/java` keeps its +x bit (install.sh checks `-x`).
+ */
+class TarWriter(private val out: OutputStream) : AutoCloseable {
+    fun putDir(name: String) = writeEntry(name, ByteArray(0), typeFlag = '5', mode = 0b111_101_101)
+    fun putFile(name: String, data: ByteArray, mode: Int) = writeEntry(name, data, typeFlag = '0', mode = mode)
+
+    private fun writeEntry(name: String, data: ByteArray, typeFlag: Char, mode: Int) {
+        val header = ByteArray(512)
+        putString(header, 0, name, 100)
+        putOctal(header, 100, mode.toLong(), 8)
+        putOctal(header, 108, 0, 8)
+        putOctal(header, 116, 0, 8)
+        putOctal(header, 124, data.size.toLong(), 12)
+        putOctal(header, 136, 0, 12)
+        header[156] = typeFlag.code.toByte()
+        putString(header, 257, "ustar", 6)
+        header[263] = '0'.code.toByte(); header[264] = '0'.code.toByte()
+        for (i in 148 until 156) header[i] = ' '.code.toByte()
+        var sum = 0
+        for (b in header) sum += (b.toInt() and 0xff)
+        putOctal(header, 148, sum.toLong(), 7)
+        header[155] = ' '.code.toByte()
+        out.write(header)
+        out.write(data)
+        val pad = (512 - data.size % 512) % 512
+        if (pad > 0) out.write(ByteArray(pad))
+    }
+
+    private fun putString(buf: ByteArray, off: Int, s: String, max: Int) {
+        val bytes = s.toByteArray()
+        System.arraycopy(bytes, 0, buf, off, minOf(bytes.size, max - 1))
+    }
+
+    private fun putOctal(buf: ByteArray, off: Int, value: Long, len: Int) {
+        val s = java.lang.Long.toOctalString(value).padStart(len - 1, '0')
+        System.arraycopy(s.toByteArray(), 0, buf, off, len - 1)
+        buf[off + len - 1] = 0
+    }
+
+    override fun close() {
+        out.write(ByteArray(1024)) // two zero blocks terminate the archive
+        out.flush()
+    }
+}

--- a/installer-gen/src/installerIntegrationTest/kotlin/com/jonnyzzz/mcpSteroid/installer/tests/InstallerBootstrapPs1Test.kt
+++ b/installer-gen/src/installerIntegrationTest/kotlin/com/jonnyzzz/mcpSteroid/installer/tests/InstallerBootstrapPs1Test.kt
@@ -1,0 +1,264 @@
+/* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
+package com.jonnyzzz.mcpSteroid.installer.tests
+
+import com.jonnyzzz.mcpSteroid.installer.ALL_PLATFORMS
+import com.jonnyzzz.mcpSteroid.installer.DevrigEntry
+import com.jonnyzzz.mcpSteroid.installer.JdkScriptEntry
+import com.jonnyzzz.mcpSteroid.installer.writeInstallerScripts
+import com.jonnyzzz.mcpSteroid.testHelper.docker.ContainerDriver
+import com.jonnyzzz.mcpSteroid.testHelper.docker.ContainerVolume
+import com.jonnyzzz.mcpSteroid.testHelper.docker.StartContainerRequest
+import com.jonnyzzz.mcpSteroid.testHelper.docker.queryContainerIp
+import com.jonnyzzz.mcpSteroid.testHelper.docker.startDockerContainerAndDispose
+import com.jonnyzzz.mcpSteroid.testHelper.docker.startProcessInContainer
+import com.jonnyzzz.mcpSteroid.testHelper.process.ProcessResult
+import com.jonnyzzz.mcpSteroid.testHelper.process.assertExitCode
+import com.jonnyzzz.mcpSteroid.testHelper.process.assertNoMessageInOutput
+import com.jonnyzzz.mcpSteroid.testHelper.process.assertOutputContains
+import com.jonnyzzz.mcpSteroid.testHelper.runWithCloseableStack
+import org.apache.commons.compress.archivers.zip.ZipArchiveEntry
+import org.apache.commons.compress.archivers.zip.ZipArchiveOutputStream
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Timeout
+import java.io.File
+import java.io.FileOutputStream
+import java.util.concurrent.TimeUnit
+
+/**
+ * PowerShell peer of [InstallerBootstrapTest]: renders `install.ps1` from a synthetic model + nginx
+ * side-car URLs (the same public [writeInstallerScripts] seam — no real 200 MB JDK download), runs
+ * it inside an Ubuntu-based `pwsh` container, and asserts the same download → sha256-verify →
+ * unpack-verbatim → content-address → launcher → devrig-delegation → ready-prompt pipeline the
+ * POSIX sibling covers.
+ *
+ * Windows-native runs of `install.ps1` need a Windows Docker host, which this repo's CI does not
+ * provision; running pwsh under Linux instead exercises the same script (`Invoke-WebRequest`,
+ * `Expand-Archive`, `Get-FileHash`, `Move-Item`, and — critically for jonnyzzz/mcp-steroid#274 —
+ * `$ProgressPreference = 'SilentlyContinue'` at the top). The template already accepts a `bin/java`
+ * stub in place of `bin/java.exe` "so pwsh-on-Linux test runs without java.exe" — the design
+ * anticipates this exact test.
+ */
+class InstallerBootstrapPs1Test {
+    private val version = INSTALLER_TEST_VERSION
+
+    // Official Microsoft pwsh-on-Ubuntu image, pinned to the LTS 7.4 line on Ubuntu 22.04 (`lts-*`
+    // tags carry the PS LTS version; the plain `ubuntu-<os>` tags float). glibc-based, so the same
+    // fake JDK zip stub the sh test uses works here too.
+    private val pwshImage = "mcr.microsoft.com/powershell:lts-7.4-ubuntu-22.04"
+    private val homeDir = INSTALLER_HOME_DIR
+
+    @Test
+    @Timeout(value = 15, unit = TimeUnit.MINUTES)
+    fun `generated install_ps1 end-to-end under pwsh on ubuntu (glibc)`() = runWithCloseableStack { lifetime ->
+        // ── 1. build fixtures into a temp dir ──
+        val fixturesDir = createInstallerWorkDir("installer-ps1-fixtures")
+        val devrigZip = File(fixturesDir, "devrig.zip").also { buildFakePwshDevrigZip(it) }
+        val jdkZip = File(fixturesDir, "jdk.zip").also { buildFakeJdkZip(it) }
+        val devrigSha = sha256(devrigZip)
+        val jdkSha = sha256(jdkZip)
+        makeWorldReadable(fixturesDir)
+
+        // ── 2. start the nginx side-car FIRST (need its bridge IP before baking URLs) ──
+        val nginx = startDockerContainerAndDispose(
+            lifetime,
+            StartContainerRequest()
+                .image(NGINX_IMAGE)
+                .logPrefix("installer-ps1-nginx")
+                .volumes(ContainerVolume(fixturesDir, "/usr/share/nginx/html", "ro")),
+        )
+        val nginxIp = nginx.queryContainerIp() ?: error("nginx side-car has no bridge IP — cannot serve fixtures")
+        log("nginx side-car serving fixtures at http://$nginxIp/")
+
+        // ── 3. render install.ps1 from a synthetic model. Windows JDK entries baked with `zip` format
+        //       (matches the real Corretto/Azul Windows archives + Expand-Archive's contract) and
+        //       javaHome="jdk" pointing at the top dir of the fixture zip. Non-Windows entries are
+        //       required by validateScriptTable (all 5 platforms) but the ps1 script only reads its own
+        //       $Platforms hashtable, which contains only windows-x64 + windows-arm64. ──
+        val jdkEntryWin = JdkScriptEntry("http://$nginxIp/jdk.zip", jdkSha, "zip", "jdk")
+        val jdkEntryPosix = JdkScriptEntry("http://$nginxIp/jdk.zip", jdkSha, "tar.gz", "jdk")
+        val table = ALL_PLATFORMS.associateWith { key ->
+            if (key.startsWith("windows-")) jdkEntryWin else jdkEntryPosix
+        }
+        // The fixture zip unpacks to devrig-<version>/, so that's the computed+asserted launcher subpath.
+        val devrig = DevrigEntry(
+            url = "http://$nginxIp/devrig.zip", sha256 = devrigSha,
+            launcherPosix = "devrig-$version/bin/devrig", launcherWindows = "devrig-$version/bin/devrig.bat",
+        )
+        val genDir = createInstallerWorkDir("installer-ps1-gen-out")
+        writeInstallerScripts(genDir.toPath(), table, devrig, version)
+        require(File(genDir, "install.ps1").isFile) { "did not produce install.ps1 in $genDir" }
+        makeWorldReadable(genDir)
+
+        // ── 4. start the pwsh install container (Ubuntu base, adds curl for verifyMockServes) ──
+        val install = startDockerContainerAndDispose(
+            lifetime,
+            StartContainerRequest()
+                .image(pwshImage)
+                .logPrefix("installer-pwsh-ubuntu")
+                .volumes(ContainerVolume(genDir, "/gen", "ro"))
+                .entryPoint(
+                    "sh", "-c",
+                    "apt-get update -qq && apt-get install -y -qq curl >/dev/null 2>&1; mkdir -p \"$homeDir\"; sleep 3000",
+                ),
+        )
+        awaitCurlInstalled(install)
+        verifyMockServes(install, nginxIp, "/devrig.zip")
+        verifyMockServes(install, nginxIp, "/jdk.zip")
+
+        val devrigKey = "devrig-windows-x64-$version-${devrigSha.take(12)}"
+        val jdkKey = "jdk-windows-x64-$version-${jdkSha.take(12)}"
+        // install.ps1 uses Join-Path everywhere; on pwsh-Linux that returns forward-slash paths.
+        val expectedLauncher = "$homeDir/.mcp-steroid/binaries/$devrigKey/devrig-$version/bin/devrig.bat"
+        val expectedJdkHome = "$homeDir/.mcp-steroid/binaries/$jdkKey/jdk"
+
+        // ── run #1: clean HOME → DOWNLOAD both, DELEGATE launcher+PATH registration to
+        //    `devrig install devrig`. Exercise the FULL auto-detect path — no DEVRIG_OS / DEVRIG_CPU
+        //    so this run stresses the same code the shipped `irm | iex` bootstrap hits on real Windows:
+        //      • $os falls back to 'windows' (template default when DEVRIG_OS is unset).
+        //      • $env:PROCESSOR_ARCHITECTURE / PROCESSOR_ARCHITEW6432 are unset on Linux → the
+        //        RuntimeInformation fallback runs and returns "X64" on x86_64 hosts, matching the
+        //        AMD64|X64 regex → $cpu = 'x64'.
+        //    That auto-detect path is exactly what regressed in #273 (RuntimeInformation ungated) —
+        //    keeping the vars unset here is the runtime coverage that stops #273 from recurring on
+        //    the auto-detect branch. USERPROFILE stays set only so we don't cross into the "no user
+        //    home resolvable" Fail branch. ──
+        val env = mapOf(
+            "HOME" to homeDir,
+            "USERPROFILE" to homeDir,
+        )
+        val run1 = runInstall(install, env)
+            .assertExitCode(0) { "install.ps1 run #1 failed:\n$this" }
+            .assertOutputContains("downloading devrig", "downloading jdk", message = "run #1 (clean HOME) must download both")
+            // The pwsh script ran the UNPACKED devrig launcher with the computed path + bundled JDK.
+            .assertOutputContains(
+                "DEVRIG_INSTALL_DEVRIG", "--install-script=$expectedLauncher", "--jdk-home=$expectedJdkHome",
+                message = "install.ps1 must delegate to 'devrig install devrig' with the computed launcher + jdk-home",
+            )
+            .assertOutputContains("devrig binary is ready", "devrig install", message = "must report ready + how to register with agents")
+        // NEVER auto-register with an agent (would edit agent configs — that is an explicit user step).
+        run1.assertNoMessageInOutput("DEVRIG_INSTALL_CALLED")
+
+        // (a) content-addressed dirs exist
+        sh(install, "ls -1 \"$homeDir/.mcp-steroid/binaries\"")
+            .assertExitCode(0) { "could not list binaries dir:\n$this" }
+            .assertOutputContains(devrigKey, jdkKey, message = "expected content-addressed dirs")
+
+        // (b) JDK downloaded + unpacked verbatim (fixture has bin/java, matching the template's
+        //     pwsh-on-Linux fallback that accepts bin/java when bin/java.exe is missing).
+        sh(install, "test -x \"$homeDir/.mcp-steroid/binaries/$jdkKey/jdk/bin/java\" && echo JDK_JAVA_OK")
+            .assertOutputContains("JDK_JAVA_OK", message = "JDK bin/java missing — not downloaded/unpacked")
+
+        // (c) idempotent re-run reuses the content-addressed dirs and DOWNLOADS NOTHING
+        val reRun = runInstall(install, env)
+            .assertExitCode(0) { "idempotent re-run failed:\n$this" }
+            .assertOutputContains("already installed: $devrigKey", "already installed: $jdkKey", message = "re-run must report 'already installed'")
+        reRun.assertNoMessageInOutput("downloading jdk")
+        reRun.assertNoMessageInOutput("downloading devrig")
+
+        log("ALL INSTALLER ASSERTIONS PASSED on ubuntu (glibc) under pwsh — download + delegate to devrig install devrig")
+    }
+
+    // ── helpers ──────────────────────────────────────────────────────────────────────────────────
+
+    private fun runInstall(c: ContainerDriver, env: Map<String, String>): ProcessResult =
+        c.startProcessInContainer {
+            args("pwsh", "-NoProfile", "-NonInteractive", "-File", "/gen/install.ps1")
+                .timeoutSeconds(300).description("run generated install.ps1").extraEnv(env)
+        }.awaitForProcessFinish()
+
+    private fun sh(c: ContainerDriver, script: String, env: Map<String, String> = mapOf("HOME" to homeDir)): ProcessResult =
+        c.startProcessInContainer {
+            args("sh", "-c", script).timeoutSeconds(120).description("sh -c").extraEnv(env)
+        }.awaitForProcessFinish()
+
+    private fun awaitCurlInstalled(c: ContainerDriver) {
+        val deadline = System.currentTimeMillis() + 4 * 60_000
+        while (System.currentTimeMillis() < deadline) {
+            val r = sh(c, "command -v curl >/dev/null 2>&1 && command -v pwsh >/dev/null 2>&1 && echo TOOLS_OK")
+            if (r.exitCode == 0 && "TOOLS_OK" in r.stdout) { log("curl + pwsh present"); return }
+            Thread.sleep(2_000)
+        }
+        error("curl + pwsh were not available in the pwsh container within the timeout (apt-get failed?)")
+    }
+
+    private fun verifyMockServes(install: ContainerDriver, nginxIp: String, path: String) {
+        val r = sh(install, "curl -fsSL -o /dev/null http://$nginxIp$path && echo SERVED_$path")
+        require(r.exitCode == 0 && "SERVED_$path" in r.stdout) {
+            "nginx side-car does not serve $path:\nstdout=${r.stdout}\nstderr=${r.stderr}"
+        }
+        log("mock server serves $path")
+    }
+
+    private fun log(msg: String) = println("[InstallerBootstrapPs1Test] $msg")
+
+    // ── fixtures ─────────────────────────────────────────────────────────────────────────────────
+
+    /**
+     * Fake devrig dist zip for the PowerShell lane. Top dir `devrig-<version>/`; inside sits
+     * `bin/devrig.bat` — a `#!/bin/sh` script disguised as `.bat`. install.ps1 does `& $launcher …`,
+     * which on pwsh-Linux is a plain execve on the file, so the shebang wins and the extension is
+     * irrelevant. Executable bit is stamped via Apache Commons Compress (`java.util.zip.ZipEntry`
+     * cannot carry a unix mode); Expand-Archive preserves it into the unpacked tree.
+     *
+     * The script records what install.ps1 delegated: `install devrig …` (new flow) vs `install
+     * <agent>` (the would-be auto-register, which install.ps1 must NOT do) vs anything else. Mirrors
+     * the POSIX buildFakeDevrigZip contract character-for-character on the expected output tokens
+     * (`DEVRIG_INSTALL_DEVRIG`, `DEVRIG_INSTALL_CALLED`, `DEVRIG_RAN`, `DEVRIG_JAVA_HOME`).
+     */
+    private fun buildFakePwshDevrigZip(target: File) {
+        val script = buildString {
+            append("#!/bin/sh\n")
+            append("if [ \"\$1\" = \"install\" ] && [ \"\$2\" = \"devrig\" ]; then\n")
+            append("  echo \"DEVRIG_INSTALL_DEVRIG \$*\"\n")
+            append("  exit 0\n")
+            append("fi\n")
+            append("case \"\$1\" in\n")
+            append("  install)\n")
+            append("    echo \"DEVRIG_INSTALL_CALLED jdk=\${DEVRIG_JAVA_HOME:-}\"\n")
+            append("    exit 0 ;;\n")
+            append("  *)\n")
+            append("    echo \"DEVRIG_RAN \$*\"\n")
+            append("    echo \"DEVRIG_JAVA_HOME=\${DEVRIG_JAVA_HOME:-}\"\n")
+            append("    exit 0 ;;\n")
+            append("esac\n")
+        }.toByteArray()
+        ZipArchiveOutputStream(FileOutputStream(target)).use { zip ->
+            zip.putArchiveEntry(ZipArchiveEntry("devrig-$version/").apply { unixMode = 0b111_101_101 })
+            zip.closeArchiveEntry()
+            zip.putArchiveEntry(ZipArchiveEntry("devrig-$version/bin/").apply { unixMode = 0b111_101_101 })
+            zip.closeArchiveEntry()
+            zip.putArchiveEntry(
+                ZipArchiveEntry("devrig-$version/bin/devrig.bat").apply {
+                    size = script.size.toLong()
+                    unixMode = 0b111_101_101 // rwxr-xr-x — install.ps1 does NOT chmod after unpack
+                },
+            )
+            zip.write(script)
+            zip.closeArchiveEntry()
+        }
+    }
+
+    /**
+     * Fake JDK zip mirroring [buildFakeJdkTarGz]: top dir `jdk/` (matches `javaHome="jdk"`),
+     * with an executable `bin/java` sh stub — the template accepts `bin/java` in place of
+     * `bin/java.exe` on pwsh-on-Linux. Windows Corretto/Azul JDKs ship as `.zip` (not `.tar.gz`),
+     * so this lane needs the zip form — install.ps1 checks `if ($fmt -ne 'zip')` and fails otherwise.
+     */
+    private fun buildFakeJdkZip(target: File) {
+        val javaStub = "#!/bin/sh\necho 'java-stub 25'\nexit 0\n".toByteArray()
+        ZipArchiveOutputStream(FileOutputStream(target)).use { zip ->
+            zip.putArchiveEntry(ZipArchiveEntry("jdk/").apply { unixMode = 0b111_101_101 })
+            zip.closeArchiveEntry()
+            zip.putArchiveEntry(ZipArchiveEntry("jdk/bin/").apply { unixMode = 0b111_101_101 })
+            zip.closeArchiveEntry()
+            zip.putArchiveEntry(
+                ZipArchiveEntry("jdk/bin/java").apply {
+                    size = javaStub.size.toLong()
+                    unixMode = 0b111_101_101
+                },
+            )
+            zip.write(javaStub)
+            zip.closeArchiveEntry()
+        }
+    }
+}

--- a/installer-gen/src/installerIntegrationTest/kotlin/com/jonnyzzz/mcpSteroid/installer/tests/InstallerBootstrapPs1Test.kt
+++ b/installer-gen/src/installerIntegrationTest/kotlin/com/jonnyzzz/mcpSteroid/installer/tests/InstallerBootstrapPs1Test.kt
@@ -158,11 +158,136 @@ class InstallerBootstrapPs1Test {
         log("ALL INSTALLER ASSERTIONS PASSED on ubuntu (glibc) under pwsh — download + delegate to devrig install devrig")
     }
 
+    @Test
+    @Timeout(value = 15, unit = TimeUnit.MINUTES)
+    fun `install_ps1 auto-detects arch from PROCESSOR env (WoW64 + ARM64), rejects x86, catches bad sha`() =
+        runWithCloseableStack { lifetime ->
+            // The x64 CI runner cannot cover WoW64 / ARM64 / x86 natively, but detection reads env vars
+            // ($env:PROCESSOR_ARCHITEW6432 / PROCESSOR_ARCHITECTURE), so pwsh-on-Linux with those vars set
+            // exercises the exact real-Windows branches. DEVRIG_OS=windows forces the Windows platform table.
+            val fixturesDir = createInstallerWorkDir("installer-ps1-arch-fixtures")
+            val devrigZip = File(fixturesDir, "devrig.zip").also { buildFakePwshDevrigZip(it) }
+            val jdkZip = File(fixturesDir, "jdk.zip").also { buildFakeJdkZip(it) }
+            val devrigSha = sha256(devrigZip)
+            val jdkSha = sha256(jdkZip)
+            makeWorldReadable(fixturesDir)
+
+            val nginx = startDockerContainerAndDispose(
+                lifetime,
+                StartContainerRequest().image(NGINX_IMAGE).logPrefix("installer-ps1-arch-nginx")
+                    .volumes(ContainerVolume(fixturesDir, "/usr/share/nginx/html", "ro")),
+            )
+            val nginxIp = nginx.queryContainerIp() ?: error("nginx side-car has no bridge IP")
+
+            val jdkEntryWin = JdkScriptEntry("http://$nginxIp/jdk.zip", jdkSha, "zip", "jdk")
+            val jdkEntryPosix = JdkScriptEntry("http://$nginxIp/jdk.zip", jdkSha, "tar.gz", "jdk")
+            val table = ALL_PLATFORMS.associateWith { key -> if (key.startsWith("windows-")) jdkEntryWin else jdkEntryPosix }
+            val devrig = DevrigEntry(
+                url = "http://$nginxIp/devrig.zip", sha256 = devrigSha,
+                launcherPosix = "devrig-$version/bin/devrig", launcherWindows = "devrig-$version/bin/devrig.bat",
+            )
+            val genDir = createInstallerWorkDir("installer-ps1-arch-gen")
+            writeInstallerScripts(genDir.toPath(), table, devrig, version)
+            makeWorldReadable(genDir)
+            // A second render with a deliberately-corrupt devrig sha → download then Get-FileHash mismatch.
+            val badGenDir = createInstallerWorkDir("installer-ps1-badsha-gen")
+            writeInstallerScripts(badGenDir.toPath(), table, devrig.copy(sha256 = "0".repeat(64)), version)
+            makeWorldReadable(badGenDir)
+
+            val install = startDockerContainerAndDispose(
+                lifetime,
+                StartContainerRequest().image(pwshImage).logPrefix("installer-pwsh-arch")
+                    .volumes(ContainerVolume(genDir, "/gen", "ro"), ContainerVolume(badGenDir, "/badgen", "ro"))
+                    .entryPoint("sh", "-c", "apt-get update -qq && apt-get install -y -qq curl >/dev/null 2>&1; mkdir -p \"$homeDir\"; sleep 3000"),
+            )
+            awaitCurlInstalled(install)
+
+            val base = mapOf("HOME" to homeDir, "USERPROFILE" to homeDir, "DEVRIG_OS" to "windows")
+            // WoW64: 32-bit PS on 64-bit Windows sets PROCESSOR_ARCHITECTURE=x86 but the real arch in
+            // PROCESSOR_ARCHITEW6432 — which must win → windows-x64.
+            runInstall(install, base + mapOf("PROCESSOR_ARCHITEW6432" to "AMD64", "PROCESSOR_ARCHITECTURE" to "x86"))
+                .assertExitCode(0) { "WoW64 run failed:\n$this" }
+                .assertOutputContains("platform: windows-x64", message = "WoW64: PROCESSOR_ARCHITEW6432=AMD64 must beat x86 → windows-x64")
+            // ARM64 (empty ARCHITEW6432 is falsy in PS → falls through to PROCESSOR_ARCHITECTURE).
+            runInstall(install, base + mapOf("PROCESSOR_ARCHITEW6432" to "", "PROCESSOR_ARCHITECTURE" to "ARM64"))
+                .assertExitCode(0) { "ARM64 run failed:\n$this" }
+                .assertOutputContains("platform: windows-arm64", message = "ARM64 must resolve to windows-arm64")
+            // x86 with no 64-bit ARCHITEW6432 → explicit rejection, non-zero exit.
+            val x86 = runInstall(install, base + mapOf("PROCESSOR_ARCHITEW6432" to "", "PROCESSOR_ARCHITECTURE" to "x86"))
+            require(x86.exitCode != 0) { "x86 must be rejected (non-zero exit):\n$x86" }
+            x86.assertOutputContains("32-bit Windows is not supported", message = "x86 must be rejected with the 32-bit message")
+            // Corrupt devrig sha → mismatch caught, non-zero exit.
+            val bad = runInstall(install, base + mapOf("PROCESSOR_ARCHITECTURE" to "AMD64"), script = "/badgen/install.ps1")
+            require(bad.exitCode != 0) { "bad-sha run must fail:\n$bad" }
+            bad.assertOutputContains("SHA-256 mismatch", message = "a corrupt devrig sha must be caught before use")
+            log("arch matrix (WoW64/ARM64/x86) + sha-mismatch assertions passed under pwsh")
+        }
+
+    @Test
+    @Timeout(value = 15, unit = TimeUnit.MINUTES)
+    fun `install_ps1 hands devrig a closed stdin (child reads EOF) and restores caller ProgressPreference`() =
+        runWithCloseableStack { lifetime ->
+            // Behavioral proof of the stdin-close (`$null | & $launcher …`): the fake devrig READS stdin and
+            // records whether it saw EOF (closed) or data. And a dot-sourced run (mimicking `irm | iex`)
+            // proves $ProgressPreference is restored to the caller's value (the #274 leak fix).
+            val fixturesDir = createInstallerWorkDir("installer-ps1-stdin-fixtures")
+            val devrigZip = File(fixturesDir, "devrig.zip").also { buildStdinProbeDevrigZip(it) }
+            val jdkZip = File(fixturesDir, "jdk.zip").also { buildFakeJdkZip(it) }
+            val devrigSha = sha256(devrigZip)
+            val jdkSha = sha256(jdkZip)
+            makeWorldReadable(fixturesDir)
+
+            val nginx = startDockerContainerAndDispose(
+                lifetime,
+                StartContainerRequest().image(NGINX_IMAGE).logPrefix("installer-ps1-stdin-nginx")
+                    .volumes(ContainerVolume(fixturesDir, "/usr/share/nginx/html", "ro")),
+            )
+            val nginxIp = nginx.queryContainerIp() ?: error("nginx side-car has no bridge IP")
+
+            val jdkEntryWin = JdkScriptEntry("http://$nginxIp/jdk.zip", jdkSha, "zip", "jdk")
+            val jdkEntryPosix = JdkScriptEntry("http://$nginxIp/jdk.zip", jdkSha, "tar.gz", "jdk")
+            val table = ALL_PLATFORMS.associateWith { key -> if (key.startsWith("windows-")) jdkEntryWin else jdkEntryPosix }
+            val devrig = DevrigEntry(
+                url = "http://$nginxIp/devrig.zip", sha256 = devrigSha,
+                launcherPosix = "devrig-$version/bin/devrig", launcherWindows = "devrig-$version/bin/devrig.bat",
+            )
+            val genDir = createInstallerWorkDir("installer-ps1-stdin-gen")
+            writeInstallerScripts(genDir.toPath(), table, devrig, version)
+            makeWorldReadable(genDir)
+
+            val install = startDockerContainerAndDispose(
+                lifetime,
+                StartContainerRequest().image(pwshImage).logPrefix("installer-pwsh-stdin")
+                    .volumes(ContainerVolume(genDir, "/gen", "ro"))
+                    .entryPoint("sh", "-c", "apt-get update -qq && apt-get install -y -qq curl >/dev/null 2>&1; mkdir -p \"$homeDir\"; sleep 3000"),
+            )
+            awaitCurlInstalled(install)
+
+            val env = mapOf("HOME" to homeDir, "USERPROFILE" to homeDir)
+            // (1) stdin close: the child devrig must see EOF, not block on / receive real input.
+            runInstall(install, env)
+                .assertExitCode(0) { "install.ps1 (stdin-probe devrig) failed:\n$this" }
+                .assertOutputContains("DEVRIG_STDIN_GOT_EOF", message = "devrig child must inherit a closed stdin (immediate EOF)")
+                .assertNoMessageInOutput("DEVRIG_STDIN_GOT_DATA")
+
+            // (2) progress restore: dot-source (as `iex` would) with a sentinel value and confirm it is
+            //     put back after the script completes — the caller's session must not leak SilentlyContinue.
+            val restore = install.startProcessInContainer {
+                args(
+                    "pwsh", "-NoProfile", "-NonInteractive", "-Command",
+                    "\$ProgressPreference='Continue'; . /gen/install.ps1; Write-Output \"PROGRESS_AFTER=\$ProgressPreference\"",
+                ).timeoutSeconds(300).description("dot-source install.ps1, check ProgressPreference restored").extraEnv(env)
+            }.awaitForProcessFinish()
+            restore.assertExitCode(0) { "dot-sourced install.ps1 failed:\n$this" }
+                .assertOutputContains("PROGRESS_AFTER=Continue", message = "install.ps1 must restore the caller's \$ProgressPreference (no session leak)")
+            log("stdin-close (EOF) + ProgressPreference-restore assertions passed under pwsh")
+        }
+
     // ── helpers ──────────────────────────────────────────────────────────────────────────────────
 
-    private fun runInstall(c: ContainerDriver, env: Map<String, String>): ProcessResult =
+    private fun runInstall(c: ContainerDriver, env: Map<String, String>, script: String = "/gen/install.ps1"): ProcessResult =
         c.startProcessInContainer {
-            args("pwsh", "-NoProfile", "-NonInteractive", "-File", "/gen/install.ps1")
+            args("pwsh", "-NoProfile", "-NonInteractive", "-File", script)
                 .timeoutSeconds(300).description("run generated install.ps1").extraEnv(env)
         }.awaitForProcessFinish()
 
@@ -231,6 +356,39 @@ class InstallerBootstrapPs1Test {
                 ZipArchiveEntry("devrig-$version/bin/devrig.bat").apply {
                     size = script.size.toLong()
                     unixMode = 0b111_101_101 // rwxr-xr-x — install.ps1 does NOT chmod after unpack
+                },
+            )
+            zip.write(script)
+            zip.closeArchiveEntry()
+        }
+    }
+
+    /**
+     * Variant fake devrig whose `install devrig` arm READS stdin and records what it saw:
+     * `DEVRIG_STDIN_GOT_EOF` (an already-closed stdin — the correct result of install.ps1's `$null |`)
+     * vs `DEVRIG_STDIN_GOT_DATA`. `read` on a closed stdin returns non-zero immediately, so the child
+     * never blocks; without the close it would hang and the test would time out.
+     */
+    private fun buildStdinProbeDevrigZip(target: File) {
+        val script = buildString {
+            append("#!/bin/sh\n")
+            append("if [ \"\$1\" = \"install\" ] && [ \"\$2\" = \"devrig\" ]; then\n")
+            append("  if IFS= read -r _line; then echo \"DEVRIG_STDIN_GOT_DATA \$_line\"; else echo \"DEVRIG_STDIN_GOT_EOF\"; fi\n")
+            append("  echo \"DEVRIG_INSTALL_DEVRIG \$*\"\n")
+            append("  exit 0\n")
+            append("fi\n")
+            append("echo \"DEVRIG_RAN \$*\"\n")
+            append("exit 0\n")
+        }.toByteArray()
+        ZipArchiveOutputStream(FileOutputStream(target)).use { zip ->
+            zip.putArchiveEntry(ZipArchiveEntry("devrig-$version/").apply { unixMode = 0b111_101_101 })
+            zip.closeArchiveEntry()
+            zip.putArchiveEntry(ZipArchiveEntry("devrig-$version/bin/").apply { unixMode = 0b111_101_101 })
+            zip.closeArchiveEntry()
+            zip.putArchiveEntry(
+                ZipArchiveEntry("devrig-$version/bin/devrig.bat").apply {
+                    size = script.size.toLong()
+                    unixMode = 0b111_101_101
                 },
             )
             zip.write(script)

--- a/installer-gen/src/installerIntegrationTest/kotlin/com/jonnyzzz/mcpSteroid/installer/tests/InstallerBootstrapTest.kt
+++ b/installer-gen/src/installerIntegrationTest/kotlin/com/jonnyzzz/mcpSteroid/installer/tests/InstallerBootstrapTest.kt
@@ -20,9 +20,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.Timeout
 import java.io.File
 import java.io.FileOutputStream
-import java.security.MessageDigest
 import java.util.concurrent.TimeUnit
-import java.util.zip.GZIPOutputStream
 import java.util.zip.ZipEntry
 import java.util.zip.ZipOutputStream
 
@@ -38,13 +36,10 @@ import java.util.zip.ZipOutputStream
  * hermetic unit tests.
  */
 class InstallerBootstrapTest {
-    private val version = "0.0.0-test"
-    private val nginxImage = "nginx:alpine"
+    private val version = INSTALLER_TEST_VERSION
     private val installImage = "ubuntu:24.04"
     private val muslImage = "alpine:3.21"
-
-    /** HOME with a space catches quoting bugs in install.sh / the launcher wrapper. */
-    private val homeDir = "/home/tester one"
+    private val homeDir = INSTALLER_HOME_DIR
 
     /**
      * The project's defining platform constraint: musl/Alpine is NOT supported (the IntelliJ IDEs need
@@ -55,7 +50,7 @@ class InstallerBootstrapTest {
     @Test
     @Timeout(value = 10, unit = TimeUnit.MINUTES)
     fun `generated install_sh refuses musl (alpine)`() = runWithCloseableStack { lifetime ->
-        val genDir = createWorkDir("installer-musl-gen")
+        val genDir = createInstallerWorkDir("installer-musl-gen")
         // A minimal valid model (nothing is downloaded on the musl-reject path) → renders a real install.sh.
         val table = ALL_PLATFORMS.associateWith { JdkScriptEntry("https://example.com/jdk.tar.gz", "a".repeat(64), "tar.gz", "jdk") }
         writeInstallerScripts(
@@ -94,7 +89,7 @@ class InstallerBootstrapTest {
     @Timeout(value = 15, unit = TimeUnit.MINUTES)
     fun `generated install_sh end-to-end on ubuntu (glibc)`() = runWithCloseableStack { lifetime ->
         // ── 1. build fixtures into a temp dir ──
-        val fixturesDir = createWorkDir("installer-fixtures")
+        val fixturesDir = createInstallerWorkDir("installer-fixtures")
         val devrigZip = File(fixturesDir, "devrig.zip").also { buildFakeDevrigZip(it) }
         val jdkTarGz = File(fixturesDir, "jdk.tar.gz").also { buildFakeJdkTarGz(it) }
         val devrigSha = sha256(devrigZip)
@@ -105,7 +100,7 @@ class InstallerBootstrapTest {
         val nginx = startDockerContainerAndDispose(
             lifetime,
             StartContainerRequest()
-                .image(nginxImage)
+                .image(NGINX_IMAGE)
                 .logPrefix("installer-nginx")
                 .volumes(ContainerVolume(fixturesDir, "/usr/share/nginx/html", "ro")),
         )
@@ -114,7 +109,7 @@ class InstallerBootstrapTest {
 
         // ── 3. render install.sh from a synthetic model: all 5 platforms point at the one fake jdk.tar.gz
         //       (javaHome="jdk"), served by the side-car. This is the new seam — no real JDK download. ──
-        val genDir = createWorkDir("installer-gen-out")
+        val genDir = createInstallerWorkDir("installer-gen-out")
         val table = ALL_PLATFORMS.associateWith { JdkScriptEntry("http://$nginxIp/jdk.tar.gz", jdkSha, "tar.gz", "jdk") }
         // The fixture zip unpacks to devrig-<version>/, so that's the computed+asserted launcher subpath.
         val devrig = DevrigEntry(
@@ -227,33 +222,6 @@ class InstallerBootstrapTest {
 
     private fun log(msg: String) = println("[InstallerBootstrapTest] $msg")
 
-    private fun createWorkDir(prefix: String): File {
-        val d = File.createTempFile(prefix, "").let { it.delete(); File(it.absolutePath + "-dir") }
-        d.mkdirs()
-        return d
-    }
-
-    private fun makeWorldReadable(dir: File) {
-        dir.walkTopDown().forEach {
-            it.setReadable(true, false)
-            if (it.isDirectory) it.setExecutable(true, false)
-        }
-        dir.setExecutable(true, false)
-    }
-
-    private fun sha256(file: File): String {
-        val md = MessageDigest.getInstance("SHA-256")
-        file.inputStream().use { ins ->
-            val buf = ByteArray(64 * 1024)
-            while (true) {
-                val n = ins.read(buf)
-                if (n < 0) break
-                md.update(buf, 0, n)
-            }
-        }
-        return md.digest().joinToString("") { "%02x".format(it) }
-    }
-
     // ── fixtures ─────────────────────────────────────────────────────────────────────────────────
 
     /**
@@ -286,64 +254,5 @@ class InstallerBootstrapTest {
             zip.putNextEntry(ZipEntry("devrig-$version/bin/")); zip.closeEntry()
             zip.putNextEntry(ZipEntry("devrig-$version/bin/devrig")); zip.write(script.toByteArray()); zip.closeEntry()
         }
-    }
-
-    /** Fake JDK tar.gz. Top dir `jdk/` (matches javaHome="jdk"), with an executable `bin/java` sh stub. */
-    private fun buildFakeJdkTarGz(target: File) {
-        val javaStub = "#!/bin/sh\necho 'java-stub 25'\nexit 0\n".toByteArray()
-        GZIPOutputStream(FileOutputStream(target)).use { gz ->
-            TarWriter(gz).use { tar ->
-                tar.putDir("jdk/")
-                tar.putDir("jdk/bin/")
-                tar.putFile("jdk/bin/java", javaStub, mode = 0b111_101_101) // rwxr-xr-x
-            }
-        }
-    }
-}
-
-/**
- * Minimal POSIX (ustar) tar writer — the JDK has no built-in tar. Enough for a few small files with
- * stored unix permission bits so the unpacked `bin/java` keeps its +x bit (install.sh checks `-x`).
- */
-private class TarWriter(private val out: java.io.OutputStream) : AutoCloseable {
-    fun putDir(name: String) = writeEntry(name, ByteArray(0), typeFlag = '5', mode = 0b111_101_101)
-    fun putFile(name: String, data: ByteArray, mode: Int) = writeEntry(name, data, typeFlag = '0', mode = mode)
-
-    private fun writeEntry(name: String, data: ByteArray, typeFlag: Char, mode: Int) {
-        val header = ByteArray(512)
-        putString(header, 0, name, 100)
-        putOctal(header, 100, mode.toLong(), 8)
-        putOctal(header, 108, 0, 8)
-        putOctal(header, 116, 0, 8)
-        putOctal(header, 124, data.size.toLong(), 12)
-        putOctal(header, 136, 0, 12)
-        header[156] = typeFlag.code.toByte()
-        putString(header, 257, "ustar", 6)
-        header[263] = '0'.code.toByte(); header[264] = '0'.code.toByte()
-        for (i in 148 until 156) header[i] = ' '.code.toByte()
-        var sum = 0
-        for (b in header) sum += (b.toInt() and 0xff)
-        putOctal(header, 148, sum.toLong(), 7)
-        header[155] = ' '.code.toByte()
-        out.write(header)
-        out.write(data)
-        val pad = (512 - data.size % 512) % 512
-        if (pad > 0) out.write(ByteArray(pad))
-    }
-
-    private fun putString(buf: ByteArray, off: Int, s: String, max: Int) {
-        val bytes = s.toByteArray()
-        System.arraycopy(bytes, 0, buf, off, minOf(bytes.size, max - 1))
-    }
-
-    private fun putOctal(buf: ByteArray, off: Int, value: Long, len: Int) {
-        val s = java.lang.Long.toOctalString(value).padStart(len - 1, '0')
-        System.arraycopy(s.toByteArray(), 0, buf, off, len - 1)
-        buf[off + len - 1] = 0
-    }
-
-    override fun close() {
-        out.write(ByteArray(1024)) // two zero blocks terminate the archive
-        out.flush()
     }
 }

--- a/installer-gen/src/main/resources/templates/install.ps1.tmpl
+++ b/installer-gen/src/main/resources/templates/install.ps1.tmpl
@@ -15,7 +15,14 @@ $ErrorActionPreference = 'Stop'
 # unpacked (Expand-Archive), turning a multi-hundred-MB download + JDK unpack into a UI-bound crawl
 # on Windows consoles. See https://github.com/PowerShell/PowerShell/issues/2138 - silence progress
 # for the whole script (Write-Log status lines still go to stderr).
+#
+# `irm | iex` runs this script in the CALLER's scope, so a bare assignment would leave the user's
+# session with progress permanently silenced. Save the prior value and restore it in the finally
+# below - that covers the success path and any uncaught terminating error (the Fail -> exit path
+# tears the session down, so the leak is moot there).
+$SteroidPrevProgressPreference = $ProgressPreference
 $ProgressPreference = 'SilentlyContinue'
+try {
 
 $Version      = '@@VERSION@@'
 $DevrigUrl    = '@@DEVRIG_URL@@'
@@ -152,3 +159,8 @@ Write-Log "devrig binary is ready."
 Write-Log ""
 Write-Log "To register devrig with your agents (Claude, Codex, Gemini), run:"
 Write-Log "    devrig install"
+}
+finally {
+  # Restore the caller's progress preference so `irm | iex` leaves the session as it found it.
+  $ProgressPreference = $SteroidPrevProgressPreference
+}

--- a/installer-gen/src/main/resources/templates/install.ps1.tmpl
+++ b/installer-gen/src/main/resources/templates/install.ps1.tmpl
@@ -11,6 +11,11 @@
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+# PowerShell's default progress bar redraws on every byte read (Invoke-WebRequest) and every entry
+# unpacked (Expand-Archive), turning a multi-hundred-MB download + JDK unpack into a UI-bound crawl
+# on Windows consoles. See https://github.com/PowerShell/PowerShell/issues/2138 - silence progress
+# for the whole script (Write-Log status lines still go to stderr).
+$ProgressPreference = 'SilentlyContinue'
 
 $Version      = '@@VERSION@@'
 $DevrigUrl    = '@@DEVRIG_URL@@'
@@ -42,10 +47,28 @@ $BinariesDir = Join-Path $SteroidHome 'binaries'
 # -- platform detection -> normalized <os>-<cpu> key --
 $cpu = $env:DEVRIG_CPU
 if (-not $cpu) {
-  switch ([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture) {
-    'Arm64' { $cpu = 'arm64' }
-    'X64'   { $cpu = 'x64' }
-    default { Fail "unsupported CPU architecture" }
+  # PROCESSOR_ARCHITECTURE / PROCESSOR_ARCHITEW6432 are Windows-native env vars set on EVERY
+  # PowerShell host (5.1 and 7.x) on every Windows build. Do NOT read
+  # [RuntimeInformation]::OSArchitecture as the primary lookup: on the .NET Framework 4.6.x that
+  # ships with base Windows 10 the property is missing entirely, and Set-StrictMode Latest turns
+  # that into a hard PropertyNotFoundStrict abort (jonnyzzz/mcp-steroid#273 - user ran
+  # `irm | iex` and got "OSArchitecture cannot be found on this object", the whole install
+  # dead in the water). PROCESSOR_ARCHITEW6432 comes first because WoW64 (32-bit PS on 64-bit
+  # Windows) sets PROCESSOR_ARCHITECTURE=x86 but exposes the real host arch in ARCHITEW6432.
+  $arch = $env:PROCESSOR_ARCHITEW6432
+  if (-not $arch) { $arch = $env:PROCESSOR_ARCHITECTURE }
+  if (-not $arch) {
+    # Reached only on non-Windows (pwsh Core on Linux/Mac in dev+test contexts) where neither
+    # env var is set. Guarded so a missing property in some future strict mode cannot
+    # re-introduce #273.
+    try { $arch = [System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture.ToString() }
+    catch { Fail "cannot detect CPU architecture: PROCESSOR_ARCHITECTURE unset and RuntimeInformation lookup threw ($($_.Exception.Message))" }
+  }
+  switch -Regex ($arch) {
+    '^(?i)ARM64$'       { $cpu = 'arm64' }
+    '^(?i)(AMD64|X64)$' { $cpu = 'x64' }
+    '^(?i)X86$'         { Fail "32-bit Windows is not supported" }
+    default             { Fail "unsupported CPU architecture: '$arch'" }
   }
 }
 $os = $env:DEVRIG_OS

--- a/installer-gen/src/test/kotlin/com/jonnyzzz/mcpSteroid/installer/InstallerGeneratorTest.kt
+++ b/installer-gen/src/test/kotlin/com/jonnyzzz/mcpSteroid/installer/InstallerGeneratorTest.kt
@@ -124,6 +124,28 @@ class InstallerGeneratorTest {
     }
 
     @Test
+    fun `install_ps1 restores the caller ProgressPreference (no session leak under irm iex)`() {
+        // `irm | iex` runs install.ps1 in the CALLER's scope, so a bare `$ProgressPreference =
+        // 'SilentlyContinue'` would leave the user's interactive session with progress permanently
+        // silenced. The script must snapshot the prior value and restore it in a `finally` so the
+        // success path and any uncaught terminating error both put the session back as they found it.
+        val ps = renderInstallerScripts(jdkScriptTable(fullModel()), devrig, "1.2.3").ps
+        val saveAt = ps.indexOf("\$SteroidPrevProgressPreference = \$ProgressPreference")
+        val setAt = ps.indexOf("\$ProgressPreference = 'SilentlyContinue'")
+        val restoreAt = ps.indexOf("\$ProgressPreference = \$SteroidPrevProgressPreference")
+        assertTrue(saveAt >= 0, "install.ps1 must snapshot the caller's \$ProgressPreference before overriding it")
+        assertTrue(restoreAt >= 0, "install.ps1 must restore the caller's \$ProgressPreference (leak fix)")
+        // Order: snapshot → override → … → restore. Restore must be the LAST of the three so it wins.
+        assertTrue(saveAt < setAt, "must snapshot BEFORE overriding \$ProgressPreference")
+        assertTrue(restoreAt > setAt, "must restore AFTER the override")
+        // The restore lives in a finally that closes a try opened right after the override.
+        val tryAt = ps.indexOf("\ntry {", setAt)
+        val finallyAt = ps.lastIndexOf("finally {")
+        assertTrue(tryAt in 0 until restoreAt, "the body must be wrapped in a try{} opened after the override")
+        assertTrue(finallyAt in 0 until restoreAt, "the restore must sit inside the finally{} block")
+    }
+
+    @Test
     fun `install_sh does not carry the PowerShell ProgressPreference setting`() {
         // Belt-and-suspenders: `$ProgressPreference` is a PowerShell-only automatic variable. The POSIX
         // install.sh must not contain it — a leak would mean the shared render pipeline crossed streams

--- a/installer-gen/src/test/kotlin/com/jonnyzzz/mcpSteroid/installer/InstallerGeneratorTest.kt
+++ b/installer-gen/src/test/kotlin/com/jonnyzzz/mcpSteroid/installer/InstallerGeneratorTest.kt
@@ -93,6 +93,74 @@ class InstallerGeneratorTest {
         }
         assertTrue(scripts.ps.contains("\$DevrigBinSub = 'devrig-1.0-abc1234/bin/devrig.bat'"), "install.ps1 missing computed binsub")
         assertTrue(scripts.ps.contains("install devrig"), "install.ps1 must delegate to 'devrig install devrig'")
+        // Silences PowerShell's default progress bar, which cripples Invoke-WebRequest / Expand-Archive
+        // throughput (jonnyzzz/mcp-steroid#274). Regression-guard: removing this line brings the bug back.
+        assertTrue(
+            scripts.ps.contains("\$ProgressPreference = 'SilentlyContinue'"),
+            "install.ps1 must silence \$ProgressPreference so Invoke-WebRequest + Expand-Archive stay fast",
+        )
+    }
+
+    @Test
+    fun `install_ps1 sets ProgressPreference before any Invoke-WebRequest or Expand-Archive call`() {
+        // A `$ProgressPreference = 'SilentlyContinue'` line placed AFTER Invoke-WebRequest / Expand-Archive
+        // would leave the first download and the first unpack still crawling under the default progress
+        // bar — the exact regression jonnyzzz/mcp-steroid#274 pins. The setting must be baked BEFORE both,
+        // so an edit that moves it below the download function fails this test.
+        val ps = renderInstallerScripts(jdkScriptTable(fullModel()), devrig, "1.2.3").ps
+        val silentAt = ps.indexOf("\$ProgressPreference = 'SilentlyContinue'")
+        assertTrue(silentAt >= 0, "install.ps1 must set \$ProgressPreference = 'SilentlyContinue'")
+        // Match the actual call syntax, not the bare cmdlet name — the setting's own comment mentions
+        // both cmdlets by name, and the test must not fire on those mentions.
+        val invokeAt = ps.indexOf("Invoke-WebRequest -Uri")
+        val expandAt = ps.indexOf("Expand-Archive -Path")
+        assertTrue(invokeAt > 0, "install.ps1 must call Invoke-WebRequest -Uri")
+        assertTrue(expandAt > 0, "install.ps1 must call Expand-Archive -Path")
+        assertTrue(invokeAt > silentAt, "\$ProgressPreference must precede Invoke-WebRequest (silentAt=$silentAt, invokeAt=$invokeAt)")
+        assertTrue(expandAt > silentAt, "\$ProgressPreference must precede Expand-Archive (silentAt=$silentAt, expandAt=$expandAt)")
+        // And it must appear exactly once (belt+suspenders — a stray duplicate would suggest a template
+        // copy/paste bug that some future edit might revert one of the two lines).
+        assertEquals(silentAt, ps.lastIndexOf("\$ProgressPreference = 'SilentlyContinue'"), "duplicate \$ProgressPreference setting")
+    }
+
+    @Test
+    fun `install_sh does not carry the PowerShell ProgressPreference setting`() {
+        // Belt-and-suspenders: `$ProgressPreference` is a PowerShell-only automatic variable. The POSIX
+        // install.sh must not contain it — a leak would mean the shared render pipeline crossed streams
+        // between the two templates.
+        val sh = renderInstallerScripts(jdkScriptTable(fullModel()), devrig, "1.2.3").sh
+        assertTrue(!sh.contains("ProgressPreference"), "install.sh must not carry the PS-only ProgressPreference setting")
+    }
+
+    @Test
+    fun `install_ps1 detects CPU arch via PROCESSOR_ARCHITECTURE, not RuntimeInformation`() {
+        // jonnyzzz/mcp-steroid#273: reading [RuntimeInformation]::OSArchitecture aborts under
+        // Set-StrictMode Latest on the .NET Framework 4.6.x that base Windows 10 ships. The primary
+        // detection path must be the always-set Windows env vars; the RuntimeInformation branch may
+        // exist ONLY as a non-Windows (pwsh-Core) fallback, guarded by try/catch.
+        val ps = renderInstallerScripts(jdkScriptTable(fullModel()), devrig, "1.2.3").ps
+        assertTrue(
+            ps.contains("\$env:PROCESSOR_ARCHITECTURE"),
+            "install.ps1 must consult \$env:PROCESSOR_ARCHITECTURE for CPU detection",
+        )
+        assertTrue(
+            ps.contains("\$env:PROCESSOR_ARCHITEW6432"),
+            "install.ps1 must also consult \$env:PROCESSOR_ARCHITEW6432 (WoW64 32-on-64 case)",
+        )
+        // If the .NET static access is present at all, the access itself must live inside a preceding
+        // try{} block — StrictMode + missing property is exactly the #273 abort. Match the qualified
+        // type reference (only appears in code, never in comments) so comment mentions of the bare
+        // word "RuntimeInformation" don't false-positive.
+        val accessMarker = "[System.Runtime.InteropServices.RuntimeInformation]"
+        val accessAt = ps.indexOf(accessMarker)
+        if (accessAt >= 0) {
+            val tryAt = ps.lastIndexOf("try {", accessAt)
+            assertTrue(
+                tryAt in 0 until accessAt,
+                "install.ps1 accesses $accessMarker but not inside a preceding try{} block — " +
+                    "unguarded access re-introduces #273 on old .NET Framework builds",
+            )
+        }
     }
 
     @Test

--- a/test-integration-agent-launch/build.gradle.kts
+++ b/test-integration-agent-launch/build.gradle.kts
@@ -45,16 +45,11 @@ val installerGenDir = project(":installer-gen").projectDir
 val installPs1Template = installerGenDir.resolve("src/main/resources/templates/install.ps1.tmpl")
 val installShTemplate = installerGenDir.resolve("src/main/resources/templates/install.sh.tmpl")
 
-tasks.test {
+// Shared config for every Test task in this module (main cross-OS `test` + the Windows-only PS lane).
+fun Test.commonAgentLaunchTestConfig() {
     useJUnitPlatform()
     testLogging { showStandardStreams = true }
     systemProperty("junit.jupiter.execution.timeout.default", "15m")
-
-    // Windows||Linux gate (see note above). On macOS this task is skipped, so `./gradlew test`,
-    // `ciAgentLaunchTests`, and IDE runs on macOS are no-ops for this module.
-    enabled = runsHere
-    onlyIf("test-integration-agent-launch runs only on Windows/Linux agents") { runsHere }
-
     doFirst {
         systemProperty(
             "agent.launch.cache.dir",
@@ -64,3 +59,39 @@ tasks.test {
         systemProperty("installer.sh.template", installShTemplate.absolutePath)
     }
 }
+
+// `InstallerPs1ExecutionTest` drives NATIVE powershell.exe, so it is structurally Windows-only. It shares
+// this module with the cross-OS `ClaudeAgentLaunchTest`, so rather than a banned runtime skip
+// (`assumeTrue(isWindows)`), it is gated at the TASK level — the only skip the root CLAUDE.md allows. The
+// main `test` task EXCLUDES it (it still runs + reports under `windowsPs1Test`, so it is not hidden), and
+// `windowsPs1Test` runs ONLY it, `enabled = isWindows`.
+val installerPs1TestClass = "com.jonnyzzz.mcpSteroid.agentlaunch.InstallerPs1ExecutionTest"
+
+tasks.test {
+    commonAgentLaunchTestConfig()
+
+    // Windows||Linux gate (see note above). On macOS this task is skipped, so `./gradlew test`,
+    // `ciAgentLaunchTests`, and IDE runs on macOS are no-ops for this module.
+    enabled = runsHere
+    onlyIf("test-integration-agent-launch runs only on Windows/Linux agents") { runsHere }
+
+    // The Windows-native PS test runs under `windowsPs1Test` instead (see below).
+    filter { excludeTestsMatching(installerPs1TestClass) }
+}
+
+val windowsPs1Test = tasks.register<Test>("windowsPs1Test") {
+    group = "verification"
+    description = "Runs InstallerPs1ExecutionTest end-to-end under native Windows powershell.exe (+ pwsh). Windows-only."
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    commonAgentLaunchTestConfig()
+
+    // Task-level Windows gate — the compliant place for a structural OS skip (no runtime assumeTrue).
+    enabled = os.isWindows
+    onlyIf("InstallerPs1ExecutionTest needs native powershell.exe (Windows only)") { os.isWindows }
+
+    filter { includeTestsMatching(installerPs1TestClass) }
+}
+
+// Keep `check` (and thus CI aggregators that depend on it) running the Windows PS lane on Windows agents.
+tasks.named("check") { dependsOn(windowsPs1Test) }

--- a/test-integration-agent-launch/build.gradle.kts
+++ b/test-integration-agent-launch/build.gradle.kts
@@ -13,6 +13,10 @@ dependencies {
     // process-driving test in the repo uses: consistent [prefix] logging, timeout + destroyForcibly,
     // captured stdout/stderr in the returned ProcessResult.
     implementation(project(":test-helper"))
+    // The Windows execution test drives writeInstallerScripts + DevrigEntry directly to render a
+    // real, executable install.ps1 into a temp dir (the syntax-check test uses placeholder string
+    // replacement, which is fine for a Parser::ParseFile check but not for an end-to-end run).
+    testImplementation(project(":installer-gen"))
 
     implementation(platform("org.junit:junit-bom:5.11.4"))
     implementation("org.junit.jupiter:junit-jupiter-api")

--- a/test-integration-agent-launch/src/test/kotlin/com/jonnyzzz/mcpSteroid/agentlaunch/InstallerPs1ExecutionTest.kt
+++ b/test-integration-agent-launch/src/test/kotlin/com/jonnyzzz/mcpSteroid/agentlaunch/InstallerPs1ExecutionTest.kt
@@ -11,7 +11,6 @@ import com.jonnyzzz.mcpSteroid.testHelper.process.assertNoMessageInOutput
 import com.jonnyzzz.mcpSteroid.testHelper.process.assertOutputContains
 import com.jonnyzzz.mcpSteroid.testHelper.process.startProcess
 import com.sun.net.httpserver.HttpServer
-import org.junit.jupiter.api.Assumptions.assumeTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.api.Timeout
@@ -46,30 +45,30 @@ import kotlin.io.path.readBytes
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class InstallerPs1ExecutionTest {
 
-    private val isWindows = System.getProperty("os.name").lowercase().contains("win")
-
     @Test
     @Timeout(value = 10, unit = TimeUnit.MINUTES)
-    fun `install_ps1 runs end-to-end under Windows PowerShell 5-1 (powershell_exe)`() {
-        // Task-level `enabled = runsHere` already keeps this test off macOS. The class-level gate
-        // makes it a NO-OP on the Linux side of the cross-OS matrix — the Docker pwsh path is what
-        // covers Linux, not powershell.exe.
-        assumeTrue(isWindows) { "InstallerPs1ExecutionTest exercises native powershell.exe; skipping on non-Windows host" }
-        runInstallEndToEnd("powershell", extraArgs = emptyList(), shellDescription = "powershell.exe (Windows PowerShell 5.1)")
-    }
-
-    @Test
-    @Timeout(value = 10, unit = TimeUnit.MINUTES)
-    fun `install_ps1 runs end-to-end under PowerShell Core (pwsh) when available on PATH`() {
-        assumeTrue(isWindows) { "pwsh coverage on Linux lives in :installer-gen InstallerBootstrapPs1Test (Docker)" }
-        val pwshOnPath = isCommandOnPath("pwsh")
-        assumeTrue(pwshOnPath) { "pwsh (PowerShell Core) not on PATH; only powershell.exe (5.1) will be exercised" }
-        runInstallEndToEnd("pwsh", extraArgs = emptyList(), shellDescription = "pwsh (PowerShell Core 7.x)")
+    fun `install_ps1 runs end-to-end under Windows PowerShell 5-1 and PowerShell Core`() {
+        // NO runtime skip: this class runs only under the Gradle task `windowsPs1Test`, which is gated
+        // `enabled = isWindows` at the task level (the compliant place per root CLAUDE.md). It needs
+        // native powershell.exe, so it is structurally Windows-only; the cross-OS `test` task excludes it.
+        //
+        // Always exercise powershell.exe (Windows PowerShell 5.1 — the default Windows 10/11 shell, where
+        // #273 manifests).
+        runInstallEndToEnd("powershell", shellDescription = "powershell.exe (Windows PowerShell 5.1)")
+        // Additionally exercise PowerShell Core when the runner has it (GH windows-latest + TC agents do).
+        // This is EXTRA coverage, not a skip — the powershell.exe assertions above already ran and asserted
+        // a real outcome; pwsh-on-Linux coverage lives in :installer-gen InstallerBootstrapPs1Test (Docker).
+        if (isCommandOnPath("pwsh")) {
+            runInstallEndToEnd("pwsh", shellDescription = "pwsh (PowerShell Core 7.x)")
+        } else {
+            println("[InstallerPs1ExecutionTest] pwsh not on PATH — exercised powershell.exe (5.1) only")
+        }
     }
 
     // ── shared driver ────────────────────────────────────────────────────────────────────────────
 
-    private fun runInstallEndToEnd(shellCommand: String, extraArgs: List<String>, shellDescription: String) {
+    private fun runInstallEndToEnd(shellCommand: String, shellDescription: String) {
+        val extraArgs = emptyList<String>()
         val workDir = cacheDir().resolve("ps1-exec-${System.nanoTime()}").also { it.createDirectories() }
         val fixturesDir = workDir.resolve("fixtures").also { it.createDirectories() }
         val genDir = workDir.resolve("gen").also { it.createDirectories() }
@@ -171,14 +170,14 @@ class InstallerPs1ExecutionTest {
         Path.of(System.getProperty("agent.launch.cache.dir")).also { it.createDirectories() }
 
     private fun isCommandOnPath(cmd: String): Boolean {
-        // Both cmd.exe `where` and PS `Get-Command` do the resolution; `where` is cheap and always
-        // present on Windows. Exit 0 → found. On non-Windows this method is never reached (gated by
-        // the assumeTrue(isWindows)).
+        // `where` is cheap and always present on Windows (the only OS this class runs on — task-gated).
+        // Exit 0 → found. A probe failure is logged (never silently swallowed) and treated as "absent".
         return try {
             val proc = ProcessBuilder("where", cmd).redirectErrorStream(true).start()
             proc.inputStream.readAllBytes() // drain so waitFor doesn't block on buffered output
             proc.waitFor(5, TimeUnit.SECONDS) && proc.exitValue() == 0
         } catch (e: Exception) {
+            System.err.println("[InstallerPs1ExecutionTest] 'where $cmd' probe failed (${e.message}); treating '$cmd' as not on PATH")
             false
         }
     }

--- a/test-integration-agent-launch/src/test/kotlin/com/jonnyzzz/mcpSteroid/agentlaunch/InstallerPs1ExecutionTest.kt
+++ b/test-integration-agent-launch/src/test/kotlin/com/jonnyzzz/mcpSteroid/agentlaunch/InstallerPs1ExecutionTest.kt
@@ -1,0 +1,248 @@
+/* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
+package com.jonnyzzz.mcpSteroid.agentlaunch
+
+import com.jonnyzzz.mcpSteroid.installer.ALL_PLATFORMS
+import com.jonnyzzz.mcpSteroid.installer.DevrigEntry
+import com.jonnyzzz.mcpSteroid.installer.JdkScriptEntry
+import com.jonnyzzz.mcpSteroid.installer.writeInstallerScripts
+import com.jonnyzzz.mcpSteroid.testHelper.process.RunProcessRequest
+import com.jonnyzzz.mcpSteroid.testHelper.process.assertExitCode
+import com.jonnyzzz.mcpSteroid.testHelper.process.assertNoMessageInOutput
+import com.jonnyzzz.mcpSteroid.testHelper.process.assertOutputContains
+import com.jonnyzzz.mcpSteroid.testHelper.process.startProcess
+import com.sun.net.httpserver.HttpServer
+import org.junit.jupiter.api.Assumptions.assumeTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.Timeout
+import java.io.FileOutputStream
+import java.net.InetSocketAddress
+import java.nio.file.Files
+import java.nio.file.Path
+import java.security.MessageDigest
+import java.time.Duration
+import java.util.concurrent.TimeUnit
+import java.util.zip.ZipEntry
+import java.util.zip.ZipOutputStream
+import kotlin.io.path.absolutePathString
+import kotlin.io.path.createDirectories
+import kotlin.io.path.readBytes
+
+/**
+ * Windows-native end-to-end run of the generated `install.ps1`. Complementary to
+ * [InstallerScriptTest] (which only PARSES the script under PowerShell 5.1) and to
+ * `InstallerBootstrapPs1Test` in `:installer-gen` (which executes it under `pwsh` 7.4 on Ubuntu
+ * Docker) — this test executes it under **Windows PowerShell 5.1** (`powershell.exe`), the default
+ * shell shipped on Windows 10 and 11. PS 5.1 is where jonnyzzz/mcp-steroid#273 actually manifests:
+ * `[RuntimeInformation]::OSArchitecture` is missing on the .NET Framework 4.6.x that base Windows
+ * 10 ships, and `Set-StrictMode Latest` turns that into a hard abort. If `pwsh` is also on PATH
+ * (the standard GitHub windows-latest runner has both), it is exercised too.
+ *
+ * No `DEVRIG_OS` / `DEVRIG_CPU` env vars: the whole point is to cover the auto-detect path the
+ * shipped `irm | iex` bootstrap hits. The test overrides `USERPROFILE` to a per-invocation temp dir
+ * to isolate content-addressed install state — that override is test hygiene, unrelated to the
+ * detection paths in the script.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class InstallerPs1ExecutionTest {
+
+    private val isWindows = System.getProperty("os.name").lowercase().contains("win")
+
+    @Test
+    @Timeout(value = 10, unit = TimeUnit.MINUTES)
+    fun `install_ps1 runs end-to-end under Windows PowerShell 5-1 (powershell_exe)`() {
+        // Task-level `enabled = runsHere` already keeps this test off macOS. The class-level gate
+        // makes it a NO-OP on the Linux side of the cross-OS matrix — the Docker pwsh path is what
+        // covers Linux, not powershell.exe.
+        assumeTrue(isWindows) { "InstallerPs1ExecutionTest exercises native powershell.exe; skipping on non-Windows host" }
+        runInstallEndToEnd("powershell", extraArgs = emptyList(), shellDescription = "powershell.exe (Windows PowerShell 5.1)")
+    }
+
+    @Test
+    @Timeout(value = 10, unit = TimeUnit.MINUTES)
+    fun `install_ps1 runs end-to-end under PowerShell Core (pwsh) when available on PATH`() {
+        assumeTrue(isWindows) { "pwsh coverage on Linux lives in :installer-gen InstallerBootstrapPs1Test (Docker)" }
+        val pwshOnPath = isCommandOnPath("pwsh")
+        assumeTrue(pwshOnPath) { "pwsh (PowerShell Core) not on PATH; only powershell.exe (5.1) will be exercised" }
+        runInstallEndToEnd("pwsh", extraArgs = emptyList(), shellDescription = "pwsh (PowerShell Core 7.x)")
+    }
+
+    // ── shared driver ────────────────────────────────────────────────────────────────────────────
+
+    private fun runInstallEndToEnd(shellCommand: String, extraArgs: List<String>, shellDescription: String) {
+        val workDir = cacheDir().resolve("ps1-exec-${System.nanoTime()}").also { it.createDirectories() }
+        val fixturesDir = workDir.resolve("fixtures").also { it.createDirectories() }
+        val genDir = workDir.resolve("gen").also { it.createDirectories() }
+        val fakeHome = workDir.resolve("home").also { it.createDirectories() }
+
+        // Build fixtures.
+        val devrigZip = fixturesDir.resolve("devrig.zip")
+        buildFakeDevrigZipForWindows(devrigZip)
+        val jdkZip = fixturesDir.resolve("jdk.zip")
+        buildFakeJdkZipForWindows(jdkZip)
+        val devrigSha = sha256(devrigZip)
+        val jdkSha = sha256(jdkZip)
+
+        // Serve fixtures over real HTTP. The install.ps1 uses Invoke-WebRequest which needs an
+        // http/https URL — file:// is not accepted. Bind to 127.0.0.1 on an ephemeral port so
+        // the test cannot collide with anything else on the runner.
+        val server = HttpServer.create(InetSocketAddress("127.0.0.1", 0), 0).apply {
+            createContext("/devrig.zip") { ex ->
+                ex.sendResponseHeaders(200, devrigZip.readBytes().size.toLong())
+                ex.responseBody.use { it.write(devrigZip.readBytes()) }
+            }
+            createContext("/jdk.zip") { ex ->
+                ex.sendResponseHeaders(200, jdkZip.readBytes().size.toLong())
+                ex.responseBody.use { it.write(jdkZip.readBytes()) }
+            }
+            start()
+        }
+        try {
+            val port = server.address.port
+            val baseUrl = "http://127.0.0.1:$port"
+
+            // Render install.ps1 through the SHIPPING code path (writeInstallerScripts). All 5
+            // platforms must be present in the table (installer-gen contract), but install.ps1
+            // reads only its own Windows platform hashtable at runtime.
+            val jdkEntryWin = JdkScriptEntry("$baseUrl/jdk.zip", jdkSha, "zip", "jdk")
+            val jdkEntryPosix = JdkScriptEntry("$baseUrl/jdk.zip", jdkSha, "tar.gz", "jdk")
+            val table = ALL_PLATFORMS.associateWith { key ->
+                if (key.startsWith("windows-")) jdkEntryWin else jdkEntryPosix
+            }
+            val devrig = DevrigEntry(
+                url = "$baseUrl/devrig.zip", sha256 = devrigSha,
+                launcherPosix = "devrig-$VERSION/bin/devrig",
+                launcherWindows = "devrig-$VERSION/bin/devrig.bat",
+            )
+            writeInstallerScripts(genDir, table, devrig, VERSION)
+            val ps1 = genDir.resolve("install.ps1")
+            check(Files.isRegularFile(ps1)) { "did not produce install.ps1 in $genDir" }
+
+            // Isolate content-addressed install state from any previous run: point USERPROFILE at
+            // a per-invocation temp dir. This is test hygiene, not detection-path steering — no
+            // DEVRIG_* var is set, so the script must self-detect the platform on real Windows.
+            val env = mapOf("USERPROFILE" to fakeHome.absolutePathString())
+
+            // ── run #1: clean home → downloads both, delegates to devrig install devrig ──
+            val run1 = RunProcessRequest(
+                args = listOf(shellCommand, "-NoProfile", "-NonInteractive") + extraArgs +
+                    listOf("-File", ps1.absolutePathString()),
+                environment = env,
+                logPrefix = "ps1-run1-$shellCommand",
+                description = "install.ps1 under $shellDescription (run 1)",
+                timeout = Duration.ofMinutes(5),
+            ).startProcess().awaitForProcessFinish()
+                .assertExitCode(0) { "install.ps1 run #1 under $shellDescription failed:\n$this" }
+                .assertOutputContains("platform: windows-", message = "must auto-detect windows-<cpu> platform")
+                .assertOutputContains("downloading devrig", "downloading jdk", message = "run #1 must download both")
+                .assertOutputContains(
+                    "DEVRIG_INSTALL_DEVRIG",
+                    message = "install.ps1 must delegate to `devrig install devrig`",
+                )
+                .assertOutputContains("devrig binary is ready", "devrig install", message = "must report ready + how to register with agents")
+            // Regression guard for jonnyzzz/mcp-steroid#273: RuntimeInformation lookup must not
+            // surface as a strict-mode abort on Windows PowerShell 5.1.
+            run1.assertNoMessageInOutput("The property 'OSArchitecture' cannot be found")
+            run1.assertNoMessageInOutput("PropertyNotFoundStrict")
+            // And must NOT auto-register with an agent — that is a separate explicit user step.
+            run1.assertNoMessageInOutput("DEVRIG_INSTALL_CALLED")
+
+            // ── run #2: idempotent — reuses content-addressed dirs, downloads NOTHING ──
+            val run2 = RunProcessRequest(
+                args = listOf(shellCommand, "-NoProfile", "-NonInteractive") + extraArgs +
+                    listOf("-File", ps1.absolutePathString()),
+                environment = env,
+                logPrefix = "ps1-run2-$shellCommand",
+                description = "install.ps1 under $shellDescription (run 2, idempotent)",
+                timeout = Duration.ofMinutes(2),
+            ).startProcess().awaitForProcessFinish()
+                .assertExitCode(0) { "install.ps1 run #2 (idempotent) under $shellDescription failed:\n$this" }
+                .assertOutputContains("already installed", message = "re-run must report 'already installed'")
+            run2.assertNoMessageInOutput("downloading devrig")
+            run2.assertNoMessageInOutput("downloading jdk")
+        } finally {
+            server.stop(0)
+        }
+    }
+
+    // ── helpers ──────────────────────────────────────────────────────────────────────────────────
+
+    private fun cacheDir(): Path =
+        Path.of(System.getProperty("agent.launch.cache.dir")).also { it.createDirectories() }
+
+    private fun isCommandOnPath(cmd: String): Boolean {
+        // Both cmd.exe `where` and PS `Get-Command` do the resolution; `where` is cheap and always
+        // present on Windows. Exit 0 → found. On non-Windows this method is never reached (gated by
+        // the assumeTrue(isWindows)).
+        return try {
+            val proc = ProcessBuilder("where", cmd).redirectErrorStream(true).start()
+            proc.inputStream.readAllBytes() // drain so waitFor doesn't block on buffered output
+            proc.waitFor(5, TimeUnit.SECONDS) && proc.exitValue() == 0
+        } catch (e: Exception) {
+            false
+        }
+    }
+
+    private fun sha256(file: Path): String {
+        val md = MessageDigest.getInstance("SHA-256")
+        Files.newInputStream(file).use { ins ->
+            val buf = ByteArray(64 * 1024)
+            while (true) {
+                val n = ins.read(buf)
+                if (n < 0) break
+                md.update(buf, 0, n)
+            }
+        }
+        return md.digest().joinToString("") { "%02x".format(it) }
+    }
+
+    /**
+     * Fake devrig dist zip. Top dir `devrig-<version>/`; inside sits `bin/devrig.bat` — a genuine
+     * cmd batch on Windows. Records what install.ps1 delegated: `install devrig …` (new flow) vs
+     * `install <agent>` (the would-be auto-register, which install.ps1 must NOT do) vs anything
+     * else. Mirrors the output tokens the sibling Docker tests already assert on.
+     */
+    private fun buildFakeDevrigZipForWindows(target: Path) {
+        val batchScript = buildString {
+            appendLine("@echo off")
+            appendLine("if /I \"%~1\"==\"install\" if /I \"%~2\"==\"devrig\" (")
+            appendLine("  echo DEVRIG_INSTALL_DEVRIG %*")
+            appendLine("  exit /b 0")
+            appendLine(")")
+            appendLine("if /I \"%~1\"==\"install\" (")
+            appendLine("  echo DEVRIG_INSTALL_CALLED jdk=%DEVRIG_JAVA_HOME%")
+            appendLine("  exit /b 0")
+            appendLine(")")
+            appendLine("echo DEVRIG_RAN %*")
+            appendLine("echo DEVRIG_JAVA_HOME=%DEVRIG_JAVA_HOME%")
+            appendLine("exit /b 0")
+        }.toByteArray(Charsets.US_ASCII)
+        ZipOutputStream(FileOutputStream(target.toFile())).use { zip ->
+            zip.putNextEntry(ZipEntry("devrig-$VERSION/")); zip.closeEntry()
+            zip.putNextEntry(ZipEntry("devrig-$VERSION/bin/")); zip.closeEntry()
+            zip.putNextEntry(ZipEntry("devrig-$VERSION/bin/devrig.bat"))
+            zip.write(batchScript)
+            zip.closeEntry()
+        }
+    }
+
+    /**
+     * Fake JDK zip. Top dir `jdk/` (matches `javaHome="jdk"`), with a `bin/java.exe` stub so
+     * install.ps1's `Test-Path (Join-Path $jdkHome 'bin\java.exe')` check succeeds. The stub is a
+     * one-line cmd batch renamed to .exe — install.ps1 never EXECUTES it, only tests existence.
+     */
+    private fun buildFakeJdkZipForWindows(target: Path) {
+        val javaStub = "@echo java-stub 25\r\n@exit /b 0\r\n".toByteArray(Charsets.US_ASCII)
+        ZipOutputStream(FileOutputStream(target.toFile())).use { zip ->
+            zip.putNextEntry(ZipEntry("jdk/")); zip.closeEntry()
+            zip.putNextEntry(ZipEntry("jdk/bin/")); zip.closeEntry()
+            zip.putNextEntry(ZipEntry("jdk/bin/java.exe"))
+            zip.write(javaStub)
+            zip.closeEntry()
+        }
+    }
+
+    companion object {
+        const val VERSION = "0.0.0-test"
+    }
+}


### PR DESCRIPTION
Fixes the two crashes/regressions that break `install.ps1` on the default Windows 10/11 shell (**Windows PowerShell 5.1**) during `irm | iex` bootstrap.

## #274 — progress bar makes the install crawl
PowerShell's default progress bar redraws on every byte read (`Invoke-WebRequest`) and every entry unpacked (`Expand-Archive`), turning the multi-hundred-MB download + JDK unpack into a UI-bound crawl. → `$ProgressPreference = 'SilentlyContinue'` for the whole script (status still goes to stderr via `Write-Log`).

## #273 — arch detection aborts under StrictMode
Detection read `[RuntimeInformation]::OSArchitecture` as the **primary** lookup. That property is missing on the .NET Framework 4.6.x base Windows 10 ships, and `Set-StrictMode -Version Latest` turns the miss into a hard `PropertyNotFoundStrict` abort (`OSArchitecture cannot be found`) — the whole install dead mid-bootstrap. → detection now reads the always-present Windows env vars `$env:PROCESSOR_ARCHITEW6432` (WoW64 32-on-64 first) / `$env:PROCESSOR_ARCHITECTURE`; `[RuntimeInformation]` is only a non-Windows (pwsh Core) fallback, **guarded by try/catch** so no future strict-mode tightening can re-introduce #273.

## Coverage
- Unit tests pin `PROCESSOR_ARCHITECTURE` as the primary path and gate any `RuntimeInformation` access behind a preceding `try{}`.
- `installerIntegrationTest` drops `DEVRIG_OS`/`DEVRIG_CPU` so the pwsh-on-Ubuntu Docker run exercises the auto-detect path.
- New `InstallerPs1ExecutionTest` runs the generated `install.ps1` end-to-end under native `powershell.exe` (PS 5.1) + `pwsh`, regression-guarding the exact #273 stderr signatures.
- A throwaway `installer-ps1-verify.yml` reproduces both lanes on GH CI (permanent home: TeamCity).

## Split out of this PR
- **stdin-close contract** (`< /dev/null` / `$null |` on the `devrig install devrig` handoff) → moved to its own foundational PR #282.
- **Windows shell-form sh-script hook regression** (`ClaudeAgentLaunchTest.hook-devrig-pattern`) → real Claude-on-Windows regression, tracked in #283. The verify workflow's Windows lane runs the full suite with `--continue`, so that one case shows an honest red without gating this fix; our `install.ps1` tests pass and are visible in the report.