### PR TITLE
website: build-time canonicalization assertions + live post-deploy check (#332)

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -87,3 +87,19 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4
+
+  # Post-deploy live canonicalization check (issue #332). Runs only after a real
+  # deploy (which only happens on the `website` branch). Verifies the live
+  # redirect + SEO contract; failing here flags a live regression without
+  # blocking the deploy that already shipped. Redirect permanence is NOT asserted
+  # (the legacy-host rule is intentionally a 307).
+  live-check:
+    runs-on: ubuntu-latest
+    needs: deploy
+    steps:
+      - uses: actions/checkout@v4
+      - name: Wait for propagation
+        run: sleep 15
+      - name: Live canonicalization checks
+        working-directory: website
+        run: bash scripts/check-live.sh

--- a/website/Makefile
+++ b/website/Makefile
@@ -56,6 +56,10 @@ build: update-config
 	@# Remove symlinks in output dir — they escape Docker mount boundary and break Hugo stat
 	@find mcp-steroid-public/mcp-steroid-plugin -type l -delete 2>/dev/null || true
 	docker compose run --rm --user "$$(id -u):$$(id -g)" build
+	@# Fail the build if the rendered output violates the canonicalization contract
+	@# (canonical/OG/Twitter/sitemap/robots on https://devrig.dev — see issue #332).
+	@# Plain grep/find on the host output dir, so no extra container round-trip.
+	sh scripts/assert-canonicalization.sh mcp-steroid-public/mcp-steroid-plugin
 	@# `=> website.zip` (with the .zip extension) tells TeamCity to bundle the matched
 	@# files into a single archive artifact instead of publishing the directory tree
 	@# verbatim. See https://www.jetbrains.com/help/teamcity/configuring-general-settings.html#Artifact+Paths

--- a/website/scripts/assert-canonicalization.sh
+++ b/website/scripts/assert-canonicalization.sh
@@ -1,0 +1,155 @@
+#!/bin/sh
+# Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Build-time canonicalization assertions (issue #332, parent #319).
+#
+# Runs against the Hugo-generated output dir (public/) AFTER the build and exits
+# non-zero if any canonicalization signal is wrong. Wired into `make build`.
+#
+# What it checks:
+#   1. every rendered .html page carries a <link rel="canonical"> tag;
+#   2. the homepage canonical is exactly https://devrig.dev/;
+#   3. the canonicalization signals (canonical href, og:url, og:image,
+#      twitter:image) all point at https://devrig.dev;
+#   4. sitemap.xml exists and every <loc> is on https://devrig.dev;
+#   5. robots.txt exists and carries "Sitemap: https://devrig.dev/sitemap.xml";
+#   6. the OLD host mcp-steroid.jonnyzzz.com appears in NONE of the
+#      canonicalization signals above.
+#
+# NOTE on the old-host check (6): it is scoped to the canonicalization SIGNALS,
+# not to a blanket scan of the whole output. Archived release notes and the
+# "Website launched at mcp-steroid.jonnyzzz.com" changelog line legitimately
+# mention the old host as historical prose; those are content, not
+# canonicalization bugs, and must not fail the build. Only the SEO signals that
+# #319 governs (canonical/og/twitter/sitemap/robots) are asserted host-clean.
+#
+# POSIX sh, no heavy deps: grep + find only. Handles both minified (unquoted
+# attributes) and non-minified (quoted) HTML, since alias/redirect stubs are not
+# minified.
+
+set -eu
+
+NEW_BASE="https://devrig.dev"
+OLD_HOST="mcp-steroid.jonnyzzz.com"
+
+# Output dir: first arg, else the Makefile's default output path relative to website/.
+DIR="${1:-mcp-steroid-public/mcp-steroid-plugin}"
+
+fail=0
+err() { printf 'FAIL: %s\n' "$1" >&2; fail=1; }
+ok()  { printf 'PASS: %s\n' "$1"; }
+
+if [ ! -d "$DIR" ]; then
+  printf 'FAIL: output dir not found: %s\n' "$DIR" >&2
+  exit 1
+fi
+
+printf 'Asserting canonicalization signals in: %s\n' "$DIR"
+
+# --- 1. every HTML page has a canonical link -------------------------------
+missing=""
+for f in $(find "$DIR" -type f -name '*.html'); do
+  if ! grep -Eq 'rel="?canonical"?' "$f"; then
+    missing="$missing $f"
+  fi
+done
+if [ -n "$missing" ]; then
+  err "HTML pages without <link rel=canonical>:$missing"
+else
+  ok "every HTML page has <link rel=canonical>"
+fi
+
+# --- 2. homepage canonical == https://devrig.dev/ --------------------------
+HOME_HTML="$DIR/index.html"
+if [ ! -f "$HOME_HTML" ]; then
+  err "homepage index.html not found"
+else
+  home_canon=$(grep -oE 'rel="?canonical"? href="?[^" >]+' "$HOME_HTML" \
+    | grep -oE 'https?://[^" >]+' | head -1)
+  if [ "$home_canon" = "$NEW_BASE/" ]; then
+    ok "homepage canonical == $NEW_BASE/"
+  else
+    err "homepage canonical is '$home_canon' (expected $NEW_BASE/)"
+  fi
+fi
+
+# --- 3. canonical/og/twitter signal URLs all on devrig.dev -----------------
+# Extract each signal's URL, tolerating quoted and unquoted attributes.
+extract() { # $1 = ERE matching "<attr-name> <url-attr>=<url>"
+  grep -rhoE "$1" --include='*.html' "$DIR" 2>/dev/null | grep -oE 'https?://[^" >]+' || true
+}
+signal_urls=$(
+  {
+    extract 'rel="?canonical"? href="?[^" >]+'
+    extract 'property="?og:url"? content="?[^" >]+'
+    extract 'property="?og:image"? content="?[^" >]+'
+    extract 'name="?twitter:image"? content="?[^" >]+'
+    extract 'name="?twitter:url"? content="?[^" >]+'
+  } | sort -u
+)
+offhost=$(printf '%s\n' "$signal_urls" | grep -v '^$' | grep -vE "^$NEW_BASE(/|$)" || true)
+if [ -n "$offhost" ]; then
+  err "canonicalization signal URLs NOT on $NEW_BASE:
+$offhost"
+else
+  ok "all canonical/og/twitter signal URLs are on $NEW_BASE"
+fi
+
+# --- 4. sitemap.xml exists and all <loc> on devrig.dev ---------------------
+SITEMAP="$DIR/sitemap.xml"
+if [ ! -f "$SITEMAP" ]; then
+  err "sitemap.xml not found"
+else
+  bad_loc=$(grep -oE '<loc>[^<]+</loc>' "$SITEMAP" \
+    | sed -e 's|<loc>||' -e 's|</loc>||' \
+    | grep -vE "^$NEW_BASE(/|$)" || true)
+  if [ -n "$bad_loc" ]; then
+    err "sitemap <loc> entries NOT on $NEW_BASE:
+$bad_loc"
+  else
+    n=$(grep -oE '<loc>[^<]+</loc>' "$SITEMAP" | wc -l | tr -d ' ')
+    ok "sitemap.xml present, all $n <loc> on $NEW_BASE"
+  fi
+fi
+
+# --- 5. robots.txt exists and carries the Sitemap line ---------------------
+ROBOTS="$DIR/robots.txt"
+if [ ! -f "$ROBOTS" ]; then
+  err "robots.txt not found"
+elif grep -Eq "^[[:space:]]*Sitemap:[[:space:]]*$NEW_BASE/sitemap\.xml[[:space:]]*$" "$ROBOTS"; then
+  ok "robots.txt has 'Sitemap: $NEW_BASE/sitemap.xml'"
+else
+  err "robots.txt missing 'Sitemap: $NEW_BASE/sitemap.xml' line"
+fi
+
+# --- 6. old host absent from the canonicalization signals ------------------
+old_in_signals=$(printf '%s\n' "$signal_urls" | grep -F "$OLD_HOST" || true)
+old_in_sitemap=""
+[ -f "$SITEMAP" ] && old_in_sitemap=$(grep -F "$OLD_HOST" "$SITEMAP" || true)
+old_in_robots=""
+[ -f "$ROBOTS" ] && old_in_robots=$(grep -F "$OLD_HOST" "$ROBOTS" || true)
+if [ -n "$old_in_signals$old_in_sitemap$old_in_robots" ]; then
+  err "old host $OLD_HOST found in canonicalization signals:
+$old_in_signals$old_in_sitemap$old_in_robots"
+else
+  ok "old host $OLD_HOST absent from all canonicalization signals"
+fi
+
+echo
+if [ "$fail" -ne 0 ]; then
+  echo "canonicalization assertions: FAILED"
+  exit 1
+fi
+echo "canonicalization assertions: PASSED"

--- a/website/scripts/check-live.sh
+++ b/website/scripts/check-live.sh
@@ -1,0 +1,130 @@
+#!/bin/sh
+# Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Post-deploy LIVE canonicalization checks (issue #332, parent #319).
+#
+# Curls the live site and verifies the redirect + SEO contract:
+#   - https://devrig.dev/                 -> 200 over HTTPS
+#   - http://devrig.dev/                  -> redirect to https://devrig.dev/
+#   - https://www.devrig.dev/             -> redirect to the apex https://devrig.dev/
+#   - https://mcp-steroid.jonnyzzz.com/<p> -> redirect to https://devrig.dev/<p> (path preserved)
+#   - homepage carries <link rel=canonical ...devrig.dev>
+#   - /robots.txt carries the "Sitemap: https://devrig.dev/sitemap.xml" line
+#   - /sitemap.xml <loc> entries are on https://devrig.dev
+#
+# Redirect codes: any of 301/302/307/308 is accepted (Jonny intentionally keeps
+# a 307 on the legacy-host rule), so permanence is NOT asserted. What IS asserted
+# is the redirect TARGET (scheme + host + preserved path).
+#
+# Run manually:  bash website/scripts/check-live.sh
+# Prints PASS/FAIL per check and exits non-zero if any check fails.
+
+set -u
+
+APEX="https://devrig.dev"
+CURL="curl -sS --max-time 20"
+
+fail=0
+ok()  { printf 'PASS: %s\n' "$1"; }
+err() { printf 'FAIL: %s\n' "$1"; fail=1; }
+
+is_redirect() { # $1 = http code
+  case "$1" in 301|302|307|308) return 0 ;; *) return 1 ;; esac
+}
+
+# http_code + first-hop Location (redirect_url), space-separated, no following.
+code_and_location() {
+  $CURL -o /dev/null -w '%{http_code} %{redirect_url}' "$1" 2>/dev/null
+}
+
+echo "Live canonicalization checks against $APEX"
+echo
+
+# --- 1. apex over HTTPS -> 200 ---------------------------------------------
+code=$($CURL -o /dev/null -w '%{http_code}' "$APEX/" 2>/dev/null || echo "000")
+if [ "$code" = "200" ]; then
+  ok "$APEX/ -> 200"
+else
+  err "$APEX/ -> $code (expected 200)"
+fi
+
+# --- 2. http apex -> redirect to https --------------------------------------
+set -- $(code_and_location "http://devrig.dev/")
+code="${1:-000}"; loc="${2:-}"
+if is_redirect "$code" && printf '%s' "$loc" | grep -q "^https://devrig\.dev/"; then
+  ok "http://devrig.dev/ -> $code $loc"
+else
+  err "http://devrig.dev/ -> $code $loc (expected 3xx to https://devrig.dev/)"
+fi
+
+# --- 3. www -> redirect to apex ---------------------------------------------
+set -- $(code_and_location "https://www.devrig.dev/")
+code="${1:-000}"; loc="${2:-}"
+if is_redirect "$code" && printf '%s' "$loc" | grep -q "^https://devrig\.dev/"; then
+  ok "https://www.devrig.dev/ -> $code $loc"
+else
+  err "https://www.devrig.dev/ -> $code $loc (expected 3xx to apex https://devrig.dev/)"
+fi
+
+# --- 4. legacy host -> redirect to apex, path preserved ---------------------
+LEGACY_PATH="/docs/"
+set -- $(code_and_location "https://mcp-steroid.jonnyzzz.com$LEGACY_PATH")
+code="${1:-000}"; loc="${2:-}"
+if is_redirect "$code" && [ "$loc" = "$APEX$LEGACY_PATH" ]; then
+  ok "legacy https://mcp-steroid.jonnyzzz.com$LEGACY_PATH -> $code $loc (path preserved)"
+else
+  err "legacy https://mcp-steroid.jonnyzzz.com$LEGACY_PATH -> $code $loc (expected 3xx to $APEX$LEGACY_PATH)"
+fi
+
+# --- 5. homepage canonical on devrig.dev ------------------------------------
+home=$($CURL "$APEX/" 2>/dev/null || true)
+canon=$(printf '%s' "$home" | grep -oE 'rel="?canonical"? href="?[^" >]+' \
+  | grep -oE 'https?://[^" >]+' | head -1)
+if printf '%s' "$canon" | grep -q "^https://devrig\.dev/"; then
+  ok "homepage canonical -> $canon"
+else
+  err "homepage canonical -> '$canon' (expected https://devrig.dev/...)"
+fi
+
+# --- 6. robots.txt Sitemap line ---------------------------------------------
+robots=$($CURL "$APEX/robots.txt" 2>/dev/null || true)
+if printf '%s\n' "$robots" | grep -Eq "^[[:space:]]*Sitemap:[[:space:]]*$APEX/sitemap\.xml[[:space:]]*$"; then
+  ok "/robots.txt has 'Sitemap: $APEX/sitemap.xml'"
+else
+  err "/robots.txt missing 'Sitemap: $APEX/sitemap.xml' line"
+fi
+
+# --- 7. sitemap.xml <loc> on devrig.dev -------------------------------------
+sitemap=$($CURL "$APEX/sitemap.xml" 2>/dev/null || true)
+locs=$(printf '%s' "$sitemap" | grep -oE '<loc>[^<]+</loc>' | sed -e 's|<loc>||' -e 's|</loc>||')
+if [ -z "$locs" ]; then
+  err "/sitemap.xml has no <loc> entries (fetch failed or empty)"
+else
+  bad=$(printf '%s\n' "$locs" | grep -vE "^$APEX(/|$)" || true)
+  if [ -n "$bad" ]; then
+    err "/sitemap.xml <loc> NOT on $APEX:
+$bad"
+  else
+    n=$(printf '%s\n' "$locs" | wc -l | tr -d ' ')
+    ok "/sitemap.xml present, all $n <loc> on $APEX"
+  fi
+fi
+
+echo
+if [ "$fail" -ne 0 ]; then
+  echo "live checks: FAILED"
+  exit 1
+fi
+echo "live checks: PASSED"


