### PR TITLE
website: swap header brand order to devrig-first

### DIFF
--- a/website/content/releases/0.101.md
+++ b/website/content/releases/0.101.md
@@ -43,7 +43,7 @@ The installer detects your platform and downloads the matching `devrig` build **
 
 `devrig` now reasons about backends as four groups (running-compatible, running-incompatible, **startable**, downloadable). `steroid_open_project` can **start a stopped-but-installed backend for you**, re-provision the current plugin, and wait until it's reachable — no manual launch. `backend_name` routing targets a specific backend when several run ([#87](https://github.com/jonnyzzz/mcp-steroid/issues/87)); `list_projects` / `list_windows` no longer mislabel the backend or duplicate their payload and report installed plugins as a structured `plugins[]` section ([#88](https://github.com/jonnyzzz/mcp-steroid/issues/88), [#89](https://github.com/jonnyzzz/mcp-steroid/issues/89), [#90](https://github.com/jonnyzzz/mcp-steroid/issues/90)); and `project_name` is now an opaque `<name>-<hash>` routing key so same-named projects route correctly ([#92](https://github.com/jonnyzzz/mcp-steroid/issues/92)).
 
-### A devrig-first settings page
+### A <span class="lighter">devrig</span>-first settings page
 
 The plugin's **Tools → MCP Steroid** settings page is back and reworked around agents and `devrig` ([#80](https://github.com/jonnyzzz/mcp-steroid/issues/80), [#103](https://github.com/jonnyzzz/mcp-steroid/issues/103)): copyable per-OS install one-liners up top, the actual server port (not a hard-coded one), a fit-to-paste JSON config, and the legacy raw-HTTP path flagged as non-recommended with a link to the devrig docs.
 

--- a/website/layouts/index.html
+++ b/website/layouts/index.html
@@ -19,14 +19,14 @@
         <div class="hero-content">
             <h1>Give your AI Agent a whole IDE, not just the files. <a href="{{ "/releases/" | relURL }}" class="version-badge version-badge-sup">v{{ .Site.Params.version }}</a></h1>
             <p class="tagline">
-                devrig hands your AI Agent the same semantic actions a JetBrains IDE gives humans &mdash; typed refactors, inspections, the debugger, real test runs &mdash; so it finishes in fewer attempts and produces more stable results: less to verify now, and fewer bugs to chase or fix later.
+                <span class="lighter">devrig</span> hands your AI Agent the same semantic actions a JetBrains IDE gives humans &mdash; typed refactors, inspections, the debugger, real test runs &mdash; so it finishes in fewer attempts and produces more stable results: less to verify now, and fewer bugs to chase or fix later.
             </p>
             <div class="cta-buttons">
                 <a href="{{ "/docs/devrig/" | relURL }}" class="btn btn-primary">
                     <svg class="btn-icon" viewBox="0 0 24 24" fill="currentColor">
                         <path d="M4 4h16v2H4V4zm0 5h10v2H4V9zm0 5h16v2H4v-2zm0 5h10v2H4v-2z"/>
                     </svg>
-                    Try devrig (CLI)
+                    Try <span class="lighter">devrig</span> (CLI)
                 </a>
                 <a href="{{ "/releases/" | relURL }}" class="btn btn-secondary">
                     <svg class="btn-icon" viewBox="0 0 24 24" fill="currentColor">
@@ -61,10 +61,10 @@
             </div>
             <div class="hero-card">
                 <h3>Headless &amp; CI-ready <span class="agent-badge">Work in progress</span></h3>
-                <p>Built for terminal, remote, and CI-style workflows: devrig manages the IDE lifecycle so agents on remote servers and in CI get the same semantic tools. This path is actively being hardened.</p>
+                <p>Built for terminal, remote, and CI-style workflows: <span class="lighter">devrig</span> manages the IDE lifecycle so agents on remote servers and in CI get the same semantic tools. This path is actively being hardened.</p>
             </div>
         </div>
