### PR TITLE
website: extend honest headless/CI framing to strategy, skill-factory, debug playbook (#177)

### DIFF
--- a/website/content/docs/how-to-debug-ide.md
+++ b/website/content/docs/how-to-debug-ide.md
@@ -722,8 +722,9 @@ throw RuntimeException("Debug marker")
 behaves differently without a UI and long blocking waits/deadlocks in platform code have been
 observed — see [#177](https://github.com/jonnyzzz/mcp-steroid/issues/177). On startup the plugin
 logs an `IDE run mode: ...` INFO line and, for a plain headless IDE, a
-`MCP Steroid is running in a headless IDE` WARN in `idea.log`. Prefer a normal desktop IDE or a
-remote development backend; the workarounds below are best-effort only.
+`MCP Steroid is running in a headless IDE` WARN in `idea.log`. Give the IDE a real display instead: the normal GUI on
+macOS/Windows, or a virtual one via Xvfb on Linux/CI (see [Running devrig in CI](/docs/running-on-ci/)). The workarounds
+below are best-effort only.
 
 **Approach:**
 - Don't rely on UI automation

--- a/website/content/docs/skill-factory.md
+++ b/website/content/docs/skill-factory.md
@@ -70,7 +70,7 @@ You don't need to be an IntelliJ platform expert. The agent does the API explora
 
 The immediate focus is skill coverage -- more documented API patterns, more worked examples, more pre-built skills. The goal is to shrink the research phase for common tasks until it's nearly zero.
 
-Longer term: event-driven skills (reacting to commits, test failures, inspection results) and headless support (running in Docker, in CI, without a GUI).
+Running in Docker and in CI already works today: the IDE runs against a real display -- the normal GUI on macOS/Windows, or a virtual one via Xvfb on Linux and CI (see [Running devrig in CI](/docs/running-on-ci/)). A true headless launch with no display (`-Djava.awt.headless=true`) is unsupported ([#177](https://github.com/jonnyzzz/mcp-steroid/issues/177)). Longer term: event-driven skills (reacting to commits, test failures, inspection results).
 
 ---
 

--- a/website/content/docs/strategy.md
+++ b/website/content/docs/strategy.md
@@ -20,7 +20,7 @@ inspections, debugger, test runs -- so the Agent finishes in fewer attempts and 
 
 devrig is an AI-agent-first product: the CLI you install and run. MCP Steroid is how it reaches your IDE -- today delivered
 as a JetBrains IDE plugin, which is where existing users already work. The long-term product direction is the same surface
-in a headless runtime so it serves AI agents anywhere they execute, not only when a developer's IDE is open.
+in a self-contained runtime so it serves AI agents anywhere they execute, not only when a developer's IDE is open.
 
 On tasks that depend on IDE capabilities, AI agents with devrig should complete more work with fewer interventions,
 lower token usage, and less rework on the human side than the same AI agents without it.
@@ -29,7 +29,7 @@ lower token usage, and less rework on the human side than the same AI agents wit
 
 1. **Phase 1 -- Plugin distribution:** ship the surface as a JetBrains IDE plugin (current)
 2. **Phase 2 -- Fine-tune:** evals, benchmarks, prompt optimization
-3. **Phase 3 -- Scale:** headless mode, packaging, SaaS, B2B distribution
+3. **Phase 3 -- Scale:** self-contained runtime, packaging, SaaS, B2B distribution
 
 ### Phase 1: Plugin distribution (current)
 
@@ -50,9 +50,12 @@ completed roughly seven optimization rounds so far, primarily on the MCP Steroid
 
 This validation loop is described in [Learning Methodology](/docs/learning-methodology/). See also [IntelliJ as a Skill Factory](/docs/skill-factory/) for how skills turn one-off API explorations into reusable AI agent capabilities.
 
-### Phase 3: Scale -- headless runtime, SaaS, B2B
+### Phase 3: Scale -- self-contained runtime, SaaS, B2B
 
-The long-term target is a self-contained runtime, available both as SaaS and as an end-user product, that serves as the headless IDE for AI agents.
+The long-term target is a self-contained runtime, available both as SaaS and as an end-user product, that runs the IDE for
+AI agents without a developer's desktop session. That runtime still gives the IDE a real display -- the normal GUI on
+macOS/Windows, or a virtual one via Xvfb on Linux and CI; a true headless launch (`-Djava.awt.headless=true`) is
+unsupported (see [#177](https://github.com/jonnyzzz/mcp-steroid/issues/177) and [Running devrig in CI](/docs/running-on-ci/)).
 
 ## Easy experimentation
 


### PR DESCRIPTION
Extends the accurate headless/CI framing from #343 to the remaining pages. A JetBrains IDE is not truly headless (`-Djava.awt.headless=true` unsupported, #177); it needs a real display — the normal GUI on macOS/Windows, or Xvfb (a virtual X display) on Linux/CI. Targeted wording fixes only; no other pages or release notes touched.

**strategy.md** (roadmap intent preserved)
- Strategic thesis: "headless runtime" → "self-contained runtime".
- Phase 3 bullet + heading: "headless mode / headless runtime" → "self-contained runtime".
- Phase 3 body: now says the long-term runtime runs the IDE without a developer's desktop session, still needs a real display (GUI on macOS/Windows, Xvfb on Linux/CI), and true headless is unsupported — links #177 and /docs/running-on-ci.

**skill-factory.md**
- "Longer term: … headless support (running in Docker, in CI, without a GUI)" → Docker/CI already works today under Xvfb (with /docs/running-on-ci link); true headless (no display) remains unsupported (#177); "longer term" is now just event-driven skills.

**how-to-debug-ide.md**
- "No Visible Window" support note: dropped the inaccurate "or a remote development backend" advice → "give the IDE a real display: GUI on macOS/Windows, or Xvfb on Linux/CI" (links /docs/running-on-ci). Rest of the playbook unchanged.

Hugo extended v0.142.0 build: 35 pages, 0 errors.