### PR DESCRIPTION
Closes #332 (parent #319).

Adds build-time assertions and post-deploy live checks for the devrig.dev canonicalization signals. Additive scripts + minimal build/CI wiring only — no site content, domain, or DNS changes.

## Build-time assertions — `website/scripts/assert-canonicalization.sh`
Runs against the Hugo output (`mcp-steroid-public/mcp-steroid-plugin/`) after `make build` and fails (non-zero) on any violation:
- every rendered HTML page has `<link rel="canonical">`;
- homepage canonical is exactly `https://devrig.dev/`;
- all canonical / `og:url` / `og:image` / `twitter:image` signal URLs are on `https://devrig.dev`;
- `sitemap.xml` exists and every `<loc>` is on `https://devrig.dev`;
- `robots.txt` exists and carries `Sitemap: https://devrig.dev/sitemap.xml`;
- the old host `mcp-steroid.jonnyzzz.com` is absent from those canonicalization signals.

POSIX sh, grep/find only, handles both minified (unquoted) and quoted HTML. Wired into the `build` target of `website/Makefile` (fails the build before publishing).

Scope note: the old-host check targets the canonicalization signals, **not** a blanket scan of the whole output. Archived release notes and the `2026-01-30` changelog line ("Website launched at mcp-steroid.jonnyzzz.com") legitimately mention the old host as history — those are content, not canonicalization bugs, so a whole-output scan would wrongly fail an already-correct build.

