### PR TITLE
Issue 251 arena project name

### DIFF
--- a/test-experiments/src/test/kotlin/com/jonnyzzz/mcpSteroid/integration/arena/ArenaOutputParsing.kt
+++ b/test-experiments/src/test/kotlin/com/jonnyzzz/mcpSteroid/integration/arena/ArenaOutputParsing.kt
@@ -1,0 +1,118 @@
+/* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
+package com.jonnyzzz.mcpSteroid.integration.arena
+
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.booleanOrNull
+import kotlinx.serialization.json.contentOrNull
+
+/** The plugin's project-resolution error prefix (ProjectScopedToolHandler.resolveProject). */
+private const val PROJECT_NOT_FOUND_PREFIX = "Project not found: \""
+
+/** Non-throwing string accessor: null unless this element is a JSON string/primitive. */
+private fun JsonElement?.stringOrNull(): String? = (this as? JsonPrimitive)?.contentOrNull
+
+/** Non-throwing boolean accessor: null unless this element is a JSON boolean primitive. */
+private fun JsonElement?.boolOrNull(): Boolean? = (this as? JsonPrimitive)?.booleanOrNull
+
+/**
+ * Extract text from a `content`/result field that may be EITHER a bare JSON string OR a JSON array of
+ * `{type,text}` content blocks (the valid raw Anthropic content-block shape). Non-throwing: safe casts
+ * only, so an unexpected shape yields "" rather than crashing the arena run.
+ */
+private fun textOf(el: JsonElement?): String =
+    (el as? JsonPrimitive)?.contentOrNull
+        ?: (el as? JsonArray)?.joinToString("\n") { (it as? JsonObject)?.get("text").stringOrNull() ?: "" }
+        ?: ""
+
+/**
+ * True when the agent's raw NDJSON contains a `steroid_execute_code` tool RESULT that failed with the
+ * plugin's project-resolution error. Structural on purpose:
+ *  - reads the raw NDJSON (never the output-filtered prose, which echoes the prompt and fetched articles);
+ *  - normalizes the wrapping `ERROR:` / `Error:` prefixes before an EXACT prefix match, so it matches the
+ *    real payload `ERROR: Project not found: "…"` (and the doubled `Error: ERROR: …` sibling field);
+ *  - attributes the error to `steroid_execute_code` via a tool-call-id -> tool-name map, because the
+ *    Claude/Gemini error result carries only `tool_use_id`/`tool_id`, no tool name. That mapping is what
+ *    prevents a false positive from a `steroid_fetch_resource` article body quoting the phrase.
+ *
+ * Robust by contract: every JSON access is a non-throwing safe cast (`as?`), so a malformed line or an
+ * unexpected content shape (e.g. `content` sent as an array/object per the raw Anthropic content-block
+ * format) simply is not flagged — the detector never throws out into `evaluate`/`runTest`.
+ */
+fun detectProjectResolutionFailure(rawNdjson: String): Boolean {
+    val idToTool = HashMap<String, String>()
+    // (toolCallId, errorText, selfToolName) — selfToolName set only when the result object itself
+    // carries the tool name (Codex); Claude/Gemini rely on the id map.
+    val candidates = mutableListOf<Triple<String?, String, String?>>()
+
+    rawNdjson.lineSequence().forEach { raw ->
+        if ('{' !in raw) return@forEach
+        val obj = (runCatching { Json.parseToJsonElement(raw) }.getOrNull() as? JsonObject) ?: return@forEach
+
+        // Claude: message.content[*] carries tool_use (calls) and tool_result (results) on separate lines.
+        ((obj["message"] as? JsonObject)?.get("content") as? JsonArray)
+            ?.forEach { entry ->
+                val item = entry as? JsonObject ?: return@forEach
+                when (item["type"].stringOrNull()) {
+                    "tool_use" -> {
+                        val id = item["id"].stringOrNull()
+                        val name = item["name"].stringOrNull()
+                        if (id != null && name != null) idToTool[id] = name
+                    }
+                    "tool_result" -> {
+                        if (item["is_error"].boolOrNull() == true) {
+                            val id = item["tool_use_id"].stringOrNull()
+                            val text = textOf(item["content"])
+                            candidates += Triple(id, text, null)
+                        }
+                    }
+                }
+            }
+
+        // Codex: item.completed with item.type == mcp_tool_call (id + tool + inline result).
+        (obj["item"] as? JsonObject)?.let { item ->
+            if (item["type"].stringOrNull() == "mcp_tool_call") {
+                val id = item["id"].stringOrNull()
+                val tool = item["tool"].stringOrNull() ?: item["name"].stringOrNull()
+                if (id != null && tool != null) idToTool[id] = tool
+                val resultText = ((item["result"] as? JsonObject)?.get("content") as? JsonArray)
+                    ?.joinToString("\n") { c -> (c as? JsonObject)?.get("text").stringOrNull() ?: "" }
+                if (!resultText.isNullOrBlank()) candidates += Triple(id, resultText, tool)
+            }
+        }
+
+        // Gemini: root object type=tool_use (call: id + tool_name) / type=tool_result (result: tool_id).
+        when (obj["type"].stringOrNull()) {
+            "tool_use" -> {
+                val id = obj["id"].stringOrNull()
+                val name = obj["tool_name"].stringOrNull()
+                if (id != null && name != null) idToTool[id] = name
+            }
+            "tool_result" -> {
+                if (obj["is_error"].boolOrNull() == true) {
+                    val id = obj["tool_id"].stringOrNull() ?: obj["tool_use_id"].stringOrNull()
+                    val text = textOf(obj["content"])
+                    candidates += Triple(id, text, null)
+                }
+            }
+        }
+    }
+
+    return candidates.any { (id, text, selfTool) ->
+        if (!stripErrorPrefixes(text).startsWith(PROJECT_NOT_FOUND_PREFIX)) return@any false
+        val toolName = selfTool ?: id?.let { idToTool[it] }
+        toolName != null && toolName.endsWith("steroid_execute_code")
+    }
+}
+
+/** Strip any leading run of case-insensitive `ERROR:` / `Error:` wrappers (the payload can be doubled). */
+private fun stripErrorPrefixes(text: String): String {
+    var s = text.trimStart()
+    while (s.length >= 6 && s.substring(0, 6).equals("error:", ignoreCase = true)) {
+        s = s.substring(6).trimStart()
+    }
+    return s
+}

--- a/test-experiments/src/test/kotlin/com/jonnyzzz/mcpSteroid/integration/arena/ArenaOutputParsing.kt
+++ b/test-experiments/src/test/kotlin/com/jonnyzzz/mcpSteroid/integration/arena/ArenaOutputParsing.kt
@@ -4,115 +4,219 @@ package com.jonnyzzz.mcpSteroid.integration.arena
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonNull
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.booleanOrNull
 import kotlinx.serialization.json.contentOrNull
 
-/** The plugin's project-resolution error prefix (ProjectScopedToolHandler.resolveProject). */
 private const val PROJECT_NOT_FOUND_PREFIX = "Project not found: \""
 
-/** Non-throwing string accessor: null unless this element is a JSON string/primitive. */
-private fun JsonElement?.stringOrNull(): String? = (this as? JsonPrimitive)?.contentOrNull
+/** One normalized steroid_execute_code result, independent of the agent CLI that emitted it. */
+data class ExecuteCodeResult(
+    val callId: String,
+    val isError: Boolean,
+    val text: String,
+)
 
-/** Non-throwing boolean accessor: null unless this element is a JSON boolean primitive. */
-private fun JsonElement?.boolOrNull(): Boolean? = (this as? JsonPrimitive)?.booleanOrNull
+/** Structural MCP facts extracted from an agent's raw NDJSON transcript. */
+data class AgentTranscript(
+    val executeCodeCallIds: List<String>,
+    val executeCodeResults: List<ExecuteCodeResult>,
+) {
+    val usedMcpSteroid: Boolean
+        get() = executeCodeCallIds.isNotEmpty()
+
+    val successfulMcpExecution: Boolean
+        get() = executeCodeResults.any { !it.isError }
+}
+
+enum class ProjectResolutionStatus {
+    CLEAN,
+    RECOVERED,
+    INITIAL_FAILURE,
+    UNRECOVERED_FAILURE,
+    ;
+
+    val shouldFailRun: Boolean
+        get() = this == INITIAL_FAILURE || this == UNRECOVERED_FAILURE
+}
+
+private data class ResultCandidate(
+    val sequence: Int,
+    val callId: String,
+    val selfToolName: String?,
+    val isError: Boolean,
+    val text: String,
+)
 
 /**
- * Extract text from a `content`/result field that may be EITHER a bare JSON string OR a JSON array of
- * `{type,text}` content blocks (the valid raw Anthropic content-block shape). Non-throwing: safe casts
- * only, so an unexpected shape yields "" rather than crashing the arena run.
+ * Normalize Claude Code, Codex, and Gemini raw NDJSON into execute-code calls/results.
+ * Tool-result attribution is by call id, so an article body returned by steroid_fetch_resource cannot
+ * masquerade as an execute-code failure merely because it quotes "Project not found".
  */
