### PR TITLE
Fix header dead zone: show heart quick-link when nav collapses (769–960px)

### DIFF
--- a/website/static/css/site.css
+++ b/website/static/css/site.css
@@ -1407,7 +1407,13 @@ h1 {
     width: 22px;
     height: 22px;
 }
-@media (max-width: 768px) {
+/* Show the standalone heart quick-link as soon as the horizontal menu
+   collapses into the hamburger (960px — see the .nav-toggle breakpoint above).
+   Previously this was 768px, leaving a 769–960px dead zone where the menu was
+   already collapsed but neither the in-menu "PoC & Support" heart nor this
+   standalone heart was visible. Keeping both breakpoints at 960px makes the
+   header degrade monotonically: the heart is always present once the menu hides. */
+@media (max-width: 960px) {
     .nav-heart-mobile {
         display: flex;
     }


### PR DESCRIPTION
## Problem

As the viewport narrows, the header changed presentation by width and left a **dead zone at 769–960px**: the horizontal nav (which carries the "PoC & Support" heart) collapses into the hamburger at 960px, but the standalone mobile heart quick-link only appeared at 768px. So for the whole 769–960px band there was no heart at all — the header looked half-empty.

## Fix

Align the `.nav-heart-mobile` breakpoint to the menu-collapse breakpoint (768px → 960px). One-line change plus a comment. Now the header degrades monotonically:

- **>960px** — full horizontal menu (heart inside "PoC & Support").
- **≤960px** — menu collapses into the hamburger **and** the standalone heart appears simultaneously.

The brand mark (logo + "devrig" + badge) was already visible at every width and is unchanged.

## Before / After

@ 960px
![960](https://raw.githubusercontent.com/jonnyzzz/mcp-steroid/29b8c84770d48fa8b102c85eb0133e9559f16262/cmp_960.png)

@ 900px
![900](https://raw.githubusercontent.com/jonnyzzz/mcp-steroid/29b8c84770d48fa8b102c85eb0133e9559f16262/cmp_900.png)

@ 820px
![820](https://raw.githubusercontent.com/jonnyzzz/mcp-steroid/29b8c84770d48fa8b102c85eb0133e9559f16262/cmp_820.png)

@ 769px
![769](https://raw.githubusercontent.com/jonnyzzz/mcp-steroid/29b8c84770d48fa8b102c85eb0133e9559f16262/cmp_769.png)

_Rendered with headless Chrome against a local hugomods/hugo:exts-0.142.0 build. Note: headless Chrome clamps the layout viewport to a 500px minimum, so widths below 500px could not be rendered here; the change only touches the 960px breakpoint, well inside the reliably-rendered range._