## Live post-deploy check — `website/scripts/check-live.sh`
Curls production and verifies: apex `https://devrig.dev/` → 200; `http://devrig.dev/` → redirect to https; `https://www.devrig.dev/` → redirect to apex; legacy `https://mcp-steroid.jonnyzzz.com/<path>` → redirect to `https://devrig.dev/<path>` (path preserved); homepage canonical on devrig.dev; robots Sitemap line; sitemap `<loc>` on devrig.dev. Accepts 301/302/307/308 — permanence is **not** asserted (the legacy-host rule is intentionally a 307). Run manually: `bash website/scripts/check-live.sh`.

Also wired as a `live-check` CI job in `.github/workflows/github-pages.yml`, gated `needs: deploy` so it runs only after a real Pages deploy (website branch). A failure flags a live regression without blocking the deploy that already shipped.

## Verified locally
- `hugo extended v0.142.0` build via the repo's docker compose → build-time assertions PASS on current output (43 HTML pages canonical, homepage `https://devrig.dev/`, 27 sitemap locs, robots + og/twitter clean).
- Negative tests: injecting an old-host `og:url` and removing the robots Sitemap line both fail the script (exit 1).
- `check-live.sh` against production → all PASS (http→301, www→301, legacy→307 path-preserved, canonical/robots/sitemap good).

Do not merge — Jonny reviews.