### PR TITLE
docs: drop devrig install --check from the site (install is idempotent)

### DIFF
--- a/website/content/releases/0.101.md
+++ b/website/content/releases/0.101.md
@@ -36,7 +36,6 @@ The installer detects your platform and downloads the matching `devrig` build **
 ### `devrig install` is smoother
 
 - `devrig install <claude | codex | gemini>` is now **idempotent** — re-running upgrades an existing registration in place and consolidates stray entries into one ([#83](https://github.com/jonnyzzz/mcp-steroid/issues/83), [#84](https://github.com/jonnyzzz/mcp-steroid/issues/84)).
-- `devrig install <agent> --check` is a read-only doctor that reports registration status without changing anything ([#86](https://github.com/jonnyzzz/mcp-steroid/issues/86)).
 - `devrig mcp` is now the canonical stdio subcommand (`mpc` stays as a hidden alias) ([#85](https://github.com/jonnyzzz/mcp-steroid/issues/85)).
 
 ### Smarter backends — start what's installed
@@ -116,7 +115,7 @@ If you encounter any issues or have suggestions, please let us know in [GitHub I
 
 - [#96](https://github.com/jonnyzzz/mcp-steroid/issues/96), [#97](https://github.com/jonnyzzz/mcp-steroid/issues/97) — devrig installation is now the main website content, with a one-command bootstrap installer.
 - [#83](https://github.com/jonnyzzz/mcp-steroid/issues/83), [#84](https://github.com/jonnyzzz/mcp-steroid/issues/84) — `devrig install <agent>` works reliably and is idempotent.
-- [#86](https://github.com/jonnyzzz/mcp-steroid/issues/86) — clearer / self-healing MCP installation state, plus `install <agent> --check`.
+- [#86](https://github.com/jonnyzzz/mcp-steroid/issues/86) — clearer / self-healing MCP installation state.
 - [#85](https://github.com/jonnyzzz/mcp-steroid/issues/85) — `devrig mcp` added as the canonical subcommand (alias of `mpc`).
 - [#80](https://github.com/jonnyzzz/mcp-steroid/issues/80), [#103](https://github.com/jonnyzzz/mcp-steroid/issues/103) — the Tools → MCP Steroid settings page is back, devrig-first, showing the actual server port.
 - [#87](https://github.com/jonnyzzz/mcp-steroid/issues/87) — `backend_name` routing parameter for `steroid_open_project`.


### PR DESCRIPTION
Removes all references to the `devrig install <agent> --check` flag from the site. `devrig install <agent>` is idempotent, so a separate `--check` step is unnecessary and should not be recommended.

Removed (both in `website/content/releases/0.101.md`):
- Highlights → "devrig install is smoother": deleted the bullet describing `devrig install <agent> --check` as a read-only doctor.
- Fixed Issues → #86: dropped the trailing "plus `install <agent> --check`" clause (kept the self-healing-installation-state note).

Notes:
- No verify step relied on `--check` — getting-started already verifies the connection via `steroid_list_projects`, left unchanged.
- Hugo build (extended v0.142.0) passes with 0 errors; no dangling headings/sentences.