### PR TITLE
website: fix live-site consistency audit findings

### DIFF
--- a/website/content/docs/capabilities.md
+++ b/website/content/docs/capabilities.md
@@ -8,7 +8,7 @@ group: "Getting Started"
 Once [devrig](/docs/devrig/) connects your agent to a JetBrains IDE through MCP Steroid,
 the agent stops guessing through file edits and calls the IDE's real semantic actions.
 
-## What your AI Agent can do
+## What your AI agent can do
 
 <ul class="features-list">
     <li><strong>Refactor safely</strong>: rename a symbol across the whole project in one operation, extract methods, move classes</li>
@@ -42,7 +42,7 @@ the agent stops guessing through file edits and calls the IDE's real semantic ac
 ## Works with your agents and IDEs
 
 Use it with MCP-capable coding agents &mdash; including Claude, Codex, Gemini, Cursor, and OpenCode &mdash;
-and with IntelliJ-family IDEs such as IntelliJ IDEA, PyCharm, GoLand, WebStorm, Rider, and Android Studio.
+and with IntelliJ-family IDEs such as IntelliJ IDEA, PyCharm, GoLand, WebStorm, Rider, CLion, and Android Studio.
 
 <div class="agents-list">
     <span class="agent-badge">Claude</span>

--- a/website/content/docs/how-it-works.md
+++ b/website/content/docs/how-it-works.md
@@ -61,7 +61,7 @@ The agent calls `initialize` once to discover all available tools. From that poi
 
 ## The tools
 
-MCP Steroid exposes nine tools. Most are supporting utilities — the core capability is `steroid_execute_code`.
+MCP Steroid exposes eight tools. Most are supporting utilities — the core capability is `steroid_execute_code`.
 
 | Tool | What it does |
 |------|-------------|

--- a/website/content/docs/learning-methodology.md
+++ b/website/content/docs/learning-methodology.md
@@ -9,10 +9,10 @@ aliases:
 
 ## Why this exists
 
-MCP Steroid targets fast-changing AI Agents on fast-changing IntelliJ-based IDE platform. Static documentation alone
+MCP Steroid targets fast-changing AI Agents on the fast-changing IntelliJ-based IDE platform. Static documentation alone
 is not enough. We need a repeatable loop that measures what works, what fails, and what should change next.
 
-We treat the MCP server itself as a always improving product, that learn from usages. Every prompt, skill description, and tool schema is 
+We treat the MCP server itself as an always-improving product that learns from usage. Every prompt, skill description, and tool schema is 
 refined through data-driven iteration -- a user manual designed specifically for AI Agents, our primary audience.
 
 ## The operating loop

--- a/website/content/docs/project-assessment-2026-02-22.md
+++ b/website/content/docs/project-assessment-2026-02-22.md
@@ -13,7 +13,7 @@ group: "Vision"
 | **Current Version** | 0.88.0 |
 | **What It Does** | Exposes full IntelliJ IDE APIs to AI agents (Claude, Codex, Gemini) via Model Context Protocol (MCP), enabling agents to write, compile, debug, refactor, and test code through the IDE rather than raw file editing |
 | **Creator** | Eugene Petrenko (jonnyzzz) |