-        <p class="hero-card-cta"><a href="{{ "/docs/devrig/" | relURL }}" class="card-link"><strong>Read the devrig guide &rarr;</strong></a></p>
+        <p class="hero-card-cta"><a href="{{ "/docs/devrig/" | relURL }}" class="card-link"><strong>Read the <span class="lighter">devrig</span> guide &rarr;</strong></a></p>
         <p class="benchmark-footnote">
             <code>devrig</code> is an early preview and the foundation for where this project is going &mdash; expect it to grow fast. Requires a JDK&nbsp;25+ on the host. MCP&nbsp;Steroid / Devrig is an independent open-source project, <strong>not affiliated with, sponsored by, or endorsed by JetBrains.</strong>
         </p>
@@ -113,7 +113,7 @@
             </div>
             <div class="hero-card">
                 <h3>When you run a team or platform</h3>
-                <p>Point your AI Agents at a large codebase and they stay consistent: devrig provisions a managed IDE backend for headless and CI runs, so every Agent gets the same semantic tools. We also run Proof-of-Concept engagements tuned to your repos.</p>
+                <p>Point your AI Agents at a large codebase and they stay consistent: <span class="lighter">devrig</span> provisions a managed IDE backend for headless and CI runs, so every Agent gets the same semantic tools. We also run Proof-of-Concept engagements tuned to your repos.</p>
                 <p class="hero-card-cta"><a href="#support" class="card-link"><strong>Book a PoC &rarr;</strong></a><br><a href="{{ "/docs/need-your-experiments-and-support/" | relURL }}" class="card-link"><strong>Submit a Scenario &rarr;</strong></a></p>
             </div>
         </div>
@@ -268,7 +268,7 @@ todoItems.forEach { println(it) }</code></pre>
             The <a href="/docs/how-to-debug-ide/">Debugging IDE with MCP Steroid</a> guide was written entirely by AI Agents &mdash; a real skill created through experimentation with full IDE access.
         </p>
         <p class="consulting-note">
-            Ready to give your AI Agent full IDE access? <a href="{{ "/docs/devrig/" | relURL }}">Try the devrig CLI</a> for terminal and managed-backend workflows, or <a href="{{ "/releases/" | relURL }}">install the plugin</a> for an IDE you already use. See the <a href="https://jonnyzzz.com/blog/2026/04/08/mcp-steroid-skill-factory/" target="_blank" rel="noopener">Skill Factory blog post</a> for a deep dive on building custom skills.
+            Ready to give your AI Agent full IDE access? <a href="{{ "/docs/devrig/" | relURL }}">Try the <span class="lighter">devrig</span> CLI</a> for terminal and managed-backend workflows, or <a href="{{ "/releases/" | relURL }}">install the plugin</a> for an IDE you already use. See the <a href="https://jonnyzzz.com/blog/2026/04/08/mcp-steroid-skill-factory/" target="_blank" rel="noopener">Skill Factory blog post</a> for a deep dive on building custom skills.
         </p>
         <p class="consulting-note">
             <strong>Proof-of-Concept program:</strong> We run Proof-of-Concept engagements for company-specific use cases &mdash; custom skills, internal tooling integrations, AI Agent workflows tailored to your codebase. <a href="https://jonnyzzz.com/support/" target="_blank" rel="noopener">Contact Eugene</a> to discuss.

--- a/website/layouts/index.html
+++ b/website/layouts/index.html
@@ -19,7 +19,7 @@
         <div class="hero-content">
             <h1>Give your AI Agent a whole IDE, not just the files. <a href="{{ "/releases/" | relURL }}" class="version-badge version-badge-sup">v{{ .Site.Params.version }}</a></h1>
             <p class="tagline">
-                MCP Steroid hands your AI Agent the same semantic actions a JetBrains IDE gives humans &mdash; typed refactors, inspections, the debugger, real test runs &mdash; so it finishes in fewer attempts and produces more stable results: less to verify now, and fewer bugs to chase or fix later.
+                devrig hands your AI Agent the same semantic actions a JetBrains IDE gives humans &mdash; typed refactors, inspections, the debugger, real test runs &mdash; so it finishes in fewer attempts and produces more stable results: less to verify now, and fewer bugs to chase or fix later.
             </p>
             <div class="cta-buttons">
                 <a href="{{ "/docs/devrig/" | relURL }}" class="btn btn-primary">