-private fun textOf(el: JsonElement?): String =
-    (el as? JsonPrimitive)?.contentOrNull
-        ?: (el as? JsonArray)?.joinToString("\n") { (it as? JsonObject)?.get("text").stringOrNull() ?: "" }
-        ?: ""
+fun decodeAgentTranscript(rawNdjson: String): AgentTranscript {
+    val idToToolName = LinkedHashMap<String, String>()
+    val executeCodeCallIds = mutableListOf<String>()
+    val resultCandidates = mutableListOf<ResultCandidate>()
+    var sequence = 0
 
-/**
- * True when the agent's raw NDJSON contains a `steroid_execute_code` tool RESULT that failed with the
- * plugin's project-resolution error. Structural on purpose:
- *  - reads the raw NDJSON (never the output-filtered prose, which echoes the prompt and fetched articles);
- *  - normalizes the wrapping `ERROR:` / `Error:` prefixes before an EXACT prefix match, so it matches the
- *    real payload `ERROR: Project not found: "…"` (and the doubled `Error: ERROR: …` sibling field);
- *  - attributes the error to `steroid_execute_code` via a tool-call-id -> tool-name map, because the
- *    Claude/Gemini error result carries only `tool_use_id`/`tool_id`, no tool name. That mapping is what
- *    prevents a false positive from a `steroid_fetch_resource` article body quoting the phrase.
- *
- * Robust by contract: every JSON access is a non-throwing safe cast (`as?`), so a malformed line or an
- * unexpected content shape (e.g. `content` sent as an array/object per the raw Anthropic content-block
- * format) simply is not flagged — the detector never throws out into `evaluate`/`runTest`.
- */
-fun detectProjectResolutionFailure(rawNdjson: String): Boolean {
-    val idToTool = HashMap<String, String>()
-    // (toolCallId, errorText, selfToolName) — selfToolName set only when the result object itself
-    // carries the tool name (Codex); Claude/Gemini rely on the id map.
-    val candidates = mutableListOf<Triple<String?, String, String?>>()
+    fun recordCall(callId: String?, toolName: String?) {
+        if (callId == null || toolName == null) return
+        idToToolName[callId] = toolName
+        if (toolName.endsWith("steroid_execute_code") && callId !in executeCodeCallIds) {
+            executeCodeCallIds += callId
+        }
+    }
 
-    rawNdjson.lineSequence().forEach { raw ->
-        if ('{' !in raw) return@forEach
-        val obj = (runCatching { Json.parseToJsonElement(raw) }.getOrNull() as? JsonObject) ?: return@forEach
+    fun recordResult(callId: String?, selfToolName: String?, isError: Boolean?, text: String) {
+        if (callId == null || isError == null) return
+        resultCandidates += ResultCandidate(sequence++, callId, selfToolName, isError, text)
+    }
 
-        // Claude: message.content[*] carries tool_use (calls) and tool_result (results) on separate lines.
+    rawNdjson.lineSequence().forEach lines@{ raw ->
+        if ('{' !in raw) return@lines
+        val obj = (runCatching { Json.parseToJsonElement(raw) }.getOrNull() as? JsonObject)
+            ?: return@lines
+
+        // Claude Code: message.content[*] tool_use / tool_result objects.
         ((obj["message"] as? JsonObject)?.get("content") as? JsonArray)
-            ?.forEach { entry ->
-                val item = entry as? JsonObject ?: return@forEach
+            ?.forEach entries@{ entry ->
+                val item = entry as? JsonObject ?: return@entries
                 when (item["type"].stringOrNull()) {
-                    "tool_use" -> {
-                        val id = item["id"].stringOrNull()
-                        val name = item["name"].stringOrNull()
-                        if (id != null && name != null) idToTool[id] = name
-                    }
-                    "tool_result" -> {
-                        if (item["is_error"].boolOrNull() == true) {
-                            val id = item["tool_use_id"].stringOrNull()
-                            val text = textOf(item["content"])
-                            candidates += Triple(id, text, null)
-                        }
-                    }
+                    "tool_use" -> recordCall(
+                        callId = item["id"].stringOrNull(),
+                        toolName = item["name"].stringOrNull(),
+                    )
+
+                    "tool_result" -> recordResult(
+                        callId = item["tool_use_id"].stringOrNull(),
+                        selfToolName = null,
+                        // Claude omits is_error on successful tool results; only failures carry true.
+                        isError = item["is_error"].boolOrNull() ?: false,
+                        text = textOf(item["content"]),
+                    )
                 }
             }
 
-        // Codex: item.completed with item.type == mcp_tool_call (id + tool + inline result).
+        // Codex: item.started / item.completed containing an mcp_tool_call.
         (obj["item"] as? JsonObject)?.let { item ->
             if (item["type"].stringOrNull() == "mcp_tool_call") {
-                val id = item["id"].stringOrNull()
-                val tool = item["tool"].stringOrNull() ?: item["name"].stringOrNull()
-                if (id != null && tool != null) idToTool[id] = tool
-                val resultText = ((item["result"] as? JsonObject)?.get("content") as? JsonArray)
-                    ?.joinToString("\n") { c -> (c as? JsonObject)?.get("text").stringOrNull() ?: "" }
-                if (!resultText.isNullOrBlank()) candidates += Triple(id, resultText, tool)
+                val callId = item["id"].stringOrNull()
+                val toolName = item["tool"].stringOrNull() ?: item["name"].stringOrNull()
+                recordCall(callId, toolName)
+
+                if (obj["type"].stringOrNull() == "item.completed") {
+                    val status = item["status"].stringOrNull()?.lowercase()
+                    val hasErrorObject = item["error"] != null && item["error"] !is JsonNull
+                    val isError = when {
+                        hasErrorObject || status == "failed" || status == "error" -> true
+                        status == "completed" || status == "success" -> false
+                        else -> null
+                    }
+                    val text = textOf((item["result"] as? JsonObject)?.get("content"))
+                        .ifBlank { textOf(item["error"]) }
+                    recordResult(callId, toolName, isError, text)
+                }
             }
         }
 
-        // Gemini: root object type=tool_use (call: id + tool_name) / type=tool_result (result: tool_id).
+        // Gemini: root objects using the real stream-json fields tool_id/status/output.
         when (obj["type"].stringOrNull()) {
-            "tool_use" -> {
-                val id = obj["id"].stringOrNull()
-                val name = obj["tool_name"].stringOrNull()
-                if (id != null && name != null) idToTool[id] = name
-            }
+            "tool_use" -> recordCall(
+                callId = obj["tool_id"].stringOrNull(),
+                toolName = obj["tool_name"].stringOrNull(),
+            )
+
             "tool_result" -> {
-                if (obj["is_error"].boolOrNull() == true) {
-                    val id = obj["tool_id"].stringOrNull() ?: obj["tool_use_id"].stringOrNull()
-                    val text = textOf(obj["content"])
-                    candidates += Triple(id, text, null)
+                val status = obj["status"].stringOrNull()?.lowercase()
+                val isError = when (status) {
+                    "error", "failed" -> true
+                    "success", "completed" -> false
+                    else -> null
                 }
+                recordResult(
+                    callId = obj["tool_id"].stringOrNull(),
+                    selfToolName = obj["tool_name"].stringOrNull(),
+                    isError = isError,
+                    text = textOf(obj["output"]),
+                )
             }
         }
     }
 
-    return candidates.any { (id, text, selfTool) ->
-        if (!stripErrorPrefixes(text).startsWith(PROJECT_NOT_FOUND_PREFIX)) return@any false
-        val toolName = selfTool ?: id?.let { idToTool[it] }
-        toolName != null && toolName.endsWith("steroid_execute_code")
+    val results = resultCandidates
+        .sortedBy { it.sequence }
+        .mapNotNull { candidate ->
+            val toolName = candidate.selfToolName ?: idToToolName[candidate.callId]
+            if (toolName?.endsWith("steroid_execute_code") != true) return@mapNotNull null
+            ExecuteCodeResult(candidate.callId, candidate.isError, candidate.text)
+        }
+
+    return AgentTranscript(
+        executeCodeCallIds = executeCodeCallIds,
+        executeCodeResults = results,
+    )
+}
+
+/**
+ * The first mandatory execute_code must resolve immediately (#251). Later project reloads may invalidate
+ * the key; that is accepted only when the agent re-lists projects and produces a later successful result.
+ */
+fun AgentTranscript.projectResolutionStatus(): ProjectResolutionStatus {
+    val firstCallId = executeCodeCallIds.firstOrNull()
+    val firstResult = firstCallId?.let { id -> executeCodeResults.firstOrNull { it.callId == id } }
+    if (firstResult?.isProjectResolutionFailure() == true) {
+        return ProjectResolutionStatus.INITIAL_FAILURE
+    }
+
+    val lastFailureIndex = executeCodeResults.indexOfLast { it.isProjectResolutionFailure() }
+    if (lastFailureIndex < 0) return ProjectResolutionStatus.CLEAN
+
+    return if (executeCodeResults.drop(lastFailureIndex + 1).any { !it.isError }) {
+        ProjectResolutionStatus.RECOVERED
+    } else {
+        ProjectResolutionStatus.UNRECOVERED_FAILURE
     }
 }
 
-/** Strip any leading run of case-insensitive `ERROR:` / `Error:` wrappers (the payload can be doubled). */
-private fun stripErrorPrefixes(text: String): String {
-    var s = text.trimStart()
-    while (s.length >= 6 && s.substring(0, 6).equals("error:", ignoreCase = true)) {
-        s = s.substring(6).trimStart()
+/**
+ * The prompt's mandatory first execute-code recipe prints `Project: ..., base: ...`. Require that first
+ * successful result to name the arena deployment path so a different but valid open project cannot make
+ * the MCP arm look healthy.
+ */
+fun AgentTranscript.firstExecutionTargetsProject(expectedProjectDir: String): Boolean {
+    val firstCallId = executeCodeCallIds.firstOrNull() ?: return false
+    val firstResult = executeCodeResults.firstOrNull { it.callId == firstCallId } ?: return false
+    if (firstResult.isError) return false
+
+    val expectedPath = expectedProjectDir.trimEnd('/')
+    return firstResult.text.lineSequence().any { line ->
+        line.substringAfter("base:", missingDelimiterValue = "").trim().trimEnd('/') == expectedPath
     }
-    return s
+}
+
+private fun ExecuteCodeResult.isProjectResolutionFailure(): Boolean =
+    isError && stripErrorPrefixes(text).startsWith(PROJECT_NOT_FOUND_PREFIX)
+
+private fun JsonElement?.stringOrNull(): String? = (this as? JsonPrimitive)?.contentOrNull
+
+private fun JsonElement?.boolOrNull(): Boolean? = (this as? JsonPrimitive)?.booleanOrNull
+
+private fun textOf(element: JsonElement?): String = when (element) {
+    is JsonPrimitive -> element.contentOrNull.orEmpty()
+    is JsonArray -> element.joinToString("\n") { textOf(it) }
+    is JsonObject -> sequenceOf("text", "output", "message", "content")
+        .map { key -> textOf(element[key]) }
+        .firstOrNull { it.isNotBlank() }
+        .orEmpty()
+    else -> ""
+}
+
+private fun stripErrorPrefixes(text: String): String {
+    var value = text.trimStart()
+    while (value.length >= 6 && value.substring(0, 6).equals("error:", ignoreCase = true)) {
+        value = value.substring(6).trimStart()
+    }
+    return value
 }

--- a/test-experiments/src/test/kotlin/com/jonnyzzz/mcpSteroid/integration/arena/ArenaOutputParsing.kt
+++ b/test-experiments/src/test/kotlin/com/jonnyzzz/mcpSteroid/integration/arena/ArenaOutputParsing.kt
@@ -12,23 +12,57 @@ import kotlinx.serialization.json.contentOrNull
 
 private const val PROJECT_NOT_FOUND_PREFIX = "Project not found: \""
 
+/**
+ * Marker the mandatory first execute-code recipe prints its open-project base path after
+ * (`Project: <name>, base: <path>`). The producer is [ArenaTestRunner.buildPrompt]'s first-call recipe
+ * and the consumer is [AgentTranscript.firstExecutionTargetsProject]; both sides read this constant so
+ * the printed format and the parser cannot silently drift.
+ */
+const val PROJECT_BASE_PATH_MARKER = "base:"
+
 /** One normalized steroid_execute_code result, independent of the agent CLI that emitted it. */
 data class ExecuteCodeResult(
-    val callId: String,
     val isError: Boolean,
     val text: String,
 )
 
+/** One steroid_execute_code call and its result, when the transcript carried one. */
+data class ExecuteCodeCall(
+    val callId: String,
+    val result: ExecuteCodeResult?,
+)
+
 /** Structural MCP facts extracted from an agent's raw NDJSON transcript. */
 data class AgentTranscript(
-    val executeCodeCallIds: List<String>,
-    val executeCodeResults: List<ExecuteCodeResult>,
+    val executeCodeCalls: List<ExecuteCodeCall>,
 ) {
     val usedMcpSteroid: Boolean
-        get() = executeCodeCallIds.isNotEmpty()
+        get() = executeCodeCalls.isNotEmpty()
 
     val successfulMcpExecution: Boolean
-        get() = executeCodeResults.any { !it.isError }
+        get() = executeCodeCalls.any { it.result?.isError == false }
+
+    /**
+     * The first mandatory execute_code must resolve immediately (#251). Later project reloads may
+     * invalidate the key; that is accepted only when the agent re-lists projects and produces a later
+     * successful result.
+     */
+    val projectResolutionStatus: ProjectResolutionStatus
+        get() {
+            if (executeCodeCalls.firstOrNull()?.result?.isProjectResolutionFailure() == true) {
+                return ProjectResolutionStatus.INITIAL_FAILURE
+            }
+
+            val results = executeCodeCalls.mapNotNull { it.result }
+            val lastFailureIndex = results.indexOfLast { it.isProjectResolutionFailure() }
+            if (lastFailureIndex < 0) return ProjectResolutionStatus.CLEAN
+
+            return if (results.drop(lastFailureIndex + 1).any { !it.isError }) {
+                ProjectResolutionStatus.RECOVERED
+            } else {
+                ProjectResolutionStatus.UNRECOVERED_FAILURE
+            }
+        }
 }
 
 enum class ProjectResolutionStatus {
@@ -36,10 +70,6 @@ enum class ProjectResolutionStatus {
     RECOVERED,
     INITIAL_FAILURE,
     UNRECOVERED_FAILURE,
-    ;
-
-    val shouldFailRun: Boolean
-        get() = this == INITIAL_FAILURE || this == UNRECOVERED_FAILURE
 }
 
 private data class ResultCandidate(
@@ -145,39 +175,20 @@ fun decodeAgentTranscript(rawNdjson: String): AgentTranscript {
         }
     }
 
-    val results = resultCandidates
+    val resultsByCallId = LinkedHashMap<String, ExecuteCodeResult>()
+    resultCandidates
         .sortedBy { it.sequence }
-        .mapNotNull { candidate ->
+        .forEach { candidate ->
             val toolName = candidate.selfToolName ?: idToToolName[candidate.callId]
-            if (toolName?.endsWith("steroid_execute_code") != true) return@mapNotNull null
-            ExecuteCodeResult(candidate.callId, candidate.isError, candidate.text)
+            if (toolName?.endsWith("steroid_execute_code") != true) return@forEach
+            resultsByCallId.putIfAbsent(candidate.callId, ExecuteCodeResult(candidate.isError, candidate.text))
         }
 
     return AgentTranscript(
-        executeCodeCallIds = executeCodeCallIds,
-        executeCodeResults = results,
+        executeCodeCalls = executeCodeCallIds.map { callId ->
+            ExecuteCodeCall(callId, resultsByCallId[callId])
+        },
     )
-}
-
-/**
- * The first mandatory execute_code must resolve immediately (#251). Later project reloads may invalidate
- * the key; that is accepted only when the agent re-lists projects and produces a later successful result.
- */
-fun AgentTranscript.projectResolutionStatus(): ProjectResolutionStatus {
-    val firstCallId = executeCodeCallIds.firstOrNull()
-    val firstResult = firstCallId?.let { id -> executeCodeResults.firstOrNull { it.callId == id } }
-    if (firstResult?.isProjectResolutionFailure() == true) {
-        return ProjectResolutionStatus.INITIAL_FAILURE
-    }
-
-    val lastFailureIndex = executeCodeResults.indexOfLast { it.isProjectResolutionFailure() }
-    if (lastFailureIndex < 0) return ProjectResolutionStatus.CLEAN
-
-    return if (executeCodeResults.drop(lastFailureIndex + 1).any { !it.isError }) {
-        ProjectResolutionStatus.RECOVERED
-    } else {
-        ProjectResolutionStatus.UNRECOVERED_FAILURE
-    }
 }
 
 /**
@@ -186,13 +197,12 @@ fun AgentTranscript.projectResolutionStatus(): ProjectResolutionStatus {
  * the MCP arm look healthy.
  */
 fun AgentTranscript.firstExecutionTargetsProject(expectedProjectDir: String): Boolean {
-    val firstCallId = executeCodeCallIds.firstOrNull() ?: return false
-    val firstResult = executeCodeResults.firstOrNull { it.callId == firstCallId } ?: return false
+    val firstResult = executeCodeCalls.firstOrNull()?.result ?: return false
     if (firstResult.isError) return false
 
     val expectedPath = expectedProjectDir.trimEnd('/')
     return firstResult.text.lineSequence().any { line ->
-        line.substringAfter("base:", missingDelimiterValue = "").trim().trimEnd('/') == expectedPath
+        line.substringAfter(PROJECT_BASE_PATH_MARKER, missingDelimiterValue = "").trim().trimEnd('/') == expectedPath
     }
 }
 

--- a/test-experiments/src/test/kotlin/com/jonnyzzz/mcpSteroid/integration/arena/ArenaProjectResolutionDetectorTest.kt
+++ b/test-experiments/src/test/kotlin/com/jonnyzzz/mcpSteroid/integration/arena/ArenaProjectResolutionDetectorTest.kt
@@ -1,88 +1,258 @@
 /* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
 package com.jonnyzzz.mcpSteroid.integration.arena
 
+import kotlinx.serialization.json.addJsonObject
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import kotlinx.serialization.json.putJsonArray
+import kotlinx.serialization.json.putJsonObject
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 
 class ArenaProjectResolutionDetectorTest {
 
-    // Real captured Claude shape (…/run-20260708-…-petclinic-27-claude-mcp/agent-claude-code-1-raw.ndjson:5):
-    // an ERROR:-wrapped resolution failure whose tool_result references the steroid_execute_code call id.
-    private val claudeCall =
-        """{"type":"assistant","message":{"role":"assistant","content":[{"type":"tool_use","id":"toolu_01Woi","name":"mcp__mcp-steroid__steroid_execute_code","input":{"code":"println(1)"}}]}}"""
-    private val claudeErrorResult =
-        """{"type":"user","message":{"role":"user","content":[{"type":"tool_result","content":"ERROR: Project not found: \"project-home\". Available project_name values: demo-project-ki3y1pmc","is_error":true,"tool_use_id":"toolu_01Woi"}]}}"""
-
     @Test
-    fun `flags a Project not found error attributed to steroid_execute_code (claude)`() {
-        val ndjson = "$claudeCall\n$claudeErrorResult\n"
-        assertTrue(detectProjectResolutionFailure(ndjson))
+    fun `claude first resolution failure remains fatal after a successful retry`() {
+        val transcript = decode(
+            claudeCall("c1"),
+            claudeResult("c1", isError = true, projectNotFound("project-home")),
+            claudeCall("c2"),
+            claudeResult("c2", isError = false, "execution_id: eid_ok"),
+        )
+
+        assertEquals(ProjectResolutionStatus.INITIAL_FAILURE, transcript.projectResolutionStatus())
+        assertTrue(transcript.usedMcpSteroid)
+        assertTrue(transcript.successfulMcpExecution)
     }
 
     @Test
-    fun `ignores the phrase when it comes from a steroid_fetch_resource article body`() {
-        val fetchCall =
-            """{"type":"assistant","message":{"role":"assistant","content":[{"type":"tool_use","id":"toolu_FETCH","name":"mcp__mcp-steroid__steroid_fetch_resource","input":{"uri":"mcp-steroid://x"}}]}}"""
-        // Article body quotes the phrase but is NOT an error and maps to fetch_resource, not execute_code.
-        val fetchResult =
-            """{"type":"user","message":{"role":"user","content":[{"type":"tool_result","content":"the error reads: Project not found: \"foo\"","is_error":false,"tool_use_id":"toolu_FETCH"}]}}"""
-        val ndjson = "$fetchCall\n$fetchResult\n"
-        assertFalse(detectProjectResolutionFailure(ndjson))
+    fun `later resolution failure followed by success is recovered`() {
+        val transcript = decode(
+            claudeCall("c1"),
+            claudeResult("c1", isError = false, "execution_id: eid_1"),
+            claudeCall("c2"),
+            claudeResult("c2", isError = true, projectNotFound("old-key")),
+            claudeCall("c3"),
+            claudeResult("c3", isError = false, "execution_id: eid_3"),
+        )
+
+        assertEquals(ProjectResolutionStatus.RECOVERED, transcript.projectResolutionStatus())
+        assertFalse(transcript.projectResolutionStatus().shouldFailRun)
     }
 
     @Test
-    fun `does not flag an is_error fetch_resource result that matches the prefix (attribution)`() {
-        // A steroid_fetch_resource CALL followed by an is_error:true result that DOES match the
-        // "Project not found" prefix. This exercises the id->tool-name attribution directly: the
-        // result passes the is_error gate and the prefix match, so it is only rejected because the
-        // tool_use_id maps to fetch_resource, not execute_code. Deleting the endsWith(execute_code)
-        // check makes THIS test fail.
-        val fetchCall =
-            """{"type":"assistant","message":{"role":"assistant","content":[{"type":"tool_use","id":"toolu_FETCH2","name":"mcp__mcp-steroid__steroid_fetch_resource","input":{"uri":"mcp-steroid://x"}}]}}"""
-        val fetchErrorResult =
-            """{"type":"user","message":{"role":"user","content":[{"type":"tool_result","content":"ERROR: Project not found: \"x\". Available project_name values: foo-abc","is_error":true,"tool_use_id":"toolu_FETCH2"}]}}"""
-        assertFalse(detectProjectResolutionFailure("$fetchCall\n$fetchErrorResult\n"))
+    fun `later resolution failure without a successful retry is fatal`() {
+        val transcript = decode(
+            claudeCall("c1"),
+            claudeResult("c1", isError = false, "execution_id: eid_1"),
+            claudeCall("c2"),
+            claudeResult("c2", isError = true, projectNotFound("old-key")),
+        )
+
+        assertEquals(ProjectResolutionStatus.UNRECOVERED_FAILURE, transcript.projectResolutionStatus())
+        assertTrue(transcript.projectResolutionStatus().shouldFailRun)
     }
 
     @Test
-    fun `flags a doubled Error prefix attributed to steroid_execute_code`() {
-        // The plugin can surface the payload with a doubled wrapper (Error: ERROR: ...);
-        // stripErrorPrefixes must peel both before the exact-prefix match.
-        val doubledResult =
-            """{"type":"user","message":{"role":"user","content":[{"type":"tool_result","content":"Error: ERROR: Project not found: \"project-home\". Available project_name values: demo-project-ki3y1pmc","is_error":true,"tool_use_id":"toolu_01Woi"}]}}"""
-        assertTrue(detectProjectResolutionFailure("$claudeCall\n$doubledResult\n"))
+    fun `gemini uses real tool_id status output fields`() {
+        val transcript = decode(
+            geminiCall("g1"),
+            geminiResult("g1", status = "error", output = projectNotFound("project-home")),
+        )
+
+        assertEquals(ProjectResolutionStatus.INITIAL_FAILURE, transcript.projectResolutionStatus())
+        assertEquals(
+            ExecuteCodeResult("g1", isError = true, text = projectNotFound("project-home")),
+            transcript.executeCodeResults.single(),
+        )
     }
 
     @Test
-    fun `flags a content-block-array error attributed to steroid_execute_code`() {
-        // Anthropic tool_result.content may arrive as a content-block ARRAY, not a bare string.
-        // textOf() must dig the text out of the array so the resolution failure is not silently missed.
-        val arrayErrorResult =
-            """{"type":"user","message":{"role":"user","content":[{"type":"tool_result","content":[{"type":"text","text":"ERROR: Project not found: \"project-home\". Available project_name values: demo-project-ki3y1pmc"}],"is_error":true,"tool_use_id":"toolu_01Woi"}]}}"""
-        assertTrue(detectProjectResolutionFailure("$claudeCall\n$arrayErrorResult\n"))
+    fun `codex failed result is normalized`() {
+        val transcript = decode(
+            codexResult("x1", status = "failed", text = projectNotFound("project-home")),
+        )
+
+        assertEquals(ProjectResolutionStatus.INITIAL_FAILURE, transcript.projectResolutionStatus())
+        assertTrue(transcript.executeCodeResults.single().isError)
     }
 
     @Test
-    fun `does not flag a clean run`() {
-        val okResult =
-            """{"type":"user","message":{"role":"user","content":[{"type":"tool_result","content":"Project: demo, base: /home/agent/project-home","is_error":false,"tool_use_id":"toolu_01Woi"}]}}"""
-        assertFalse(detectProjectResolutionFailure("$claudeCall\n$okResult\n"))
+    fun `successful codex output quoting Project not found is not an error`() {
+        val transcript = decode(
+            codexResult("x1", status = "completed", text = projectNotFound("quoted-example")),
+        )
+
+        assertEquals(ProjectResolutionStatus.CLEAN, transcript.projectResolutionStatus())
+        assertTrue(transcript.successfulMcpExecution)
     }
 
     @Test
-    fun `flags gemini-shaped resolution failure`() {
-        val call =
-            """{"type":"tool_use","id":"g1","tool_name":"mcp_mcp-steroid_steroid_execute_code","parameters":{"code":"x"}}"""
-        val err =
-            """{"type":"tool_result","tool_id":"g1","is_error":true,"content":"ERROR: Project not found: \"project-home\". Available project_name values: foo-abc"}"""
-        assertTrue(detectProjectResolutionFailure("$call\n$err\n"))
+    fun `fetch resource article body is not attributed to execute code`() {
+        val transcript = decode(
+            claudeCall("f1", toolName = "mcp__mcp-steroid__steroid_fetch_resource"),
+            claudeResult("f1", isError = true, projectNotFound("article-example")),
+        )
+
+        assertFalse(transcript.usedMcpSteroid)
+        assertTrue(transcript.executeCodeResults.isEmpty())
+        assertEquals(ProjectResolutionStatus.CLEAN, transcript.projectResolutionStatus())
     }
 
     @Test
-    fun `flags codex-shaped resolution failure`() {
-        val line =
-            """{"type":"item.completed","item":{"id":"item_5","type":"mcp_tool_call","server":"mcp-steroid","tool":"steroid_execute_code","result":{"content":[{"type":"text","text":"ERROR: Project not found: \"project-home\". Available project_name values: foo-abc"}]}}}"""
-        assertTrue(detectProjectResolutionFailure("$line\n"))
+    fun `claude content block array and doubled Error wrappers are normalized`() {
+        val transcript = decode(
+            claudeCall("c1"),
+            claudeResult(
+                callId = "c1",
+                isError = true,
+                text = "Error: ERROR: ${projectNotFound("project-home")}",
+                contentAsArray = true,
+            ),
+        )
+
+        assertEquals(ProjectResolutionStatus.INITIAL_FAILURE, transcript.projectResolutionStatus())
     }
+
+    @Test
+    fun `claude success without is_error is recorded as successful`() {
+        val transcript = decode(
+            claudeCall("c1"),
+            claudeResult(
+                callId = "c1",
+                isError = null,
+                text = "Project: task-project, base: /home/agent/project-home",
+            ),
+        )
+
+        assertTrue(transcript.successfulMcpExecution)
+        assertEquals(ProjectResolutionStatus.CLEAN, transcript.projectResolutionStatus())
+    }
+
+    @Test
+    fun `first execute code result must report the expected project base path`() {
+        val expectedProjectDir = "/home/agent/project-home"
+        val correctProject = decode(
+            claudeCall("correct"),
+            claudeResult(
+                callId = "correct",
+                isError = null,
+                text = "Project: task-project, base: $expectedProjectDir",
+            ),
+        )
+        val wrongProject = decode(
+            claudeCall("wrong"),
+            claudeResult(
+                callId = "wrong",
+                isError = null,
+                text = "Project: demo-project, base: /home/agent/demo-project",
+            ),
+        )
+
+        assertTrue(correctProject.firstExecutionTargetsProject(expectedProjectDir))
+        assertFalse(wrongProject.firstExecutionTargetsProject(expectedProjectDir))
+    }
+
+    @Test
+    fun `prose mention is not structural MCP usage`() {
+        val prose = buildJsonObject {
+            put("type", "message")
+            put("role", "assistant")
+            put("content", "I should call steroid_execute_code next")
+        }.toString()
+
+        val transcript = decode(prose)
+        assertFalse(transcript.usedMcpSteroid)
+        assertFalse(transcript.successfulMcpExecution)
+    }
+
+    private fun decode(vararg lines: String): AgentTranscript =
+        decodeAgentTranscript(lines.joinToString(separator = "\n", postfix = "\n"))
+
+    private fun claudeCall(
+        callId: String,
+        toolName: String = "mcp__mcp-steroid__steroid_execute_code",
+    ): String = buildJsonObject {
+        put("type", "assistant")
+        putJsonObject("message") {
+            put("role", "assistant")
+            putJsonArray("content") {
+                addJsonObject {
+                    put("type", "tool_use")
+                    put("id", callId)
+                    put("name", toolName)
+                    putJsonObject("input") { put("code", "println(1)") }
+                }
+            }
+        }
+    }.toString()
+
+    private fun claudeResult(
+        callId: String,
+        isError: Boolean?,
+        text: String,
+        contentAsArray: Boolean = false,
+    ): String = buildJsonObject {
+        put("type", "user")
+        putJsonObject("message") {
+            put("role", "user")
+            putJsonArray("content") {
+                addJsonObject {
+                    put("type", "tool_result")
+                    put("tool_use_id", callId)
+                    if (isError != null) put("is_error", isError)
+                    if (contentAsArray) {
+                        putJsonArray("content") {
+                            addJsonObject {
+                                put("type", "text")
+                                put("text", text)
+                            }
+                        }
+                    } else {
+                        put("content", text)
+                    }
+                }
+            }
+        }
+    }.toString()
+
+    private fun codexResult(callId: String, status: String, text: String): String = buildJsonObject {
+        put("type", "item.completed")
+        putJsonObject("item") {
+            put("id", callId)
+            put("type", "mcp_tool_call")
+            put("server", "mcp-steroid")
+            put("tool", "steroid_execute_code")
+            put("status", status)
+            putJsonObject("arguments") { put("code", "println(1)") }
+            putJsonObject("result") {
+                putJsonArray("content") {
+                    addJsonObject {
+                        put("type", "text")
+                        put("text", text)
+                    }
+                }
+            }
+        }
+    }.toString()
+
+    private fun geminiCall(callId: String): String = buildJsonObject {
+        put("type", "tool_use")
+        put("tool_name", "mcp_mcp-steroid_steroid_execute_code")
+        put("tool_id", callId)
+        putJsonObject("parameters") { put("code", "println(1)") }
+    }.toString()
+
+    private fun geminiResult(callId: String, status: String, output: String): String = buildJsonObject {
+        put("type", "tool_result")
+        put("tool_id", callId)
+        put("tool_name", "mcp_mcp-steroid_steroid_execute_code")
+        put("status", status)
+        put("output", output)
+    }.toString()
+
+    private fun projectNotFound(name: String): String =
+        "ERROR: Project not found: \"$name\". Available project_name values: project-abc12345"
 }

--- a/test-experiments/src/test/kotlin/com/jonnyzzz/mcpSteroid/integration/arena/ArenaProjectResolutionDetectorTest.kt
+++ b/test-experiments/src/test/kotlin/com/jonnyzzz/mcpSteroid/integration/arena/ArenaProjectResolutionDetectorTest.kt
@@ -1,0 +1,88 @@
+/* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
+package com.jonnyzzz.mcpSteroid.integration.arena
+
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class ArenaProjectResolutionDetectorTest {
+
+    // Real captured Claude shape (…/run-20260708-…-petclinic-27-claude-mcp/agent-claude-code-1-raw.ndjson:5):
+    // an ERROR:-wrapped resolution failure whose tool_result references the steroid_execute_code call id.
+    private val claudeCall =
+        """{"type":"assistant","message":{"role":"assistant","content":[{"type":"tool_use","id":"toolu_01Woi","name":"mcp__mcp-steroid__steroid_execute_code","input":{"code":"println(1)"}}]}}"""
+    private val claudeErrorResult =
+        """{"type":"user","message":{"role":"user","content":[{"type":"tool_result","content":"ERROR: Project not found: \"project-home\". Available project_name values: demo-project-ki3y1pmc","is_error":true,"tool_use_id":"toolu_01Woi"}]}}"""
+
+    @Test
+    fun `flags a Project not found error attributed to steroid_execute_code (claude)`() {
+        val ndjson = "$claudeCall\n$claudeErrorResult\n"
+        assertTrue(detectProjectResolutionFailure(ndjson))
+    }
+
+    @Test
+    fun `ignores the phrase when it comes from a steroid_fetch_resource article body`() {
+        val fetchCall =
+            """{"type":"assistant","message":{"role":"assistant","content":[{"type":"tool_use","id":"toolu_FETCH","name":"mcp__mcp-steroid__steroid_fetch_resource","input":{"uri":"mcp-steroid://x"}}]}}"""
+        // Article body quotes the phrase but is NOT an error and maps to fetch_resource, not execute_code.
+        val fetchResult =
+            """{"type":"user","message":{"role":"user","content":[{"type":"tool_result","content":"the error reads: Project not found: \"foo\"","is_error":false,"tool_use_id":"toolu_FETCH"}]}}"""
+        val ndjson = "$fetchCall\n$fetchResult\n"
+        assertFalse(detectProjectResolutionFailure(ndjson))
+    }
+
+    @Test
+    fun `does not flag an is_error fetch_resource result that matches the prefix (attribution)`() {
+        // A steroid_fetch_resource CALL followed by an is_error:true result that DOES match the
+        // "Project not found" prefix. This exercises the id->tool-name attribution directly: the
+        // result passes the is_error gate and the prefix match, so it is only rejected because the
+        // tool_use_id maps to fetch_resource, not execute_code. Deleting the endsWith(execute_code)
+        // check makes THIS test fail.
+        val fetchCall =
+            """{"type":"assistant","message":{"role":"assistant","content":[{"type":"tool_use","id":"toolu_FETCH2","name":"mcp__mcp-steroid__steroid_fetch_resource","input":{"uri":"mcp-steroid://x"}}]}}"""
+        val fetchErrorResult =
+            """{"type":"user","message":{"role":"user","content":[{"type":"tool_result","content":"ERROR: Project not found: \"x\". Available project_name values: foo-abc","is_error":true,"tool_use_id":"toolu_FETCH2"}]}}"""
+        assertFalse(detectProjectResolutionFailure("$fetchCall\n$fetchErrorResult\n"))
+    }
+
+    @Test
+    fun `flags a doubled Error prefix attributed to steroid_execute_code`() {
+        // The plugin can surface the payload with a doubled wrapper (Error: ERROR: ...);
+        // stripErrorPrefixes must peel both before the exact-prefix match.
+        val doubledResult =
+            """{"type":"user","message":{"role":"user","content":[{"type":"tool_result","content":"Error: ERROR: Project not found: \"project-home\". Available project_name values: demo-project-ki3y1pmc","is_error":true,"tool_use_id":"toolu_01Woi"}]}}"""
+        assertTrue(detectProjectResolutionFailure("$claudeCall\n$doubledResult\n"))
+    }
+
+    @Test
+    fun `flags a content-block-array error attributed to steroid_execute_code`() {
+        // Anthropic tool_result.content may arrive as a content-block ARRAY, not a bare string.
+        // textOf() must dig the text out of the array so the resolution failure is not silently missed.
+        val arrayErrorResult =
+            """{"type":"user","message":{"role":"user","content":[{"type":"tool_result","content":[{"type":"text","text":"ERROR: Project not found: \"project-home\". Available project_name values: demo-project-ki3y1pmc"}],"is_error":true,"tool_use_id":"toolu_01Woi"}]}}"""
+        assertTrue(detectProjectResolutionFailure("$claudeCall\n$arrayErrorResult\n"))
+    }
+
+    @Test
+    fun `does not flag a clean run`() {
+        val okResult =
+            """{"type":"user","message":{"role":"user","content":[{"type":"tool_result","content":"Project: demo, base: /home/agent/project-home","is_error":false,"tool_use_id":"toolu_01Woi"}]}}"""
+        assertFalse(detectProjectResolutionFailure("$claudeCall\n$okResult\n"))
+    }
+
+    @Test
+    fun `flags gemini-shaped resolution failure`() {
+        val call =
+            """{"type":"tool_use","id":"g1","tool_name":"mcp_mcp-steroid_steroid_execute_code","parameters":{"code":"x"}}"""
+        val err =
+            """{"type":"tool_result","tool_id":"g1","is_error":true,"content":"ERROR: Project not found: \"project-home\". Available project_name values: foo-abc"}"""
+        assertTrue(detectProjectResolutionFailure("$call\n$err\n"))
+    }
+
+    @Test
+    fun `flags codex-shaped resolution failure`() {
+        val line =
+            """{"type":"item.completed","item":{"id":"item_5","type":"mcp_tool_call","server":"mcp-steroid","tool":"steroid_execute_code","result":{"content":[{"type":"text","text":"ERROR: Project not found: \"project-home\". Available project_name values: foo-abc"}]}}}"""
+        assertTrue(detectProjectResolutionFailure("$line\n"))
+    }
+}

--- a/test-experiments/src/test/kotlin/com/jonnyzzz/mcpSteroid/integration/arena/ArenaProjectResolutionDetectorTest.kt
+++ b/test-experiments/src/test/kotlin/com/jonnyzzz/mcpSteroid/integration/arena/ArenaProjectResolutionDetectorTest.kt
@@ -22,7 +22,7 @@ class ArenaProjectResolutionDetectorTest {
             claudeResult("c2", isError = false, "execution_id: eid_ok"),
         )
 
-        assertEquals(ProjectResolutionStatus.INITIAL_FAILURE, transcript.projectResolutionStatus())
+        assertEquals(ProjectResolutionStatus.INITIAL_FAILURE, transcript.projectResolutionStatus)
         assertTrue(transcript.usedMcpSteroid)
         assertTrue(transcript.successfulMcpExecution)
     }
@@ -38,8 +38,7 @@ class ArenaProjectResolutionDetectorTest {
             claudeResult("c3", isError = false, "execution_id: eid_3"),
         )
 
-        assertEquals(ProjectResolutionStatus.RECOVERED, transcript.projectResolutionStatus())
-        assertFalse(transcript.projectResolutionStatus().shouldFailRun)
+        assertEquals(ProjectResolutionStatus.RECOVERED, transcript.projectResolutionStatus)
     }
 
     @Test
@@ -51,8 +50,7 @@ class ArenaProjectResolutionDetectorTest {
             claudeResult("c2", isError = true, projectNotFound("old-key")),
         )
 
-        assertEquals(ProjectResolutionStatus.UNRECOVERED_FAILURE, transcript.projectResolutionStatus())
-        assertTrue(transcript.projectResolutionStatus().shouldFailRun)
+        assertEquals(ProjectResolutionStatus.UNRECOVERED_FAILURE, transcript.projectResolutionStatus)
     }
 
     @Test
@@ -62,10 +60,10 @@ class ArenaProjectResolutionDetectorTest {
             geminiResult("g1", status = "error", output = projectNotFound("project-home")),
         )
 
-        assertEquals(ProjectResolutionStatus.INITIAL_FAILURE, transcript.projectResolutionStatus())
+        assertEquals(ProjectResolutionStatus.INITIAL_FAILURE, transcript.projectResolutionStatus)
         assertEquals(
-            ExecuteCodeResult("g1", isError = true, text = projectNotFound("project-home")),
-            transcript.executeCodeResults.single(),
+            ExecuteCodeCall("g1", ExecuteCodeResult(isError = true, text = projectNotFound("project-home"))),
+            transcript.executeCodeCalls.single(),
         )
     }
 
@@ -75,8 +73,8 @@ class ArenaProjectResolutionDetectorTest {
             codexResult("x1", status = "failed", text = projectNotFound("project-home")),
         )
 
-        assertEquals(ProjectResolutionStatus.INITIAL_FAILURE, transcript.projectResolutionStatus())
-        assertTrue(transcript.executeCodeResults.single().isError)
+        assertEquals(ProjectResolutionStatus.INITIAL_FAILURE, transcript.projectResolutionStatus)
+        assertTrue(transcript.executeCodeCalls.single().result?.isError == true)
     }
 
     @Test
@@ -85,7 +83,7 @@ class ArenaProjectResolutionDetectorTest {
             codexResult("x1", status = "completed", text = projectNotFound("quoted-example")),
         )
 
-        assertEquals(ProjectResolutionStatus.CLEAN, transcript.projectResolutionStatus())
+        assertEquals(ProjectResolutionStatus.CLEAN, transcript.projectResolutionStatus)
         assertTrue(transcript.successfulMcpExecution)
     }
 
@@ -97,8 +95,8 @@ class ArenaProjectResolutionDetectorTest {
         )
 
         assertFalse(transcript.usedMcpSteroid)
-        assertTrue(transcript.executeCodeResults.isEmpty())
-        assertEquals(ProjectResolutionStatus.CLEAN, transcript.projectResolutionStatus())
+        assertTrue(transcript.executeCodeCalls.isEmpty())
+        assertEquals(ProjectResolutionStatus.CLEAN, transcript.projectResolutionStatus)
     }
 
     @Test
@@ -113,7 +111,7 @@ class ArenaProjectResolutionDetectorTest {
             ),
         )
 
-        assertEquals(ProjectResolutionStatus.INITIAL_FAILURE, transcript.projectResolutionStatus())
+        assertEquals(ProjectResolutionStatus.INITIAL_FAILURE, transcript.projectResolutionStatus)
     }
 
     @Test
@@ -128,7 +126,7 @@ class ArenaProjectResolutionDetectorTest {
         )
 
         assertTrue(transcript.successfulMcpExecution)
-        assertEquals(ProjectResolutionStatus.CLEAN, transcript.projectResolutionStatus())
+        assertEquals(ProjectResolutionStatus.CLEAN, transcript.projectResolutionStatus)
     }
 
     @Test

--- a/test-experiments/src/test/kotlin/com/jonnyzzz/mcpSteroid/integration/arena/ArenaPromptContractTest.kt
+++ b/test-experiments/src/test/kotlin/com/jonnyzzz/mcpSteroid/integration/arena/ArenaPromptContractTest.kt
@@ -55,6 +55,35 @@ class ArenaPromptContractTest {
     }
 
     @Test
+    fun `mcp prompt makes agent discover project name via list_projects instead of hardcoding it`() {
+        val prompt = ArenaTestRunner(
+            container = ContainerDriver(
+                logPrefix = "prompt-test",
+                containerId = "unused",
+                startRequest = StartContainerRequest(),
+            ),
+            projectGuestDir = "/workspace",
+        ).buildPrompt(testCase = sampleMavenTestCase(), projectDir = "/home/agent/project-home", withMcp = true)
+
+        assertFalse(
+            prompt.contains("Project name in IntelliJ is always"),
+            "The static project-name claim must be gone — the routing key is plugin-computed and dynamic (#251)",
+        )
+        assertTrue(
+            prompt.contains("steroid_list_projects"),
+            "Prompt must route the agent to discover the project via steroid_list_projects",
+        )
+        assertTrue(
+            prompt.contains("pick the entry whose `path` is `/home/agent/project-home`") && prompt.contains("`project_name`"),
+            "Prompt must tell the agent to select by path and reuse the exact project_name routing key",
+        )
+        assertTrue(
+            prompt.contains("If a later `steroid_execute_code` call returns `Project not found`"),
+            "Prompt must instruct re-discovery when the routing key changes mid-session (#309)",
+        )
+    }
+
+    @Test
     fun `gradle prompt batches targeted tests across subprojects`() {
         val prompt = ArenaTestRunner(
             container = ContainerDriver(

--- a/test-experiments/src/test/kotlin/com/jonnyzzz/mcpSteroid/integration/arena/ArenaTestRunner.kt
+++ b/test-experiments/src/test/kotlin/com/jonnyzzz/mcpSteroid/integration/arena/ArenaTestRunner.kt
@@ -391,7 +391,7 @@ class ArenaTestRunner(
         val agentDurationMs = System.currentTimeMillis() - agentStartMs
 
         // Step 5: Evaluate
-        val evaluation = evaluate(testCase, agentResult, agentResult.rawStdout)
+        val evaluation = evaluate(testCase, agentResult, agentResult.rawStdout, projectDir)
         val diff = git.diff(projectDir)
         logDir?.resolve("agent-result.patch")?.writeText(diff)
 
@@ -400,13 +400,30 @@ class ArenaTestRunner(
         println("[ARENA]   Agent exit code: ${agentResult.exitCode}")
         println("[ARENA]   Agent claimed fix: ${evaluation.agentClaimedFix}")
         println("[ARENA]   Used MCP: ${evaluation.usedMcpSteroid}")
+        println("[ARENA]   Successful MCP execution: ${evaluation.successfulMcpExecution}")
+        println("[ARENA]   First MCP execution targeted project: ${evaluation.firstExecutionTargetedProject}")
         println("[ARENA] ========================================")
 
         if (withMcp && evaluation.projectResolutionFailed) {
             error(
-                "[ARENA] ${testCase.instanceId}: a steroid_execute_code call failed with " +
-                    "\"Project not found\" — the MCP arm could not resolve the project, so this run does " +
-                    "not measure the MCP transport. Failing instead of silently degrading to bash (#251)."
+                "[ARENA] ${testCase.instanceId}: steroid_execute_code project resolution ended in " +
+                    "${evaluation.projectResolutionStatus}. The first call must resolve immediately, and a " +
+                    "later routing-key failure must be followed by a successful execute_code retry (#251)."
+            )
+        }
+
+        if (withMcp && !evaluation.successfulMcpExecution) {
+            error(
+                "[ARENA] ${testCase.instanceId}: the MCP arm produced no successful " +
+                    "steroid_execute_code result, so this run does not measure successful IDE execution."
+            )
+        }
+
+        if (withMcp && !evaluation.firstExecutionTargetedProject) {
+            error(
+                "[ARENA] ${testCase.instanceId}: the mandatory first steroid_execute_code result did not " +
+                    "confirm project.basePath=$projectDir, so the MCP arm may have operated on another " +
+                    "open project (#251)."
             )
         }
 
@@ -422,15 +439,25 @@ class ArenaTestRunner(
     /**
      * Evaluate the agent's response against the test case expectations.
      */
-    private fun evaluate(testCase: DpaiaTestCase, result: ProcessResult, rawNdjson: String): ArenaEvaluation {
+    private fun evaluate(
+        testCase: DpaiaTestCase,
+        result: ProcessResult,
+        rawNdjson: String,
+        expectedProjectDir: String,
+    ): ArenaEvaluation {
         val combined = result.stdout + "\n" + result.stderr
+        val transcript = decodeAgentTranscript(rawNdjson)
+        val projectResolutionStatus = transcript.projectResolutionStatus()
 
         return ArenaEvaluation(
             agentExitedSuccessfully = result.exitCode == 0,
-            usedMcpSteroid = combined.contains("steroid_execute_code", ignoreCase = true),
+            usedMcpSteroid = transcript.usedMcpSteroid,
+            successfulMcpExecution = transcript.successfulMcpExecution,
+            firstExecutionTargetedProject = transcript.firstExecutionTargetsProject(expectedProjectDir),
             agentClaimedFix = combined.contains("ARENA_FIX_APPLIED: yes", ignoreCase = true),
             agentSummary = extractMarker(combined, "ARENA_SUMMARY:"),
-            projectResolutionFailed = detectProjectResolutionFailure(rawNdjson),
+            projectResolutionStatus = projectResolutionStatus,
+            projectResolutionFailed = projectResolutionStatus.shouldFailRun,
         )
     }
 
@@ -463,12 +490,21 @@ data class ArenaEvaluation(
     /** Whether the agent used steroid_execute_code */
     val usedMcpSteroid: Boolean,
 
+    /** Whether at least one steroid_execute_code call completed successfully */
+    val successfulMcpExecution: Boolean,
+
+    /** Whether the mandatory first steroid_execute_code result confirmed the arena project base path. */
+    val firstExecutionTargetedProject: Boolean,
+
     /** Whether the agent reported it applied a fix */
     val agentClaimedFix: Boolean,
 
     /** The agent's one-line summary of changes, if provided */
     val agentSummary: String?,
 
-    /** True when a steroid_execute_code call failed to resolve the project (setup/prompt defect). */
+    /** Resolution outcome across the ordered steroid_execute_code results. */
+    val projectResolutionStatus: ProjectResolutionStatus = ProjectResolutionStatus.CLEAN,
+
+    /** True for an initial resolution regression or a later failure without a successful recovery. */
     val projectResolutionFailed: Boolean = false,
 )

--- a/test-experiments/src/test/kotlin/com/jonnyzzz/mcpSteroid/integration/arena/ArenaTestRunner.kt
+++ b/test-experiments/src/test/kotlin/com/jonnyzzz/mcpSteroid/integration/arena/ArenaTestRunner.kt
@@ -185,7 +185,9 @@ class ArenaTestRunner(
             appendLine("- **Do NOT use `steroid_execute_code` to run `./mvnw` or `./gradlew` via ProcessBuilder** — the ProcessBuilder pattern inside steroid is banned (classpath conflicts + token overflow). Use Bash for Maven/Gradle CLI invocations.")
             appendLine("- **Do not rerun Maven/Gradle just to recover hidden output.** If a completed targeted test run only lost `BUILD SUCCESS` behind `tail` or `grep`, inspect the saved output or preserve more output next time instead of rerunning the same target. Rerun when you changed code, saw a real failure, got an incomplete run, or Gradle skipped tests.")
             appendLine("- Keep one stable `task_id` for this task.")
-            appendLine("- **Project name in IntelliJ is always `project-home`** — use this exact name in every `steroid_execute_code` call. Never use the GitHub repo name (e.g. \"petclinic\", \"spring-petclinic\") as the project name.")
+            appendLine("- **Discover the project first**: Your VERY FIRST tool call must be `steroid_list_projects` (no arguments). From its response, pick the entry whose `path` is `$projectDir` and use that entry's exact `project_name` value in every subsequent `steroid_execute_code` call. Do NOT guess the name and do NOT use the GitHub repo name (e.g. \"petclinic\", \"spring-petclinic\").")
+            appendLine("- The `project_name` is an opaque routing key (a readable name plus a hash), not the folder name — it is only knowable from `steroid_list_projects`, never a fixed literal.")
+            appendLine("- If a later `steroid_execute_code` call returns `Project not found`, the routing key changed (e.g. after a project reload). Re-call `steroid_list_projects`, re-select by `path`, and continue with the refreshed `project_name` — do NOT fall back to bash.")
             appendLine("- **The IDE is already configured** — do NOT attempt JDK/SDK setup, do NOT install plugins. Start immediately with your first real task call.")
             appendLine("- **Check VCS changes on your FIRST call** (via `ChangeListManager.getInstance(project).allChanges`) to detect any prior agent work — do NOT assume a clean slate when there are multiple agent sessions.")
             appendLine("- **Validation/service changes → regression risk**: When you add a validation rule to an existing service method (e.g., `saveUser()`, `createOwner()`), EVERY other test that calls this method with data that now fails validation will break. BEFORE declaring success, scan for all test call sites: `PsiSearchHelper.getInstance(project).processAllFilesWithWord(\"saveUser\", scope, { f -> ...; true }, true)`. Common regression culprits: `Abstract*Tests`, `*JdbcTests`, `*JpaTests`, `*SpringDataJpaTests` — update their test data (e.g. passwords, names) to satisfy the new rule.")
@@ -216,7 +218,7 @@ class ArenaTestRunner(
             appendLine("  - **If you have already made 10 Read/Glob/Grep calls without yet making an Edit or Write: STOP IMMEDIATELY. Make your first code change now.** The test patch shows exactly what each test expects — further reading adds no value and will cause a timeout. Scope constraint: read only VCS-diff files + their direct imports. No build files, no entity classes, no application.yml, no pom.xml from unrelated modules.")
             appendLine("- **Multi-module project scoping (CRITICAL for microservices)**: When the VCS diff lists test files from 3+ distinct modules (microservices/separate subdirs): implement **sequentially per module**. Pattern: Read tests from MODULE_1 → Write/Edit MODULE_1 implementation → move to MODULE_2. Do NOT read tests from all N modules before writing any code — that creates an N-module exploration loop that always times out. A single service with 2-3 test files is enough signal to start writing its implementation without reading other services first.")
             appendLine("  - **Reactive migration trap**: When converting from Spring MVC to WebFlux (RestTemplate→WebClient, CrudRepository→ReactiveCrudRepository), do NOT explore all services before changing any. Pick the simplest service, convert it fully (implementation + interface), compile-check, then move to the next. Parallel exploration of a 4-service migration always exceeds the 900s budget.")
-            appendLine("- **MANDATORY first steroid call**: Your FIRST action must be a `steroid_execute_code` call that checks VCS changes and project readiness. This is required even for simple tasks — it confirms the IDE sees the project and shows exactly what the test patch changed.")
+            appendLine("- **MANDATORY first `steroid_execute_code` call**: After discovering the `project_name` via `steroid_list_projects`, your first `steroid_execute_code` call must check VCS changes and project readiness. This is required even for simple tasks — it confirms the IDE sees the project and shows exactly what the test patch changed.")
             appendLine("- **MANDATORY compilation check after edits**: After all file edits (before running Maven/Gradle tests), run ONE `steroid_execute_code` call to trigger IntelliJ compilation. **Do NOT use `./mvnw test-compile` or `./gradlew compileJava` for this check** — IntelliJ incremental build catches errors in ~2-5s vs a cold Maven compile (~25-60s). Use this exact code:")
             appendLine("  ```kotlin")
             appendLine("  val result = com.intellij.task.ProjectTaskManager.getInstance(project).buildAllModules().blockingGet(120_000)")
@@ -389,7 +391,7 @@ class ArenaTestRunner(
         val agentDurationMs = System.currentTimeMillis() - agentStartMs
 
         // Step 5: Evaluate
-        val evaluation = evaluate(testCase, agentResult)
+        val evaluation = evaluate(testCase, agentResult, agentResult.rawStdout)
         val diff = git.diff(projectDir)
         logDir?.resolve("agent-result.patch")?.writeText(diff)
 
@@ -399,6 +401,14 @@ class ArenaTestRunner(
         println("[ARENA]   Agent claimed fix: ${evaluation.agentClaimedFix}")
         println("[ARENA]   Used MCP: ${evaluation.usedMcpSteroid}")
         println("[ARENA] ========================================")
+
+        if (withMcp && evaluation.projectResolutionFailed) {
+            error(
+                "[ARENA] ${testCase.instanceId}: a steroid_execute_code call failed with " +
+                    "\"Project not found\" — the MCP arm could not resolve the project, so this run does " +
+                    "not measure the MCP transport. Failing instead of silently degrading to bash (#251)."
+            )
+        }
 
         return ArenaTestResult(
             testCase = testCase,
@@ -412,7 +422,7 @@ class ArenaTestRunner(
     /**
      * Evaluate the agent's response against the test case expectations.
      */
-    private fun evaluate(testCase: DpaiaTestCase, result: ProcessResult): ArenaEvaluation {
+    private fun evaluate(testCase: DpaiaTestCase, result: ProcessResult, rawNdjson: String): ArenaEvaluation {
         val combined = result.stdout + "\n" + result.stderr
 
         return ArenaEvaluation(
@@ -420,6 +430,7 @@ class ArenaTestRunner(
             usedMcpSteroid = combined.contains("steroid_execute_code", ignoreCase = true),
             agentClaimedFix = combined.contains("ARENA_FIX_APPLIED: yes", ignoreCase = true),
             agentSummary = extractMarker(combined, "ARENA_SUMMARY:"),
+            projectResolutionFailed = detectProjectResolutionFailure(rawNdjson),
         )
     }
 
@@ -457,4 +468,7 @@ data class ArenaEvaluation(
 
     /** The agent's one-line summary of changes, if provided */
     val agentSummary: String?,
+
+    /** True when a steroid_execute_code call failed to resolve the project (setup/prompt defect). */
+    val projectResolutionFailed: Boolean = false,
 )

--- a/test-experiments/src/test/kotlin/com/jonnyzzz/mcpSteroid/integration/arena/ArenaTestRunner.kt
+++ b/test-experiments/src/test/kotlin/com/jonnyzzz/mcpSteroid/integration/arena/ArenaTestRunner.kt
@@ -2,6 +2,7 @@
 package com.jonnyzzz.mcpSteroid.integration.arena
 
 import com.jonnyzzz.mcpSteroid.testHelper.AiAgentSession
+import com.jonnyzzz.mcpSteroid.testHelper.AiProcessResult
 import com.jonnyzzz.mcpSteroid.testHelper.process.ProcessResult
 import com.jonnyzzz.mcpSteroid.testHelper.docker.ContainerDriver
 import com.jonnyzzz.mcpSteroid.testHelper.git.GitDriver
@@ -239,7 +240,7 @@ class ArenaTestRunner(
             appendLine("- For multi-file edits (renames, annotation changes, identical changes across N files), use the single-script read-replace-save shape inside `steroid_execute_code` described above — NOT a chain of native `Edit` calls. Still use steroid for the mandatory first call and compilation check.")
             appendLine("- **First call recipe** — combine readiness + Docker + VCS changes + **build environment** in ONE `steroid_execute_code` call (saves ~60s vs 3 separate calls):")
             appendLine("  ```kotlin")
-            appendLine("  println(\"Project: ${'$'}{project.name}, base: ${'$'}{project.basePath}\")")
+            appendLine("  println(\"Project: ${'$'}{project.name}, $PROJECT_BASE_PATH_MARKER ${'$'}{project.basePath}\")")
             appendLine("  // Docker socket check — no process spawn needed (ProcessBuilder inside steroid is banned)")
             appendLine("  val dockerOk = java.io.File(\"/var/run/docker.sock\").exists()")
             appendLine("  println(\"Docker: ${'$'}dockerOk\")")
@@ -391,7 +392,7 @@ class ArenaTestRunner(
         val agentDurationMs = System.currentTimeMillis() - agentStartMs
 
         // Step 5: Evaluate
-        val evaluation = evaluate(testCase, agentResult, agentResult.rawStdout, projectDir)
+        val evaluation = evaluate(agentResult, projectDir)
         val diff = git.diff(projectDir)
         logDir?.resolve("agent-result.patch")?.writeText(diff)
 
@@ -440,14 +441,19 @@ class ArenaTestRunner(
      * Evaluate the agent's response against the test case expectations.
      */
     private fun evaluate(
-        testCase: DpaiaTestCase,
-        result: ProcessResult,
-        rawNdjson: String,
+        result: AiProcessResult,
         expectedProjectDir: String,
     ): ArenaEvaluation {
         val combined = result.stdout + "\n" + result.stderr
-        val transcript = decodeAgentTranscript(rawNdjson)
-        val projectResolutionStatus = transcript.projectResolutionStatus()
+        val transcript = decodeAgentTranscript(result.rawStdout)
+        val projectResolutionStatus = transcript.projectResolutionStatus
+
+        // The runner owns the pass/fail policy: an initial resolution regression, or a later failure
+        // with no successful execute_code retry, fails the run (#251).
+        val projectResolutionFailed = when (projectResolutionStatus) {
+            ProjectResolutionStatus.INITIAL_FAILURE, ProjectResolutionStatus.UNRECOVERED_FAILURE -> true
+            ProjectResolutionStatus.CLEAN, ProjectResolutionStatus.RECOVERED -> false
+        }
 
         return ArenaEvaluation(
             agentExitedSuccessfully = result.exitCode == 0,
@@ -457,7 +463,7 @@ class ArenaTestRunner(
             agentClaimedFix = combined.contains("ARENA_FIX_APPLIED: yes", ignoreCase = true),
             agentSummary = extractMarker(combined, "ARENA_SUMMARY:"),
             projectResolutionStatus = projectResolutionStatus,
-            projectResolutionFailed = projectResolutionStatus.shouldFailRun,
+            projectResolutionFailed = projectResolutionFailed,
         )
     }
 

--- a/test-experiments/src/test/kotlin/com/jonnyzzz/mcpSteroid/integration/arena/DpaiaScenarioBaseTest.kt
+++ b/test-experiments/src/test/kotlin/com/jonnyzzz/mcpSteroid/integration/arena/DpaiaScenarioBaseTest.kt
@@ -117,6 +117,15 @@ abstract class DpaiaScenarioBaseTest {
 
             val ideProjectDir = session.intellijDriver.getGuestProjectDir()
 
+            // #251 Part C: lock the existing waitForMcpReady path-guarantee explicitly at the arena layer.
+            // Path check only — it does NOT prove the repo content/identity (a wrong project sharing the
+            // path would still pass); the FAIL_TO_PASS + green build in the run establish content.
+            val openProjects = session.mcpSteroid.mcpListProjects()
+            check(openProjects.any { it.path == ideProjectDir }) {
+                "[ARENA] No IDE project open at the arena deploy path $ideProjectDir before the agent run " +
+                    "(open: ${openProjects.joinToString { "${it.name}@${it.path}" }}). Deploy/open regression (#251)."
+            }
+
             // ── Agent run (TIMED) ────────────────────────────────────────────────
             val agent: AiAgentSession = when (agentName) {
                 "claude" -> session.aiAgents.claude


### PR DESCRIPTION
fixed #251 
now arena discovers project_name through steroid_list_projects, selects it by path, verifies that first execute_code targets right project. if project resolution or mcp execution fails, the arena fails the run instead of silently falling back to bash
a full arena run completed successfully, tests passed