### PR TITLE
Rebuild homepage around installing devrig (#322, #325)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -168,8 +168,11 @@ When changing files across multiple sub-folders, read the guides for each.
 
 ## Project Overview
 
-MCP Steroid — IntelliJ Platform plugin that exposes a standalone MCP server letting LLM agents drive the
-IDE via Kotlin code execution.
+devrig is the product — the CLI you install and run. One command installs devrig with its own bundled
+runtime (no manual setup); `devrig install <agent>` wires it into Claude Code, Codex, or Gemini. To reach
+real IDE semantics, devrig talks to **MCP Steroid**, the IntelliJ Platform plugin that exposes a standalone
+MCP server letting LLM agents drive the IDE via Kotlin code execution — installed in your JetBrains IDE as
+well (JetBrains Marketplace).
 
 - **Public repo**: https://github.com/jonnyzzz/mcp-steroid
 - **Docs**: [README.md](README.md), [docs/guides/AGENT-STEROID-GUIDE.md](docs/guides/AGENT-STEROID-GUIDE.md)

--- a/website/content/demos.md
+++ b/website/content/demos.md
@@ -1,0 +1,5 @@
+---
+title: "Demos & what's new"
+description: "Featured videos of MCP Steroid and devrig driving a real JetBrains IDE, plus the latest project updates"
+layout: "demos"
+---

--- a/website/content/docs/capabilities.md
+++ b/website/content/docs/capabilities.md
@@ -1,0 +1,61 @@
+---
+title: "What your AI agent can do"
+description: "The IDE actions devrig and MCP Steroid give your coding agent, who it helps, and the agents and IDEs it works with"
+weight: 12
+group: "Getting Started"
+---
+
+Once [devrig](/docs/devrig/) connects your agent to a JetBrains IDE through MCP Steroid,
+the agent stops guessing through file edits and calls the IDE's real semantic actions.
+
+## What your AI Agent can do
+
+<ul class="features-list">
+    <li><strong>Refactor safely</strong>: rename a symbol across the whole project in one operation, extract methods, move classes</li>
+    <li><strong>Debug</strong>: set breakpoints, step through code, inspect variables &mdash; all programmatically</li>
+    <li><strong>Run inspections</strong>: surface real errors before committing, not just syntax issues</li>
+    <li><strong>Execute tests</strong>: run and analyze test results without leaving the AI Agent flow</li>
+    <li><strong>See the IDE</strong>: screenshot capture, UI interaction, modal dialog handling</li>
+    <li><strong>Run without an open IDE</strong>: with <code>devrig</code>, the agent connects to a running IDE &mdash; or downloads and starts one itself</li>
+    <li><strong>Integrate third-party plugins</strong>: call APIs from IntelliJ plugins loaded in the IDE &mdash; internal tooling, language plugins, custom inspections &mdash; without a custom MCP server</li>
+    <li><strong>Go beyond the built-in MCP server</strong>: run IntelliJ API through <code>steroid_execute_code</code> &mdash; not just a fixed catalogue of file/search tools</li>
+    <li><strong><a href="/docs/skill-factory/">Create skills from the running IDE</a></strong>: pass an IntelliJ API snippet yourself, or let your AI Agent learn from the running IDE and write the Skill for you</li>
+</ul>
+
+## Who it helps
+
+<div class="hero-cards hero-cards-three">
+    <div class="hero-card">
+        <h3>When you ship features</h3>
+        <p>Your AI Agent drives a real JetBrains IDE on your code &mdash; safe renames, extract/move refactors, inspections, the debugger, and test runs &mdash; using the same tools you would.</p>
+    </div>
+    <div class="hero-card">
+        <h3>When you review &amp; verify</h3>
+        <p>Your AI Agent runs the same inspections, build, and tests you use to check your own work, inside the IDE, before opening a review.</p>
+    </div>
+    <div class="hero-card">
+        <h3>When you run a team or platform</h3>
+        <p>Point your AI Agents at a large codebase: <code>devrig</code> provisions a managed IDE backend so agents get the same semantic tools. We also run Proof-of-Concept engagements tuned to your repos.</p>
+    </div>
+</div>
+
+## Works with your agents and IDEs
+
+Use it with MCP-capable coding agents &mdash; including Claude, Codex, Gemini, Cursor, and OpenCode &mdash;
+and with IntelliJ-family IDEs such as IntelliJ IDEA, PyCharm, GoLand, WebStorm, Rider, and Android Studio.
+
+<div class="agents-list">
+    <span class="agent-badge">Claude</span>
+    <span class="agent-badge">GPT</span>
+    <span class="agent-badge">Gemini</span>
+    <span class="agent-badge">Codex CLI</span>
+    <span class="agent-badge">Cursor</span>
+    <span class="agent-badge">OpenCode</span>
+</div>
+
+## Next steps
+
+- [Install devrig](/docs/devrig/) and register your agent
+- [Getting Started](/docs/getting-started/) with the MCP Steroid plugin
+- [Build custom skills](/docs/skill-factory/) from the running IDE
+- [Watch demos](/demos/) of the agent working inside the IDE

--- a/website/content/docs/devrig.md
+++ b/website/content/docs/devrig.md
@@ -39,9 +39,10 @@ download and start more on demand:
 <figcaption style="color:#909090;font-size:0.85rem;margin-top:0.4rem;">One <code>devrig</code> process bridges your agent to every IntelliJ-family IDE running on the machine — and can start more.</figcaption>
 </figure>
 
-Devrig is a Java application and requires **Java 25** to run. It does not bundle
-a JVM: `java` must be on the `PATH`, or `JAVA_HOME` / `DEVRIG_JAVA_HOME` must
-point at a Java 25 home.
+Devrig is a Java application. The one-command installer downloads devrig
+together with a matching Java runtime into `~/.mcp-steroid`, so there is nothing
+to set up by hand. To run devrig under a Java you manage instead, point
+`DEVRIG_JAVA_HOME` (or `JAVA_HOME`) at it.
 
 ## Install
 
@@ -132,7 +133,7 @@ Environment variables:
 
 | Variable | Effect |
 |---|---|
-| `DEVRIG_JAVA_HOME` | JDK/JRE home used to launch devrig (devrig needs Java 25). Overrides `JAVA_HOME` for the devrig process only. |
+| `DEVRIG_JAVA_HOME` | JDK/JRE home used to launch devrig, instead of the bundled runtime. Overrides `JAVA_HOME` for the devrig process only. |
 | `DEVRIG_JVM_OPTS` | Extra JVM options for the devrig launch — for example `-Xmx512m`. |
 
 ## Example: an agent provisions an IDE

--- a/website/content/docs/dpaia-wall-clock-archive.md
+++ b/website/content/docs/dpaia-wall-clock-archive.md
@@ -1,0 +1,75 @@
+---
+title: "Archived: early DPAIA wall-clock table"
+description: "The early DPAIA wall-clock comparison, kept for the record only — withdrawn as current evidence"
+weight: 90
+group: "Vision"
+---
+
+<div class="benchmark-footnote" style="border:1px solid rgba(254,40,87,0.35);border-radius:12px;padding:1rem 1.25rem;margin-bottom:1.5rem;">
+<strong>Historical only — not current evidence.</strong> This early DPAIA wall-clock table was
+removed from the homepage. Review (issue&nbsp;#251) found the measured runs did not meaningfully
+exercise the intended product, so these numbers should <strong>not</strong> be read as a current
+performance claim. It is kept here for the record only. For results backed by re-executable tests,
+see <a href="/docs/experiment-findings/">Experiment Findings</a>.
+</div>
+
+The table below compared AI Agents with IDE-native semantic actions vs. file-only workflows on a
+selection of DPAIA tasks. It is retained unedited for transparency.
+
+<div class="benchmark-table-wrapper">
+    <table class="benchmark-table">
+        <thead>
+            <tr>
+                <th>Case</th>
+                <th>Task</th>
+                <th>With MCP</th>
+                <th>Without MCP</th>
+                <th>&Delta;</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td class="benchmark-case">dpaia_jhipster_sample_app-3</td>
+                <td>Rename ROLE_ADMIN across JHipster app (9 files)</td>
+                <td>202s</td>
+                <td>440s</td>
+                <td class="benchmark-faster"><strong>&minus;54%</strong></td>
+            </tr>
+            <tr>
+                <td class="benchmark-case">dpaia_empty_maven_springboot3-1</td>
+                <td>JWT auth from scratch (5+ new files)</td>
+                <td>288s</td>
+                <td>396s</td>
+                <td class="benchmark-faster"><strong>&minus;27%</strong></td>
+            </tr>
+            <tr>
+                <td class="benchmark-case">dpaia_feature_service-25</td>
+                <td>Parent-child JPA &amp; Flyway (10 files)</td>
+                <td>382s</td>
+                <td>523s</td>
+                <td class="benchmark-faster"><strong>&minus;27%</strong></td>
+            </tr>
+            <tr>
+                <td class="benchmark-case">dpaia_feature_service-125</td>
+                <td>Multi-layer JPA+service+controller (15 files)</td>
+                <td>788s</td>
+                <td>1002s</td>
+                <td class="benchmark-faster"><strong>&minus;21%</strong></td>
+            </tr>
+            <tr>
+                <td class="benchmark-case">dpaia_spring_petclinic_rest-14</td>
+                <td>Simple URL prefix replace (7 files)</td>
+                <td>188s</td>
+                <td>181s</td>
+                <td>+4%</td>
+            </tr>
+            <tr>
+                <td class="benchmark-case">dpaia_train_ticket-1</td>
+                <td>Extend OrderRepository JPQL (4 files)</td>
+                <td>727s</td>
+                <td>633s</td>
+                <td>+15%</td>
+            </tr>
+        </tbody>
+    </table>
+</div>

--- a/website/content/docs/experiment-findings.md
+++ b/website/content/docs/experiment-findings.md
@@ -128,3 +128,8 @@ All experiments run continuously on CI; every number above is parsed from the ru
 [experiments-report](https://github.com/jonnyzzz/mcp-steroid/tree/main/experiments-report) pipeline —
 the same code that renders our internal dashboard. To reproduce locally, see the test classes linked
 above; run IDs are TeamCity build IDs recorded for provenance.
+
+---
+
+*Looking for the early DPAIA wall-clock table that used to be on the homepage? It has been
+withdrawn as current evidence (issue #251) and is [kept for the record only](/docs/dpaia-wall-clock-archive/).*

--- a/website/content/docs/experiment-findings.md
+++ b/website/content/docs/experiment-findings.md
@@ -1,6 +1,8 @@
 ---
 title: "Experiment Findings: IDE vs Shell Agents"
 description: "Measured A/B results — the same coding tasks with and without MCP Steroid, on real codebases, with evidence-based scoring"
+group: "Vision"
+weight: 28
 ---
 
 We continuously run A/B experiments where the **same agent gets the same task twice**: once with

--- a/website/content/releases/0.100.md
+++ b/website/content/releases/0.100.md
@@ -26,11 +26,11 @@ The first CLI surface is intentionally practical:
 - `devrig install <claude | codex | gemini>` — register the devrig MCP server with an agent using the correct per-agent syntax, so the `steroid_*` tools appear immediately.
 - `devrig project`, `devrig version`, `devrig help` — the usual operator checks.
 
-`devrig` keeps its state under a fixed `~/.mcp-steroid` home. It ships **without** a bundled runtime and is compiled for **Java 25**, so the agent host must provide a **JDK/JRE 25+** — on `PATH`, via `JAVA_HOME`, or via the `DEVRIG_JAVA_HOME` launcher override. devrig is a preview and the foundation for future work.
+`devrig` keeps its state under a fixed `~/.mcp-steroid` home. It ships **without** a bundled runtime, so the agent host must provide a **JDK/JRE** — on `PATH`, via `JAVA_HOME`, or via the `DEVRIG_JAVA_HOME` launcher override. devrig is a preview and the foundation for future work.
 
 ### IntelliJ 2025.3 (build 253) is no longer supported
 
-The plugin now targets **IntelliJ 2026.1 (`261`)** as its primary baseline, with **2026.2 EAP (`262`)** as a secondary verification target (`since-build = 261`). The build moved to **JDK 25**, Kotlin **2.3.20**, and Ktor **3.3.2**, matching what the 2026.1 line bundles.
+The plugin now targets **IntelliJ 2026.1 (`261`)** as its primary baseline, with **2026.2 EAP (`262`)** as a secondary verification target (`since-build = 261`). The build moved to a newer JDK, Kotlin **2.3.20**, and Ktor **3.3.2**, matching what the 2026.1 line bundles.
 
 ### `steroid_execute_code` gets an explicit `modal` mode
 

--- a/website/content/releases/0.100.md
+++ b/website/content/releases/0.100.md
@@ -26,11 +26,11 @@ The first CLI surface is intentionally practical:
 - `devrig install <claude | codex | gemini>` — register the devrig MCP server with an agent using the correct per-agent syntax, so the `steroid_*` tools appear immediately.
 - `devrig project`, `devrig version`, `devrig help` — the usual operator checks.
 
-`devrig` keeps its state under a fixed `~/.mcp-steroid` home. It ships **without** a bundled runtime, so the agent host must provide a **JDK/JRE** — on `PATH`, via `JAVA_HOME`, or via the `DEVRIG_JAVA_HOME` launcher override. devrig is a preview and the foundation for future work.
+`devrig` keeps its state under a fixed `~/.mcp-steroid` home. It ships **without** a bundled runtime and is compiled for **Java 25**, so the agent host must provide a **JDK/JRE 25+** — on `PATH`, via `JAVA_HOME`, or via the `DEVRIG_JAVA_HOME` launcher override. devrig is a preview and the foundation for future work.
 
 ### IntelliJ 2025.3 (build 253) is no longer supported
 
-The plugin now targets **IntelliJ 2026.1 (`261`)** as its primary baseline, with **2026.2 EAP (`262`)** as a secondary verification target (`since-build = 261`). The build moved to a newer JDK, Kotlin **2.3.20**, and Ktor **3.3.2**, matching what the 2026.1 line bundles.
+The plugin now targets **IntelliJ 2026.1 (`261`)** as its primary baseline, with **2026.2 EAP (`262`)** as a secondary verification target (`since-build = 261`). The build moved to **JDK 25**, Kotlin **2.3.20**, and Ktor **3.3.2**, matching what the 2026.1 line bundles.
 
 ### `steroid_execute_code` gets an explicit `modal` mode
 

--- a/website/content/releases/0.101.md
+++ b/website/content/releases/0.101.md
@@ -1,12 +1,12 @@
 ---
 title: "v0.101"
-description: "One-command install for devrig — curl | sh / irm | iex download devrig + a Java 25 runtime into a predictable ~/.mcp-steroid layout. Smarter startable backends, backend_name routing, a devrig-first settings page."
+description: "One-command install for devrig — curl | sh / irm | iex download devrig + a bundled Java runtime into a predictable ~/.mcp-steroid layout. Smarter startable backends, backend_name routing, a devrig-first settings page."
 aliases:
   - /release-0.101/
 ---
 
 <div class="success">
-<p><strong>MCP Steroid v0.101 — devrig becomes the way you install and run.</strong> A single command now downloads <code>devrig</code> and a matching Java 25 runtime and lays them out under <code>~/.mcp-steroid</code>, so your agent can connect to an IDE you already have open — or have devrig download, start, and stop a managed backend for you.</p>
+<p><strong>MCP Steroid v0.101 — devrig becomes the way you install and run.</strong> A single command now downloads <code>devrig</code> and a matching Java runtime and lays them out under <code>~/.mcp-steroid</code>, so your agent can connect to an IDE you already have open — or have devrig download, start, and stop a managed backend for you.</p>
 </div>
 
 <p><strong>devrig is the recommended entry point.</strong> Direct use of the MCP Steroid plugin's HTTP server is still fully supported, but we recommend migrating to <code>devrig</code>: it owns installation, the Java runtime, agent registration, and backend lifecycle.</p>
@@ -27,11 +27,11 @@ curl -fsSL https://mcp-steroid.jonnyzzz.com/install.sh | sh</pre>
 <pre style="background: rgba(40, 167, 69, 0.1); padding: 0.5rem 1rem; border-radius: 4px; user-select: all;"># Windows
 irm https://mcp-steroid.jonnyzzz.com/install.ps1 | iex</pre>
 
-The installer detects your platform and downloads the matching `devrig` build **and a Java 25 runtime** (Amazon Corretto 25 on macOS/Linux/Windows-x64; Azul Zulu 25 on Windows-arm64) — so you no longer need to install a JDK yourself. Every URL and SHA-256 is baked in at build time (no live discovery), each download is SHA-256–verified, and a missing prerequisite is reported up front rather than failing half-way. It then hands off to `devrig install devrig`, which registers the stable launcher.
+The installer detects your platform and downloads the matching `devrig` build **and a matching Java runtime** (Amazon Corretto on macOS/Linux/Windows-x64; Azul Zulu on Windows-arm64) — so you no longer need to install a JDK yourself. Every URL and SHA-256 is baked in at build time (no live discovery), each download is SHA-256–verified, and a missing prerequisite is reported up front rather than failing half-way. It then hands off to `devrig install devrig`, which registers the stable launcher.
 
 ### A predictable layout under `~/.mcp-steroid`
 
-`devrig` keeps everything under one fixed home — `bin/devrig` (the stable launcher on your PATH, owned and self-healed by the binary on every start) and `binaries/<artifact>-<os>-<cpu>-<version>-<sha12>/` (the content-addressed devrig dist + the matching Java 25). Re-installs are idempotent, and the launcher pins the Java 25 it runs under.
+`devrig` keeps everything under one fixed home — `bin/devrig` (the stable launcher on your PATH, owned and self-healed by the binary on every start) and `binaries/<artifact>-<os>-<cpu>-<version>-<sha12>/` (the content-addressed devrig dist + the matching Java runtime). Re-installs are idempotent, and the launcher pins the Java runtime it runs under.
 
 ### `devrig install` is smoother
 

--- a/website/hugo.toml
+++ b/website/hugo.toml
@@ -124,43 +124,43 @@ staticDir = ['static', 'build/generated-static']
   text = "Supported IntelliJ-based IDEs, including Rider, Android Studio, and GoLand"
 
 [[params.featuredVideos]]
-  id = "HtDDNyAoLak"
-  title = "Codex Debugs in IntelliJ IDEA"
-  meta = "Codex + debugger"
-  duration = "1:03:24"
-
-[[params.featuredVideos]]
   id = "6ByedA15n8Q"
-  title = "MCP Steroid Demo 5"
-  meta = "Most popular demo"
+  title = "Watch an agent refactor in IntelliJ"
+  meta = "Most popular · 1 min"
   duration = "1:00"
 
 [[params.featuredVideos]]
-  id = "8MjogrpfXLU"
-  title = "MCP Steroid & IntelliJ Debugger"
-  meta = "Debugger integration"
-  duration = "8:25"
-
-[[params.featuredVideos]]
-  id = "JGcRk7Y3-Z8"
-  title = "Now we call tasks in IntelliJ"
-  meta = "Task execution demo"
-  duration = "2:21"
-
-[[params.featuredVideos]]
-  id = "ibc0saTT06M"
-  title = "Real Work in Monorepo Part 2"
-  meta = "Deep dive demo"
-  duration = "18:37"
-
-[[params.featuredVideos]]
   id = "QIl57FrAJtk"
-  title = "Cursor Talks with IntelliJ"
+  title = "Cursor drives IntelliJ live"
   meta = "Cursor integration"
   duration = "0:44"
 
 [[params.featuredVideos]]
+  id = "JGcRk7Y3-Z8"
+  title = "An agent runs IntelliJ tasks"
+  meta = "Task execution"
+  duration = "2:21"
+
+[[params.featuredVideos]]
+  id = "8MjogrpfXLU"
+  title = "Debugging in IntelliJ from the agent"
+  meta = "Debugger integration"
+  duration = "8:25"
+
+[[params.featuredVideos]]
+  id = "HtDDNyAoLak"
+  title = "Codex debugs a full session"
+  meta = "Full debugging session"
+  duration = "1:03:24"
+
+[[params.featuredVideos]]
+  id = "ibc0saTT06M"
+  title = "Real work in a monorepo"
+  meta = "Deep dive"
+  duration = "18:37"
+
+[[params.featuredVideos]]
   id = "JNtYCWlRYak"
-  title = "Antigravity Mandelbrot Window"
+  title = "Rendering a Mandelbrot window"
   meta = "Visual demo"
   duration = "0:39"

--- a/website/hugo.toml
+++ b/website/hugo.toml
@@ -69,7 +69,7 @@ staticDir = ['static', 'build/generated-static']
 
 [[params.whatsnew]]
   date = "2026-06-24"
-  text = "v0.101 released — one-command devrig install (curl | sh / irm | iex) downloads devrig + a Java 25 runtime into ~/.mcp-steroid; startable managed backends, backend_name routing, opaque project_name, a devrig-first settings page"
+  text = "v0.101 released — one-command devrig install (curl | sh / irm | iex) downloads devrig and its own runtime into ~/.mcp-steroid; startable managed backends, backend_name routing, opaque project_name, a devrig-first settings page"
 
 [[params.whatsnew]]
   date = "2026-06-02"

--- a/website/layouts/_default/demos.html
+++ b/website/layouts/_default/demos.html
@@ -1,0 +1,74 @@
+{{/*
+  Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com)
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/}}
+{{ define "main" }}
+<article class="page-content">
+    <h1>{{ .Title }}</h1>
+
+    <section class="videos-section">
+        <div class="about-content videos-box">
+            <h2 class="section-title">Featured Demos</h2>
+            <div class="videos-carousel">
+                {{ range .Site.Params.featuredVideos }}
+                <div class="video-card">
+                    <a href="https://www.youtube.com/watch?v={{ .id }}&list=PLitZWClhc4Qgz3w8qrtctMR_lpIc81n0f" target="_blank" rel="noopener">
+                        <div class="video-thumbnail">
+                            <img src="https://img.youtube.com/vi/{{ .id }}/mqdefault.jpg" alt="{{ .title }}">
+                            <span class="video-duration">{{ .duration }}</span>
+                            <div class="video-play-overlay">
+                                <svg viewBox="0 0 24 24" fill="currentColor">
+                                    <path d="M8 5v14l11-7z"/>
+                                </svg>
+                            </div>
+                        </div>
+                        <div class="video-info">
+                            <div class="video-title">{{ .title }}</div>
+                            <div class="video-meta">{{ .meta }}</div>
+                        </div>
+                    </a>
+                </div>
+                {{ end }}
+                <div class="video-card view-more-card">
+                    <a href="{{ .Site.Params.playlistUrl }}" target="_blank" rel="noopener">
+                        <div class="view-more-content">
+                            <svg class="view-more-icon" viewBox="0 0 24 24" fill="currentColor">
+                                <path d="M8 5v14l11-7z"/>
+                            </svg>
+                            <span class="view-more-text">View More Videos</span>
+                            <span class="view-more-count">Full playlist on YouTube</span>
+                        </div>
+                    </a>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <section class="whatsnew-section">
+        <div class="whatsnew-banner">
+            <h2 class="section-title">What&rsquo;s New</h2>
+            <ul class="whatsnew-list">
+                {{ range .Site.Params.whatsnew }}
+                <li class="whatsnew-item">
+                    <span class="whatsnew-date">{{ .date }}</span>
+                    <span class="whatsnew-text">{{ .text }}</span>
+                </li>
+                {{ end }}
+            </ul>
+        </div>
+    </section>
+
+    <p style="text-align:center;margin-top:1.5rem;">See every version on the <a href="{{ "/releases/" | relURL }}">releases page</a>.</p>
+</article>
+{{ end }}

--- a/website/layouts/index.html
+++ b/website/layouts/index.html
@@ -23,11 +23,6 @@
                 One <span class="lighter">devrig</span> command connects Claude&nbsp;Code, Codex, or Gemini to typed refactors, inspections, the debugger, and real test runs &mdash; not just text edits.
             </p>
 
-            <div class="cta-buttons">
-                <a href="#install" class="btn btn-primary">Install <span class="lighter">devrig</span></a>
-                <a href="{{ "/releases/" | relURL }}" class="btn btn-secondary">Get the IDE plugin</a>
-            </div>
-
             <p class="hero-sublinks">
                 <a href="{{ "/docs/capabilities/" | relURL }}">What your agent can do</a>
                 <span class="hero-sublink-sep">&middot;</span>
@@ -40,7 +35,7 @@
 <section class="about-section" id="install">
     <div class="about-content">
         <h2 class="section-title">Install <span class="lighter">devrig</span> &mdash; one command</h2>
-        <p class="section-lede"><span class="lighter">devrig</span> is the primary way in: one line installs the CLI and its own Java&nbsp;25 runtime. Already run a JetBrains IDE? The <strong>MCP&nbsp;Steroid</strong> plugin also installs on its own.</p>
+        <p class="section-lede"><span class="lighter">devrig</span> is the primary way in: one line installs the CLI and everything it needs to run &mdash; no manual setup. Already run a JetBrains IDE? The <strong>MCP&nbsp;Steroid</strong> plugin installs on its own too.</p>
         <div class="install-cta">
             <div class="install-cmd" data-cmd="curl -fsSL https://devrig.dev/install.sh | sh">
                 <span class="install-cmd-os">macOS / Linux</span>
@@ -53,6 +48,7 @@
                 <button type="button" class="install-copy" aria-label="Copy the Windows install command">Copy</button>
             </div>
             <p class="install-cta-sub">Then register your agent: <code>devrig install claude|codex|gemini</code>. <a href="{{ "/docs/devrig/" | relURL }}">Read the devrig guide &rarr;</a></p>
+            <p class="install-cta-sub">In your JetBrains IDE, also install the <strong>MCP&nbsp;Steroid</strong> plugin &rarr; <a href="https://plugins.jetbrains.com/plugin/30019-mcp-steroid" target="_blank" rel="noopener">JetBrains Marketplace</a>.</p>
             <p class="install-trust">No telemetry &mdash; we collect nothing. Checksums are generated on the fly, not shipped or pinned. Everything installs into <code>~/.mcp-steroid</code>.</p>
         </div>
     </div>
@@ -134,11 +130,11 @@
             </div>
             <div class="hero-card">
                 <h3>One bridge to the IDEs you run</h3>
-                <p>A single <span class="lighter">devrig</span> process connects your agent to the IntelliJ-family IDEs already open on your machine, across projects &mdash; or it downloads and starts a managed backend for you.</p>
+                <p>A single <span class="lighter">devrig</span> process connects your agent to the IntelliJ-family IDEs already open on your machine, across projects &mdash; or it downloads and starts a managed backend, giving your agent a real JetBrains IDE experience even on a headless server or CI box.</p>
             </div>
             <div class="hero-card">
                 <h3>No manual MCP wiring</h3>
-                <p><code>devrig install &lt;agent&gt;</code> registers MCP&nbsp;Steroid with Claude&nbsp;Code, Codex, or Gemini, and the installer brings its own Java&nbsp;25 runtime &mdash; nothing to hand-configure.</p>
+                <p><code>devrig install &lt;agent&gt;</code> registers MCP&nbsp;Steroid with Claude&nbsp;Code, Codex, or Gemini, and the installer brings its own runtime &mdash; nothing to hand-configure.</p>
             </div>
         </div>
         <p class="hero-card-cta"><a href="{{ "/docs/capabilities/" | relURL }}" class="card-link"><strong>See what your agent can do &rarr;</strong></a></p>

--- a/website/layouts/index.html
+++ b/website/layouts/index.html
@@ -17,10 +17,10 @@
 <div class="hero">
     <div class="hero-grid">
         <div class="hero-content">
-            <p class="hero-eyebrow"><span class="lighter">devrig</span> + MCP&nbsp;Steroid for JetBrains IDEs</p>
-            <h1>Connect your coding agent to JetBrains IDE intelligence. <a href="{{ "/releases/" | relURL }}" class="version-badge version-badge-sup">v{{ .Site.Params.version }}</a></h1>
+            <p class="hero-eyebrow"><span class="lighter">devrig</span> + MCP&nbsp;Steroid for JetBrains IDEs <a href="{{ "/releases/" | relURL }}" class="version-badge hero-eyebrow-version">v{{ .Site.Params.version }}</a></p>
+            <h1>Give your AI coding agent a real JetBrains IDE &mdash; real refactors, inspections, and a debugger.</h1>
             <p class="tagline">
-                <span class="lighter">devrig</span> is the CLI you install and run. It connects your MCP-capable coding agent &mdash; Claude&nbsp;Code, Codex, Gemini &mdash; to a real JetBrains IDE through the <strong>MCP&nbsp;Steroid</strong> plugin, so the agent can use typed refactors, inspections, the debugger, and real test runs instead of only editing text.
+                One <span class="lighter">devrig</span> command connects Claude&nbsp;Code, Codex, or Gemini to typed refactors, inspections, the debugger, and real test runs &mdash; not just text edits.
             </p>
 
             <div class="cta-buttons">
@@ -53,6 +53,7 @@
                 <button type="button" class="install-copy" aria-label="Copy the Windows install command">Copy</button>
             </div>
             <p class="install-cta-sub">Then register your agent: <code>devrig install claude|codex|gemini</code>. <a href="{{ "/docs/devrig/" | relURL }}">Read the devrig guide &rarr;</a></p>
+            <p class="install-trust">No telemetry &mdash; we collect nothing. Checksums are generated on the fly, not shipped or pinned. Everything installs into <code>~/.mcp-steroid</code>.</p>
         </div>
     </div>
 </section>
@@ -92,6 +93,33 @@
                 </a>
             </div>
         </div>
+    </div>
+</section>
+
+<section class="about-section" id="proof">
+    <div class="about-content">
+        <h2 class="section-title">What a verified run looks like</h2>
+        <p class="section-lede">We run the <strong>same task twice</strong> &mdash; same model, same repo &mdash; once with the IDE through MCP&nbsp;Steroid, once as a plain shell agent (grep, sed, javac). Every result below is scored on machine-checkable evidence, not on what the agent claims about itself.</p>
+        <div class="hero-cards hero-cards-three">
+            <div class="hero-card proof-card">
+                <div class="proof-stat">1m 48s <span class="proof-vs">vs 18m 13s</span></div>
+                <h3>Structural search across YouTrackDB</h3>
+                <p>Find every no-arg <code>Optional.get()</code> across a multi-module reactor. The IDE's AST-exact matcher: 1m&nbsp;48s / $0.75 at the same completeness the grep agent reached in 18m&nbsp;13s / $3.32.</p>
+            </div>
+            <div class="hero-card proof-card">
+                <div class="proof-stat">4/4 <span class="proof-vs">vs 3/4</span></div>
+                <h3>Redundant-cast inspection on Keycloak</h3>
+                <p>Which files hold a genuinely redundant cast, ground-truthed by <code>javac -Xlint:cast</code>? The IDE inspection: 4/4 true positives in 1m&nbsp;01s; the shell agent got 3/4 in 2m&nbsp;40s.</p>
+            </div>
+            <div class="hero-card proof-card">
+                <div class="proof-stat">green build <span class="proof-vs">vs died mid-way</span></div>
+                <h3>Safe rename across Keycloak</h3>
+                <p>An atomic PSI rename finished in 7m&nbsp;39s with a clean build; the manual shell sweep died mid-way after 18 minutes with nothing usable &mdash; the win is a verified-by-construction result, not just speed.</p>
+            </div>
+        </div>
+        <p class="proof-negative"><strong>We publish the losses too:</strong> on that same structural search, GPT&nbsp;5.5's IDE leg gave up after 1m&nbsp;25s without an exact match while its own grep baseline scored an exact 13/13 in 7m&nbsp;32s &mdash; the Codex flow there still needs work.</p>
+        <p class="proof-provenance">Recorded on internal CI; build IDs retained for provenance (SSR&nbsp;<code>993038190</code>, inspection&nbsp;<code>993036643</code>, rename&nbsp;<code>992152358</code>, GPT&nbsp;SSR&nbsp;<code>993038200</code> &mdash; all green). Reproduce from the public tests: <a href="https://github.com/jonnyzzz/mcp-steroid/tree/main/test-experiments" target="_blank" rel="noopener">test-experiments</a> and the evidence-based <a href="https://github.com/jonnyzzz/mcp-steroid/blob/main/test-integration/src/main/kotlin/com/jonnyzzz/mcpSteroid/integration/tests/SemanticTaskScoring.kt" target="_blank" rel="noopener">SemanticTaskScoring.kt</a>.</p>
+        <p class="hero-card-cta"><a href="{{ "/docs/experiment-findings/" | relURL }}" class="card-link"><strong>Read the full experiment findings &rarr;</strong></a></p>
     </div>
 </section>
 

--- a/website/layouts/index.html
+++ b/website/layouts/index.html
@@ -17,278 +17,106 @@
 <div class="hero">
     <div class="hero-grid">
         <div class="hero-content">
-            <h1>Give your AI Agent a whole IDE, not just the files. <a href="{{ "/releases/" | relURL }}" class="version-badge version-badge-sup">v{{ .Site.Params.version }}</a></h1>
+            <p class="hero-eyebrow"><span class="lighter">devrig</span> + MCP&nbsp;Steroid for JetBrains IDEs</p>
+            <h1>Connect your coding agent to JetBrains IDE intelligence. <a href="{{ "/releases/" | relURL }}" class="version-badge version-badge-sup">v{{ .Site.Params.version }}</a></h1>
             <p class="tagline">
-                <span class="lighter">devrig</span> hands your AI Agent the same semantic actions a JetBrains IDE gives humans &mdash; typed refactors, inspections, the debugger, real test runs &mdash; so it finishes in fewer attempts and produces more stable results: less to verify now, and fewer bugs to chase or fix later.
+                <span class="lighter">devrig</span> is the CLI you install and run. It connects your MCP-capable coding agent &mdash; Claude&nbsp;Code, Codex, Gemini &mdash; to a real JetBrains IDE through the <strong>MCP&nbsp;Steroid</strong> plugin, so the agent can use typed refactors, inspections, the debugger, and real test runs instead of only editing text.
             </p>
-            <div class="cta-buttons">
-                <a href="{{ "/docs/devrig/" | relURL }}" class="btn btn-primary">
-                    <svg class="btn-icon" viewBox="0 0 24 24" fill="currentColor">
-                        <path d="M4 4h16v2H4V4zm0 5h10v2H4V9zm0 5h16v2H4v-2zm0 5h10v2H4v-2z"/>
-                    </svg>
-                    Try <span class="lighter">devrig</span> (CLI)
-                </a>
-                <a href="{{ "/releases/" | relURL }}" class="btn btn-secondary">
-                    <svg class="btn-icon" viewBox="0 0 24 24" fill="currentColor">
-                        <path d="M19 9h-4V3H9v6H5l7 7 7-7zM5 18v2h14v-2H5z"/>
-                    </svg>
-                    Install plugin
-                </a>
-                <a href="{{ .Site.Params.playlistUrl }}" class="btn btn-secondary" target="_blank" rel="noopener">
-                    <svg class="btn-icon" viewBox="0 0 24 24" fill="currentColor">
-                        <path d="M8 5v14l11-7z"/>
-                    </svg>
-                    Watch demos
-                </a>
+
+            <div class="install-cta">
+                <p class="install-cta-label">Install <span class="lighter">devrig</span> &mdash; one command:</p>
+                <div class="install-cmd" data-cmd="curl -fsSL https://devrig.dev/install.sh | sh">
+                    <span class="install-cmd-os">macOS / Linux</span>
+                    <code class="install-cmd-text">curl -fsSL https://devrig.dev/install.sh | sh</code>
+                    <button type="button" class="install-copy" aria-label="Copy the macOS / Linux install command">Copy</button>
+                </div>
+                <div class="install-cmd" data-cmd="irm https://devrig.dev/install.ps1 | iex">
+                    <span class="install-cmd-os">Windows</span>
+                    <code class="install-cmd-text">irm https://devrig.dev/install.ps1 | iex</code>
+                    <button type="button" class="install-copy" aria-label="Copy the Windows install command">Copy</button>
+                </div>
+                <p class="install-cta-sub">Then register your agent: <code>devrig install claude|codex|gemini</code>. <a href="{{ "/docs/devrig/" | relURL }}">Read the devrig guide &rarr;</a></p>
             </div>
+
+            <p class="hero-sublinks">
+                <a href="{{ "/demos/" | relURL }}">Watch demos</a>
+                <span class="hero-sublink-sep">&middot;</span>
+                <a href="{{ "/docs/capabilities/" | relURL }}">What your agent can do</a>
+                <span class="hero-sublink-sep">&middot;</span>
+                <a href="{{ "/releases/" | relURL }}">Already use the plugin? Install a release</a>
+            </p>
         </div>
     </div>
 </div>
 
+<section class="about-section" id="value">
+    <div class="about-content">
+        <h2 class="section-title">Why it matters</h2>
+        <p class="section-lede">A coding agent limited to reading and writing files has to guess at what the IDE already knows. <span class="lighter">devrig</span> hands it the real thing.</p>
+        <div class="hero-cards hero-cards-three">
+            <div class="hero-card">
+                <h3>Real IDE semantics, not text guesses</h3>
+                <p>Your agent calls the same actions a JetBrains IDE gives a human &mdash; typed rename/extract/move refactors, inspections, the debugger, and real test runs &mdash; on your actual project model.</p>
+            </div>
+            <div class="hero-card">
+                <h3>One bridge to the IDEs you run</h3>
+                <p>A single <span class="lighter">devrig</span> process connects your agent to the IntelliJ-family IDEs already open on your machine, across projects &mdash; or it downloads and starts a managed backend for you.</p>
+            </div>
+            <div class="hero-card">
+                <h3>No manual MCP wiring</h3>
+                <p><code>devrig install &lt;agent&gt;</code> registers MCP&nbsp;Steroid with Claude&nbsp;Code, Codex, or Gemini, and the installer brings its own Java&nbsp;25 runtime &mdash; nothing to hand-configure.</p>
+            </div>
+        </div>
+        <p class="hero-card-cta"><a href="{{ "/docs/capabilities/" | relURL }}" class="card-link"><strong>See what your agent can do &rarr;</strong></a></p>
+    </div>
+</section>
+
 <section class="about-section" id="devrig">
     <div class="about-content">
-        <h2 class="section-title">New: <code>devrig</code> &mdash; give your agent an IDE, even on a headless box <span class="agent-badge">Preview</span></h2>
+        <h2 class="section-title"><span class="lighter">devrig</span> is the product. MCP&nbsp;Steroid is how it reaches your IDE.</h2>
         <p class="section-lede">
-            <code>devrig</code> is a new standalone CLI that bridges any MCP-capable agent &mdash; Claude Code, Codex, Gemini &mdash; into a real IntelliJ-family IDE over stdio. It connects to <strong>every IDE you already have open at once</strong> &mdash; across projects, through a single bridge &mdash; or it <strong>downloads, installs, and starts one for the agent</strong> (IDEA Community/Ultimate, PyCharm, Android Studio), so your agent reaches real IDE semantics without you hand-wiring any MCP configuration.
+            <strong><span class="lighter">devrig</span></strong> is the CLI and local control plane you install and run. To reach real IDE semantics it talks to the <strong>MCP&nbsp;Steroid</strong> plugin running inside a JetBrains IDE. You install <span class="lighter">devrig</span>; <span class="lighter">devrig</span> uses MCP&nbsp;Steroid.
         </p>
         <figure style="margin:1.25rem 0;">
             <img src="{{ "/devrig-bridge.svg" | relURL }}" alt="One devrig bridge connects your AI Agent to all running IDEs at once — and can start more" loading="lazy" style="width:100%;max-width:720px;height:auto;display:block;margin:0 auto;border-radius:12px;">
         </figure>
         <div class="hero-cards hero-cards-two">
             <div class="hero-card">
-                <h3>Connect to all of them &mdash; or provision</h3>
-                <p>One <code>devrig</code> process bridges your agent to every IntelliJ-family IDE running on the machine at once (across projects), or it fetches and launches a fresh one. Either way the agent talks to real IDEs, not a guess.</p>
+                <h3><span class="lighter">devrig</span> &mdash; the CLI you install</h3>
+                <p>The standalone command-line control plane. It registers your agent, bridges MCP calls to a running IDE across projects, and can download, start, and stop a managed IntelliJ backend. This is the thing you install and run.</p>
             </div>
             <div class="hero-card">
-                <h3>Headless &amp; CI-ready <span class="agent-badge">Work in progress</span></h3>
-                <p>Built for terminal, remote, and CI-style workflows: <span class="lighter">devrig</span> manages the IDE lifecycle so agents on remote servers and in CI get the same semantic tools. This path is actively being hardened.</p>
+                <h3>MCP&nbsp;Steroid &mdash; the IDE plugin</h3>
+                <p>The JetBrains IDE plugin that exposes the IDE's real semantic actions. <span class="lighter">devrig</span> connects to it so your agent reaches typed refactors, inspections, the debugger, and test runs. Also installable directly for an IDE you already use.</p>
             </div>
         </div>
         <p class="hero-card-cta"><a href="{{ "/docs/devrig/" | relURL }}" class="card-link"><strong>Read the <span class="lighter">devrig</span> guide &rarr;</strong></a></p>
         <p class="benchmark-footnote">
-            <code>devrig</code> is an early preview and the foundation for where this project is going &mdash; expect it to grow fast. Requires a JDK&nbsp;25+ on the host. MCP&nbsp;Steroid / Devrig is an independent open-source project, <strong>not affiliated with, sponsored by, or endorsed by JetBrains.</strong>
+            MCP&nbsp;Steroid / Devrig is an independent open-source project, <strong>not affiliated with, sponsored by, or endorsed by JetBrains.</strong> IntelliJ&nbsp;IDEA, PyCharm, and other IDE names are trademarks of JetBrains&nbsp;s.r.o.
         </p>
-    </div>
-</section>
-
-<section class="about-section">
-    <div class="about-content">
-        <h2 class="section-title">Why MCP Steroid / Devrig</h2>
-        <p class="section-lede">Works with any MCP-capable AI Agent &mdash; Claude, Codex, Gemini, Cursor, OpenCode, or any other MCP client. Run it in your JetBrains IDE today, or headless via the new <code>devrig</code> CLI.</p>
-        <div class="agents-list">
-            <span class="agent-badge">Claude</span>
-            <span class="agent-badge">GPT</span>
-            <span class="agent-badge">Gemini</span>
-            <span class="agent-badge">Codex CLI</span>
-            <span class="agent-badge">Cursor</span>
-            <span class="agent-badge">OpenCode</span>
-            <span class="agent-badge">Any MCP Client</span>
-        </div>
-        <div class="hero-cards hero-cards-two">
-            <div class="hero-card">
-                <h3><a href="#benchmarks" class="card-link">Fewer wasted iterations</a></h3>
-                <p>AI Agents finish semantic tasks in fewer attempts when they can use real refactorings, inspections, and the debugger instead of guessing through file edits. Measured on selected <a href="https://dpaia.org" target="_blank" rel="noopener" class="card-link">DPAIA</a> projects.</p>
-            </div>
-            <div class="hero-card">
-                <h3>Closed verify loop</h3>
-                <p>Your AI Agent runs inspections, the build, and the tests through the same IDE humans use to verify their own work &mdash; the Agent catches its mistakes before the human review queue does.</p>
-            </div>
-        </div>
-    </div>
-</section>
-
-<section class="about-section">
-    <div class="about-content">
-        <h2 class="section-title">Built for AI Agents</h2>
-        <p class="section-lede">MCP Steroid gives the AI Agents you already use real IDE power &mdash; not another UI to babysit. Whatever your role, your Agent does more of the work and leaves you less to clean up:</p>
-        <div class="hero-cards hero-cards-three">
-            <div class="hero-card">
-                <h3>When you ship features</h3>
-                <p>Your AI Agent drives a real JetBrains IDE on your code &mdash; safe renames, extract/move refactors, inspections, the debugger, and test runs &mdash; so it lands changes in fewer cleanup loops and you re-review less.</p>
-                <p class="hero-card-cta"><a href="{{ "/docs/devrig/" | relURL }}" class="card-link"><strong>Start With devrig &rarr;</strong></a><br><a href="{{ "/releases/" | relURL }}" class="card-link"><strong>Install the Plugin &rarr;</strong></a></p>
-            </div>
-            <div class="hero-card">
-                <h3>When you review &amp; verify</h3>
-                <p>Your AI Agent runs the same inspections, build, and tests you use to check your own work &mdash; so it catches its own mistakes before they ever reach your review queue.</p>
-            </div>
-            <div class="hero-card">
-                <h3>When you run a team or platform</h3>
-                <p>Point your AI Agents at a large codebase and they stay consistent: <span class="lighter">devrig</span> provisions a managed IDE backend for headless and CI runs, so every Agent gets the same semantic tools. We also run Proof-of-Concept engagements tuned to your repos.</p>
-                <p class="hero-card-cta"><a href="#support" class="card-link"><strong>Book a PoC &rarr;</strong></a><br><a href="{{ "/docs/need-your-experiments-and-support/" | relURL }}" class="card-link"><strong>Submit a Scenario &rarr;</strong></a></p>
-            </div>
-        </div>
-    </div>
-</section>
-
-<section class="about-section" id="benchmarks">
-    <div class="benchmark-panel">
-        <h2 class="section-title">Evidence: fewer wasted iterations, not just speed</h2>
-        <p class="benchmark-subtitle">
-            <a href="https://dpaia.org" target="_blank" rel="noopener">DPAIA</a> wall-clock results comparing AI Agents with IDE-native semantic actions (MCP Steroid) vs. file-only workflows. On tasks requiring real semantic understanding the Agent finishes in fewer attempts; read the delta as &ldquo;rework the Agent avoided&rdquo;:
-        </p>
-        <div class="benchmark-table-wrapper">
-            <table class="benchmark-table">
-                <thead>
-                    <tr>
-                        <th>Case</th>
-                        <th>Task</th>
-                        <th>With MCP</th>
-                        <th>Without MCP</th>
-                        <th>&Delta;</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    <tr>
-                        <td class="benchmark-case">dpaia_jhipster_sample_app-3</td>
-                        <td>Rename ROLE_ADMIN across JHipster app (9 files)</td>
-                        <td>202s</td>
-                        <td>440s</td>
-                        <td class="benchmark-faster"><strong>&minus;54%</strong></td>
-                    </tr>
-                    <tr>
-                        <td class="benchmark-case">dpaia_empty_maven_springboot3-1</td>
-                        <td>JWT auth from scratch (5+ new files)</td>
-                        <td>288s</td>
-                        <td>396s</td>
-                        <td class="benchmark-faster"><strong>&minus;27%</strong></td>
-                    </tr>
-                    <tr>
-                        <td class="benchmark-case">dpaia_feature_service-25</td>
-                        <td>Parent-child JPA &amp; Flyway (10 files)</td>
-                        <td>382s</td>
-                        <td>523s</td>
-                        <td class="benchmark-faster"><strong>&minus;27%</strong></td>
-                    </tr>
-                    <tr>
-                        <td class="benchmark-case">dpaia_feature_service-125</td>
-                        <td>Multi-layer JPA+service+controller (15 files)</td>
-                        <td>788s</td>
-                        <td>1002s</td>
-                        <td class="benchmark-faster"><strong>&minus;21%</strong></td>
-                    </tr>
-                    <tr>
-                        <td class="benchmark-case">dpaia_spring_petclinic_rest-14</td>
-                        <td>Simple URL prefix replace (7 files)</td>
-                        <td>188s</td>
-                        <td>181s</td>
-                        <td>+4%</td>
-                    </tr>
-                    <tr>
-                        <td class="benchmark-case">dpaia_train_ticket-1</td>
-                        <td>Extend OrderRepository JPQL (4 files)</td>
-                        <td>727s</td>
-                        <td>633s</td>
-                        <td>+15%</td>
-                    </tr>
-                </tbody>
-            </table>
-        </div>
-        <p class="benchmark-footnote">
-            Tasks requiring semantic understanding &mdash; refactorings across many files, multi-layer code generation &mdash; show the largest reduction in wasted iterations. Simple text replacements perform similarly with or without IDE access. <a href="https://github.com/jonnyzzz/mcp-steroid/issues" target="_blank" rel="noopener">Suggest your project</a> for the next benchmark run.
-        </p>
-    </div>
-</section>
-
-<section class="about-section">
-    <div class="about-content">
-        <h2 class="section-title">What Your AI Agent Can Do</h2>
-        <ul class="features-list">
-            <li><strong>Refactor safely</strong>: rename a symbol across 50 files in one operation, extract methods, move classes</li>
-            <li><strong>Debug</strong>: set breakpoints, step through code, inspect variables &mdash; all programmatically</li>
-            <li><strong>Run inspections</strong>: catch real errors before committing, not just syntax issues</li>
-            <li><strong>Execute tests</strong>: run and analyze test results without leaving the AI Agent flow</li>
-            <li><strong>See the IDE</strong>: screenshot capture, UI interaction, modal dialog handling</li>
-            <li><strong>Run without an open IDE</strong>: with <code>devrig</code>, the agent connects to a running IDE &mdash; or downloads and starts one itself &mdash; for headless, CI, and fresh-machine work</li>
-            <li><strong>Integrate any third-party plugin</strong>: call APIs from any IntelliJ plugin loaded in the IDE &mdash; internal tooling, language plugins, custom inspections &mdash; without a custom MCP server</li>
-            <li><strong>Go beyond the built-in MCP server</strong>: run any IntelliJ API through <code>steroid_execute_code</code> &mdash; not just a fixed catalogue of file/search tools</li>
-            <li><strong><a href="#create-skills" class="card-link">Create skills from the running IDE</a></strong>: pass an IntelliJ API snippet yourself, or let your AI Agent learn from the running IDE and write the Skill for you</li>
-        </ul>
-    </div>
-</section>
-
-<section class="videos-section">
-    <div class="about-content videos-box">
-        <h2 class="section-title">Featured Demos</h2>
-        <div class="videos-carousel">
-            {{ range .Site.Params.featuredVideos }}
-            <div class="video-card">
-                <a href="https://www.youtube.com/watch?v={{ .id }}&list=PLitZWClhc4Qgz3w8qrtctMR_lpIc81n0f" target="_blank" rel="noopener">
-                    <div class="video-thumbnail">
-                        <img src="https://img.youtube.com/vi/{{ .id }}/mqdefault.jpg" alt="{{ .title }}">
-                        <span class="video-duration">{{ .duration }}</span>
-                        <div class="video-play-overlay">
-                            <svg viewBox="0 0 24 24" fill="currentColor">
-                                <path d="M8 5v14l11-7z"/>
-                            </svg>
-                        </div>
-                    </div>
-                    <div class="video-info">
-                        <div class="video-title">{{ .title }}</div>
-                        <div class="video-meta">{{ .meta }}</div>
-                    </div>
-                </a>
-            </div>
-            {{ end }}
-            <div class="video-card view-more-card">
-                <a href="{{ .Site.Params.playlistUrl }}" target="_blank" rel="noopener">
-                    <div class="view-more-content">
-                        <svg class="view-more-icon" viewBox="0 0 24 24" fill="currentColor">
-                            <path d="M8 5v14l11-7z"/>
-                        </svg>
-                        <span class="view-more-text">View More Videos</span>
-                        <span class="view-more-count">Full playlist on YouTube</span>
-                    </div>
-                </a>
-            </div>
-        </div>
-    </div>
-</section>
-
-<section class="about-section">
-    <div class="about-content">
-        <h2 class="section-title" id="create-skills">Create Powerful IntelliJ-Driven Skills</h2>
-        <p>
-            Create custom skills for your AI Agent in minutes. Describe what you want, give it an IntelliJ API example, and let the AI Agent iterate. No plugin development needed.
-        </p>
-        <pre class="code-example"><code>import com.intellij.psi.search.PsiSearchHelper
-import com.intellij.psi.search.GlobalSearchScope
-
-// Example: find all TODO comments in the project
-val todoItems = readAction {
-    val searchHelper = PsiSearchHelper.getInstance(project)
-    val result = mutableListOf&lt;String&gt;()
-    searchHelper.processCommentsContainingIdentifier("TODO", GlobalSearchScope.projectScope(project)) { comment -&gt;
-        result.add("${comment.containingFile.virtualFile.path}: ${comment.text.trim()}")
-        true
-    }
-    result
-}
-todoItems.forEach { println(it) }</code></pre>
-        <p>
-            The <a href="/docs/how-to-debug-ide/">Debugging IDE with MCP Steroid</a> guide was written entirely by AI Agents &mdash; a real skill created through experimentation with full IDE access.
-        </p>
-        <p class="consulting-note">
-            Ready to give your AI Agent full IDE access? <a href="{{ "/docs/devrig/" | relURL }}">Try the <span class="lighter">devrig</span> CLI</a> for terminal and managed-backend workflows, or <a href="{{ "/releases/" | relURL }}">install the plugin</a> for an IDE you already use. See the <a href="https://jonnyzzz.com/blog/2026/04/08/mcp-steroid-skill-factory/" target="_blank" rel="noopener">Skill Factory blog post</a> for a deep dive on building custom skills.
-        </p>
-        <p class="consulting-note">
-            <strong>Proof-of-Concept program:</strong> We run Proof-of-Concept engagements for company-specific use cases &mdash; custom skills, internal tooling integrations, AI Agent workflows tailored to your codebase. <a href="https://jonnyzzz.com/support/" target="_blank" rel="noopener">Contact Eugene</a> to discuss.
-        </p>
-    </div>
-</section>
-
-<section class="whatsnew-section">
-    <div class="whatsnew-banner">
-        <h2 class="section-title">What&rsquo;s New</h2>
-        <ul class="whatsnew-list">
-            {{ range .Site.Params.whatsnew }}
-            <li class="whatsnew-item">
-                <span class="whatsnew-date">{{ .date }}</span>
-                <span class="whatsnew-text">{{ .text }}</span>
-            </li>
-            {{ end }}
-        </ul>
     </div>
 </section>
 
 {{ partial "support-section.html" . }}
+
+<script>
+    // Install-command copy buttons (progressive enhancement; the command text is
+    // also selectable as a fallback when clipboard access is unavailable).
+    document.querySelectorAll('.install-cmd').forEach(function (row) {
+        var btn = row.querySelector('.install-copy');
+        var cmd = row.getAttribute('data-cmd');
+        if (!btn) return;
+        btn.addEventListener('click', function () {
+            var done = function () { btn.textContent = 'Copied'; setTimeout(function () { btn.textContent = 'Copy'; }, 1600); };
+            if (navigator.clipboard && navigator.clipboard.writeText) {
+                navigator.clipboard.writeText(cmd).then(done, function () { btn.textContent = 'Select & copy'; });
+            } else {
+                var sel = window.getSelection(); var range = document.createRange();
+                range.selectNodeContents(row.querySelector('.install-cmd-text'));
+                sel.removeAllRanges(); sel.addRange(range);
+                btn.textContent = 'Select & copy';
+            }
+        });
+    });
+</script>
 {{ end }}

--- a/website/layouts/index.html
+++ b/website/layouts/index.html
@@ -23,31 +23,77 @@
                 <span class="lighter">devrig</span> is the CLI you install and run. It connects your MCP-capable coding agent &mdash; Claude&nbsp;Code, Codex, Gemini &mdash; to a real JetBrains IDE through the <strong>MCP&nbsp;Steroid</strong> plugin, so the agent can use typed refactors, inspections, the debugger, and real test runs instead of only editing text.
             </p>
 
-            <div class="install-cta">
-                <p class="install-cta-label">Install <span class="lighter">devrig</span> &mdash; one command:</p>
-                <div class="install-cmd" data-cmd="curl -fsSL https://devrig.dev/install.sh | sh">
-                    <span class="install-cmd-os">macOS / Linux</span>
-                    <code class="install-cmd-text">curl -fsSL https://devrig.dev/install.sh | sh</code>
-                    <button type="button" class="install-copy" aria-label="Copy the macOS / Linux install command">Copy</button>
-                </div>
-                <div class="install-cmd" data-cmd="irm https://devrig.dev/install.ps1 | iex">
-                    <span class="install-cmd-os">Windows</span>
-                    <code class="install-cmd-text">irm https://devrig.dev/install.ps1 | iex</code>
-                    <button type="button" class="install-copy" aria-label="Copy the Windows install command">Copy</button>
-                </div>
-                <p class="install-cta-sub">Then register your agent: <code>devrig install claude|codex|gemini</code>. <a href="{{ "/docs/devrig/" | relURL }}">Read the devrig guide &rarr;</a></p>
+            <div class="cta-buttons">
+                <a href="#install" class="btn btn-primary">Install <span class="lighter">devrig</span></a>
+                <a href="{{ "/releases/" | relURL }}" class="btn btn-secondary">Get the IDE plugin</a>
             </div>
 
             <p class="hero-sublinks">
-                <a href="{{ "/demos/" | relURL }}">Watch demos</a>
-                <span class="hero-sublink-sep">&middot;</span>
                 <a href="{{ "/docs/capabilities/" | relURL }}">What your agent can do</a>
                 <span class="hero-sublink-sep">&middot;</span>
-                <a href="{{ "/releases/" | relURL }}">Already use the plugin? Install a release</a>
+                <a href="{{ "/docs/devrig/" | relURL }}">Read the <span class="lighter">devrig</span> guide</a>
             </p>
         </div>
     </div>
 </div>
+
+<section class="about-section" id="install">
+    <div class="about-content">
+        <h2 class="section-title">Install <span class="lighter">devrig</span> &mdash; one command</h2>
+        <p class="section-lede"><span class="lighter">devrig</span> is the primary way in: one line installs the CLI and its own Java&nbsp;25 runtime. Already run a JetBrains IDE? The <strong>MCP&nbsp;Steroid</strong> plugin also installs on its own.</p>
+        <div class="install-cta">
+            <div class="install-cmd" data-cmd="curl -fsSL https://devrig.dev/install.sh | sh">
+                <span class="install-cmd-os">macOS / Linux</span>
+                <code class="install-cmd-text">curl -fsSL https://devrig.dev/install.sh | sh</code>
+                <button type="button" class="install-copy" aria-label="Copy the macOS / Linux install command">Copy</button>
+            </div>
+            <div class="install-cmd" data-cmd="irm https://devrig.dev/install.ps1 | iex">
+                <span class="install-cmd-os">Windows</span>
+                <code class="install-cmd-text">irm https://devrig.dev/install.ps1 | iex</code>
+                <button type="button" class="install-copy" aria-label="Copy the Windows install command">Copy</button>
+            </div>
+            <p class="install-cta-sub">Then register your agent: <code>devrig install claude|codex|gemini</code>. <a href="{{ "/docs/devrig/" | relURL }}">Read the devrig guide &rarr;</a></p>
+        </div>
+    </div>
+</section>
+
+<section class="videos-section" id="demos-preview">
+    <div class="about-content videos-box">
+        <h2 class="section-title">See it drive a real IDE</h2>
+        <div class="videos-carousel">
+            {{ range first 4 .Site.Params.featuredVideos }}
+            <div class="video-card">
+                <a href="https://www.youtube.com/watch?v={{ .id }}&list=PLitZWClhc4Qgz3w8qrtctMR_lpIc81n0f" target="_blank" rel="noopener">
+                    <div class="video-thumbnail">
+                        <img src="https://img.youtube.com/vi/{{ .id }}/mqdefault.jpg" alt="{{ .title }}" loading="lazy">
+                        <span class="video-duration">{{ .duration }}</span>
+                        <div class="video-play-overlay">
+                            <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                                <path d="M8 5v14l11-7z"/>
+                            </svg>
+                        </div>
+                    </div>
+                    <div class="video-info">
+                        <div class="video-title">{{ .title }}</div>
+                        <div class="video-meta">{{ .meta }}</div>
+                    </div>
+                </a>
+            </div>
+            {{ end }}
+            <div class="video-card view-more-card">
+                <a href="{{ "/demos/" | relURL }}">
+                    <div class="view-more-content">
+                        <svg class="view-more-icon" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                            <path d="M8 5v14l11-7z"/>
+                        </svg>
+                        <span class="view-more-text">Watch demos</span>
+                        <span class="view-more-count">All videos &amp; what&rsquo;s new</span>
+                    </div>
+                </a>
+            </div>
+        </div>
+    </div>
+</section>
 
 <section class="about-section" id="value">
     <div class="about-content">

--- a/website/layouts/partials/support-section.html
+++ b/website/layouts/partials/support-section.html
@@ -14,6 +14,9 @@
         </p>
         <p>We run Proof-of-Concept engagements for company-specific use cases &mdash; custom skills, internal tooling integrations, AI Agent workflows tailored to your codebase. <a href="https://jonnyzzz.com/support/" target="_blank" rel="noopener">Learn more about consulting and Proof-of-Concept options</a>.</p>
         <p class="support-footnote">Beyond GitHub Sponsors, MCP Steroid also accepts in-kind support: compute tokens for evaluation runs, hardware for the multi-IDE test matrix, and licenses for benchmarking and observability tools. If you or your organisation would like to back the project or the research behind it on those terms, reach out &mdash; contact details are linked below.</p>
+        {{ if .IsHome }}
+        <p class="support-footnote">We are also looking for <strong>partnerships</strong> on two fronts: <strong>(a) training models</strong> &mdash; collaborating on data, evaluation, and tuning for agent-in-the-IDE workflows &mdash; and <strong>(b) embedding devrig into your company's processes</strong> &mdash; adopting it inside your engineering and CI workflows. If either fits your organisation, <a href="https://jonnyzzz.com/support/" target="_blank" rel="noopener">get in touch</a>.</p>
+        {{ end }}
         <div class="support-links">
             <a href="https://jonnyzzz.com/support/" target="_blank" rel="noopener" class="btn btn-secondary">
                 <svg class="btn-icon heart-icon-btn" viewBox="0 0 24 24" fill="currentColor"><path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"/></svg>

--- a/website/static/css/site.css
+++ b/website/static/css/site.css
@@ -1575,3 +1575,77 @@ h1 {
     .hero-sublink-sep { display: none; }
     .hero-sublinks a { display: block; margin: 0.4rem 0; }
 }
+
+/* Hero eyebrow version badge (moved out of the H1) */
+.hero-eyebrow-version {
+    font-size: 0.75rem;
+    padding: 0.1rem 0.5rem;
+    margin-bottom: 0;
+    margin-left: 0.4rem;
+    vertical-align: middle;
+    -webkit-text-fill-color: var(--color-code);
+    background-clip: unset;
+    -webkit-background-clip: unset;
+}
+
+/* Install trust note (small print, unobtrusive) */
+.install-trust {
+    font-size: 0.8rem;
+    color: var(--color-quaternary);
+    line-height: 1.5;
+    margin: 0.9rem 0 0 0;
+}
+.install-trust code {
+    font-size: 0.78rem;
+    color: var(--color-code);
+}
+
+/* Proof section stat cards */
+.proof-card .proof-stat {
+    font-size: 1.35rem;
+    font-weight: 700;
+    color: var(--color-primary);
+    margin-bottom: 0.4rem;
+    line-height: 1.2;
+}
+.proof-card .proof-vs {
+    font-size: 0.85rem;
+    font-weight: 500;
+    color: var(--color-quaternary);
+    white-space: nowrap;
+}
+.proof-negative {
+    font-size: 0.9rem;
+    color: var(--color-tertiary);
+    line-height: 1.6;
+    margin: 1.25rem 0 0 0;
+    padding-left: 0.9rem;
+    border-left: 2px solid rgba(254, 40, 87, 0.5);
+}
+.proof-provenance {
+    font-size: 0.8rem;
+    color: var(--color-quaternary);
+    line-height: 1.6;
+    margin: 1rem 0 0.5rem 0;
+}
+.proof-provenance code { font-size: 0.78rem; color: var(--color-code); }
+.proof-provenance a { color: var(--color-link); text-decoration: none; }
+.proof-provenance a:hover { text-decoration: underline; }
+
+/* Carousel: right-edge fade so the clipped last tile reads as an
+   intentional "scroll for more" affordance, not a broken cut. */
+.videos-box {
+    position: relative;
+}
+.videos-box::after {
+    content: "";
+    position: absolute;
+    top: 1.5rem;
+    right: 0;
+    bottom: 1.5rem;
+    width: 2.5rem;
+    pointer-events: none;
+    background: linear-gradient(to right, rgba(20, 20, 30, 0), rgba(20, 20, 30, 0.55));
+    border-top-right-radius: 12px;
+    border-bottom-right-radius: 12px;
+}

--- a/website/static/css/site.css
+++ b/website/static/css/site.css
@@ -398,7 +398,8 @@ a:focus-visible {
  *
  * Without the hash, no min-height applies and the section sits
  * tight against the footer at its natural content height. */
-#support {
+#support,
+#install {
     scroll-margin-top: 4rem;
 }
 #support:target {

--- a/website/static/css/site.css
+++ b/website/static/css/site.css
@@ -418,12 +418,12 @@ a:focus-visible {
                 0 8px 32px rgba(0, 0, 0, 0.25);
 }
 .hero {
-    text-align: center;
-    max-width: 980px;
+    text-align: left;
+    max-width: 1000px;
     margin: 0 auto 3rem auto;
     display: flex;
     flex-direction: column;
-    align-items: center;
+    align-items: flex-start;
     width: 100%;
 }
     .logo {
@@ -1493,7 +1493,7 @@ h1 {
 }
 .install-cta {
     max-width: 680px;
-    margin: 2rem auto 0.5rem auto;
+    margin: 2rem 0 0.5rem 0;
     width: 100%;
 }
 .install-cta-label {

--- a/website/static/css/site.css
+++ b/website/static/css/site.css
@@ -1475,3 +1475,102 @@ h1 {
     text-decoration: none;
 }
 .footer-copyright a:hover { text-decoration: underline; }
+
+/* ── Homepage focus rebuild (#322): hero eyebrow, install-command CTA, sublinks ── */
+/* Keep the hero from shrink-wrapping to the nowrap install command (would overflow
+   the viewport on narrow screens): force full width and let the grid track shrink. */
+.hero-grid {
+    width: 100%;
+    grid-template-columns: minmax(0, 1fr);
+}
+.hero-eyebrow {
+    font-size: 0.9rem;
+    font-weight: 600;
+    letter-spacing: 0.04em;
+    color: var(--color-tertiary);
+    margin: 0 0 0.75rem 0;
+}
+.install-cta {
+    max-width: 680px;
+    margin: 2rem auto 0.5rem auto;
+    width: 100%;
+}
+.install-cta-label {
+    font-weight: 600;
+    color: var(--color-secondary);
+    margin: 0 0 0.75rem 0;
+}
+.install-cmd {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    background: rgba(0, 0, 0, 0.35);
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    border-radius: 10px;
+    padding: 0.6rem 0.75rem;
+    margin-bottom: 0.6rem;
+    text-align: left;
+    min-width: 0;
+}
+.install-cmd-os {
+    flex: 0 0 auto;
+    font-size: 0.75rem;
+    font-weight: 600;
+    color: var(--color-quaternary);
+    min-width: 92px;
+}
+.install-cmd-text {
+    flex: 1 1 auto;
+    min-width: 0;
+    font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace;
+    font-size: 0.95rem;
+    color: var(--color-code);
+    user-select: all;
+    overflow-x: auto;
+    white-space: nowrap;
+    background: none;
+    padding: 0;
+}
+.install-copy {
+    flex: 0 0 auto;
+    cursor: pointer;
+    border: none;
+    border-radius: 8px;
+    padding: 0.45rem 0.9rem;
+    font-size: 0.85rem;
+    font-weight: 600;
+    color: #ffffff;
+    background: var(--gradient-brand);
+    transition: transform 0.15s, box-shadow 0.15s;
+}
+.install-copy:hover {
+    transform: translateY(-1px);
+    box-shadow: 0 4px 14px rgba(107, 87, 255, 0.35);
+}
+.install-cta-sub {
+    font-size: 0.9rem;
+    color: var(--color-tertiary);
+    margin: 0.75rem 0 0 0;
+}
+.hero-sublinks {
+    margin: 1.5rem 0 0 0;
+    font-size: 0.9rem;
+    color: var(--color-quaternary);
+}
+.hero-sublinks a {
+    color: var(--color-link);
+    text-decoration: none;
+}
+.hero-sublinks a:hover { text-decoration: underline; }
+.hero-sublink-sep {
+    margin: 0 0.6rem;
+    color: var(--color-quaternary);
+    opacity: 0.6;
+}
+@media (max-width: 640px) {
+    .install-cmd { flex-wrap: wrap; }
+    .install-cmd-text { flex-basis: 100%; order: 3; }
+    .install-copy { margin-left: auto; }
+    .hero-sublink-sep { display: none; }
+    .hero-sublinks a { display: block; margin: 0.4rem 0; }
+}


### PR DESCRIPTION
Refocuses the landing page on one primary action — install devrig — and moves dense sections onto their own pages. Content/structure change; header, brand styling, and the bridge diagram are unchanged.

Aligns with #322 (one truthful devrig activation path) and #325 (no unverified claims).

## New homepage structure (top → bottom)
1. Header / nav (unchanged: devrig-first, MCP Steroid badge)
2. Hero + primary CTA — copy the one-line install command (macOS/Linux + Windows), plus subdued secondary links
3. Why it matters — the core product value, honest, no benchmark numbers
4. "devrig is the product. MCP Steroid is how it reaches your IDE." — the bridge diagram + the devrig↔MCP Steroid relationship
5. Proof-of-Concept & Support — unchanged, now also inviting partnerships

## What moved where
- Features, who-it-helps, agent/IDE compatibility → `/docs/capabilities/`
- Featured videos + What's New feed → `/demos/`
- Early DPAIA wall-clock table → `/docs/dpaia-wall-clock-archive/` (kept clearly historical, linked from Experiment Findings)
- Skills teaser → links to existing `/docs/skill-factory/`

All moved content stays reachable via homepage links and the docs sidebar.

## Honest-claims cleanup (#325)
- Removed the DPAIA benchmark table from the homepage (withdrawn as current evidence per #251); archived, not deleted
- Dropped "fewer bugs", "finishes in fewer attempts", "every IDE", "any MCP client" absolutes from the acquisition copy
- Kept factual capability descriptions

## Notes
- Primary CTA is install-devrig; the plugin path is a subdued secondary link
- Partnership text (training models; embedding devrig into company processes) is homepage-only — release-page support footers are unchanged
- Verified: hugo extended v0.142.0 build clean; no horizontal overflow at 320/390/768/1280px
- Did not implement #322's full command-tabs/branching acceptance list — scoped to Jonny's structure spec; flagged for follow-up