### PR TITLE
installer: correct the stdin-close rationale for PowerShell (follow-up to #282)

### DIFF
--- a/installer-gen/src/main/resources/templates/install.ps1.tmpl
+++ b/installer-gen/src/main/resources/templates/install.ps1.tmpl
@@ -145,11 +145,12 @@ if (-not (Test-Path (Join-Path $jdkHome 'bin\java.exe'))) {
 # registers itself. JAVA_HOME is set only so the unpacked devrig runs under the bundled JDK right now.
 Write-Log "registering devrig (devrig install devrig)..."
 $env:JAVA_HOME = $jdkHome
-# Pipe $null so the launcher inherits an already-closed stdin: when this installer is bootstrapped
-# via `irm | iex`, the parent PS reads stdin from a pipe still open to the shell that ran `irm`.
-# A devrig subprocess that read stdin (or waited on a Console.ReadLine style prompt) would hang
-# forever with no user recourse. `$null |` gives it an empty input stream so the first read returns
-# EOF immediately - `devrig install devrig` is contractually non-interactive (see runInstallDevrigCommand).
+# Pipe $null so the launcher's child process gets an empty stdin that reads EOF immediately. `irm | iex`
+# is a PowerShell OBJECT pipeline (not a POSIX stdin pipe), so the script runs inside the caller's PS
+# host and a native child would otherwise inherit THAT host's stdin handle - an interactive console, or
+# in a non-interactive/redirected host an open stream. Either way a devrig subprocess that read stdin (or
+# waited on a Console.ReadLine style prompt) could block with no user recourse. `$null |` removes that
+# risk - `devrig install devrig` is contractually non-interactive (see runInstallDevrigCommand).
 $null | & $launcher install devrig "--install-script=$launcher" "--jdk-home=$jdkHome"
 if ($LASTEXITCODE -ne 0) { Fail "'devrig install devrig' failed (exit $LASTEXITCODE) - the launcher could not register itself" }
 

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/InstallCommand.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/InstallCommand.kt
@@ -26,13 +26,14 @@ const val INSTALL_CHECK_DRIFT_EXIT_CODE = 1
  * does ONLY that — no agent registration. Quiet: best-effort registration, one confirmation line.
  *
  * **Non-interactive contract.** This command is invoked by the generated bootstrap installers
- * (`install.sh` / `install.ps1`) which are themselves piped from `curl | sh` / `irm | iex`. Those
- * installers hand it an already-CLOSED stdin (`< /dev/null` on POSIX, `$null |` on PowerShell) precisely
- * because the bootstrap's own stdin is a pipe still open to the outer shell — a subprocess that read it
- * would hang forever with no user recourse. So this code path (and everything it calls) MUST be fully
- * non-interactive: NO stdin reads, NO prompts, NO `Console.readLine` / `readln`. Every input arrives as
- * an explicit flag; any missing input must fail fast (return non-zero) rather than block waiting for a
- * user who cannot answer.
+ * (`install.sh` / `install.ps1`), typically run as `curl | sh` / `irm | iex`. Those installers hand it a
+ * stdin that reads EOF immediately (`< /dev/null` on POSIX, `$null |` on PowerShell) so it can never
+ * inherit a live input stream: on POSIX the `sh` process's own stdin is the pipe from `curl`, and on
+ * Windows the child would otherwise inherit the caller's PowerShell host stdin. In either shape a
+ * subprocess that read stdin — or waited on a prompt — could block with no user recourse. So this code
+ * path (and everything it calls) MUST be fully non-interactive: NO stdin reads, NO prompts, NO
+ * `Console.readLine` / `readln`. Every input arrives as an explicit flag; any missing input must fail
+ * fast (return non-zero) rather than block waiting for a user who cannot answer.
  */
 fun DevrigServices.runInstallDevrigCommand(command: DevrigCommand.DevrigCommandInstallDevrig): Int {
     val installScript = command.installScript


### PR DESCRIPTION
Follow-up to #282 (merged). A codex peer review flagged that the WHY comments describe PowerShell's `irm | iex` as if it were a POSIX `curl | sh` stdin pipe — it isn't; `irm | iex` is a PowerShell **object** pipeline.

- The `$null |` defense is still correct and useful: the script runs inside the caller's PS host, and a launched native child would otherwise inherit **that host's** stdin handle (an interactive console, or an open stream in a non-interactive host).
- Only the comment in `install.ps1.tmpl` and the `runInstallDevrigCommand` KDoc are reworded for accuracy. **No behavior change.**

Landed separately because #282 merged before the review completed.