### PR TITLE
docs: align getting-started + strategy with devrig-first framing (#325)

### DIFF
--- a/website/content/docs/devrig.md
+++ b/website/content/docs/devrig.md
@@ -1,18 +1,18 @@
 ---
-title: "Devrig CLI"
+title: "devrig CLI"
 description: "A standalone CLI that registers MCP Steroid with your AI Agent, bridges it to a running IDE, and can download and start a managed IntelliJ backend"
 weight: 15
 group: "Getting Started"
 ---
 
-> **Independent open-source project.** MCP Steroid and Devrig are independent
+> **Independent open-source project.** MCP Steroid and devrig are independent
 > open-source projects. They are **not made by, endorsed by, or affiliated
 > with JetBrains s.r.o.** *IntelliJ IDEA, PyCharm, GoLand, WebStorm, Rider,
 > CLion, and JetBrains are trademarks of JetBrains s.r.o.*
 
-## What is Devrig?
+## What is devrig?
 
-**Devrig** is a small standalone command-line tool that connects your AI Agent
+**devrig** is a small standalone command-line tool that connects your AI Agent
 to a JetBrains IDE running MCP Steroid — with no manual MCP configuration.
 
 It does three jobs:
@@ -39,7 +39,7 @@ download and start more on demand:
 <figcaption style="color:#909090;font-size:0.85rem;margin-top:0.4rem;">One <code>devrig</code> process bridges your agent to every IntelliJ-family IDE running on the machine — and can start more.</figcaption>
 </figure>
 
-Devrig is a Java application. The one-command installer downloads devrig
+devrig is a Java application. The one-command installer downloads devrig
 together with a matching Java runtime into `~/.mcp-steroid`, so there is nothing
 to set up by hand. To run devrig under a Java you manage instead, point
 `DEVRIG_JAVA_HOME` (or `JAVA_HOME`) at it.

--- a/website/content/docs/getting-started.md
+++ b/website/content/docs/getting-started.md
@@ -1,93 +1,106 @@
 ---
 title: "Getting Started"
-description: "Install and set up MCP Steroid with your AI Agent"
+description: "Install devrig, register your AI agent, and add the MCP Steroid plugin"
 weight: 10
 group: "Getting Started"
 ---
 
-## What is MCP Steroid?
+## What is devrig?
 
-MCP Steroid gives AI Agents **visual understanding and full control** of your IntelliJ-based IDE through the Model Context Protocol. Unlike traditional code assistants
-that only see text, MCP Steroid lets agents SEE your IDE: dialogs, toolbars, debugger state, test results, and visual elements.
+**devrig** is the product you install: a small command-line tool that connects your
+AI coding agent (Claude Code, Codex, or Gemini) to a real JetBrains IDE. It brings its
+own runtime, registers itself with your agent, and bridges the agent's calls to the
+IDE — no manual MCP wiring.
 
-**[Read the full introduction →](https://jonnyzzz.com/blog/2026/01/04/mcp-steroids-intellij/)**
+devrig reaches the IDE through **MCP Steroid**, a JetBrains IDE plugin that exposes the
+IDE's real semantic actions — typed refactors, inspections, the debugger, and test runs.
+You install devrig; devrig uses MCP Steroid.
 
-## Installation
+## 1. Install devrig — one command
 
-MCP Steroid is distributed as an IntelliJ plugin. Currently, in early access - [message Eugene Petrenko on LinkedIn](https://linkedin.com/in/jonnyzzz) to get access.
+**macOS / Linux**
+
+```bash
+curl -fsSL https://devrig.dev/install.sh | sh
+```
+
+**Windows (PowerShell)**
+
+```powershell
+irm https://devrig.dev/install.ps1 | iex
+```
+
+This installs the `devrig` CLI together with its own runtime into `~/.mcp-steroid` —
+there is nothing else to set up by hand.
+
+## 2. Register your AI agent
+
+```bash
+devrig install claude
+devrig install codex
+devrig install gemini
+```
+
+`devrig install <agent>` registers devrig as the `mcp-steroid` MCP server in Claude Code,
+Codex, or Gemini. The agent must be one of `claude`, `codex`, or `gemini`. See the
+[devrig CLI guide](/docs/devrig/) for the full command set.
+
+## 3. Install the MCP Steroid plugin
+
+In your JetBrains IDE, install **MCP Steroid** from the
+[JetBrains Marketplace](https://plugins.jetbrains.com/plugin/30019-mcp-steroid).
 
 ### Requirements
 
-- IntelliJ IDEA 2025.3+ (or any IntelliJ-based IDE: Rider, Android Studio, GoLand, WebStorm, PyCharm, etc.)
+- A JetBrains IDE — IntelliJ IDEA, PyCharm, GoLand, WebStorm, Rider, CLion, or Android Studio
 - The IDE must run with its normal UI or as a remote development backend — headless launches
   (`-Djava.awt.headless=true`) are unsupported (best-effort, see
   [#177](https://github.com/jonnyzzz/mcp-steroid/issues/177))
-- An MCP-compatible AI Agent (Claude Code, Codex, Gemini, or any MCP client)
+- An MCP-compatible AI agent (Claude Code, Codex, Gemini, or any MCP client)
 
-### Install the Plugin
+## Verify the connection
 
-1. Download the plugin ZIP file (provided via LinkedIn)
-2. In IntelliJ, go to **Settings > Plugins > Gear icon > Install Plugin from Disk**
-3. Select the downloaded ZIP file
-4. Restart IntelliJ
+When the plugin starts, it writes a description file at `.idea/mcp-steroid.md` in each open
+project with the connection details. Ask your agent to list the open projects:
 
-## Connecting Your AI Agent
-
-When the plugin starts, it automatically creates a description file at `.idea/mcp-steroid.md` in each open project.
-This file contains all necessary instruction for you to continue.
-
-Verify the connection:
 ```bash
 claude -p "List all open projects using steroid_list_projects"
 codex exec "List all open projects using steroid_list_projects"
 gemini "List all open projects using steroid_list_projects"
 ```
 
-Any MCP-compatible client can connect using the HTTP/SSE transport at the server URL.
-
-We recommend you to aks your AI Agent to use IntelliJ APIs and use IntelliJ while it is working.
-
-## Use Cases & Examples
-
-MCP Steroid enables powerful agentic workflows:
-
-- **Multi-Agent Orchestration**: Use a primary agent to coordinate multiple AI Agents working on different aspects of your codebase. [Read about orchestrating AI fleets →](https://jonnyzzz.com/blog/2026/01/30/orchestrating-ai-fleets/)
-- **Natural Language Development**: Instruct agents in plain English while they handle the technical implementation. [Learn about coding in English with AI →](https://jonnyzzz.com/blog/2026/01/27/coding-in-english-with-ai/)
-- **Documentation Refactoring**: See how 16 agents improved documentation quality by 15% and reduced time-to-value by 5x. [Read the case study →](https://jonnyzzz.com/blog/2026/01/24/16-ai-agents-documentation-refactor/)
+If you see your open IntelliJ projects, the connection works and your agent can now use all
+MCP Steroid capabilities. We recommend asking your agent to use IntelliJ APIs and the IDE
+while it works.
 
 ## Troubleshooting
 
-### Connection Issues
+**MCP server not starting**
 
-**MCP Server Not Starting**
-- Check if IntelliJ is running with a project open
+- Check that IntelliJ is running
 - Verify `.idea/mcp-steroid.md` exists in your project
-- Check registry key: `Help > Find Action > Registry...` → `mcp.steroid.server.port`
+- Check the registry key: `Help > Find Action > Registry...` → `mcp.steroid.server.port`
 
-**Port Conflicts**
+**Port conflicts**
 
 If port 6315 is in use, change it:
+
 1. Go to `Help > Find Action > Registry...`
 2. Search for `mcp.steroid.server.port`
 3. Set a different port (e.g., 6316)
 4. Restart IntelliJ
-5. Update your MCP client configuration with the new URL from `.idea/mcp-steroid.md`
+5. Update your MCP client with the new URL from `.idea/mcp-steroid.md`
 
-**Headless IDE (Unsupported)**
+**Headless IDE (unsupported)**
 
-If `idea.log` contains the WARN `MCP Steroid is running in a headless IDE`, the IDE was launched
-without a UI (e.g. `-Djava.awt.headless=true`). Headless mode is unsupported (best-effort): the
-platform behaves differently without a UI and long blocking waits/deadlocks in platform code have
-been observed — see [#177](https://github.com/jonnyzzz/mcp-steroid/issues/177). Run a normal
-desktop IDE or a remote development backend instead. The plugin logs an `IDE run mode: ...` INFO
-line on every startup, so the environment is always recorded in `idea.log`.
-
-
-After connecting your AI Agent, you should see a list of currently open IntelliJ projects when testing with the `steroid_list_projects` tool. If the connection works, your AI Agent can now access all MCP Steroid capabilities.
-
-For more troubleshooting help, see [GitHub Issues](https://github.com/jonnyzzz/mcp-steroid/issues).
+If `idea.log` contains the WARN `MCP Steroid is running in a headless IDE`, the IDE was
+launched without a UI (e.g. `-Djava.awt.headless=true`). Headless mode is unsupported
+(best-effort): long blocking waits and deadlocks in platform code have been observed — see
+[#177](https://github.com/jonnyzzz/mcp-steroid/issues/177). Run a normal desktop IDE or a
+remote development backend instead.
 
 ## Next Steps
 
-- [Configuration Options](/docs/configuration/) - Customize server settings and timeouts
-- [GitHub Issues](https://github.com/jonnyzzz/mcp-steroid/issues) - Report bugs or request features
+- [devrig CLI](/docs/devrig/) — every command, and how devrig bridges your agent to the IDE
+- [Configuration Options](/docs/configuration/) — customize server settings and timeouts
+- [GitHub Issues](https://github.com/jonnyzzz/mcp-steroid/issues) — report bugs or request features

--- a/website/content/docs/strategy.md
+++ b/website/content/docs/strategy.md
@@ -1,29 +1,29 @@
 ---
 title: "Strategy"
-description: "How MCP Steroid helps your AI Agent change code with fewer cleanup loops"
+description: "How MCP Steroid helps your AI agent change code with fewer cleanup loops"
 weight: 30
 group: "Vision"
 aliases:
   - /strategy/
 ---
 
-## Reliable code changes for AI Agents
+## Reliable code changes for AI agents
 
-MCP Steroid makes your AI Agent change code with fewer cleanup loops. File-only workflows break on real tasks because the
+MCP Steroid makes your AI agent change code with fewer cleanup loops. File-only workflows break on real tasks because the
 Agent cannot run inspections, execute refactorings, launch debugger flows, or use live IDE context and actions. The larger
 the repository, the more research the Agent must do -- and the more tokens it burns -- without IDE-grade understanding.
 
-MCP Steroid closes that gap by giving AI Agents the same semantic actions JetBrains IDEs give humans -- typed refactors,
+MCP Steroid closes that gap by giving AI agents the same semantic actions JetBrains IDEs give humans -- typed refactors,
 inspections, debugger, test runs -- so the Agent finishes in fewer attempts and humans spend less time verifying its output.
 
 ## Strategic thesis
 
-MCP Steroid is an AI-Agent-first product. Today the value is delivered as a JetBrains IDE plugin, which is where existing
-users already work; the long-term product direction is the same surface in a headless runtime so it serves AI Agents anywhere
-they execute, not only when a developer's IDE is open.
+devrig is an AI-agent-first product: the CLI you install and run. MCP Steroid is how it reaches your IDE -- today delivered
+as a JetBrains IDE plugin, which is where existing users already work. The long-term product direction is the same surface
+in a headless runtime so it serves AI agents anywhere they execute, not only when a developer's IDE is open.
 
-On tasks that depend on IDE capabilities, AI Agents with MCP Steroid should complete more work with fewer interventions,
-lower token usage, and less rework on the human side than the same AI Agents without it.
+On tasks that depend on IDE capabilities, AI agents with devrig should complete more work with fewer interventions,
+lower token usage, and less rework on the human side than the same AI agents without it.
 
 ## Three-phase product arc
 
@@ -33,41 +33,30 @@ lower token usage, and less rework on the human side than the same AI Agents wit
 
 ### Phase 1: Plugin distribution (current)
 
-Today MCP Steroid runs as a plugin inside JetBrains IDEs. A developer connects their AI Agent 
+Today MCP Steroid runs as a plugin inside JetBrains IDEs. A developer connects their AI agent 
 (Claude Code, Codex, Gemini, or any MCP client) to a running IDE instance -- IntelliJ IDEA, PyCharm, Android Studio, Rider, and others -- where their project is already open.
 
 ### Phase 2: Fine-tune -- evals, benchmarks, learn, and iterate
 
-**Result: 20-54% speedup on benchmarks** when AI Agents use MCP Steroid with full IDE access vs. file-only workflows.
-
-DPAIA benchmark results across diverse Spring Boot tasks:
-
-| Task | With MCP | Without MCP | Delta |
-|------|----------|-------------|-------|
-| Rename ROLE\_ADMIN across JHipster app (9 files) | 202s | 440s | **-54%** |
-| JWT auth from scratch (5+ new files) | 288s | 396s | **-27%** |
-| Parent-child JPA & Flyway (10 files) | 382s | 523s | **-27%** |
-| Multi-layer JPA+service+controller (15 files) | 788s | 1002s | **-21%** |
-| Simple URL prefix replace (7 files) | 188s | 181s | +4% |
-| Extend OrderRepository JPQL (4 files) | 727s | 633s | +15% |
-
-Tasks requiring semantic understanding -- refactorings across many files, multi-layer code generation -- show the largest gains. Simple text replacements perform similarly with or without IDE access.
+We run the same task twice -- same model, same repo -- once with the IDE through MCP Steroid and once as a plain shell
+agent, and score every run on machine-checkable evidence rather than on what the agent claims about itself. See the
+[experiment findings](/docs/experiment-findings/) for the verified results, including the runs where the IDE path did not win.
 
 We are collecting scenarios and execution logs from real MCP Steroid sessions (share your `.idea/mcp-steroid` folder with us).
 
 The collected data is analyzed to identify sharp edges in the current implementation and to improve prompts, skills,
-and documentation. AI Agents help us craft the better product for AI Agents. This is an iterative process; we have
+and documentation. AI agents help us craft the better product for AI agents. This is an iterative process; we have
 completed roughly seven optimization rounds so far, primarily on the MCP Steroid project itself.
 
-This validation loop is described in [Learning Methodology](/docs/learning-methodology/). See also [IntelliJ as a Skill Factory](/docs/skill-factory/) for how skills turn one-off API explorations into reusable AI Agent capabilities.
+This validation loop is described in [Learning Methodology](/docs/learning-methodology/). See also [IntelliJ as a Skill Factory](/docs/skill-factory/) for how skills turn one-off API explorations into reusable AI agent capabilities.
 
 ### Phase 3: Scale -- headless runtime, SaaS, B2B
 
-The long-term target is a self-contained runtime, available both as SaaS and as an end-user product, that serves as the headless IDE for AI Agents.
+The long-term target is a self-contained runtime, available both as SaaS and as an end-user product, that serves as the headless IDE for AI agents.
 
 ## Easy experimentation
 
-MCP Steroid provides an easy way to experiment with new tasks, prompts, and skills locally. Create a new skill, ask your AI Agent to use `steroid_execute_code`, and give it an example code snippet using IntelliJ API to solve your goal:
+MCP Steroid provides an easy way to experiment with new tasks, prompts, and skills locally. Create a new skill, ask your AI agent to use `steroid_execute_code`, and give it an example code snippet using IntelliJ API to solve your goal:
 
 ```kotlin
 import com.intellij.psi.search.PsiSearchHelper
@@ -86,7 +75,7 @@ val todoItems = readAction {
 todoItems.forEach { println(it) }
 ```
 
-The [Debugging IDE with MCP Steroid](/docs/how-to-debug-ide/) guide was written entirely by AI Agents using this approach -- a real skill created through experimentation with full IDE access.
+The [Debugging IDE with MCP Steroid](/docs/how-to-debug-ide/) guide was written entirely by AI agents using this approach -- a real skill created through experimentation with full IDE access.
 
 ## How you can help
 


### PR DESCRIPTION
Phase-1 cross-site consistency fixes found by a QA pass. Content-only, no layout/CSS changes.

## Fixes

**getting-started** — was entirely old-framing (opened "What is MCP Steroid?", MCP Steroid as the main product; stale "early access — message on LinkedIn / download ZIP / install from disk"). Rewritten devrig-first:
- devrig is the product you install (one command: `curl … install.sh | sh` / `irm … install.ps1 | iex`)
- register your agent: `devrig install claude|codex|gemini`
- in your JetBrains IDE, install MCP Steroid from the [Marketplace](https://plugins.jetbrains.com/plugin/30019-mcp-steroid)
- removed LinkedIn / early-access / ZIP / install-from-disk and the marketing "Use Cases" block; kept verify + troubleshooting

**strategy** —
- removed the withdrawn "Result: 20-54% speedup on benchmarks" claim (#325) and the DPAIA table that restated the same numbers; now points to the honest experiment-findings page
- reframed the thesis so devrig is the product and MCP Steroid is how it reaches the IDE

**casing** — brand `devrig` normalized to lowercase (devrig.md "Devrig" → "devrig", incl. the "devrig CLI" title/sidebar/H1); `AI Agent` → `AI agent` on the edited pages.

## Verification
- Hugo extended v0.142.0 build: 0 errors
- No new horizontal overflow at 390/1280 (content-only edits; the wide benchmark table was removed). Mobile nav pill-strip scroll is the site's pre-existing responsive design (identical on untouched pages).

🤖 Generated with [Claude Code](https://claude.com/claude-code)