### PR TITLE
website: shorten homepage <title> to devrig-first, drop duplicate name

### DIFF
--- a/website/content/_index.md
+++ b/website/content/_index.md
@@ -1,3 +1,3 @@
 ---
-title: "MCP Steroid"
+title: ""
 ---

--- a/website/hugo.toml
+++ b/website/hugo.toml
@@ -14,7 +14,7 @@
 
 baseURL = 'https://devrig.dev/'
 languageCode = 'en-us'
-title = 'devrig — reliable code changes for your AI agent'
+title = 'devrig — reliable code changes for your AI Agent'
 disableKinds = ['taxonomy', 'term']
 
 # Two static roots, merged by Hugo: checked-in assets (static/) + the generator output

--- a/website/hugo.toml
+++ b/website/hugo.toml
@@ -14,7 +14,7 @@
 
 baseURL = 'https://devrig.dev/'
 languageCode = 'en-us'
-title = 'MCP Steroid - Reliable code changes for your AI Agent'
+title = 'devrig — reliable code changes for your AI agent'
 disableKinds = ['taxonomy', 'term']
 
 # Two static roots, merged by Hugo: checked-in assets (static/) + the generator output


### PR DESCRIPTION
## What
Homepage `<title>` was `MCP Steroid | MCP Steroid - Reliable code changes for your AI Agent` — long and with a duplicated product name.

- `website/hugo.toml`: `title` → `devrig — reliable code changes for your AI agent`
- `website/content/_index.md`: front-matter `title` → `""` so `baseof.html` emits just `Site.Title` on the homepage (no `MCP Steroid | ` prefix, no duplication).

Result:
- Home: `<title>devrig — reliable code changes for your AI agent</title>`
- Subpages unchanged shape: e.g. `Documentation | devrig — reliable code changes for your AI agent`

Addresses the #319 criterion — correct homepage title/description without duplicate product names.

## Verification
`hugo` (extended v0.142.0, via `hugomods/hugo:exts-0.142.0`) build: 0 errors, 31 pages. Confirmed generated `public/index.html` `<title>` is the new short devrig-first string with no duplication; subpage titles still render sensibly.

## Notes
Title-only change. **Wording awaiting review** — not merged, no deploy (`website` branch untouched). Feel free to adjust the tagline.