-| **Website** | [mcp-steroid.jonnyzzz.com](https://mcp-steroid.jonnyzzz.com/) |
+| **Website** | [devrig.dev](https://devrig.dev/) |
 | **Target Platform** | IntelliJ IDEA 2025.3+ (GoLand, WebStorm expansion underway) |
 
 ---

--- a/website/content/docs/settings-connection-info.md
+++ b/website/content/docs/settings-connection-info.md
@@ -38,7 +38,7 @@ Ready-to-run CLI commands for each supported agent — click the copy icon to gr
 |--------|---------|
 | Claude | `claude mcp add --transport http --scope user mcp-steroid http://...` |
 | Codex  | `codex mcp add mcp-steroid --url http://...` |
-| Gemini | `mcp add mc --type http ...` |
+| Gemini | `gemini mcp add mcp-steroid --type http http://... --scope user --trust` |
 
 ### JSON Config
 

--- a/website/content/docs/strategy.md
+++ b/website/content/docs/strategy.md
@@ -10,11 +10,11 @@ aliases:
 ## Reliable code changes for AI agents
 
 MCP Steroid makes your AI agent change code with fewer cleanup loops. File-only workflows break on real tasks because the
-Agent cannot run inspections, execute refactorings, launch debugger flows, or use live IDE context and actions. The larger
-the repository, the more research the Agent must do -- and the more tokens it burns -- without IDE-grade understanding.
+agent cannot run inspections, execute refactorings, launch debugger flows, or use live IDE context and actions. The larger
+the repository, the more research the agent must do -- and the more tokens it burns -- without IDE-grade understanding.
 
 MCP Steroid closes that gap by giving AI agents the same semantic actions JetBrains IDEs give humans -- typed refactors,
-inspections, debugger, test runs -- so the Agent finishes in fewer attempts and humans spend less time verifying its output.
+inspections, debugger, test runs -- so the agent finishes in fewer attempts and humans spend less time verifying its output.
 
 ## Strategic thesis
 

--- a/website/content/releases/0.100.md
+++ b/website/content/releases/0.100.md
@@ -50,7 +50,7 @@ The human-in-the-loop review gate was removed in full — the `review.*` registr
 
 Add this URL in **Settings** -> **Plugins** -> ⚙️ -> **Manage Plugin Repositories...**:
 
-<pre style="background: rgba(40, 167, 69, 0.1); padding: 0.5rem 1rem; border-radius: 4px; user-select: all;">https://mcp-steroid.jonnyzzz.com/updatePlugins.xml</pre>
+<pre style="background: rgba(40, 167, 69, 0.1); padding: 0.5rem 1rem; border-radius: 4px; user-select: all;">https://devrig.dev/updatePlugins.xml</pre>
 
 The IDE will find the plugin and notify you when updates are available.
 

--- a/website/content/releases/0.101.md
+++ b/website/content/releases/0.101.md
@@ -22,10 +22,10 @@ aliases:
 You no longer assemble `devrig` by hand. A generated bootstrap installer does it for you:
 
 <pre style="background: rgba(40, 167, 69, 0.1); padding: 0.5rem 1rem; border-radius: 4px; user-select: all;"># macOS / Linux
-curl -fsSL https://mcp-steroid.jonnyzzz.com/install.sh | sh</pre>
+curl -fsSL https://devrig.dev/install.sh | sh</pre>
 
 <pre style="background: rgba(40, 167, 69, 0.1); padding: 0.5rem 1rem; border-radius: 4px; user-select: all;"># Windows
-irm https://mcp-steroid.jonnyzzz.com/install.ps1 | iex</pre>
+irm https://devrig.dev/install.ps1 | iex</pre>
 
 The installer detects your platform and downloads the matching `devrig` build **and a matching Java runtime** (Amazon Corretto on macOS/Linux/Windows-x64; Azul Zulu on Windows-arm64) — so you no longer need to install a JDK yourself. Every URL and SHA-256 is baked in at build time (no live discovery), each download is SHA-256–verified, and a missing prerequisite is reported up front rather than failing half-way. It then hands off to `devrig install devrig`, which registers the stable launcher.
 
@@ -56,7 +56,7 @@ The most-used PSI subpackages are imported by default so common recipes need few
 
 Add this URL in **Settings** -> **Plugins** -> ⚙️ -> **Manage Plugin Repositories...**:
 
-<pre style="background: rgba(40, 167, 69, 0.1); padding: 0.5rem 1rem; border-radius: 4px; user-select: all;">https://mcp-steroid.jonnyzzz.com/updatePlugins.xml</pre>
+<pre style="background: rgba(40, 167, 69, 0.1); padding: 0.5rem 1rem; border-radius: 4px; user-select: all;">https://devrig.dev/updatePlugins.xml</pre>
 
 The IDE will find the plugin and notify you when updates are available.
 

--- a/website/content/releases/0.95.0.md
+++ b/website/content/releases/0.95.0.md
@@ -63,7 +63,7 @@ Compatible against both IntelliJ 2025.3 (IU-253.28294.334) and 2026.1 (IU-261.22
 
 Add this URL in **Settings** -> **Plugins** -> ⚙️ -> **Manage Plugin Repositories...**:
 
-<pre style="background: rgba(40, 167, 69, 0.1); padding: 0.5rem 1rem; border-radius: 4px; user-select: all;">https://mcp-steroid.jonnyzzz.com/updatePlugins.xml</pre>
+<pre style="background: rgba(40, 167, 69, 0.1); padding: 0.5rem 1rem; border-radius: 4px; user-select: all;">https://devrig.dev/updatePlugins.xml</pre>
 
 The IDE will find the plugin and notify you when updates are available.
 

--- a/website/hugo.toml
+++ b/website/hugo.toml
@@ -85,7 +85,7 @@ staticDir = ['static', 'build/generated-static']
 
 [[params.whatsnew]]
   date = "2026-04-18"
-  text = "v0.93.0 released — Plugin verifier compliance, rewritten MCP instructions, Maven test fix, steroid_fetch_resource"
+  text = "v0.93.0 released — Open for collaboration, drop-in LSP replacement, Maven test fix, plugin verifier compliance"
 
 [[params.whatsnew]]
   date = "2026-04-08"


### PR DESCRIPTION
Fixes 7 findings from a live-site RLM consistency audit of devrig.dev. Finding #5 (homepage "same completeness" wording) intentionally excluded.

- **#1 (factual)** how-it-works: "MCP Steroid exposes nine tools" → "eight" (table lists exactly 8).
- **#2 (factual)** settings-connection-info: broken Gemini quick-start command `mcp add mc --type http ...` → `gemini mcp add mcp-steroid --type http http://... --scope user --trust` (correct server name + URL, matching the Claude/Codex rows; `--type http` is the real Gemini flag per the repo's `geminiMcpAddArgs`).
- **#3 (casing)** capabilities H1 "AI Agent" → "AI agent" (matches page title / hero); strategy: 3× mid-sentence "the Agent" → "the agent".
- **#4 (IDE list)** capabilities: added CLion so the supported-IDE list matches getting-started and /docs/devrig.
- **#6 (domain)** releases 0.101/0.100/0.95.0 + project-assessment: `mcp-steroid.jonnyzzz.com` → `devrig.dev` in copyable install one-liners, updatePlugins.xml URLs, and the website field (copy-paste snippets only; historical prose left intact).
- **#7 (summary)** demos "What's New": v0.93.0 entry reconciled with the release page summary.
- **#8 (grammar)** learning-methodology: "on fast-changing IntelliJ-based IDE platform" → "on the fast-changing..."; "as a always improving product, that learn from usages" → "as an always-improving product that learns from usage".

Build: hugo extended v0.142.0, 0 errors. No horizontal overflow at 390px or 1280px on any touched page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)