### PR TITLE
homepage: simplify install copy (telemetry line + plugin messaging)

### DIFF
--- a/website/layouts/index.html
+++ b/website/layouts/index.html
@@ -35,7 +35,7 @@
 <section class="about-section" id="install">
     <div class="about-content">
         <h2 class="section-title">Install <span class="lighter">devrig</span> &mdash; one command</h2>
-        <p class="section-lede"><span class="lighter">devrig</span> is the primary way in: one line installs the CLI and everything it needs to run &mdash; no manual setup. Already run a JetBrains IDE? The <strong>MCP&nbsp;Steroid</strong> plugin installs on its own too.</p>
+        <p class="section-lede"><span class="lighter">devrig</span> is the primary way in: one line installs the CLI and everything it needs to run &mdash; no manual setup.</p>
         <div class="install-cta">
             <div class="install-cmd" data-cmd="curl -fsSL https://devrig.dev/install.sh | sh">
                 <span class="install-cmd-os">macOS / Linux</span>
@@ -49,7 +49,6 @@
             </div>
             <p class="install-cta-sub">Then register your agent: <code>devrig install claude|codex|gemini</code>. <a href="{{ "/docs/devrig/" | relURL }}">Read the devrig guide &rarr;</a></p>
             <p class="install-cta-sub">In your JetBrains IDE, also install the <strong>MCP&nbsp;Steroid</strong> plugin &rarr; <a href="https://plugins.jetbrains.com/plugin/30019-mcp-steroid" target="_blank" rel="noopener">JetBrains Marketplace</a>.</p>
-            <p class="install-trust">No telemetry &mdash; we collect nothing. Checksums are generated on the fly, not shipped or pinned. Everything installs into <code>~/.mcp-steroid</code>.</p>
         </div>
     </div>
 </section>


### PR DESCRIPTION
Small copy-only edit to the install section of the devrig.dev homepage (`website/layouts/index.html`).

- Removed the "No telemetry — we collect nothing…" trust paragraph.
- Removed the misleading "the MCP Steroid plugin installs on its own too" clause from the install lede.

One clear message remains: devrig installs the CLI in one command, and you install the MCP Steroid plugin in your JetBrains IDE (the explicit Marketplace link is kept). No other content changed.

Verified: hugo extended v0.142.0 build (0 errors); no horizontal overflow at 390px or 1280px.