--- a/website/layouts/partials/nav.html
+++ b/website/layouts/partials/nav.html
@@ -17,7 +17,7 @@
     <div class="nav-container">
         <a href="{{ "/" | relURL }}" class="nav-brand">
             <img src="{{ "pluginIcon.svg" | relURL }}" alt="MCP Steroid" class="nav-logo">
-            <span class="nav-title">devrig</span>
+            <span class="nav-title lighter">devrig</span>
             <span class="nav-badge">MCP Steroid</span>
         </a>
 

--- a/website/layouts/partials/nav.html
+++ b/website/layouts/partials/nav.html
@@ -17,8 +17,8 @@
     <div class="nav-container">
         <a href="{{ "/" | relURL }}" class="nav-brand">
             <img src="{{ "pluginIcon.svg" | relURL }}" alt="MCP Steroid" class="nav-logo">
-            <span class="nav-title">MCP Steroid</span>
-            <span class="nav-devrig">devrig</span>
+            <span class="nav-title">devrig</span>
+            <span class="nav-badge">MCP Steroid</span>
         </a>
 
         <a href="/#support" class="nav-heart-mobile" aria-label="PoC & Support">

--- a/website/static/css/site.css
+++ b/website/static/css/site.css
@@ -75,7 +75,7 @@ a:hover {
 }
 .nav-brand {
     display: flex;
-    align-items: baseline;
+    align-items: center;
     gap: 0.75rem;
     text-decoration: none;
     color: var(--color-primary);
@@ -86,16 +86,13 @@ a:hover {
 .nav-logo {
     width: 32px;
     height: 32px;
-    /* logo has no text baseline; keep it visually centered while the two
-       brand tokens (.nav-title / .nav-badge) share a text baseline */
-    align-self: center;
 }
 /* Ensure minimum touch target size (44x44px) */
 .nav-brand {
     padding: 6px 0;
     min-height: 44px;
     display: flex;
-    align-items: baseline;
+    align-items: center;
 }
 .nav-title {
     font-weight: 700;

--- a/website/static/css/site.css
+++ b/website/static/css/site.css
@@ -34,6 +34,9 @@
     /* Accent Colors */
     --color-link: #a0a0ff;
     --color-code: #c0c0ff;
+
+    /* Shared nav font size — wordmark, menu items and badge read at one size */
+    --nav-font-size: 0.95rem;
 }
 
 * {
@@ -96,7 +99,7 @@ a:hover {
 }
 .nav-title {
     font-weight: 700;
-    font-size: 1.1rem;
+    font-size: var(--nav-font-size);
     background: var(--gradient-brand);
     -webkit-background-clip: text;
     -webkit-text-fill-color: transparent;
@@ -110,7 +113,7 @@ a:hover {
 .nav-link {
     color: var(--color-tertiary);
     text-decoration: none;
-    font-size: 0.95rem;
+    font-size: var(--nav-font-size);
     font-weight: 500;
     transition: color 0.2s;
     display: flex;
@@ -419,7 +422,7 @@ margin-bottom: 2rem;
     h1 {
 font-size: 2.5rem;
 margin-bottom: 0.75rem;
-background: linear-gradient(135deg, #8A7AFF 0%, #FF5277 100%);
+background: linear-gradient(135deg, #A99CFF 0%, #FF6E8E 100%);
 -webkit-background-clip: text;
 -webkit-text-fill-color: transparent;
 background-clip: text;
@@ -1431,7 +1434,7 @@ h1 {
 /* ── secondary brand badge in the top-left nav (next to "devrig") ─────────── */
 .nav-badge {
     font-family: var(--font-mono, ui-monospace, monospace);
-    font-size: 0.7rem;
+    font-size: var(--nav-font-size);
     font-weight: 700;
     line-height: 1;
     letter-spacing: 0.01em;

--- a/website/static/css/site.css
+++ b/website/static/css/site.css
@@ -75,7 +75,7 @@ a:hover {
 }
 .nav-brand {
     display: flex;
-    align-items: center;
+    align-items: baseline;
     gap: 0.75rem;
     text-decoration: none;
     color: var(--color-primary);
@@ -86,13 +86,16 @@ a:hover {
 .nav-logo {
     width: 32px;
     height: 32px;
+    /* logo has no text baseline; keep it visually centered while the two
+       brand tokens (.nav-title / .nav-badge) share a text baseline */
+    align-self: center;
 }
 /* Ensure minimum touch target size (44x44px) */
 .nav-brand {
     padding: 6px 0;
     min-height: 44px;
     display: flex;
-    align-items: center;
+    align-items: baseline;
 }
 .nav-title {
     font-weight: 700;
@@ -1440,7 +1443,6 @@ h1 {
     padding: 3px 7px;
     border-radius: 6px;
     white-space: nowrap;
-    align-self: center;
 }
 @media (max-width: 480px) {
     .nav-container { padding-left: 0.9rem; padding-right: 0.9rem; }

--- a/website/static/css/site.css
+++ b/website/static/css/site.css
@@ -109,6 +109,13 @@ a:hover {
     background-clip: text;
     color: transparent;
 }
+/* Inside a button/CTA the gradient-clipped brand word blends into the pill
+   background; force it to the solid white button label so it stays readable. */
+.btn .lighter {
+    background: none;
+    -webkit-text-fill-color: #ffffff;
+    color: #ffffff;
+}
 .nav-links {
     display: flex;
     align-items: center;

--- a/website/static/css/site.css
+++ b/website/static/css/site.css
@@ -419,7 +419,7 @@ margin-bottom: 2rem;
     h1 {
 font-size: 2.5rem;
 margin-bottom: 0.75rem;
-background: var(--gradient-brand);
+background: linear-gradient(135deg, #8A7AFF 0%, #FF5277 100%);
 -webkit-background-clip: text;
 -webkit-text-fill-color: transparent;
 background-clip: text;

--- a/website/static/css/site.css
+++ b/website/static/css/site.css
@@ -1428,8 +1428,8 @@ h1 {
     font-size: 0.85rem;
 }
 
-/* ── devrig brand badge in the top-left nav (next to "MCP Steroid") ───────── */
-.nav-devrig {
+/* ── secondary brand badge in the top-left nav (next to "devrig") ─────────── */
+.nav-badge {
     font-family: var(--font-mono, ui-monospace, monospace);
     font-size: 0.7rem;
     font-weight: 700;
@@ -1444,7 +1444,7 @@ h1 {
 }
 @media (max-width: 480px) {
     .nav-container { padding-left: 0.9rem; padding-right: 0.9rem; }
-    .nav-devrig { font-size: 0.62rem; padding: 2px 5px; }
+    .nav-badge { font-size: 0.62rem; padding: 2px 5px; }
     .nav-brand { gap: 0.4rem; }
     .nav-title { font-size: 1rem; }
 }

--- a/website/static/css/site.css
+++ b/website/static/css/site.css
@@ -100,10 +100,14 @@ a:hover {
 .nav-title {
     font-weight: 700;
     font-size: var(--nav-font-size);
-    background: var(--gradient-brand);
+}
+/* Shared light-gradient "special presentation" for the brand word "devrig". */
+.lighter {
+    background: linear-gradient(135deg, #A99CFF 0%, #FF6E8E 100%);
     -webkit-background-clip: text;
     -webkit-text-fill-color: transparent;
     background-clip: text;
+    color: transparent;
 }
 .nav-links {
     display: flex;


### PR DESCRIPTION
## What
Site header led with `MCP Steroid` (wordmark) then a small `devrig` badge — inconsistent with the devrig-first `<title>` from #334.

Swaps the two brand tokens so the header reads devrig-first:
- before: [logo] **MCP Steroid** `devrig`(badge)
- after:  [logo] **devrig** `MCP Steroid`(badge)

## Changes
- `website/layouts/partials/nav.html`: swap the two brand `<span>`s — devrig takes the `nav-title` wordmark slot, MCP Steroid the badge slot.
- `website/static/css/site.css`: rename `.nav-devrig` → `.nav-badge` (badge class was brand-bound; now role-based). Styling, separators, capitalization unchanged.

## Verification
Hugo extended v0.142.0 build: 0 errors, 31 pages. Rendered header confirmed devrig-first; local screenshot captured.