### PR TITLE
website: tidy homepage layout spacing (3 gap fixes)

### DIFF
--- a/website/static/css/site.css
+++ b/website/static/css/site.css
@@ -420,7 +420,7 @@ a:focus-visible {
 .hero {
     text-align: left;
     max-width: 1000px;
-    margin: 0 auto 3rem auto;
+    margin: 0 auto 1.5rem auto;
     display: flex;
     flex-direction: column;
     align-items: flex-start;
@@ -777,7 +777,7 @@ text-decoration: underline;
     /* Responsive design */
     @media (max-width: 768px) {
         .hero {
-            margin-bottom: 3rem;
+            margin-bottom: 1.75rem;
         }
 h1 {
     font-size: 2rem;
@@ -1495,6 +1495,13 @@ h1 {
     max-width: 680px;
     margin: 2rem 0 0.5rem 0;
     width: 100%;
+}
+/* Homepage install card: the command block and its sub-lines fill the card
+ * width (removing the dead space on the right of the 680px block), and follow
+ * the section lede tightly instead of the default 2rem gap. */
+#install .install-cta {
+    max-width: none;
+    margin-top: 0.75rem;
 }
 .install-cta-label {
     font-weight: 600;


### PR DESCRIPTION
Layout/spacing polish for the homepage — CSS-only, homepage-scoped. No content, sections, or scripts changed.

Three gaps Jonny flagged:

1. **Hero → Install gap** — the hero sub-links ("What your agent can do · Read the devrig guide") floated far above the Install section. Reduced `.hero` bottom margin `3rem → 1.5rem` (desktop) and `3rem → 1.75rem` (≤768px).

2. **Install section right-side void** — the command rows + Copy buttons were capped at 680px and floated left inside the 1000px card, leaving dead space on the right. `#install .install-cta` now fills the card (`max-width: 680px → none`), so the command bars/Copy buttons and the sub-lines all align with the section title and lede. Scoped to `#install` so the shared getting-started install block is unchanged.

3. **Lede → first command gap** — extra space between the Install lede and the first command row. Tightened `#install .install-cta` top margin `2rem → 0.75rem`.

Verified: hugo extended v0.142.0 build with 0 errors; no horizontal overflow at 390 or 1280 (scrollWidth == innerWidth at both); all sections render; Copy-button script untouched (partial unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)