### PR TITLE
website: fix docs pages horizontal overflow on mobile

### DIFF
--- a/website/static/css/site.css
+++ b/website/static/css/site.css
@@ -1141,6 +1141,10 @@ h1 {
 @media (max-width: 900px) {
     .docs-layout {
         flex-direction: column;
+        /* In the column layout, stretch children to the container width.
+           Without this the flex-start cross-axis alignment lets .docs-content
+           size to its content and overflow the viewport horizontally. */
+        align-items: stretch;
     }
 }
 /* Docs layout responsive */


### PR DESCRIPTION
## Problem
Docs-layout pages (e.g. `/docs/getting-started/`, `/docs/how-it-works/`, `/docs/configuration/`) overflowed horizontally at a 390px mobile viewport: `document.scrollWidth` = 610 vs `clientWidth` = 390 (~220px overflow). The homepage was unaffected.

## Root cause
`.docs-layout` sets `align-items: flex-start`. In the `<=900px` column (mobile) layout, that flex-start cross-axis alignment stops the `.docs-content` article from stretching to the container width, so it sized to its own max-content width (578px) and pushed the page past the viewport.

## Fix
Add `align-items: stretch` to `.docs-layout` inside the existing `@media (max-width: 900px)` block, so children fill the container width. Scoped to the docs-layout selector only — homepage and desktop (`>900px`) rules are untouched. Wide inner elements (`pre`, `table`, `.install-cmd`) already scroll inside their own box (`overflow-x:auto` / `min-width:0`).

## Verification (headless Chrome + CDP, mobile emulation)
- `scrollWidth == clientWidth == 390` (no overflow) on `/docs/getting-started/`, `/docs/how-it-works/`, `/docs/configuration/`, `/docs/settings-connection-info/`
- Desktop `/docs/getting-started/` @1280: `scrollWidth == clientWidth == 1280` (unchanged)
- Homepage @390 and @1280: `scrollWidth == clientWidth`, unaffected
- Hugo build: 35 pages, 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)