### PR TITLE
installer: close stdin on 'devrig install devrig' (non-interactive contract)

### DIFF
--- a/installer-gen/src/main/resources/templates/install.ps1.tmpl
+++ b/installer-gen/src/main/resources/templates/install.ps1.tmpl
@@ -115,7 +115,12 @@ if (-not (Test-Path (Join-Path $jdkHome 'bin\java.exe'))) {
 # registers itself. JAVA_HOME is set only so the unpacked devrig runs under the bundled JDK right now.
 Write-Log "registering devrig (devrig install devrig)..."
 $env:JAVA_HOME = $jdkHome
-& $launcher install devrig "--install-script=$launcher" "--jdk-home=$jdkHome"
+# Pipe $null so the launcher inherits an already-closed stdin: when this installer is bootstrapped
+# via `irm | iex`, the parent PS reads stdin from a pipe still open to the shell that ran `irm`.
+# A devrig subprocess that read stdin (or waited on a Console.ReadLine style prompt) would hang
+# forever with no user recourse. `$null |` gives it an empty input stream so the first read returns
+# EOF immediately - `devrig install devrig` is contractually non-interactive (see runInstallDevrigCommand).
+$null | & $launcher install devrig "--install-script=$launcher" "--jdk-home=$jdkHome"
 if ($LASTEXITCODE -ne 0) { Fail "'devrig install devrig' failed (exit $LASTEXITCODE) - the launcher could not register itself" }
 
 # -- done. We do NOT auto-register devrig with agents - that edits agent configs, so it is an

--- a/installer-gen/src/main/resources/templates/install.sh.tmpl
+++ b/installer-gen/src/main/resources/templates/install.sh.tmpl
@@ -170,8 +170,13 @@ main() {
   # -- hand off to devrig: it OWNS ~/.mcp-steroid/bin/devrig + PATH (no duplicate wrapper here) --
   # We pass every non-trivial parameter explicitly (the install-tree launcher + the bundled JDK); devrig
   # registers itself. JAVA_HOME is set only so the unpacked devrig runs under the bundled JDK right now.
+  # Redirect stdin from /dev/null so devrig inherits an already-closed stdin: when this installer is
+  # bootstrapped via `curl | sh`, the parent sh reads stdin from a pipe still open to the shell that
+  # ran curl. A devrig subprocess that read stdin (or waited on a prompt) would hang forever with no
+  # user recourse. `< /dev/null` gives it an already-closed stdin - `devrig install devrig` is
+  # contractually non-interactive (see runInstallDevrigCommand; mirrors the install.ps1 `$null |`).
   log "registering devrig (devrig install devrig)..."
-  JAVA_HOME="$jdk_home" "$launcher" install devrig --install-script="$launcher" --jdk-home="$jdk_home" \
+  JAVA_HOME="$jdk_home" "$launcher" install devrig --install-script="$launcher" --jdk-home="$jdk_home" < /dev/null \
     || fail "'devrig install devrig' failed - the launcher could not register itself"
 
   # -- done. We do NOT auto-register devrig with agents - that edits agent configs, so it is an

--- a/installer-gen/src/test/kotlin/com/jonnyzzz/mcpSteroid/installer/InstallerGeneratorTest.kt
+++ b/installer-gen/src/test/kotlin/com/jonnyzzz/mcpSteroid/installer/InstallerGeneratorTest.kt
@@ -96,6 +96,33 @@ class InstallerGeneratorTest {
     }
 
     @Test
+    fun `install_ps1 closes stdin on the devrig launcher invocation`() {
+        // Bootstrapping via `irm | iex` leaves the parent PS host with stdin still connected to the outer
+        // shell's pipe. A devrig subprocess that reads stdin would hang forever with no user recourse.
+        // `$null |` gives the launcher an empty input stream so the first read is EOF — enforcing the
+        // `devrig install devrig` non-interactive contract (see runInstallDevrigCommand).
+        val ps = renderInstallerScripts(jdkScriptTable(fullModel()), devrig, "1.2.3").ps
+        assertTrue(
+            ps.contains("\$null | & \$launcher install devrig"),
+            "install.ps1 must pipe \$null into the devrig launcher so the child cannot inherit an open stdin",
+        )
+    }
+
+    @Test
+    fun `install_sh closes stdin on the devrig launcher invocation`() {
+        // Mirror of the ps1 stdin-close on the POSIX side: `curl | sh` bootstrap leaves stdin open to the
+        // outer shell's pipe. `< /dev/null` gives devrig an already-closed stdin.
+        val sh = renderInstallerScripts(jdkScriptTable(fullModel()), devrig, "1.2.3").sh
+        // Match the actual invocation line to avoid false positives on other `< /dev/null` uses.
+        val launcherLine = sh.lines().firstOrNull { it.contains("\"\$launcher\" install devrig") }
+            ?: error("install.sh must invoke \"\$launcher\" install devrig")
+        assertTrue(
+            "< /dev/null" in launcherLine,
+            "install.sh must redirect stdin from /dev/null on the devrig launcher line: '$launcherLine'",
+        )
+    }
+
+    @Test
     fun `rendered install scripts are ASCII-only`() {
         val scripts = renderInstallerScripts(jdkScriptTable(fullModel()), devrig, "1.2.3")
 

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/InstallCommand.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/InstallCommand.kt
@@ -24,6 +24,15 @@ const val INSTALL_CHECK_DRIFT_EXIT_CODE = 1
  * on every start), here driven from the install script's EXPLICIT parameters: `--install-script` (the
  * unpacked install-tree launcher the wrapper execs) and `--jdk-home` (pinned as `DEVRIG_JAVA_HOME`). It
  * does ONLY that — no agent registration. Quiet: best-effort registration, one confirmation line.
+ *
+ * **Non-interactive contract.** This command is invoked by the generated bootstrap installers
+ * (`install.sh` / `install.ps1`) which are themselves piped from `curl | sh` / `irm | iex`. Those
+ * installers hand it an already-CLOSED stdin (`< /dev/null` on POSIX, `$null |` on PowerShell) precisely
+ * because the bootstrap's own stdin is a pipe still open to the outer shell — a subprocess that read it
+ * would hang forever with no user recourse. So this code path (and everything it calls) MUST be fully
+ * non-interactive: NO stdin reads, NO prompts, NO `Console.readLine` / `readln`. Every input arrives as
+ * an explicit flag; any missing input must fail fast (return non-zero) rather than block waiting for a
+ * user who cannot answer.
  */
 fun DevrigServices.runInstallDevrigCommand(command: DevrigCommand.DevrigCommandInstallDevrig): Int {
     val installScript = command.installScript


### PR DESCRIPTION
## What

Close stdin on the `devrig install devrig` handoff in both generated bootstrap installers, and document the non-interactive contract on the command it invokes.

## Why

When the installer is bootstrapped via `curl | sh` (POSIX) or `irm | iex` (PowerShell), the parent shell's stdin is a **pipe still open to the outer shell** that ran `curl`/`irm`. Handing that open stdin down to the `devrig install devrig` subprocess means any stdin read — or an interactive prompt — inside devrig would **block forever with no user recourse**. This is part 2 of #273 (the arch-detect crash is part 1).

## Changes

- **`install.sh`** — redirect the launcher invocation's stdin from `/dev/null`.
- **`install.ps1`** — pipe `$null` into the launcher invocation.
- **`runInstallDevrigCommand`** — document the contract: this path is invoked with an already-closed stdin, so **no stdin reads / prompts are permitted**; missing input must fail fast (non-zero), never block.
- **Unit tests** — pin both stdin closes on the actual launcher line.

## Contract

`devrig install devrig` is contractually **non-interactive**: no `readln`/`Console.readLine`/prompts on that path. Every input arrives as an explicit flag (`--install-script`, `--jdk-home`); anything missing fails fast rather than waiting for a user who cannot answer.

This is the foundational PR — the PowerShell arch/progress fixes (#273/#274, PR #281) build on top.