### PR TITLE
website: repoint doc/prose links to devrig.dev

### DIFF
--- a/website/content/releases/0.100.md
+++ b/website/content/releases/0.100.md
@@ -73,7 +73,7 @@ Search for **MCP Steroid** in **Settings** -> **Plugins** -> **Marketplace**.
 
 ## Connecting to Cloud Agents
 
-See [Getting Started](https://mcp-steroid.jonnyzzz.com/docs/getting-started/).
+See [Getting Started](https://devrig.dev/docs/getting-started/).
 
 ## Supported AI Agents
 

--- a/website/content/releases/0.101.md
+++ b/website/content/releases/0.101.md
@@ -79,7 +79,7 @@ Search for **MCP Steroid** in **Settings** -> **Plugins** -> **Marketplace**.
 
 ## Connecting to Cloud Agents
 
-See [Getting Started](https://mcp-steroid.jonnyzzz.com/docs/getting-started/).
+See [Getting Started](https://devrig.dev/docs/getting-started/).
 
 ## Supported AI Agents
 

--- a/website/content/releases/0.86.0.md
+++ b/website/content/releases/0.86.0.md
@@ -16,7 +16,7 @@ aliases:
 This is an **early preview version** of MCP Steroid. Thank you for helping us test and improve the plugin!
 
 <div class="warning">
-<p><strong>Important:</strong> This preview build has expired. Please <a href="https://mcp-steroid.jonnyzzz.com/releases/0.87.0/">upgrade to v0.87.0</a>.</p>
+<p><strong>Important:</strong> This preview build has expired. Please <a href="https://devrig.dev/releases/0.87.0/">upgrade to v0.87.0</a>.</p>
 </div>
 
 Note: this preview plugin is currently tested only on macOS.
@@ -42,7 +42,7 @@ Download the latest plugin build from GitHub Releases:
 - **[The Release on GitHub](https://github.com/jonnyzzz/mcp-steroid/releases/tag/0.86.0-SNAPSHOT-2026-02-01-20-29-4ad98c4)**
 - [v0.86.0-SNAPSHOT (2026-02-01).zip](https://github.com/jonnyzzz/mcp-steroid/releases/tag/0.86.0-SNAPSHOT-2026-02-01-20-29-4ad98c4) - Current preview plugin build
 
-**[End User License Agreement (EULA)](https://mcp-steroid.jonnyzzz.com/EULA)** - By downloading and using this plugin, you agree to the terms of the EULA.
+**[End User License Agreement (EULA)](https://devrig.dev/EULA)** - By downloading and using this plugin, you agree to the terms of the EULA.
 
 ### Installation
 
@@ -54,7 +54,7 @@ Download the latest plugin build from GitHub Releases:
 
 ## Connecting to Cloud Agents
 
-See [Getting Started](https://mcp-steroid.jonnyzzz.com/docs/getting-started/).
+See [Getting Started](https://devrig.dev/docs/getting-started/).
 
 ### How to Submit Your Data
 

--- a/website/content/releases/0.87.0.md
+++ b/website/content/releases/0.87.0.md
@@ -34,7 +34,7 @@ That is the best place to discuss the plugin, ideas, features.
 
 SHA-256: `7a7ee4edee94aa3a298c4543407e6e80723e9e26a2ca92fc3bdc09acb45abbc3`
 
-**[End User License Agreement (EULA)](https://mcp-steroid.jonnyzzz.com/EULA)** - By downloading and using this plugin, you agree to the terms of the EULA.
+**[End User License Agreement (EULA)](https://devrig.dev/EULA)** - By downloading and using this plugin, you agree to the terms of the EULA.
 
 ### Installation
 
@@ -46,7 +46,7 @@ SHA-256: `7a7ee4edee94aa3a298c4543407e6e80723e9e26a2ca92fc3bdc09acb45abbc3`
 
 ## Connecting to Cloud Agents
 
-See [Getting Started](https://mcp-steroid.jonnyzzz.com/docs/getting-started/).
+See [Getting Started](https://devrig.dev/docs/getting-started/).
 
 ## Supported AI Agents
 

--- a/website/content/releases/0.88.0.md
+++ b/website/content/releases/0.88.0.md
@@ -54,7 +54,7 @@ SHA-256: `9874d56c017cb0b6808d8a44959a10968eb020ae1b4ad7dbd65845eaee0bbd91`
 
 ## Connecting to Cloud Agents
 
-See [Getting Started](https://mcp-steroid.jonnyzzz.com/docs/getting-started/).
+See [Getting Started](https://devrig.dev/docs/getting-started/).
 
 ## Supported AI Agents
 

--- a/website/content/releases/0.89.0.md
+++ b/website/content/releases/0.89.0.md
@@ -55,12 +55,12 @@ SHA-256: `71e50254953e90189f26a1149bb976731a0fef82c1961cbb7c102864c6f904a9`
 3. Select the downloaded ZIP file
 4. Restart the IDE
 
-**[End User License Agreement (EULA)](https://mcp-steroid.jonnyzzz.com/EULA)** - By downloading and using this plugin, you agree to the terms of the EULA.
+**[End User License Agreement (EULA)](https://devrig.dev/EULA)** - By downloading and using this plugin, you agree to the terms of the EULA.
 
 
 ## Connecting to Cloud Agents
 
-See [Getting Started](https://mcp-steroid.jonnyzzz.com/docs/getting-started/).
+See [Getting Started](https://devrig.dev/docs/getting-started/).
 
 ## Supported AI Agents
 

--- a/website/content/releases/0.90.0.md
+++ b/website/content/releases/0.90.0.md
@@ -55,11 +55,11 @@ SHA-256: `b749a8b4394c3314082be21d79ecb0ac990b64db6979e045bf7e4af5eca272da`
 3. Select the downloaded ZIP file
 4. Restart the IDE
 
-**[End User License Agreement (EULA)](https://mcp-steroid.jonnyzzz.com/EULA)** - By downloading and using this plugin, you agree to the terms of the EULA.
+**[End User License Agreement (EULA)](https://devrig.dev/EULA)** - By downloading and using this plugin, you agree to the terms of the EULA.
 
 ## Connecting to Cloud Agents
 
-See [Getting Started](https://mcp-steroid.jonnyzzz.com/docs/getting-started/).
+See [Getting Started](https://devrig.dev/docs/getting-started/).
 
 ## Supported AI Agents
 

--- a/website/content/releases/0.91.0.md
+++ b/website/content/releases/0.91.0.md
@@ -53,11 +53,11 @@ SHA-256: `a2e6c519440d003769c8a55928dbd623c2a57aaba0b837d2fdefc090ff178e88`
 3. Select the downloaded ZIP file
 4. Restart the IDE
 
-**[End User License Agreement (EULA)](https://mcp-steroid.jonnyzzz.com/EULA)** - By downloading and using this plugin, you agree to the terms of the EULA.
+**[End User License Agreement (EULA)](https://devrig.dev/EULA)** - By downloading and using this plugin, you agree to the terms of the EULA.
 
 ## Connecting to Cloud Agents
 
-See [Getting Started](https://mcp-steroid.jonnyzzz.com/docs/getting-started/).
+See [Getting Started](https://devrig.dev/docs/getting-started/).
 
 ## Supported AI Agents
 

--- a/website/content/releases/0.92.0.md
+++ b/website/content/releases/0.92.0.md
@@ -57,7 +57,7 @@ SHA-256: `8f01755fe14568315e59f70c6195e72878b3fbee928f1dacea6b8b52db5867e7`
 
 ## Connecting to Cloud Agents
 
-See [Getting Started](https://mcp-steroid.jonnyzzz.com/docs/getting-started/).
+See [Getting Started](https://devrig.dev/docs/getting-started/).
 
 ## Supported AI Agents
 

--- a/website/content/releases/0.93.0.md
+++ b/website/content/releases/0.93.0.md
@@ -85,7 +85,7 @@ Search for **MCP Steroid** in **Settings** -> **Plugins** -> **Marketplace**.
 
 ## Connecting to Cloud Agents
 
-See [Getting Started](https://mcp-steroid.jonnyzzz.com/docs/getting-started/).
+See [Getting Started](https://devrig.dev/docs/getting-started/).
 
 ## Supported AI Agents
 

--- a/website/content/releases/0.94.0.md
+++ b/website/content/releases/0.94.0.md
@@ -98,7 +98,7 @@ Search for **MCP Steroid** in **Settings** -> **Plugins** -> **Marketplace**.
 
 ## Connecting to Cloud Agents
 
-See [Getting Started](https://mcp-steroid.jonnyzzz.com/docs/getting-started/).
+See [Getting Started](https://devrig.dev/docs/getting-started/).
 
 ## Supported AI Agents
 

--- a/website/content/releases/0.95.0.md
+++ b/website/content/releases/0.95.0.md
@@ -85,7 +85,7 @@ Search for **MCP Steroid** in **Settings** -> **Plugins** -> **Marketplace**.
 
 ## Connecting to Cloud Agents
 
-See [Getting Started](https://mcp-steroid.jonnyzzz.com/docs/getting-started/).
+See [Getting Started](https://devrig.dev/docs/getting-started/).
 
 ## Supported AI Agents
 


### PR DESCRIPTION
Cleanup of remaining old-host doc/prose links after #348 (which fixed copyable INSTALL commands + updatePlugins.xml). The old host 301s to devrig.dev, so this is canonical-link hygiene.

Replaced host `mcp-steroid.jonnyzzz.com` -> `devrig.dev` in clickable links only (18 occurrences, 12 files):
- "See Getting Started" -> /docs/getting-started/ (release notes 0.86-0.95, 0.100, 0.101)
- EULA links -> /EULA (0.86, 0.87, 0.89, 0.90, 0.91)
- "upgrade to v0.87.0" href -> /releases/0.87.0/ (0.86.0)

Intentionally left unchanged:
- 7 copyable `updatePlugins.xml` `<pre>` blocks (plugin-repo URLs, #348's category, not clickable prose)
- hugo.toml "Website launched at mcp-steroid.jonnyzzz.com" banner (historical narrative fact)

Hugo extended v0.142.0 build: 0 errors. No clickable old-host links remain.