### PR TITLE
feat(mcp-core): expose CLI metadata from tool specs

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -98,6 +98,15 @@
   IDE failing its `/windows` fetch errors the whole call (`coroutineScope` + `error(...)`), unlike
   `list_projects` which degrades per-backend. Return partial windows + a per-backend error marker.
 
+- [ ] **devrig CLI must own `--out` and the `--wait` polling loop (#284)**: the schema-driven-command
+  reshape removed the `out` parameter from `VisionScreenshotToolSpec` and turned `--wait` into a
+  declared `CliExtraOption` on `steroid_open_project`, because neither is a tool input. The tool
+  metadata therefore no longer carries either behavior: the CLI frontend must document `--out` as a
+  framework flag beside `--json` (a render-path redirect writing a returned image to a path — note
+  `steroid_execute_code` also returns PNGs via `logImage`, e.g. the modal-dialog failure screenshot,
+  so it is not screenshot-only) and must implement `--wait` as a `list_windows` poll until the project
+  reports initialized. Without those two, both flags silently vanish from the CLI.
+
 - [ ] **red-code reporter false-positives on Kotlin files**: `reportProjectRedCode` (PSI reference scan,
   `mcp-steroid-import.kt`) reports Kotlin stdlib/operator references (`mutableMapOf`, `runCatching`,
   `trim()`, `!!`, `=`) as UNRESOLVED — 95/646 on the stock Gradle test-project's `SsrRunCatchingDemo.kt`

--- a/TODO.md
+++ b/TODO.md
@@ -107,6 +107,19 @@
   so it is not screenshot-only) and must implement `--wait` as a `list_windows` poll until the project
   reports initialized. Without those two, both flags silently vanish from the CLI.
 
+- [ ] **Harden the CLI tool-spec metadata layer (#284 follow-up)**: three review findings deferred from
+  PR #356. (1) `CliToolSpec.schema` exposes the mutable `ToolSchema` — any consumer can call
+  `register()` after registration and change the advertised `inputSchema`; expose a read-only view
+  (interface with `asMcpJson()`/`asCliParams()` only). (2) No declaration-time flag-collision
+  validation: a parameter flag, its `cliFileSource` flag, and a tool-level `CliExtraOption` flag can
+  collide — builder checks are order-dependent (`.cliFileSource("--x").cliFlag("--x")` passes) and a
+  bare `--` is accepted as a flag; validate per-tool flag/alias uniqueness at registration or pin it
+  with a `devrigToolSpecs()`-wide test. (3) Wire bounds declared via the `extra {}` closure
+  (`success_rating` 0..1) are invisible to `asCliParams()`, while `timeout` carries a CLI-only
+  `cliMinimum` — the generated CLI cannot enforce the wire bound without parsing `asMcpJson()`; also
+  `cliSynopsis` hardcodes "(default 600)" where the MCP description interpolates the constant, so the
+  two can silently diverge.
+
 - [ ] **red-code reporter false-positives on Kotlin files**: `reportProjectRedCode` (PSI reference scan,
   `mcp-steroid-import.kt`) reports Kotlin stdlib/operator references (`mutableMapOf`, `runCatching`,
   `trim()`, `!!`, `=`) as UNRESOLVED — 95/646 on the stock Gradle test-project's `SsrRunCatchingDemo.kt`

--- a/mcp-core/src/main/kotlin/com/jonnyzzz/mcpSteroid/mcp/McpRegistrars.kt
+++ b/mcp-core/src/main/kotlin/com/jonnyzzz/mcpSteroid/mcp/McpRegistrars.kt
@@ -7,6 +7,9 @@ import kotlinx.serialization.json.JsonObject
  * A single MCP tool, bundling the metadata and the invocation logic. Replaces the
  * previous parameter-list passed to [McpToolRegistrar.registerTool] so each tool is
  * a self-describing object.
+ *
+ * It carries only what the MCP wire needs. The CLI projection ([CliToolSpec.cli] and [CliToolSpec.schema])
+ * lives on [CliToolSpec], so a plain MCP tool double never has to supply CLI metadata.
  */
 interface McpTool {
     val name: String
@@ -16,13 +19,61 @@ interface McpTool {
     suspend fun call(context: ToolCallContext): ToolCallResult
 }
 
-abstract class McpToolBase : McpTool {
-    private val params = mutableListOf<InputSchemaElement<*>>()
+/**
+ * An [McpTool] that also describes its devrig subcommand. CLI consumers read [cli] and [schema]
+ * directly, while MCP clients continue to see only the narrow [McpTool] surface.
+ */
+interface CliToolSpec : McpTool {
+    /** CLI command descriptor for this tool. */
+    val cli: CliCommandSpec
 
-    protected fun <R> InputSchemaElement<R>.registerToSchema() = apply { params.add(this) }
+    /** The parameter owner, offering the MCP-JSON (`asMcpJson`) and CLI-param (`asCliParams`) projections. */
+    val schema: ToolSchema
+}
+
+/**
+ * Describes how a tool appears as a `devrig` subcommand. This metadata carries no behavior and is not
+ * part of the MCP wire protocol.
+ */
+data class CliCommandSpec(
+    /** Subcommand name; default = [McpTool.name] with the `steroid_` prefix stripped. */
+    val name: String,
+    /** One-line synopsis for CLI help, distinct from the full MCP description. */
+    val synopsis: String,
+    /** Extra subcommand aliases (e.g. `prompt` for `fetch_resource`). */
+    val aliases: List<String> = emptyList(),
+    /** Exclude from the CLI if ever needed. */
+    val hidden: Boolean = false,
+)
+
+/** Derives the default CLI subcommand name from an MCP tool [toolName] by stripping the `steroid_` prefix. */
+fun defaultCliName(toolName: String): String = toolName.removePrefix("steroid_")
+
+abstract class McpToolBase : CliToolSpec {
+    /** Single owner of the registered parameters, exposing the MCP-JSON and CLI-param projections. */
+    final override val schema = ToolSchema()
+
+    protected fun <R> InputSchemaElement<R>.registerToSchema(): InputSchemaElement<R> = schema.register(this)
 
     final override val inputSchema: JsonObject
-        get() = InputSchemaElement.buildSchema(params)
+        get() = schema.asMcpJson()
+
+    /** One-line CLI synopsis for this tool's `devrig` subcommand, distinct from [description]. */
+    protected abstract val cliSynopsis: String
+
+    /** Extra CLI subcommand aliases; empty by default. */
+    protected open val cliAliases: List<String> get() = emptyList()
+
+    /** When true the tool is not exposed as a CLI subcommand; false by default. */
+    protected open val cliHidden: Boolean get() = false
+
+    override val cli: CliCommandSpec
+        get() = CliCommandSpec(
+            name = defaultCliName(name),
+            synopsis = cliSynopsis,
+            aliases = cliAliases,
+            hidden = cliHidden,
+        )
 }
 
 

--- a/mcp-core/src/main/kotlin/com/jonnyzzz/mcpSteroid/mcp/McpRegistrars.kt
+++ b/mcp-core/src/main/kotlin/com/jonnyzzz/mcpSteroid/mcp/McpRegistrars.kt
@@ -32,6 +32,32 @@ interface CliToolSpec : McpTool {
 }
 
 /**
+ * The value shape a CLI frontend must parse for a [CliExtraOption]. Holds only the shapes a declared
+ * extra option actually uses: a value-taking shape gets a constant when — and only when — some tool
+ * declares one, so the CLI's parsing branch and the declaration that needs it always arrive together
+ * and no branch is written against a shape nothing declares.
+ */
+enum class CliOptionType {
+    /** A switch: present or absent, no argument. */
+    BOOLEAN,
+}
+
+/**
+ * A CLI option scoped to one tool's subcommand that is **not** one of the tool's inputs: the CLI acts
+ * on it itself — orchestrating around the call, e.g. polling the IDE after the tool has returned — and
+ * never sends it to the tool. It lives on [CliCommandSpec], not on [ToolSchema], precisely because it
+ * is not a parameter: there is no value for the tool to receive.
+ */
+data class CliExtraOption(
+    /** The CLI option, e.g. `--wait`. */
+    val flag: String,
+    /** What the CLI must parse for [flag]. */
+    val type: CliOptionType,
+    /** Short one-line help for [flag]. */
+    val synopsis: String,
+)
+
+/**
  * Describes how a tool appears as a `devrig` subcommand. This metadata carries no behavior and is not
  * part of the MCP wire protocol.
  */
@@ -44,6 +70,8 @@ data class CliCommandSpec(
     val aliases: List<String> = emptyList(),
     /** Exclude from the CLI if ever needed. */
     val hidden: Boolean = false,
+    /** Tool-scoped CLI options the CLI handles itself rather than passing to the tool; see [CliExtraOption]. */
+    val extraOptions: List<CliExtraOption> = emptyList(),
 )
 
 /** Derives the default CLI subcommand name from an MCP tool [toolName] by stripping the `steroid_` prefix. */
@@ -67,12 +95,20 @@ abstract class McpToolBase : CliToolSpec {
     /** When true the tool is not exposed as a CLI subcommand; false by default. */
     protected open val cliHidden: Boolean get() = false
 
+    /**
+     * Tool-scoped CLI options the CLI acts on itself instead of sending to the tool (see
+     * [CliExtraOption]); none by default. Declared here rather than on [schema] because they are not
+     * parameters — the tool never receives their value.
+     */
+    protected open val cliExtraOptions: List<CliExtraOption> get() = emptyList()
+
     override val cli: CliCommandSpec
         get() = CliCommandSpec(
             name = defaultCliName(name),
             synopsis = cliSynopsis,
             aliases = cliAliases,
             hidden = cliHidden,
+            extraOptions = cliExtraOptions,
         )
 }
 

--- a/mcp-core/src/main/kotlin/com/jonnyzzz/mcpSteroid/mcp/McpRegistrars.kt
+++ b/mcp-core/src/main/kotlin/com/jonnyzzz/mcpSteroid/mcp/McpRegistrars.kt
@@ -47,15 +47,31 @@ enum class CliOptionType {
  * on it itself — orchestrating around the call, e.g. polling the IDE after the tool has returned — and
  * never sends it to the tool. It lives on [CliCommandSpec], not on [ToolSchema], precisely because it
  * is not a parameter: there is no value for the tool to receive.
+ *
+ * [name] is this option's identity — stable even if [flag] is later respelled — mirroring how
+ * [InputSchemaParamSpec.name] is identity and [InputSchemaParamSpec.cliFlag] is presentation.
  */
 data class CliExtraOption(
-    /** The CLI option, e.g. `--wait`. */
-    val flag: String,
+    /** Identity of this option, independent of its CLI spelling; e.g. `wait`. */
+    val name: String,
     /** What the CLI must parse for [flag]. */
     val type: CliOptionType,
     /** Short one-line help for [flag]. */
     val synopsis: String,
-)
+    /**
+     * The CLI option, e.g. `--wait`; defaults to `--$name` so a declaration needing no custom spelling
+     * states the name once.
+     */
+    val flag: String = "--$name",
+) {
+    init {
+        require(name.isNotBlank()) { "CliExtraOption needs a non-blank name" }
+        require(flag.startsWith("--")) {
+            "CliExtraOption '$name' flag must be a long option starting with '--', was '$flag'"
+        }
+        require(synopsis.isNotBlank()) { "CliExtraOption '$name' needs a one-line synopsis" }
+    }
+}
 
 /**
  * Describes how a tool appears as a `devrig` subcommand. This metadata carries no behavior and is not

--- a/mcp-core/src/main/kotlin/com/jonnyzzz/mcpSteroid/mcp/McpSchema.kt
+++ b/mcp-core/src/main/kotlin/com/jonnyzzz/mcpSteroid/mcp/McpSchema.kt
@@ -14,6 +14,21 @@ import kotlinx.serialization.json.put
 import kotlinx.serialization.json.putJsonArray
 import kotlinx.serialization.json.putJsonObject
 
+/**
+ * A second CLI source for one parameter's value: an option whose argument is a filesystem path — or
+ * `-` for standard input — and whose *content* becomes the value of the parameter that declares it.
+ * Declaration only; opening the file is the CLI frontend's job.
+ *
+ * Because both [InputSchemaParamSpec.cliFlag] and [flag] fill the same value, a CLI frontend rejects
+ * being given both without needing any per-parameter rule: the exclusivity follows from the shape.
+ */
+data class CliFileSource(
+    /** The CLI option that takes the path, e.g. `--code-file`. Never `--<name>` of the parameter itself. */
+    val flag: String,
+    /** Short one-line help for [flag]; [InputSchemaParamSpec.cliSynopsis] describes the direct form. */
+    val synopsis: String,
+)
+
 data class InputSchemaParamSpec(
     val name: String,
     val type: String,
@@ -24,8 +39,19 @@ data class InputSchemaParamSpec(
     // CLI hints are exposed by [ToolSchema.asCliParams] and are never serialized into MCP inputSchema JSON.
     /** CLI flag for this parameter; defaults to `--<name>` (e.g. `project_name` -> `--project_name`). */
     val cliFlag: String = "--$name",
-    /** Short one-line flag help for the CLI; when null the generator falls back to a trimmed [description]. */
-    val cliSynopsis: String? = null,
+    /**
+     * Short one-line flag help for the CLI. Required for every CLI-visible parameter (see
+     * [ToolSchema.asCliParams]); [InputSchemaElement.Companion.param] seeds it with a temporary empty
+     * string that a real call site must overwrite via [cliSynopsis].
+     */
+    val cliSynopsis: String,
+    /**
+     * An alternate CLI source for *this* parameter's value — a path-taking flag whose file content is
+     * the value; null when the CLI offers only the direct form. See [CliFileSource] and the
+     * [InputSchemaElement.cliFileSource] builder. Read only by the CLI projection; never affects
+     * [ToolSchema.asMcpJson], because the parameter itself is an ordinary MCP parameter either way.
+     */
+    val cliFileSource: CliFileSource? = null,
     /** True when the parameter is a CLI positional argument rather than a flag (e.g. `uri`). */
     val cliPositional: Boolean = false,
     /** True when the parameter is not exposed as a CLI flag at all. */
@@ -39,6 +65,16 @@ data class InputSchemaParamSpec(
     val cliOptional: Boolean = false,
     /** Allowed values recorded by [enumString], so CLI help can print `a | b | c`; null when unconstrained. */
     val enumValues: List<String>? = null,
+    /**
+     * CLI-only lower bound for a numeric parameter, enforced by the CLI frontend, not by the MCP
+     * `inputSchema` (which has its own, unrelated `minimum`/`maximum` extras). Only valid when [type]
+     * is `"integer"` or `"number"`; see [cliMinimum] builder.
+     */
+    val cliMinimum: Double? = null,
+    /** CLI-only upper bound for a numeric parameter; see [cliMinimum] for the constraints. */
+    val cliMaximum: Double? = null,
+    /** Curated wording the CLI shows when this parameter is missing; data only, rendered by the CLI. */
+    val cliMissingHint: String? = null,
 )
 
 /**
@@ -54,17 +90,37 @@ data class InputSchemaParamSpec(
 class ToolSchema {
     private val elements = mutableListOf<InputSchemaElement<*>>()
 
-    /** Registers [e] into this schema, preserving declaration order, and returns it for chaining. */
+    /**
+     * Registers [e] into this schema, preserving declaration order, and returns it for chaining.
+     * Fails fast when [e] declares a [CliFileSource] the CLI could never use on its own: a parameter
+     * the CLI still demands directly (MCP-[InputSchemaParamSpec.required] and not
+     * [InputSchemaParamSpec.cliOptional]) gains nothing from a path-taking alternative.
+     */
     fun <R> register(e: InputSchemaElement<R>): InputSchemaElement<R> {
+        val fileSource = e.spec.cliFileSource
+        require(fileSource == null || !e.spec.required || e.spec.cliOptional) {
+            "Parameter '${e.spec.name}' declares the CLI file source '${fileSource?.flag}' but the CLI " +
+                "would still demand it directly; also declare cliOptional() so '${fileSource?.flag}' " +
+                "alone is accepted"
+        }
         elements.add(e)
         return e
     }
 
-    /** MCP form: the JSON `inputSchema` sent to MCP clients. */
+    /** MCP form: the JSON `inputSchema` sent to MCP clients; CLI metadata is never part of it. */
     fun asMcpJson(): JsonObject = InputSchemaElement.buildSchema(elements)
 
-    /** CLI form — the parameter metadata only; the parsers stay encapsulated on the elements. */
-    fun asCliParams(): List<InputSchemaParamSpec> = elements.map { it.spec }
+    /**
+     * CLI form — the parameter metadata only; the parsers stay encapsulated on the elements. Fails
+     * fast when a CLI-visible (non-[InputSchemaParamSpec.cliHidden]) parameter has a blank
+     * [InputSchemaParamSpec.cliSynopsis]: every parameter the CLI shows the user must carry its own
+     * one-line help rather than silently falling back to the (often much longer) MCP [description].
+     */
+    fun asCliParams(): List<InputSchemaParamSpec> = elements.map { it.spec }.onEach { spec ->
+        require(spec.cliHidden || spec.cliSynopsis.isNotBlank()) {
+            "Parameter '${spec.name}' is CLI-visible but has no cliSynopsis"
+        }
+    }
 }
 
 data class InputSchemaElement<R>(
@@ -80,7 +136,7 @@ interface InputSchemaParamParser<R> {
 }
 
 fun InputSchemaElement.Companion.param(name: String) = InputSchemaElement(
-    spec = InputSchemaParamSpec(name = name, description = "Not Set", type = "Error", required = false),
+    spec = InputSchemaParamSpec(name = name, description = "Not Set", type = "Error", required = false, cliSynopsis = ""),
     parser = object : InputSchemaParamParser<Nothing> {
         override fun parseParameter(context: ToolCallContext): Nothing {
             throw ToolCallErrorException("Not implemented for $name")
@@ -110,6 +166,58 @@ fun <R> InputSchemaElement<R>.cliHidden() = copy(spec = spec.copy(cliHidden = tr
  * `inputSchema`, which keeps it required.
  */
 fun <R> InputSchemaElement<R>.cliOptional() = copy(spec = spec.copy(cliOptional = true))
+
+/**
+ * Declares that the CLI also accepts this parameter's value as the *content of a file*: [flag] takes a
+ * path (or `-` for standard input) and the text it yields becomes this parameter's value. The parameter
+ * stays an ordinary MCP parameter — only the path form is CLI-exclusive — so this never changes
+ * [ToolSchema.asMcpJson]. See [CliFileSource].
+ *
+ * Chain it after the type builder (`.string()`), and pair it with [cliOptional] when the parameter is
+ * [required] so the CLI accepts [flag] on its own — [ToolSchema.register] fails fast otherwise.
+ */
+fun <R> InputSchemaElement<R>.cliFileSource(flag: String, synopsis: String): InputSchemaElement<R> {
+    require(spec.type == "string") {
+        "cliFileSource feeds file text into '${spec.name}', so it needs a string parameter, but the type " +
+            "is '${spec.type}' (declare .string() before .cliFileSource())"
+    }
+    require(flag.startsWith("--")) {
+        "cliFileSource flag for '${spec.name}' must be a long option starting with '--', was '$flag'"
+    }
+    require(flag != spec.cliFlag) {
+        "cliFileSource flag for '${spec.name}' must differ from the parameter's own flag '$flag'"
+    }
+    require(synopsis.isNotBlank()) { "cliFileSource '$flag' for '${spec.name}' needs a one-line synopsis" }
+    return copy(spec = spec.copy(cliFileSource = CliFileSource(flag = flag, synopsis = synopsis)))
+}
+
+/**
+ * CLI-only lower bound, enforced by the CLI frontend; never serialized into the MCP `inputSchema`.
+ * Fails fast unless the element's type is `"integer"` or `"number"`.
+ */
+fun <R> InputSchemaElement<R>.cliMinimum(value: Double): InputSchemaElement<R> {
+    require(spec.type == "integer" || spec.type == "number") {
+        "cliMinimum requires a numeric parameter, but '${spec.name}' has type '${spec.type}'"
+    }
+    return copy(spec = spec.copy(cliMinimum = value))
+}
+
+/**
+ * CLI-only upper bound, enforced by the CLI frontend; never serialized into the MCP `inputSchema`.
+ * Fails fast unless the element's type is `"integer"` or `"number"`.
+ */
+fun <R> InputSchemaElement<R>.cliMaximum(value: Double): InputSchemaElement<R> {
+    require(spec.type == "integer" || spec.type == "number") {
+        "cliMaximum requires a numeric parameter, but '${spec.name}' has type '${spec.type}'"
+    }
+    return copy(spec = spec.copy(cliMaximum = value))
+}
+
+/**
+ * Curated wording the CLI shows when this parameter is missing (e.g. naming an env var or flag);
+ * data only — rendering happens in the CLI frontend, never here. Absent from the MCP `inputSchema`.
+ */
+fun <R> InputSchemaElement<R>.cliMissingHint(text: String) = copy(spec = spec.copy(cliMissingHint = text))
 
 fun InputSchemaElement<Nothing>.boolean() = InputSchemaElement(
     spec = spec.copy(type = "boolean"),

--- a/mcp-core/src/main/kotlin/com/jonnyzzz/mcpSteroid/mcp/McpSchema.kt
+++ b/mcp-core/src/main/kotlin/com/jonnyzzz/mcpSteroid/mcp/McpSchema.kt
@@ -1,6 +1,7 @@
 package com.jonnyzzz.mcpSteroid.mcp
 
 import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonObjectBuilder
 import kotlinx.serialization.json.add
 import kotlinx.serialization.json.booleanOrNull
@@ -20,7 +21,51 @@ data class InputSchemaParamSpec(
     val required: Boolean,
     /** Additional JSON keys merged into the property body (e.g. `minimum`, `maximum`, `items`). */
     val extra: JsonObjectBuilder.() -> Unit = {},
+    // CLI hints are exposed by [ToolSchema.asCliParams] and are never serialized into MCP inputSchema JSON.
+    /** CLI flag for this parameter; defaults to `--<name>` (e.g. `project_name` -> `--project_name`). */
+    val cliFlag: String = "--$name",
+    /** Short one-line flag help for the CLI; when null the generator falls back to a trimmed [description]. */
+    val cliSynopsis: String? = null,
+    /** True when the parameter is a CLI positional argument rather than a flag (e.g. `uri`). */
+    val cliPositional: Boolean = false,
+    /** True when the parameter is not exposed as a CLI flag at all. */
+    val cliHidden: Boolean = false,
+    /**
+     * True when the CLI treats this parameter as optional even though [required] is true for the MCP call.
+     * Used for parameters the CLI can supply itself, such as a `project_name` inferred from the current
+     * directory. The MCP `inputSchema` remains required.
+     * Read only by the CLI projection/rendering; never affects [asMcpJson].
+     */
+    val cliOptional: Boolean = false,
+    /** Allowed values recorded by [enumString], so CLI help can print `a | b | c`; null when unconstrained. */
+    val enumValues: List<String>? = null,
 )
+
+/**
+ * Owns the registered [InputSchemaElement]s of a single tool and offers two projections of them:
+ * the MCP JSON `inputSchema` sent to clients, and the CLI parameter metadata consumed by the devrig
+ * CLI frontend. The per-parameter parser stays encapsulated inside each [InputSchemaElement]; only
+ * [InputSchemaParamSpec] values are exposed by [asCliParams].
+ *
+ * The schema is the mutable owner of the parameter set: elements are added via [register] (in
+ * declaration order), and both projections read that single ordered list. [McpToolBase] holds one
+ * `ToolSchema` and routes its `registerToSchema()` into [register].
+ */
+class ToolSchema {
+    private val elements = mutableListOf<InputSchemaElement<*>>()
+
+    /** Registers [e] into this schema, preserving declaration order, and returns it for chaining. */
+    fun <R> register(e: InputSchemaElement<R>): InputSchemaElement<R> {
+        elements.add(e)
+        return e
+    }
+
+    /** MCP form: the JSON `inputSchema` sent to MCP clients. */
+    fun asMcpJson(): JsonObject = InputSchemaElement.buildSchema(elements)
+
+    /** CLI form — the parameter metadata only; the parsers stay encapsulated on the elements. */
+    fun asCliParams(): List<InputSchemaParamSpec> = elements.map { it.spec }
+}
 
 data class InputSchemaElement<R>(
     val spec: InputSchemaParamSpec,
@@ -48,6 +93,24 @@ fun <R> InputSchemaElement<R>.description(description: String) = InputSchemaElem
     parser
 )
 
+/** Sets a short one-line CLI flag help; a CLI-only hint absent from the MCP `inputSchema`. */
+fun <R> InputSchemaElement<R>.cliSynopsis(text: String) = copy(spec = spec.copy(cliSynopsis = text))
+
+/** Marks this parameter as a CLI positional argument rather than a flag; a CLI-only hint. */
+fun <R> InputSchemaElement<R>.cliPositional() = copy(spec = spec.copy(cliPositional = true))
+
+/** Overrides the CLI flag (default `--<name>`); a CLI-only hint absent from the MCP `inputSchema`. */
+fun <R> InputSchemaElement<R>.cliFlag(flag: String) = copy(spec = spec.copy(cliFlag = flag))
+
+/** Hides this parameter from the CLI (still part of the MCP schema); a CLI-only hint. */
+fun <R> InputSchemaElement<R>.cliHidden() = copy(spec = spec.copy(cliHidden = true))
+
+/**
+ * Marks this parameter as CLI-optional even when [required]; a CLI-only hint that never touches the MCP
+ * `inputSchema`, which keeps it required.
+ */
+fun <R> InputSchemaElement<R>.cliOptional() = copy(spec = spec.copy(cliOptional = true))
+
 fun InputSchemaElement<Nothing>.boolean() = InputSchemaElement(
     spec = spec.copy(type = "boolean"),
     parser = object : InputSchemaParamParser<Boolean?> {
@@ -73,6 +136,7 @@ fun InputSchemaElement<Nothing>.string() = InputSchemaElement(
 fun <R : Any> InputSchemaElement<Nothing>.enumString(values: Map<String, R>) = InputSchemaElement(
     spec = spec.copy(
         type = "string",
+        enumValues = values.keys.toList(),
         extra = {
             putJsonArray("enum") {
                 values.keys.forEach {

--- a/mcp-core/src/test/kotlin/com/jonnyzzz/mcpSteroid/mcp/ToolSchemaCliMetadataTest.kt
+++ b/mcp-core/src/test/kotlin/com/jonnyzzz/mcpSteroid/mcp/ToolSchemaCliMetadataTest.kt
@@ -1,0 +1,170 @@
+/* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
+package com.jonnyzzz.mcpSteroid.mcp
+
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * Verifies that CLI metadata can be read from the shared tool schema without changing the MCP
+ * `inputSchema` projection.
+ */
+class ToolSchemaCliMetadataTest {
+
+    private class SampleTool : McpToolBase() {
+        override val name = "steroid_sample"
+        override val description = "Sample tool for CLI metadata tests"
+        override val cliSynopsis = "do a sample thing"
+
+        val alpha = InputSchemaElement.param("alpha").description("Alpha").string().required().registerToSchema()
+        val beta = InputSchemaElement.param("beta").description("Beta").int().registerToSchema()
+        val mode = InputSchemaElement.param("mode").description("Mode")
+            .enumString(mapOf("a" to 1, "b" to 2, "c" to 3)).registerToSchema()
+        val uri = InputSchemaElement.param("uri").description("URI").string().required().cliPositional().registerToSchema()
+        val code = InputSchemaElement.param("code").description("Code").string()
+            .cliFlag("--code-file").cliSynopsis("path to a file").registerToSchema()
+        val secret = InputSchemaElement.param("secret").description("Secret").string().cliHidden().registerToSchema()
+        val opt = InputSchemaElement.param("opt").description("Opt").string().required().cliOptional().registerToSchema()
+        val tags = InputSchemaElement.param("tags").description("Tags").stringArray().registerToSchema()
+
+        override suspend fun call(context: ToolCallContext): ToolCallResult = error("not used")
+    }
+
+    private val tool = SampleTool()
+
+    @Test
+    fun `cli name strips the steroid prefix`() {
+        assertEquals("sample", tool.cli.name)
+    }
+
+    @Test
+    fun `cliSynopsis surfaces in cli synopsis`() {
+        assertEquals("do a sample thing", tool.cli.synopsis)
+    }
+
+    @Test
+    fun `CliCommandSpec defaults are empty aliases and not hidden`() {
+        assertEquals(emptyList<String>(), tool.cli.aliases)
+        assertFalse(tool.cli.hidden)
+    }
+
+    @Test
+    fun `cliFlag defaults to dash-dash-name and can be overridden`() {
+        assertEquals("--alpha", tool.alpha.spec.cliFlag)
+        assertEquals("--code-file", tool.code.spec.cliFlag)
+    }
+
+    @Test
+    fun `cliPositional and cliHidden are reflected in the spec`() {
+        assertTrue(tool.uri.spec.cliPositional)
+        assertFalse(tool.alpha.spec.cliPositional)
+        assertTrue(tool.secret.spec.cliHidden)
+        assertFalse(tool.alpha.spec.cliHidden)
+    }
+
+    @Test
+    fun `cliSynopsis on a param defaults to null and can be set`() {
+        assertNull(tool.alpha.spec.cliSynopsis)
+        assertEquals("path to a file", tool.code.spec.cliSynopsis)
+    }
+
+    @Test
+    fun `cliOptional defaults to false and the builder sets it without touching required`() {
+        assertFalse(tool.alpha.spec.cliOptional)
+        assertTrue(tool.opt.spec.cliOptional)
+        // cliOptional is a CLI-only projection: the param stays MCP-required.
+        assertTrue(tool.opt.spec.required)
+    }
+
+    @Test
+    fun `cliOptional never leaks into the MCP required list`() {
+        val required = tool.schema.asMcpJson()["required"]!!.jsonArray.map { it.jsonPrimitive.content }
+        assertTrue(required.contains("opt"), "cliOptional must not drop a param from MCP required: $required")
+    }
+
+    @Test
+    fun `enumString records enumValues in registration order`() {
+        assertEquals(listOf("a", "b", "c"), tool.mode.spec.enumValues)
+        assertNull(tool.alpha.spec.enumValues)
+    }
+
+    @Test
+    fun `asCliParams returns one spec per registered param in registration order`() {
+        assertEquals(
+            listOf("alpha", "beta", "mode", "uri", "code", "secret", "opt", "tags"),
+            tool.schema.asCliParams().map { it.name },
+        )
+    }
+
+    @Test
+    fun `asMcpJson renders the real MCP schema for the registered params`() {
+        // inputSchema literally delegates to schema.asMcpJson() (see McpToolBase), so asserting their
+        // equality would be a tautology; the byte-for-byte "unchanged vs before" guarantee lives in the
+        // golden *ToolSpecSchemaTest. Here we assert asMcpJson produces the expected schema structure.
+        val json = tool.schema.asMcpJson()
+        val props = json["properties"]!!.jsonObject
+        assertEquals("integer", tool.beta.spec.type)
+        assertEquals("array", tool.tags.spec.type)
+        assertEquals("string", props["alpha"]!!.jsonObject["type"]!!.jsonPrimitive.content)
+        assertEquals("integer", props["beta"]!!.jsonObject["type"]!!.jsonPrimitive.content)
+        assertEquals("array", props["tags"]!!.jsonObject["type"]!!.jsonPrimitive.content)
+        val required = json["required"]!!.jsonArray.map { it.jsonPrimitive.content }
+        assertTrue(required.contains("alpha"))
+        assertFalse(required.contains("beta"))
+    }
+
+    @Test
+    fun `CLI hint fields never leak into the MCP JSON schema`() {
+        val rendered = Json.encodeToString(JsonObject.serializer(), tool.schema.asMcpJson())
+        for (leak in listOf("cliFlag", "cliSynopsis", "cliPositional", "cliHidden", "cliOptional", "enumValues")) {
+            assertFalse(rendered.contains(leak), "MCP schema must not contain CLI hint field '$leak': $rendered")
+        }
+    }
+
+    @Test
+    fun `McpToolBase is a CliToolSpec exposing cli and schema`() {
+        val spec: CliToolSpec = tool
+        assertEquals("sample", spec.cli.name)
+        assertEquals(tool.schema.asCliParams(), spec.schema.asCliParams())
+    }
+
+    @Test
+    fun `a plain McpTool double needs no cli metadata`() {
+        val plain = object : McpTool {
+            override val name = "steroid_plain"
+            override val description = "a plain tool"
+            override val inputSchema = InputSchemaElement.buildSchema(emptyList())
+            override suspend fun call(context: ToolCallContext): ToolCallResult = error("not used")
+        }
+        assertEquals("steroid_plain", plain.name)
+    }
+
+    @Test
+    fun `defaultCliName strips the steroid prefix`() {
+        assertEquals("plain", defaultCliName("steroid_plain"))
+        assertEquals("already_bare", defaultCliName("already_bare"))
+    }
+
+    @Test
+    fun `ToolSchema register preserves order and feeds both projections`() {
+        val schema = ToolSchema()
+        val first = schema.register(InputSchemaElement.param("first").description("First").string().required())
+        val second = schema.register(InputSchemaElement.param("second").description("Second").int())
+        // register returns the element it was handed, so declarations can chain.
+        assertEquals("first", first.spec.name)
+        assertEquals("second", second.spec.name)
+        // Both projections read the same ordered list.
+        assertEquals(listOf("first", "second"), schema.asCliParams().map { it.name })
+        val props = schema.asMcpJson()["properties"]!!.jsonObject
+        assertEquals(setOf("first", "second"), props.keys)
+        val required = schema.asMcpJson()["required"]!!.jsonArray.map { it.jsonPrimitive.content }
+        assertEquals(listOf("first"), required)
+    }
+}

--- a/mcp-core/src/test/kotlin/com/jonnyzzz/mcpSteroid/mcp/ToolSchemaCliMetadataTest.kt
+++ b/mcp-core/src/test/kotlin/com/jonnyzzz/mcpSteroid/mcp/ToolSchemaCliMetadataTest.kt
@@ -53,7 +53,7 @@ class ToolSchemaCliMetadataTest {
         override val description = "Tool with a tool-level extra CLI option"
         override val cliSynopsis = "do a thing and optionally wait"
         override val cliExtraOptions = listOf(
-            CliExtraOption("--wait", CliOptionType.BOOLEAN, "poll until the thing is done"),
+            CliExtraOption(name = "wait", type = CliOptionType.BOOLEAN, synopsis = "poll until the thing is done"),
         )
 
         // One ordinary parameter, so "the extra option is not among the parameters" has something to
@@ -89,9 +89,55 @@ class ToolSchemaCliMetadataTest {
     fun `a declared tool-level extra CLI option surfaces on the command spec`() {
         val waiting = WaitingTool()
         assertEquals(
-            listOf(CliExtraOption("--wait", CliOptionType.BOOLEAN, "poll until the thing is done")),
+            listOf(
+                CliExtraOption(name = "wait", type = CliOptionType.BOOLEAN, synopsis = "poll until the thing is done"),
+            ),
             waiting.cli.extraOptions,
         )
+    }
+
+    @Test
+    fun `CliExtraOption name is identity and flag defaults to dash-dash-name`() {
+        val option = CliExtraOption(name = "wait", type = CliOptionType.BOOLEAN, synopsis = "poll until done")
+        assertEquals("wait", option.name)
+        assertEquals("--wait", option.flag)
+    }
+
+    @Test
+    fun `CliExtraOption flag can be overridden independently of name`() {
+        val option = CliExtraOption(
+            name = "wait",
+            type = CliOptionType.BOOLEAN,
+            synopsis = "poll until done",
+            flag = "--block-until-ready",
+        )
+        assertEquals("wait", option.name)
+        assertEquals("--block-until-ready", option.flag)
+    }
+
+    @Test
+    fun `CliExtraOption rejects a blank name`() {
+        val error = assertThrows(IllegalArgumentException::class.java) {
+            CliExtraOption(name = "", type = CliOptionType.BOOLEAN, synopsis = "poll until done")
+        }
+        assertTrue(error.message!!.contains("name"), "error should mention the missing name: ${error.message}")
+    }
+
+    @Test
+    fun `CliExtraOption rejects a blank synopsis`() {
+        val error = assertThrows(IllegalArgumentException::class.java) {
+            CliExtraOption(name = "wait", type = CliOptionType.BOOLEAN, synopsis = "")
+        }
+        assertTrue(error.message!!.contains("wait"), "error should name the declaration: ${error.message}")
+    }
+
+    @Test
+    fun `CliExtraOption rejects a flag that does not start with dash-dash`() {
+        val error = assertThrows(IllegalArgumentException::class.java) {
+            CliExtraOption(name = "wait", type = CliOptionType.BOOLEAN, synopsis = "poll until done", flag = "-wait")
+        }
+        assertTrue(error.message!!.contains("wait"), "error should name the declaration: ${error.message}")
+        assertTrue(error.message!!.contains("-wait"), "error should name the offending flag: ${error.message}")
     }
 
     @Test

--- a/mcp-core/src/test/kotlin/com/jonnyzzz/mcpSteroid/mcp/ToolSchemaCliMetadataTest.kt
+++ b/mcp-core/src/test/kotlin/com/jonnyzzz/mcpSteroid/mcp/ToolSchemaCliMetadataTest.kt
@@ -9,6 +9,7 @@ import kotlinx.serialization.json.jsonPrimitive
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 
@@ -23,16 +24,44 @@ class ToolSchemaCliMetadataTest {
         override val description = "Sample tool for CLI metadata tests"
         override val cliSynopsis = "do a sample thing"
 
-        val alpha = InputSchemaElement.param("alpha").description("Alpha").string().required().registerToSchema()
-        val beta = InputSchemaElement.param("beta").description("Beta").int().registerToSchema()
+        val alpha = InputSchemaElement.param("alpha").description("Alpha").string().required()
+            .cliSynopsis("Alpha value").registerToSchema()
+        val beta = InputSchemaElement.param("beta").description("Beta").int()
+            .cliSynopsis("Beta count").registerToSchema()
         val mode = InputSchemaElement.param("mode").description("Mode")
-            .enumString(mapOf("a" to 1, "b" to 2, "c" to 3)).registerToSchema()
-        val uri = InputSchemaElement.param("uri").description("URI").string().required().cliPositional().registerToSchema()
+            .enumString(mapOf("a" to 1, "b" to 2, "c" to 3)).cliSynopsis("Selection mode").registerToSchema()
+        val uri = InputSchemaElement.param("uri").description("URI").string().required().cliPositional()
+            .cliSynopsis("Target URI").registerToSchema()
         val code = InputSchemaElement.param("code").description("Code").string()
             .cliFlag("--code-file").cliSynopsis("path to a file").registerToSchema()
         val secret = InputSchemaElement.param("secret").description("Secret").string().cliHidden().registerToSchema()
-        val opt = InputSchemaElement.param("opt").description("Opt").string().required().cliOptional().registerToSchema()
-        val tags = InputSchemaElement.param("tags").description("Tags").stringArray().registerToSchema()
+        val opt = InputSchemaElement.param("opt").description("Opt").string().required().cliOptional()
+            .cliSynopsis("Optional value").registerToSchema()
+        val tags = InputSchemaElement.param("tags").description("Tags").stringArray()
+            .cliSynopsis("Tag list").registerToSchema()
+        val script = InputSchemaElement.param("script").description("Script").string().required()
+            .cliSynopsis("script body to run").cliOptional()
+            .cliFileSource("--script-file", "path to a script file; pass \"-\" to read from stdin")
+            .registerToSchema()
+
+        override suspend fun call(context: ToolCallContext): ToolCallResult = error("not used")
+    }
+
+    /** A tool whose subcommand carries an extra CLI option the CLI itself acts on, not a tool input. */
+    private class WaitingTool : McpToolBase() {
+        override val name = "steroid_waiting"
+        override val description = "Tool with a tool-level extra CLI option"
+        override val cliSynopsis = "do a thing and optionally wait"
+        override val cliExtraOptions = listOf(
+            CliExtraOption("--wait", CliOptionType.BOOLEAN, "poll until the thing is done"),
+        )
+
+        // One ordinary parameter, so "the extra option is not among the parameters" has something to
+        // distinguish itself from; the element itself is never read, only registered.
+        init {
+            InputSchemaElement.param("alpha").description("Alpha").string().required()
+                .cliSynopsis("Alpha value").registerToSchema()
+        }
 
         override suspend fun call(context: ToolCallContext): ToolCallResult = error("not used")
     }
@@ -50,9 +79,28 @@ class ToolSchemaCliMetadataTest {
     }
 
     @Test
-    fun `CliCommandSpec defaults are empty aliases and not hidden`() {
+    fun `CliCommandSpec defaults are empty aliases, no extra options and not hidden`() {
         assertEquals(emptyList<String>(), tool.cli.aliases)
+        assertEquals(emptyList<CliExtraOption>(), tool.cli.extraOptions)
         assertFalse(tool.cli.hidden)
+    }
+
+    @Test
+    fun `a declared tool-level extra CLI option surfaces on the command spec`() {
+        val waiting = WaitingTool()
+        assertEquals(
+            listOf(CliExtraOption("--wait", CliOptionType.BOOLEAN, "poll until the thing is done")),
+            waiting.cli.extraOptions,
+        )
+    }
+
+    @Test
+    fun `a tool-level extra CLI option is not a parameter and cannot reach the MCP schema`() {
+        val waiting = WaitingTool()
+        assertEquals(listOf("alpha"), waiting.schema.asCliParams().map { it.name })
+        assertEquals(setOf("alpha"), waiting.schema.asMcpJson()["properties"]!!.jsonObject.keys)
+        val rendered = Json.encodeToString(JsonObject.serializer(), waiting.schema.asMcpJson())
+        assertFalse(rendered.contains("wait"), "an extra CLI option must not reach the MCP schema: $rendered")
     }
 
     @Test
@@ -70,8 +118,9 @@ class ToolSchemaCliMetadataTest {
     }
 
     @Test
-    fun `cliSynopsis on a param defaults to null and can be set`() {
-        assertNull(tool.alpha.spec.cliSynopsis)
+    fun `cliSynopsis defaults to an empty string until set, and the builder sets it`() {
+        val fresh = InputSchemaElement.param("fresh").description("Fresh").string()
+        assertEquals("", fresh.spec.cliSynopsis)
         assertEquals("path to a file", tool.code.spec.cliSynopsis)
     }
 
@@ -98,7 +147,7 @@ class ToolSchemaCliMetadataTest {
     @Test
     fun `asCliParams returns one spec per registered param in registration order`() {
         assertEquals(
-            listOf("alpha", "beta", "mode", "uri", "code", "secret", "opt", "tags"),
+            listOf("alpha", "beta", "mode", "uri", "code", "secret", "opt", "tags", "script"),
             tool.schema.asCliParams().map { it.name },
         )
     }
@@ -123,7 +172,11 @@ class ToolSchemaCliMetadataTest {
     @Test
     fun `CLI hint fields never leak into the MCP JSON schema`() {
         val rendered = Json.encodeToString(JsonObject.serializer(), tool.schema.asMcpJson())
-        for (leak in listOf("cliFlag", "cliSynopsis", "cliPositional", "cliHidden", "cliOptional", "enumValues")) {
+        val leaks = listOf(
+            "cliFlag", "cliSynopsis", "cliPositional", "cliHidden", "cliOptional", "enumValues",
+            "cliFileSource", "--script-file",
+        )
+        for (leak in leaks) {
             assertFalse(rendered.contains(leak), "MCP schema must not contain CLI hint field '$leak': $rendered")
         }
     }
@@ -155,8 +208,12 @@ class ToolSchemaCliMetadataTest {
     @Test
     fun `ToolSchema register preserves order and feeds both projections`() {
         val schema = ToolSchema()
-        val first = schema.register(InputSchemaElement.param("first").description("First").string().required())
-        val second = schema.register(InputSchemaElement.param("second").description("Second").int())
+        val first = schema.register(
+            InputSchemaElement.param("first").description("First").string().required().cliSynopsis("First value")
+        )
+        val second = schema.register(
+            InputSchemaElement.param("second").description("Second").int().cliSynopsis("Second value")
+        )
         // register returns the element it was handed, so declarations can chain.
         assertEquals("first", first.spec.name)
         assertEquals("second", second.spec.name)
@@ -166,5 +223,164 @@ class ToolSchemaCliMetadataTest {
         assertEquals(setOf("first", "second"), props.keys)
         val required = schema.asMcpJson()["required"]!!.jsonArray.map { it.jsonPrimitive.content }
         assertEquals(listOf("first"), required)
+    }
+
+    @Test
+    fun `asCliParams rejects a CLI-visible parameter with a blank synopsis`() {
+        val schema = ToolSchema()
+        schema.register(InputSchemaElement.param("bare").description("Bare").string())
+        val error = assertThrows(IllegalArgumentException::class.java) { schema.asCliParams() }
+        assertTrue(error.message!!.contains("bare"), "error should name the parameter: ${error.message}")
+    }
+
+    @Test
+    fun `asCliParams allows a blank synopsis on a cliHidden parameter`() {
+        val schema = ToolSchema()
+        schema.register(InputSchemaElement.param("bare").description("Bare").string().cliHidden())
+        assertEquals(listOf("bare"), schema.asCliParams().map { it.name })
+    }
+
+    @Test
+    fun `a file source declares a second CLI source for the parameter's own value`() {
+        val fileSource = tool.script.spec.cliFileSource
+        assertEquals("--script-file", fileSource?.flag)
+        assertEquals("path to a script file; pass \"-\" to read from stdin", fileSource?.synopsis)
+        // The parameter keeps its own direct flag; the file source is the alternative, not a replacement.
+        assertEquals("--script", tool.script.spec.cliFlag)
+        assertNull(tool.alpha.spec.cliFileSource, "a parameter with no declared file source reports none")
+    }
+
+    @Test
+    fun `a file-source parameter stays a normal MCP parameter on the wire`() {
+        // Unlike the CLI-only parameter this replaces, the value still exists on the MCP wire — only the
+        // *path* form is CLI-exclusive, so nothing is filtered out of asMcpJson.
+        val json = tool.schema.asMcpJson()
+        assertEquals("string", json["properties"]!!.jsonObject["script"]!!.jsonObject["type"]!!.jsonPrimitive.content)
+        val required = json["required"]!!.jsonArray.map { it.jsonPrimitive.content }
+        assertTrue(required.contains("script"), "a file source must not drop the param from MCP required: $required")
+    }
+
+    @Test
+    fun `a file source renders the exact same MCP JSON as the same parameter without one`() {
+        fun schemaOf(withFileSource: Boolean) = ToolSchema().also {
+            var element = InputSchemaElement.param("code").description("Code").string().required()
+                .cliSynopsis("code body").cliOptional()
+            if (withFileSource) element = element.cliFileSource("--code-file", "path to a script file")
+            it.register(element)
+        }
+
+        val plain = Json.encodeToString(JsonObject.serializer(), schemaOf(withFileSource = false).asMcpJson())
+        val sourced = Json.encodeToString(JsonObject.serializer(), schemaOf(withFileSource = true).asMcpJson())
+        assertEquals(plain, sourced)
+    }
+
+    @Test
+    fun `a file source rejects a non-string parameter`() {
+        val error = assertThrows(IllegalArgumentException::class.java) {
+            InputSchemaElement.param("count").description("Count").int().cliFileSource("--count-file", "path")
+        }
+        assertTrue(error.message!!.contains("count"), "error should name the parameter: ${error.message}")
+    }
+
+    @Test
+    fun `a file source rejects a flag that collides with the parameter's own flag`() {
+        val error = assertThrows(IllegalArgumentException::class.java) {
+            InputSchemaElement.param("code").description("Code").string().cliFileSource("--code", "path")
+        }
+        assertTrue(error.message!!.contains("--code"), "error should name the colliding flag: ${error.message}")
+    }
+
+    @Test
+    fun `a file-source parameter that the CLI would still demand directly throws at registration time`() {
+        // A file source only helps if the CLI may omit the direct value; required-and-not-cliOptional
+        // would make the CLI reject `--code-file` alone, which is the whole point of declaring it.
+        val schema = ToolSchema()
+        val element = InputSchemaElement.param("code").description("Code").string().required()
+            .cliSynopsis("code body").cliFileSource("--code-file", "path to a script file")
+        val error = assertThrows(IllegalArgumentException::class.java) { schema.register(element) }
+        assertTrue(error.message!!.contains("code"), "error should name the parameter: ${error.message}")
+        assertTrue(
+            error.message!!.contains("cliOptional"),
+            "error should point at the missing declaration: ${error.message}",
+        )
+    }
+
+    @Test
+    fun `cliMinimum and cliMaximum surface in asCliParams`() {
+        val bounded = InputSchemaElement.param("count").description("Count").int()
+            .cliSynopsis("How many").cliMinimum(1.0).cliMaximum(10.0)
+        assertEquals(1.0, bounded.spec.cliMinimum)
+        assertEquals(10.0, bounded.spec.cliMaximum)
+    }
+
+    @Test
+    fun `cliMinimum and cliMaximum never affect asMcpJson`() {
+        fun withoutBounds() = ToolSchema().also {
+            it.register(InputSchemaElement.param("count").description("Count").int().cliSynopsis("How many"))
+        }
+
+        fun withBounds() = ToolSchema().also {
+            it.register(
+                InputSchemaElement.param("count").description("Count").int()
+                    .cliSynopsis("How many").cliMinimum(1.0).cliMaximum(10.0)
+            )
+        }
+
+        val plain = Json.encodeToString(JsonObject.serializer(), withoutBounds().asMcpJson())
+        val bounded = Json.encodeToString(JsonObject.serializer(), withBounds().asMcpJson())
+        assertEquals(plain, bounded)
+    }
+
+    @Test
+    fun `cliMinimum rejects a non-numeric parameter`() {
+        val error = assertThrows(IllegalArgumentException::class.java) {
+            InputSchemaElement.param("name").description("Name").string().cliMinimum(1.0)
+        }
+        assertTrue(error.message!!.contains("name"), "error should name the parameter: ${error.message}")
+    }
+
+    @Test
+    fun `cliMaximum rejects a non-numeric parameter`() {
+        val error = assertThrows(IllegalArgumentException::class.java) {
+            InputSchemaElement.param("name").description("Name").string().cliMaximum(1.0)
+        }
+        assertTrue(error.message!!.contains("name"), "error should name the parameter: ${error.message}")
+    }
+
+    @Test
+    fun `cliMissingHint round-trips through asCliParams and stays out of asMcpJson`() {
+        val schema = ToolSchema()
+        schema.register(
+            InputSchemaElement.param("token").description("Token").string().required()
+                .cliSynopsis("Auth token").cliMissingHint("Set MCP_STEROID_TOKEN or pass --token")
+        )
+        val hint = schema.asCliParams().single { it.name == "token" }.cliMissingHint
+        assertEquals("Set MCP_STEROID_TOKEN or pass --token", hint)
+        val rendered = Json.encodeToString(JsonObject.serializer(), schema.asMcpJson())
+        assertFalse(rendered.contains("MCP_STEROID_TOKEN"), "cliMissingHint must not leak into the MCP schema: $rendered")
+    }
+
+    @Test
+    fun `golden schema - every invisible CLI field leaves asMcpJson unchanged`() {
+        fun plainSchema() = ToolSchema().also {
+            it.register(InputSchemaElement.param("alpha").description("Alpha").string().required())
+            it.register(InputSchemaElement.param("count").description("Count").int())
+        }
+
+        fun decoratedSchema() = ToolSchema().also {
+            it.register(
+                InputSchemaElement.param("alpha").description("Alpha").string().required()
+                    .cliSynopsis("Alpha value").cliFlag("--alpha-value").cliMissingHint("pass --alpha-value")
+                    .cliOptional().cliFileSource("--alpha-file", "read Alpha from this file")
+            )
+            it.register(
+                InputSchemaElement.param("count").description("Count").int()
+                    .cliSynopsis("Count value").cliMinimum(0.0).cliMaximum(100.0)
+            )
+        }
+
+        val plain = Json.encodeToString(JsonObject.serializer(), plainSchema().asMcpJson())
+        val decorated = Json.encodeToString(JsonObject.serializer(), decoratedSchema().asMcpJson())
+        assertEquals(plain, decorated)
     }
 }

--- a/mcp-steroid-server/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/CommonToolParams.kt
+++ b/mcp-steroid-server/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/CommonToolParams.kt
@@ -1,6 +1,7 @@
 package com.jonnyzzz.mcpSteroid.server
 
 import com.jonnyzzz.mcpSteroid.mcp.InputSchemaElement
+import com.jonnyzzz.mcpSteroid.mcp.cliFileSource
 import com.jonnyzzz.mcpSteroid.mcp.cliOptional
 import com.jonnyzzz.mcpSteroid.mcp.cliSynopsis
 import com.jonnyzzz.mcpSteroid.mcp.description
@@ -25,7 +26,7 @@ object CommonToolParams {
                         "folder name). steroid_list_projects returns both `project_name` (the unique key " +
                         "to pass here) and `name` (the raw folder name, informational only); they are not equal."
             )
-            .cliSynopsis("routing key from `devrig list_projects` (NOT the folder name); inferred from the cwd when omitted")
+            .cliSynopsis("routing key from `devrig list_projects`, not the folder name")
             .string()
             .required()
             .cliOptional()
@@ -37,6 +38,7 @@ object CommonToolParams {
                 "Your task identifier — reuse the same value across related tool calls " +
                         "to group them in audit logs."
             )
+            .cliSynopsis("your task id; reuse it across related calls for audit logs")
             .string()
             .required()
 
@@ -48,6 +50,7 @@ object CommonToolParams {
     fun windowId() =
         InputSchemaElement.param("window_id")
             .description("Window id from steroid_list_windows identifying the target IDE window.")
+            .cliSynopsis("window id from `devrig list_windows` to target")
             .string()
 
     /** Required `reason` string with the audit-log convention: `Reason for $action. Required for audit logs.` */
@@ -58,6 +61,15 @@ object CommonToolParams {
                 "This helps us learn and improve. " +
                 "Use steroid_execute_feedback to share improvements, suggestions, and feedback."
             )
+            .cliSynopsis("your intent and expected outcome, for the audit log")
             .string()
             .required()
 }
+
+/**
+ * Declares the `--code-file` alternate source shared by the `code` parameter of `execute_code` and
+ * `execute_feedback`: the CLI reads the script/snippet from a file (or standard input when the path is
+ * `-`) and uses it as `code`. Chain it after `.string()`, alongside `.cliOptional()`.
+ */
+fun <R> InputSchemaElement<R>.cliCodeFileSource() =
+    cliFileSource(flag = "--code-file", synopsis = "path to a script file; pass \"-\" to read from stdin")

--- a/mcp-steroid-server/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/CommonToolParams.kt
+++ b/mcp-steroid-server/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/CommonToolParams.kt
@@ -1,6 +1,8 @@
 package com.jonnyzzz.mcpSteroid.server
 
 import com.jonnyzzz.mcpSteroid.mcp.InputSchemaElement
+import com.jonnyzzz.mcpSteroid.mcp.cliOptional
+import com.jonnyzzz.mcpSteroid.mcp.cliSynopsis
 import com.jonnyzzz.mcpSteroid.mcp.description
 import com.jonnyzzz.mcpSteroid.mcp.param
 import com.jonnyzzz.mcpSteroid.mcp.required
@@ -12,7 +14,10 @@ import com.jonnyzzz.mcpSteroid.mcp.string
  * `.registerToSchema()` to attach it to their tool's input schema.
  */
 object CommonToolParams {
-    /** Required `project_name` used to dispatch a tool call to an already-open IDE project. */
+    /**
+     * Required `project_name` used to dispatch a tool call to an already-open IDE project.
+     * MCP-required, but CLI-optional because devrig can infer it from the current directory.
+     */
     fun projectName() =
         InputSchemaElement.param("project_name")
             .description(
@@ -20,8 +25,10 @@ object CommonToolParams {
                         "folder name). steroid_list_projects returns both `project_name` (the unique key " +
                         "to pass here) and `name` (the raw folder name, informational only); they are not equal."
             )
+            .cliSynopsis("routing key from `devrig list_projects` (NOT the folder name); inferred from the cwd when omitted")
             .string()
             .required()
+            .cliOptional()
 
     /** Required `task_id` used to group related executions in audit logs. */
     fun taskId() =

--- a/mcp-steroid-server/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/ExecuteCodeTool.kt
+++ b/mcp-steroid-server/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/ExecuteCodeTool.kt
@@ -4,7 +4,10 @@ import com.jonnyzzz.mcpSteroid.mcp.InputSchemaElement
 import com.jonnyzzz.mcpSteroid.mcp.McpToolBase
 import com.jonnyzzz.mcpSteroid.mcp.ToolCallContext
 import com.jonnyzzz.mcpSteroid.mcp.ToolCallResult
+import com.jonnyzzz.mcpSteroid.mcp.cliMinimum
+import com.jonnyzzz.mcpSteroid.mcp.cliMissingHint
 import com.jonnyzzz.mcpSteroid.mcp.cliOptional
+import com.jonnyzzz.mcpSteroid.mcp.cliSynopsis
 import com.jonnyzzz.mcpSteroid.mcp.description
 import com.jonnyzzz.mcpSteroid.mcp.enumString
 import com.jonnyzzz.mcpSteroid.mcp.get
@@ -84,8 +87,9 @@ class ExecuteCodeToolSpec(val handler: () -> ExecuteCodeToolHandler) : McpToolBa
 
     val projectName = CommonToolParams.projectName().registerToSchema()
 
-    // MCP callers must send code directly. A CLI frontend may synthesize it from a file or stdin, so
-    // this remains MCP-required while the CLI projection treats it as optional.
+    // MCP callers must send code directly. The CLI also accepts it as a file (or stdin) via the
+    // declared --code-file source, so it remains MCP-required while the CLI projection treats it as
+    // optional.
     val code = InputSchemaElement.param("code")
         .description(
             "Kotlin code. The response carries an execution_id header plus ONLY what the script " +
@@ -100,20 +104,32 @@ class ExecuteCodeToolSpec(val handler: () -> ExecuteCodeToolHandler) : McpToolBa
                 "${CodingWithIntelliJContextApiPromptArticle().uri} — fetch it with " +
                 "steroid_fetch_resource."
         )
+        .cliSynopsis("Kotlin script body to run (omit when using --code-file)")
+        .cliMissingHint(
+            "missing code. Pass --code-file=<path> (preferred) or --code=\"...\". Example:\n" +
+                "  devrig execute_code --project_name=\"<key>\" --code-file=repro.kts --task_id=t1 --reason=\"reproduce issue\""
+        )
         .string()
         .required()
         .cliOptional()
+        .cliCodeFileSource()
         .registerToSchema()
 
-    val taskId = CommonToolParams.taskId().registerToSchema()
+    val taskId = CommonToolParams.taskId()
+        .cliMissingHint("missing --task_id. Any string works; reuse it across related calls.")
+        .registerToSchema()
 
-    val reason = CommonToolParams.reason().registerToSchema()
+    val reason = CommonToolParams.reason()
+        .cliMissingHint("missing --reason. Describe your intent and expected outcome for the audit log.")
+        .registerToSchema()
 
     private val defaultTimeoutSeconds = 600
     val timeout = InputSchemaElement.param("timeout")
         .description("Timeout in seconds for your script BODY (default: $defaultTimeoutSeconds, configurable via mcp.steroid.execution.timeout registry key). The smart_non_modal pre-flight commit and smart-mode waits have their own internal deadlock-safety bounds and are not governed by this value.")
+        .cliSynopsis("seconds to allow the script body to run (default 600)")
         .int()
         .withDefaultValue(defaultTimeoutSeconds)
+        .cliMinimum(1.0)
         .registerToSchema()
 
     val modal = InputSchemaElement.param("modal")
@@ -136,6 +152,7 @@ class ExecuteCodeToolSpec(val handler: () -> ExecuteCodeToolHandler) : McpToolBa
                 "dialogs included; for intentional modal-dialog workflows (open/inspect/close a dialog " +
                 "yourself) or trivial / hardcoded IDE actions ONLY, never for PSI/editing."
         )
+        .cliSynopsis("modal-dialog policy for running the script")
         .enumString(ModalMode.entries.associateBy { it.wire })
         .withDefaultValue(ModalMode.SMART_NON_MODAL)
         .registerToSchema()

--- a/mcp-steroid-server/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/ExecuteCodeTool.kt
+++ b/mcp-steroid-server/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/ExecuteCodeTool.kt
@@ -4,6 +4,7 @@ import com.jonnyzzz.mcpSteroid.mcp.InputSchemaElement
 import com.jonnyzzz.mcpSteroid.mcp.McpToolBase
 import com.jonnyzzz.mcpSteroid.mcp.ToolCallContext
 import com.jonnyzzz.mcpSteroid.mcp.ToolCallResult
+import com.jonnyzzz.mcpSteroid.mcp.cliOptional
 import com.jonnyzzz.mcpSteroid.mcp.description
 import com.jonnyzzz.mcpSteroid.mcp.enumString
 import com.jonnyzzz.mcpSteroid.mcp.get
@@ -79,9 +80,12 @@ data class ExecCodeParams(
 class ExecuteCodeToolSpec(val handler: () -> ExecuteCodeToolHandler) : McpToolBase() {
     override val name = "steroid_execute_code"
     override val description get() = ExecuteCodeToolDescriptionPromptArticle().readPayload(PromptsContext.Generic)
+    override val cliSynopsis = "run a Kotlin script in the target IDE"
 
     val projectName = CommonToolParams.projectName().registerToSchema()
 
+    // MCP callers must send code directly. A CLI frontend may synthesize it from a file or stdin, so
+    // this remains MCP-required while the CLI projection treats it as optional.
     val code = InputSchemaElement.param("code")
         .description(
             "Kotlin code. The response carries an execution_id header plus ONLY what the script " +
@@ -98,6 +102,7 @@ class ExecuteCodeToolSpec(val handler: () -> ExecuteCodeToolHandler) : McpToolBa
         )
         .string()
         .required()
+        .cliOptional()
         .registerToSchema()
 
     val taskId = CommonToolParams.taskId().registerToSchema()

--- a/mcp-steroid-server/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/ExecuteFeedbackTool.kt
+++ b/mcp-steroid-server/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/ExecuteFeedbackTool.kt
@@ -44,6 +44,7 @@ class ExecuteFeedbackToolSpec(val handler: () -> ExecuteFeedbackToolHandler) : M
 
             Feedback helps track execution history and identify patterns for improvement.
         """.trimIndent()
+    override val cliSynopsis = "rate an execution and suggest improvements"
 
     val projectName = CommonToolParams.projectName().registerToSchema()
 

--- a/mcp-steroid-server/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/ExecuteFeedbackTool.kt
+++ b/mcp-steroid-server/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/ExecuteFeedbackTool.kt
@@ -4,6 +4,8 @@ import com.jonnyzzz.mcpSteroid.mcp.InputSchemaElement
 import com.jonnyzzz.mcpSteroid.mcp.McpToolBase
 import com.jonnyzzz.mcpSteroid.mcp.ToolCallContext
 import com.jonnyzzz.mcpSteroid.mcp.ToolCallResult
+import com.jonnyzzz.mcpSteroid.mcp.cliMissingHint
+import com.jonnyzzz.mcpSteroid.mcp.cliSynopsis
 import com.jonnyzzz.mcpSteroid.mcp.description
 import com.jonnyzzz.mcpSteroid.mcp.errorResult
 import com.jonnyzzz.mcpSteroid.mcp.get
@@ -52,11 +54,17 @@ class ExecuteFeedbackToolSpec(val handler: () -> ExecuteFeedbackToolHandler) : M
 
     val executionId = InputSchemaElement.param("execution_id")
         .description("The execution_id returned from the most recent steroid_execute_code call for this task")
+        .cliSynopsis("execution_id from the most recent execute_code call")
         .string()
         .registerToSchema()
 
     val successRating = InputSchemaElement.param("success_rating")
         .description("Rate the success of the execution from 0.00 (complete failure) to 1.00 (complete success)")
+        .cliSynopsis("success rating from 0.00 (fail) to 1.00 (success)")
+        .cliMissingHint(
+            "missing --success_rating (number 0.00..1.00). Example:\n" +
+                "  devrig execute_feedback --project_name=\"<key>\" --task_id=t1 --success_rating=0.9 --explanation=\"...\""
+        )
         .number()
         .minimum(0.0)
         .maximum(1.0)
@@ -65,13 +73,17 @@ class ExecuteFeedbackToolSpec(val handler: () -> ExecuteFeedbackToolHandler) : M
 
     val explanation = InputSchemaElement.param("explanation")
         .description("Explain why you gave this rating. Provide improvements, suggestions, and critical thinking to improve this tool")
+        .cliSynopsis("what worked, what didn't, and what you'll try next")
+        .cliMissingHint("missing --explanation. Describe what worked, what didn't, and what you'll try next.")
         .string()
         .required()
         .registerToSchema()
 
     val code = InputSchemaElement.param("code")
         .description("Optional: The code snippet that was executed. Useful for tracking what code produced which results.")
+        .cliSynopsis("code snippet the feedback refers to (optional)")
         .string()
+        .cliCodeFileSource()
         .registerToSchema()
 
     override suspend fun call(context: ToolCallContext): ToolCallResult {

--- a/mcp-steroid-server/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/FetchResourceToolHandler.kt
+++ b/mcp-steroid-server/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/FetchResourceToolHandler.kt
@@ -33,7 +33,7 @@ class FetchResourceToolHandler(
     private val handler: () -> PromptsContextHandler,
 ) : McpToolBase() {
 
-    private val log by lazy { thisLogger() }
+    private val log = thisLogger()
 
     override val name = "steroid_fetch_resource"
 

--- a/mcp-steroid-server/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/FetchResourceToolHandler.kt
+++ b/mcp-steroid-server/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/FetchResourceToolHandler.kt
@@ -5,6 +5,8 @@ import com.jonnyzzz.mcpSteroid.mcp.InputSchemaElement
 import com.jonnyzzz.mcpSteroid.mcp.McpToolBase
 import com.jonnyzzz.mcpSteroid.mcp.ToolCallContext
 import com.jonnyzzz.mcpSteroid.mcp.ToolCallResult
+import com.jonnyzzz.mcpSteroid.mcp.cliMissingHint
+import com.jonnyzzz.mcpSteroid.mcp.cliSynopsis
 import com.jonnyzzz.mcpSteroid.mcp.description
 import com.jonnyzzz.mcpSteroid.mcp.get
 import com.jonnyzzz.mcpSteroid.mcp.param
@@ -56,6 +58,8 @@ class FetchResourceToolHandler(
 
     val uri = InputSchemaElement.param("uri")
         .description("The mcp-steroid:// URI to fetch (see the tool description for the canonical entry points, or fetch mcp-steroid://prompt/skill for the index)")
+        .cliSynopsis("mcp-steroid:// resource URI to fetch")
+        .cliMissingHint("missing --uri. Example:\n  devrig fetch_resource --uri=${SkillPromptArticle().uri}")
         .string()
         .required()
         .registerToSchema()

--- a/mcp-steroid-server/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/FetchResourceToolHandler.kt
+++ b/mcp-steroid-server/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/FetchResourceToolHandler.kt
@@ -31,7 +31,7 @@ class FetchResourceToolHandler(
     private val handler: () -> PromptsContextHandler,
 ) : McpToolBase() {
 
-    private val log = thisLogger()
+    private val log by lazy { thisLogger() }
 
     override val name = "steroid_fetch_resource"
 
@@ -50,6 +50,9 @@ class FetchResourceToolHandler(
                 "Any IDE task? → $skillUri | " +
                 "Full reference? → $codingGuideUri"
     }
+
+    override val cliSynopsis = "fetch a mcp-steroid:// guide by URI"
+    override val cliAliases = listOf("prompt")
 
     val uri = InputSchemaElement.param("uri")
         .description("The mcp-steroid:// URI to fetch (see the tool description for the canonical entry points, or fetch mcp-steroid://prompt/skill for the index)")

--- a/mcp-steroid-server/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/ListProjectsTool.kt
+++ b/mcp-steroid-server/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/ListProjectsTool.kt
@@ -14,6 +14,7 @@ import kotlinx.serialization.Serializable
 class ListProjectsToolSpec(val handler: () -> ListProjectsToolHandler) : McpToolBase() {
     override val name = "steroid_list_projects"
     override val description = "List all open projects in the IDE. Each entry has `project_name` (a unique routing key — pass it to steroid_execute_code and the other project-scoped tools) and `name` (the raw folder name, informational only); they are not equal. Resolve an entry's `backend_name` to the owning IDE's identity (`intellij` = `{name, version, build}`) via the `backends` lookup in the same response."
+    override val cliSynopsis = "list open projects and their routing keys"
 
     override suspend fun call(context: ToolCallContext): ToolCallResult {
         val response = handler().collectListProjectsResponse()

--- a/mcp-steroid-server/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/ListWindowsTool.kt
+++ b/mcp-steroid-server/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/ListWindowsTool.kt
@@ -14,6 +14,7 @@ import kotlinx.serialization.Serializable
 class ListWindowsToolSpec(val handler: () -> ListWindowsToolHandler) : McpToolBase() {
     override val name = "steroid_list_windows"
     override val description = "List open IDE windows and their background tasks, with per-window readiness (modal/indexing/initialized) and a `window_id` for screenshot/input targeting in multi-window setups. Each window and background-task entry references its project by `project_name` — the single routing key for the project-scoped tools; look up that project's human-readable `name` and `path` via steroid_list_projects by the key (they are not duplicated here). `project_name` is null for windows not tied to a project. Resolve an entry's `backend_name` to the owning IDE's identity (`intellij` = `{name, version, build}`) via the `backends` lookup in the same response."
+    override val cliSynopsis = "list IDE windows, readiness, and background tasks"
 
     override suspend fun call(context: ToolCallContext): ToolCallResult {
         val response = handler().collectListWindowsResponse()

--- a/mcp-steroid-server/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/McpSteroidTools.kt
+++ b/mcp-steroid-server/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/McpSteroidTools.kt
@@ -1,10 +1,11 @@
 package com.jonnyzzz.mcpSteroid.server
 
+import com.jonnyzzz.mcpSteroid.mcp.CliToolSpec
 import com.jonnyzzz.mcpSteroid.mcp.McpServerCore
 
 abstract class McpSteroidTools {
     /**
-     * Registers the tools common to every backend surface (in-IDE plugin and devrig CLI).
+     * Registers the tools common to every backend surface.
      *
      * `steroid_open_project` is intentionally NOT registered here: its spec differs per surface
      * (the in-IDE plugin advertises no `backend_name`, devrig advertises a required `backend_name`
@@ -13,15 +14,29 @@ abstract class McpSteroidTools {
      */
     fun registerAll(server: McpServerCore) {
         val tools = server.toolRegistry
-
-        tools.registerTool(ListProjectsToolSpec { handler<ListProjectsToolHandler>() })
-        tools.registerTool(ListWindowsToolSpec { handler<ListWindowsToolHandler>() })
-        tools.registerTool(ExecuteCodeToolSpec { handler<ExecuteCodeToolHandler>() })
-        tools.registerTool(ExecuteFeedbackToolSpec { handler<ExecuteFeedbackToolHandler>() })
-        tools.registerTool(VisionScreenshotToolSpec { handler<VisionScreenshotToolHandler>() })
-        tools.registerTool(VisionInputToolSpec { handler<VisionInputToolHandler>() })
-        tools.registerTool(FetchResourceToolHandler { handler<PromptsContextHandler>() })
+        commonToolSpecs().forEach { tools.registerTool(it) }
     }
+
+    /**
+     * Tool specs common to the in-IDE and devrig surfaces, in registration order. `steroid_open_project`
+     * is excluded because its routing parameters differ between the two surfaces.
+     */
+    fun commonToolSpecs(): List<CliToolSpec> = listOf(
+        ListProjectsToolSpec { handler<ListProjectsToolHandler>() },
+        ListWindowsToolSpec { handler<ListWindowsToolHandler>() },
+        ExecuteCodeToolSpec { handler<ExecuteCodeToolHandler>() },
+        ExecuteFeedbackToolSpec { handler<ExecuteFeedbackToolHandler>() },
+        VisionScreenshotToolSpec { handler<VisionScreenshotToolHandler>() },
+        VisionInputToolSpec { handler<VisionInputToolHandler>() },
+        FetchResourceToolHandler { handler<PromptsContextHandler>() },
+    )
+
+    /**
+     * Tool specs exposed by devrig. Its `steroid_open_project` includes `backend_name` so calls can be
+     * routed to one of the discovered IDE backends.
+     */
+    fun devrigToolSpecs(): List<CliToolSpec> =
+        commonToolSpecs() + OpenProjectToolSpec(includeBackendName = true) { handler<OpenProjectToolHandler>() }
 
     inline fun <reified T : Any> handler(): T = handler(T::class.java)
     abstract fun <T> handler(type: Class<T>): T

--- a/mcp-steroid-server/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/OpenProjectTool.kt
+++ b/mcp-steroid-server/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/OpenProjectTool.kt
@@ -1,10 +1,13 @@
 package com.jonnyzzz.mcpSteroid.server
 
+import com.jonnyzzz.mcpSteroid.mcp.CliExtraOption
+import com.jonnyzzz.mcpSteroid.mcp.CliOptionType
 import com.jonnyzzz.mcpSteroid.mcp.InputSchemaElement
 import com.jonnyzzz.mcpSteroid.mcp.McpToolBase
 import com.jonnyzzz.mcpSteroid.mcp.ToolCallContext
 import com.jonnyzzz.mcpSteroid.mcp.ToolCallResult
 import com.jonnyzzz.mcpSteroid.mcp.boolean
+import com.jonnyzzz.mcpSteroid.mcp.cliSynopsis
 import com.jonnyzzz.mcpSteroid.mcp.description
 import com.jonnyzzz.mcpSteroid.mcp.errorResult
 import com.jonnyzzz.mcpSteroid.mcp.get
@@ -44,6 +47,7 @@ class OpenProjectToolSpec(
 
     val projectPath = InputSchemaElement.param("project_path")
         .description("Absolute path to the project directory to open.")
+        .cliSynopsis("absolute path to the project directory to open")
         .string()
         .required()
         .registerToSchema()
@@ -54,6 +58,7 @@ class OpenProjectToolSpec(
 
     val trustProject = InputSchemaElement.param("trust_project")
         .description("If true, trust the project path before opening (skips trust dialog). Default: true")
+        .cliSynopsis("skip the trust-project dialog (default: true)")
         .boolean()
         .registerToSchema()
 
@@ -71,9 +76,21 @@ class OpenProjectToolSpec(
                     "the same repository — open: worktrees share build/index/VCS context, avoiding " +
                     "redundant indexing. See mcp-steroid://open-project/managing-backends."
             )
+            .cliSynopsis("backend id from `devrig backend --json` to target")
             .string()
             .registerToSchema()
     } else null
+
+    // Not a tool input: the tool returns as soon as opening starts, and the CLI itself polls
+    // list_windows afterwards until the project is initialized. Declared unconditionally — unlike
+    // backend_name, this changes nothing on the MCP wire, so it needs no per-surface gate.
+    override val cliExtraOptions = listOf(
+        CliExtraOption(
+            flag = "--wait",
+            type = CliOptionType.BOOLEAN,
+            synopsis = "poll until the project is initialized (no modal, indexing done)",
+        ),
+    )
 
     override suspend fun call(context: ToolCallContext): ToolCallResult {
         val projectPathStr = context[projectPath]

--- a/mcp-steroid-server/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/OpenProjectTool.kt
+++ b/mcp-steroid-server/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/OpenProjectTool.kt
@@ -86,7 +86,7 @@ class OpenProjectToolSpec(
     // backend_name, this changes nothing on the MCP wire, so it needs no per-surface gate.
     override val cliExtraOptions = listOf(
         CliExtraOption(
-            flag = "--wait",
+            name = "wait",
             type = CliOptionType.BOOLEAN,
             synopsis = "poll until the project is initialized (no modal, indexing done)",
         ),

--- a/mcp-steroid-server/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/OpenProjectTool.kt
+++ b/mcp-steroid-server/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/OpenProjectTool.kt
@@ -40,6 +40,7 @@ class OpenProjectToolSpec(
         append(BASE_DESCRIPTION)
         if (includeBackendName) append("\n\n").append(BACKEND_NAME_DESCRIPTION)
     }
+    override val cliSynopsis = "open a project in the IDE"
 
     val projectPath = InputSchemaElement.param("project_path")
         .description("Absolute path to the project directory to open.")

--- a/mcp-steroid-server/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/VisionInputTool.kt
+++ b/mcp-steroid-server/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/VisionInputTool.kt
@@ -4,6 +4,8 @@ import com.jonnyzzz.mcpSteroid.mcp.InputSchemaElement
 import com.jonnyzzz.mcpSteroid.mcp.McpToolBase
 import com.jonnyzzz.mcpSteroid.mcp.ToolCallContext
 import com.jonnyzzz.mcpSteroid.mcp.ToolCallResult
+import com.jonnyzzz.mcpSteroid.mcp.cliMissingHint
+import com.jonnyzzz.mcpSteroid.mcp.cliSynopsis
 import com.jonnyzzz.mcpSteroid.mcp.description
 import com.jonnyzzz.mcpSteroid.mcp.get
 import com.jonnyzzz.mcpSteroid.mcp.param
@@ -52,10 +54,17 @@ class VisionInputToolSpec(val handler: () -> VisionInputToolHandler) : McpToolBa
 
     val windowId = CommonToolParams.windowId()
         .required()
+        .cliMissingHint("missing required --window_id (get it from `devrig list_windows`)")
         .registerToSchema()
 
     val sequence = InputSchemaElement.param("sequence")
         .description("Comma-separated input sequence (stick/press/type/click/delay)")
+        .cliSynopsis("comma-separated input steps (stick/press/type/click/delay)")
+        .cliMissingHint(
+            "missing --sequence. Example:\n" +
+                "  devrig input --project_name=\"<key>\" --window_id=\"<win>\" --task_id=t1 --reason=\"...\" \\\n" +
+                "    --sequence=\"press:CTRL+P, type:Main, delay:200, press:ENTER\""
+        )
         .string()
         .required()
         .registerToSchema()

--- a/mcp-steroid-server/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/VisionInputTool.kt
+++ b/mcp-steroid-server/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/VisionInputTool.kt
@@ -42,6 +42,7 @@ class VisionInputToolSpec(val handler: () -> VisionInputToolHandler) : McpToolBa
         The input is delivered to the window identified by window_id (from steroid_list_windows) and the focus is forced to that window.
         Click coordinates with the screenshot target (e.g. @120,200) are interpreted relative to the window as reported by steroid_list_windows / steroid_take_screenshot.
     """.trimIndent()
+    override val cliSynopsis = "send keyboard/mouse input to the IDE"
 
     val projectName = CommonToolParams.projectName().registerToSchema()
 

--- a/mcp-steroid-server/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/VisionScreenshotTool.kt
+++ b/mcp-steroid-server/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/VisionScreenshotTool.kt
@@ -32,6 +32,7 @@ class VisionScreenshotToolSpec(val handler: () -> VisionScreenshotToolHandler) :
 
         After execution, call steroid_execute_feedback to log your feedback.
     """.trimIndent()
+    override val cliSynopsis = "capture a screenshot of the IDE"
 
     val projectName = CommonToolParams.projectName().registerToSchema()
 

--- a/mcp-steroid-server/src/test/kotlin/com/jonnyzzz/mcpSteroid/server/DevrigToolSpecsGoldenSchemaTest.kt
+++ b/mcp-steroid-server/src/test/kotlin/com/jonnyzzz/mcpSteroid/server/DevrigToolSpecsGoldenSchemaTest.kt
@@ -1,0 +1,112 @@
+/* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
+package com.jonnyzzz.mcpSteroid.server
+
+import com.jonnyzzz.mcpSteroid.mcp.CliToolSpec
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+/**
+ * The golden test that matters for the schema-driven CLI (issue #284): CLI metadata (`cliSynopsis`,
+ * `cliMinimum`/`cliMaximum`, `cliMissingHint`, `cliFileSource`, and the tool-level
+ * `CliCommandSpec.extraOptions`) must never change a single byte of the MCP `inputSchema` that ships to
+ * clients. No CLI declaration is filtered out of `asMcpJson()` any more — every declaration is either a
+ * hint on a real MCP parameter or lives outside the schema entirely — so this test is what proves the
+ * hints stay invisible.
+ *
+ * `description` values are masked out to a fixed [DESCRIPTION_MASK] placeholder before comparison (see
+ * [maskDescriptions]) — those texts are actively-tuned prompt-engineering copy (see e.g. commit
+ * `8a1b212b`), and the eight `*ToolSpecSchemaTest.kt` files already pin them individually. Everything
+ * else — property set, property order, `type`, `required`, `enum`, `minimum`/`maximum` — stays
+ * byte-identical, which is exactly the surface CLI metadata could accidentally leak onto.
+ *
+ * Each expected string below was captured from `main` (commit 2fb59a5f, the tip of `main` at the time
+ * this test was written), NOT from this branch's working tree — capturing it from the edited tree would
+ * make the comparison tautological (it would pass no matter what the CLI-metadata edits did to
+ * `asMcpJson()`). It was produced by checking out a disposable `git worktree add /tmp/mcp-steroid-main-golden
+ * main`, adding a throwaway JUnit test there that instantiates every `devrigToolSpecs(...)` tool with an
+ * `unreachableHandler()` handler and writes `Json.encodeToString(JsonObject.serializer(), tool.inputSchema)`
+ * for each to a file, running `./gradlew :mcp-steroid-server:test --tests '*GoldenSchemaDumpTest*'` inside
+ * that worktree, and then removing the worktree and the throwaway test entirely
+ * (`git worktree remove /tmp/mcp-steroid-main-golden --force`) — nothing from that worktree was merged
+ * or left behind. The `description` values were then masked out of the captured strings by parsing them
+ * as JSON and applying the same [maskDescriptions] transform used below, not by hand-editing the text.
+ *
+ * **To legitimately update these constants** (a new devrig tool, a new/renamed/removed property, a
+ * changed `type`/`required`/`enum`/`minimum`/`maximum`): regenerate from `main` (or another commit known
+ * to be free of uncommitted CLI-metadata changes) using the worktree recipe above — never from this
+ * branch's working tree, which would make the test tautological again. Before accepting the new
+ * constant, eyeball the diff for exactly one thing: does it introduce a **new property**, a **`cli*`
+ * key**, or a **new `minimum`/`maximum`** that isn't an intentional, reviewed part of the change you're
+ * making? If so, stop — that is precisely the CLI-metadata-leaking-onto-the-wire failure this test
+ * exists to catch. A `description`-only difference is invisible here by design; it is covered by the
+ * per-tool `*ToolSpecSchemaTest.kt` files instead.
+ */
+class DevrigToolSpecsGoldenSchemaTest {
+
+    @Test
+    fun `every devrig tool's inputSchema is byte-identical to the schema captured from main, descriptions masked`() {
+        val tools = devrigToolSpecsForTest().associateBy { it.name }
+        assertEquals(8, tools.size, "devrigToolSpecs() must list exactly the 8 tools this golden test covers")
+
+        assertGoldenSchema(tools, "steroid_list_projects", GOLDEN_LIST_PROJECTS)
+        assertGoldenSchema(tools, "steroid_list_windows", GOLDEN_LIST_WINDOWS)
+        assertGoldenSchema(tools, "steroid_execute_code", GOLDEN_EXECUTE_CODE)
+        assertGoldenSchema(tools, "steroid_execute_feedback", GOLDEN_EXECUTE_FEEDBACK)
+        assertGoldenSchema(tools, "steroid_take_screenshot", GOLDEN_TAKE_SCREENSHOT)
+        assertGoldenSchema(tools, "steroid_input", GOLDEN_INPUT)
+        assertGoldenSchema(tools, "steroid_fetch_resource", GOLDEN_FETCH_RESOURCE)
+        assertGoldenSchema(tools, "steroid_open_project", GOLDEN_OPEN_PROJECT)
+    }
+
+    private fun assertGoldenSchema(
+        tools: Map<String, CliToolSpec>,
+        toolName: String,
+        expected: String,
+    ) {
+        val tool = tools.getValue(toolName)
+        val rendered = Json.encodeToString(JsonObject.serializer(), maskDescriptions(tool.inputSchema))
+        assertEquals(expected, rendered, "$toolName: inputSchema (descriptions masked) drifted from the schema captured on main")
+    }
+
+    /**
+     * Recursively replaces the value of every `"description"` key in [obj] with [DESCRIPTION_MASK],
+     * walking nested [JsonObject]s and [JsonArray]s alike. Operates on the parsed [JsonElement] tree —
+     * never on the rendered string — so an escaped quote or backslash inside a description can't defeat
+     * it the way a regex over the rendered JSON text could.
+     */
+    private fun maskDescriptions(obj: JsonObject): JsonObject = JsonObject(
+        obj.mapValues { (key, value) ->
+            if (key == "description") JsonPrimitive(DESCRIPTION_MASK) else maskDescriptionsElement(value)
+        },
+    )
+
+    private fun maskDescriptionsElement(element: JsonElement): JsonElement = when (element) {
+        is JsonObject -> maskDescriptions(element)
+        is JsonArray -> JsonArray(element.map { maskDescriptionsElement(it) })
+        else -> element
+    }
+
+    private companion object {
+        const val DESCRIPTION_MASK = "<description omitted by golden-schema mask>"
+
+        const val GOLDEN_LIST_PROJECTS = """{"type":"object","properties":{},"required":[]}"""
+        const val GOLDEN_LIST_WINDOWS = """{"type":"object","properties":{},"required":[]}"""
+
+        const val GOLDEN_EXECUTE_CODE = """{"type":"object","properties":{"project_name":{"type":"string","description":"<description omitted by golden-schema mask>"},"code":{"type":"string","description":"<description omitted by golden-schema mask>"},"task_id":{"type":"string","description":"<description omitted by golden-schema mask>"},"reason":{"type":"string","description":"<description omitted by golden-schema mask>"},"timeout":{"type":"integer","description":"<description omitted by golden-schema mask>"},"modal":{"type":"string","description":"<description omitted by golden-schema mask>","enum":["smart_non_modal","non_modal","unleashed"]}},"required":["project_name","code","task_id","reason"]}"""
+
+        const val GOLDEN_EXECUTE_FEEDBACK = """{"type":"object","properties":{"project_name":{"type":"string","description":"<description omitted by golden-schema mask>"},"task_id":{"type":"string","description":"<description omitted by golden-schema mask>"},"execution_id":{"type":"string","description":"<description omitted by golden-schema mask>"},"success_rating":{"type":"number","description":"<description omitted by golden-schema mask>","minimum":0.0,"maximum":1.0},"explanation":{"type":"string","description":"<description omitted by golden-schema mask>"},"code":{"type":"string","description":"<description omitted by golden-schema mask>"}},"required":["project_name","task_id","success_rating","explanation"]}"""
+
+        const val GOLDEN_TAKE_SCREENSHOT = """{"type":"object","properties":{"project_name":{"type":"string","description":"<description omitted by golden-schema mask>"},"task_id":{"type":"string","description":"<description omitted by golden-schema mask>"},"reason":{"type":"string","description":"<description omitted by golden-schema mask>"},"window_id":{"type":"string","description":"<description omitted by golden-schema mask>"}},"required":["project_name","task_id","reason"]}"""
+
+        const val GOLDEN_INPUT = """{"type":"object","properties":{"project_name":{"type":"string","description":"<description omitted by golden-schema mask>"},"task_id":{"type":"string","description":"<description omitted by golden-schema mask>"},"reason":{"type":"string","description":"<description omitted by golden-schema mask>"},"window_id":{"type":"string","description":"<description omitted by golden-schema mask>"},"sequence":{"type":"string","description":"<description omitted by golden-schema mask>"}},"required":["project_name","task_id","reason","window_id","sequence"]}"""
+
+        const val GOLDEN_FETCH_RESOURCE = """{"type":"object","properties":{"uri":{"type":"string","description":"<description omitted by golden-schema mask>"},"project_name":{"type":"string","description":"<description omitted by golden-schema mask>"}},"required":["uri","project_name"]}"""
+
+        const val GOLDEN_OPEN_PROJECT = """{"type":"object","properties":{"project_path":{"type":"string","description":"<description omitted by golden-schema mask>"},"task_id":{"type":"string","description":"<description omitted by golden-schema mask>"},"reason":{"type":"string","description":"<description omitted by golden-schema mask>"},"trust_project":{"type":"boolean","description":"<description omitted by golden-schema mask>"},"backend_name":{"type":"string","description":"<description omitted by golden-schema mask>"}},"required":["project_path","task_id","reason"]}"""
+    }
+}

--- a/mcp-steroid-server/src/test/kotlin/com/jonnyzzz/mcpSteroid/server/DevrigToolSpecsGoldenSchemaTest.kt
+++ b/mcp-steroid-server/src/test/kotlin/com/jonnyzzz/mcpSteroid/server/DevrigToolSpecsGoldenSchemaTest.kt
@@ -19,22 +19,25 @@ import org.junit.jupiter.api.Test
  * hints stay invisible.
  *
  * `description` values are masked out to a fixed [DESCRIPTION_MASK] placeholder before comparison (see
- * [maskDescriptions]) — those texts are actively-tuned prompt-engineering copy (see e.g. commit
- * `8a1b212b`), and the eight `*ToolSpecSchemaTest.kt` files already pin them individually. Everything
- * else — property set, property order, `type`, `required`, `enum`, `minimum`/`maximum` — stays
- * byte-identical, which is exactly the surface CLI metadata could accidentally leak onto.
+ * [maskDescriptions]) — those texts are actively-tuned prompt-engineering copy, and they are
+ * **deliberately pinned by no test**: the per-tool `*ToolSpecSchemaTest.kt` files assert only that each
+ * description is present and non-blank, so routine prompt edits never churn this test. The accepted
+ * trade-off is that a leak *into a description's text* is invisible here. Everything else — property
+ * set, property order, `type`, `required`, `enum`, `minimum`/`maximum` — stays byte-identical, which is
+ * exactly the surface CLI metadata could accidentally leak onto.
  *
- * Each expected string below was captured from `main` (commit 2fb59a5f, the tip of `main` at the time
- * this test was written), NOT from this branch's working tree — capturing it from the edited tree would
- * make the comparison tautological (it would pass no matter what the CLI-metadata edits did to
- * `asMcpJson()`). It was produced by checking out a disposable `git worktree add /tmp/mcp-steroid-main-golden
- * main`, adding a throwaway JUnit test there that instantiates every `devrigToolSpecs(...)` tool with an
- * `unreachableHandler()` handler and writes `Json.encodeToString(JsonObject.serializer(), tool.inputSchema)`
- * for each to a file, running `./gradlew :mcp-steroid-server:test --tests '*GoldenSchemaDumpTest*'` inside
- * that worktree, and then removing the worktree and the throwaway test entirely
- * (`git worktree remove /tmp/mcp-steroid-main-golden --force`) — nothing from that worktree was merged
- * or left behind. The `description` values were then masked out of the captured strings by parsing them
- * as JSON and applying the same [maskDescriptions] transform used below, not by hand-editing the text.
+ * Each expected string below was captured from `main` at commit `75c611b1` (the merge-base of the branch
+ * that introduced this test), NOT from that branch's working tree — capturing it from the edited tree
+ * would make the comparison tautological (it would pass no matter what the CLI-metadata edits did to
+ * `asMcpJson()`). Capture recipe: check out a disposable `git worktree add /tmp/mcp-steroid-main-golden
+ * <main-commit>`, add a throwaway JUnit test there that instantiates every devrig tool with an
+ * `unreachableHandler()` handler, applies the same [maskDescriptions] transform to each `inputSchema`
+ * (masking on the parsed JSON tree, never by hand-editing text), and writes
+ * `Json.encodeToString(JsonObject.serializer(), masked)` per tool to a file; run
+ * `./gradlew :mcp-steroid-server:test --tests '*GoldenSchemaDumpTest*'` inside that worktree; then remove
+ * the worktree and the throwaway test entirely (`git worktree remove /tmp/mcp-steroid-main-golden
+ * --force`) — nothing from it is merged or left behind. All eight constants were re-captured from
+ * `75c611b1` with exactly this recipe during the PR #356 review and matched byte-for-byte.
  *
  * **To legitimately update these constants** (a new devrig tool, a new/renamed/removed property, a
  * changed `type`/`required`/`enum`/`minimum`/`maximum`): regenerate from `main` (or another commit known
@@ -43,8 +46,8 @@ import org.junit.jupiter.api.Test
  * constant, eyeball the diff for exactly one thing: does it introduce a **new property**, a **`cli*`
  * key**, or a **new `minimum`/`maximum`** that isn't an intentional, reviewed part of the change you're
  * making? If so, stop — that is precisely the CLI-metadata-leaking-onto-the-wire failure this test
- * exists to catch. A `description`-only difference is invisible here by design; it is covered by the
- * per-tool `*ToolSpecSchemaTest.kt` files instead.
+ * exists to catch. A `description`-only difference is invisible here by design — descriptions are
+ * unpinned tuned copy (see the masking rationale above), not covered by any byte-level test.
  */
 class DevrigToolSpecsGoldenSchemaTest {
 

--- a/mcp-steroid-server/src/test/kotlin/com/jonnyzzz/mcpSteroid/server/DevrigToolSpecsTest.kt
+++ b/mcp-steroid-server/src/test/kotlin/com/jonnyzzz/mcpSteroid/server/DevrigToolSpecsTest.kt
@@ -1,0 +1,66 @@
+/* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
+package com.jonnyzzz.mcpSteroid.server
+
+import com.jonnyzzz.mcpSteroid.mcp.CliToolSpec
+import com.jonnyzzz.mcpSteroid.mcp.McpToolRegistry
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * Verifies that the canonical devrig tool list and its MCP registry projection stay in sync.
+ */
+class DevrigToolSpecsTest {
+
+    /** Enumerating metadata never resolves a handler; resolving one is a bug. */
+    private class NoHandlerTools : McpSteroidTools() {
+        override fun <T> handler(type: Class<T>): T =
+            error("handler ${type.name} must not be resolved while enumerating tool specs")
+    }
+
+    private val expectedDevrigTools = listOf(
+        "steroid_list_projects",
+        "steroid_list_windows",
+        "steroid_execute_code",
+        "steroid_execute_feedback",
+        "steroid_take_screenshot",
+        "steroid_input",
+        "steroid_fetch_resource",
+        "steroid_open_project",
+    )
+
+    @Test
+    fun `devrigToolSpecs returns every devrig tool exactly once in registration order`() {
+        val names = NoHandlerTools().devrigToolSpecs().map { it.name }
+        assertEquals(expectedDevrigTools, names, "devrigToolSpecs must list every devrig tool exactly once")
+        assertEquals(names.toSet().size, names.size, "no tool may appear twice")
+    }
+
+    @Test
+    fun `devrigToolSpecs is a List of CliToolSpec so the CLI reads cli and schema without a cast`() {
+        val specs: List<CliToolSpec> = NoHandlerTools().devrigToolSpecs()
+        for (spec in specs) {
+            assertTrue(spec.cli.synopsis.isNotBlank(), "${spec.name}: cli.synopsis must be non-blank")
+            assertEquals(spec.inputSchema, spec.schema.asMcpJson(), "${spec.name}: schema must back inputSchema")
+        }
+    }
+
+    @Test
+    fun `registering the factory list advertises exactly the same MCP tools`() {
+        val registry = McpToolRegistry()
+        for (spec in NoHandlerTools().devrigToolSpecs()) {
+            registry.registerTool(spec)
+        }
+        assertEquals(
+            expectedDevrigTools,
+            registry.listTools().map { it.name },
+        )
+    }
+
+    @Test
+    fun `devrig open_project advertises the backend_name routing param`() {
+        val openProject = NoHandlerTools().devrigToolSpecs().single { it.name == "steroid_open_project" }
+        val params = openProject.schema.asCliParams().map { it.name }
+        assertTrue(params.contains("backend_name"), "devrig open_project must expose backend_name: $params")
+    }
+}

--- a/mcp-steroid-server/src/test/kotlin/com/jonnyzzz/mcpSteroid/server/ToolSpecCliMetadataTest.kt
+++ b/mcp-steroid-server/src/test/kotlin/com/jonnyzzz/mcpSteroid/server/ToolSpecCliMetadataTest.kt
@@ -1,6 +1,7 @@
 /* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
 package com.jonnyzzz.mcpSteroid.server
 
+import com.jonnyzzz.mcpSteroid.mcp.CliOptionType
 import com.jonnyzzz.mcpSteroid.mcp.CliToolSpec
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
@@ -44,7 +45,9 @@ class ToolSpecCliMetadataTest {
 
     @Test
     fun `every tool has a short non-blank one-line synopsis`() {
-        for (tool in allTools) {
+        // Iterates the canonical devrigToolSpecs() list (not a hand-picked one) so a tool added there in
+        // the future is checked automatically instead of silently shipping without a subcommand synopsis.
+        for (tool in devrigToolSpecsForTest()) {
             val synopsis = tool.cli.synopsis
             assertFalse(synopsis.isBlank(), "${tool.name}: cli.synopsis must be non-blank")
             assertFalse(synopsis.contains("\n"), "${tool.name}: cli.synopsis must be a single line")
@@ -84,7 +87,7 @@ class ToolSpecCliMetadataTest {
             val projectName = tool.schema.asCliParams().single { it.name == "project_name" }
             assertTrue(projectName.cliOptional, "${tool.name}: project_name must be cliOptional")
             assertTrue(projectName.required, "${tool.name}: project_name must stay MCP-required")
-            assertFalse(projectName.cliSynopsis.isNullOrBlank(), "${tool.name}: project_name needs a curated cliSynopsis")
+            assertFalse(projectName.cliSynopsis.isBlank(), "${tool.name}: project_name needs a curated cliSynopsis")
         }
     }
 
@@ -102,9 +105,157 @@ class ToolSpecCliMetadataTest {
         for (tool in allTools) {
             assertEquals(tool.inputSchema, tool.schema.asMcpJson(), "${tool.name}: asMcpJson must equal inputSchema")
             val rendered = Json.encodeToString(JsonObject.serializer(), tool.inputSchema)
-            for (leak in listOf("cliFlag", "cliSynopsis", "cliPositional", "cliHidden", "cliOptional", "enumValues")) {
+            val leakStrings = listOf(
+                "cliFlag", "cliSynopsis", "cliPositional", "cliHidden", "cliOptional", "enumValues",
+                "cliFileSource", "cliMinimum", "cliMaximum", "cliMissingHint", "extraOptions",
+                // The declared CLI-only flag names themselves: a file-source flag and a tool-level extra
+                // must be as invisible on the wire as the metadata field that declares them.
+                "--code-file", "--wait",
+            )
+            for (leak in leakStrings) {
                 assertFalse(rendered.contains(leak), "${tool.name}: MCP schema leaked CLI hint '$leak'")
             }
         }
+    }
+
+    @Test
+    fun `every CLI-visible flag of every devrig tool has a short one-line synopsis`() {
+        // Iterates the canonical devrigToolSpecs() list (not a hand-picked one) so a tool added there
+        // in the future is checked automatically instead of silently shipping without help text. Covers
+        // all three flag kinds the CLI renders: parameters, their file sources, and tool-level extras.
+        for (tool in devrigToolSpecsForTest()) {
+            val synopses = buildList {
+                for (param in tool.schema.asCliParams().filterNot { it.cliHidden }) {
+                    add(param.name to param.cliSynopsis)
+                    param.cliFileSource?.let { add("${param.name}${it.flag}" to it.synopsis) }
+                }
+                for (extra in tool.cli.extraOptions) add(extra.flag to extra.synopsis)
+            }
+            for ((label, synopsis) in synopses) {
+                assertFalse(
+                    synopsis.isBlank(),
+                    "${tool.name}.$label: synopsis must be non-blank",
+                )
+                assertFalse(
+                    synopsis.contains("\n"),
+                    "${tool.name}.$label: synopsis must be a single line",
+                )
+                assertFalse(
+                    synopsis.endsWith("."),
+                    "${tool.name}.$label: synopsis must not end with a trailing period: $synopsis",
+                )
+                assertTrue(
+                    synopsis.length <= 72,
+                    "${tool.name}.$label: synopsis must be <= 72 chars, was ${synopsis.length}: $synopsis",
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `each devrig tool declares exactly its expected CLI file sources`() {
+        // parameter name -> the flag that reads that parameter's value from a file.
+        val expectedFileSourcesByTool = mapOf(
+            "steroid_list_projects" to emptyMap(),
+            "steroid_list_windows" to emptyMap(),
+            "steroid_execute_code" to mapOf("code" to "--code-file"),
+            "steroid_execute_feedback" to mapOf("code" to "--code-file"),
+            "steroid_take_screenshot" to emptyMap(),
+            "steroid_input" to emptyMap(),
+            "steroid_fetch_resource" to emptyMap(),
+            "steroid_open_project" to emptyMap(),
+        )
+
+        // Iterate the canonical devrigToolSpecs() list and assert it names exactly the tools the
+        // expected map covers — completeness check first, so a tool added to (or removed from) the
+        // canonical list without a matching map entry fails loudly here, not silently.
+        val tools = devrigToolSpecsForTest()
+        assertEquals(
+            expectedFileSourcesByTool.keys,
+            tools.map { it.name }.toSet(),
+            "expectedFileSourcesByTool must name exactly the tools devrigToolSpecs() returns",
+        )
+        for (tool in tools) {
+            val expected = expectedFileSourcesByTool.getValue(tool.name)
+            val actual = tool.schema.asCliParams()
+                .mapNotNull { param -> param.cliFileSource?.let { param.name to it.flag } }
+                .toMap()
+            assertEquals(expected, actual, "${tool.name}: declared CLI file sources")
+        }
+    }
+
+    @Test
+    fun `a parameter with a file source may be omitted on the CLI while staying MCP-required`() {
+        // This is what makes --code-file usable on its own, and it is declared, not coded per tool.
+        for (tool in listOf(executeCode, executeFeedback)) {
+            val code = tool.schema.asCliParams().single { it.name == "code" }
+            assertEquals("--code-file", code.cliFileSource?.flag, "${tool.name}: code file-source flag")
+            assertFalse(
+                code.required && !code.cliOptional,
+                "${tool.name}: code declares a file source so the CLI must not demand --code",
+            )
+        }
+        // execute_code's code is MCP-required; execute_feedback's is optional. Either way the CLI can
+        // take the file instead — the generator needs no per-tool knowledge of which case it is in.
+        val required = executeCode.inputSchema["required"]!!.jsonArray.map { it.jsonPrimitive.content }
+        assertTrue(required.contains("code"), "execute_code: code must stay MCP-required: $required")
+    }
+
+    @Test
+    fun `each devrig tool declares exactly its expected tool-level extra CLI options`() {
+        val expectedExtrasByTool = mapOf(
+            "steroid_list_projects" to emptyList(),
+            "steroid_list_windows" to emptyList(),
+            "steroid_execute_code" to emptyList(),
+            "steroid_execute_feedback" to emptyList(),
+            "steroid_take_screenshot" to emptyList(),
+            "steroid_input" to emptyList(),
+            "steroid_fetch_resource" to emptyList(),
+            "steroid_open_project" to listOf("--wait"),
+        )
+
+        val tools = devrigToolSpecsForTest()
+        assertEquals(
+            expectedExtrasByTool.keys,
+            tools.map { it.name }.toSet(),
+            "expectedExtrasByTool must name exactly the tools devrigToolSpecs() returns",
+        )
+        for (tool in tools) {
+            assertEquals(
+                expectedExtrasByTool.getValue(tool.name),
+                tool.cli.extraOptions.map { it.flag },
+                "${tool.name}: declared tool-level extra CLI options",
+            )
+        }
+
+        val wait = tools.single { it.name == "steroid_open_project" }.cli.extraOptions.single()
+        assertEquals(CliOptionType.BOOLEAN, wait.type, "--wait is a boolean switch")
+        assertFalse(wait.synopsis.isBlank(), "--wait needs help text")
+        // An extra option is not a tool input: it must not appear among the parameters.
+        val params = tools.single { it.name == "steroid_open_project" }.schema.asCliParams().map { it.name }
+        assertFalse(params.contains("wait"), "--wait must not be a schema parameter: $params")
+    }
+
+    @Test
+    fun `CLI-only declarations are identical on the in-IDE and devrig surfaces`() {
+        // The surface rule: a declaration is gated per surface only when it changes the MCP wire (that is
+        // what includeBackendName does for backend_name). CLI metadata never reaches the wire, so it is
+        // declared unconditionally — one rule for file sources and extra options alike.
+        val devrigOpenProject = devrigToolSpecsForTest().single { it.name == "steroid_open_project" }
+        assertEquals(
+            devrigOpenProject.cli.extraOptions,
+            openProject.cli.extraOptions,
+            "open_project: extra CLI options must not depend on the surface",
+        )
+        assertEquals(
+            devrigOpenProject.schema.asCliParams().mapNotNull { it.cliFileSource },
+            openProject.schema.asCliParams().mapNotNull { it.cliFileSource },
+            "open_project: CLI file sources must not depend on the surface",
+        )
+        // The wire-affecting parameter still is gated, which is the distinction the rule draws.
+        assertFalse(
+            openProject.schema.asCliParams().any { it.name == "backend_name" },
+            "the in-IDE open_project must still advertise no backend_name",
+        )
     }
 }

--- a/mcp-steroid-server/src/test/kotlin/com/jonnyzzz/mcpSteroid/server/ToolSpecCliMetadataTest.kt
+++ b/mcp-steroid-server/src/test/kotlin/com/jonnyzzz/mcpSteroid/server/ToolSpecCliMetadataTest.kt
@@ -1,0 +1,110 @@
+/* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
+package com.jonnyzzz.mcpSteroid.server
+
+import com.jonnyzzz.mcpSteroid.mcp.CliToolSpec
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonPrimitive
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * Verifies CLI metadata on the real tool specs and ensures it stays outside the MCP schema projection.
+ */
+class ToolSpecCliMetadataTest {
+
+    private val executeCode = ExecuteCodeToolSpec { unreachableHandler() }
+    private val executeFeedback = ExecuteFeedbackToolSpec { unreachableHandler() }
+    private val listProjects = ListProjectsToolSpec { unreachableHandler() }
+    private val listWindows = ListWindowsToolSpec { unreachableHandler() }
+    private val openProject = OpenProjectToolSpec(handler = { unreachableHandler() })
+    private val takeScreenshot = VisionScreenshotToolSpec { unreachableHandler() }
+    private val input = VisionInputToolSpec(handler = { unreachableHandler() })
+    private val fetchResource = FetchResourceToolHandler { unreachableHandler() }
+
+    private val allTools: List<CliToolSpec> = listOf(
+        executeCode, executeFeedback, listProjects, listWindows,
+        openProject, takeScreenshot, input, fetchResource,
+    )
+
+    @Test
+    fun `cli name strips the steroid prefix for every tool`() {
+        assertEquals("execute_code", executeCode.cli.name)
+        assertEquals("execute_feedback", executeFeedback.cli.name)
+        assertEquals("list_projects", listProjects.cli.name)
+        assertEquals("list_windows", listWindows.cli.name)
+        assertEquals("open_project", openProject.cli.name)
+        assertEquals("take_screenshot", takeScreenshot.cli.name)
+        assertEquals("input", input.cli.name)
+        assertEquals("fetch_resource", fetchResource.cli.name)
+    }
+
+    @Test
+    fun `every tool has a short non-blank one-line synopsis`() {
+        for (tool in allTools) {
+            val synopsis = tool.cli.synopsis
+            assertFalse(synopsis.isBlank(), "${tool.name}: cli.synopsis must be non-blank")
+            assertFalse(synopsis.contains("\n"), "${tool.name}: cli.synopsis must be a single line")
+            assertTrue(
+                synopsis.length < 80,
+                "${tool.name}: cli.synopsis must be short (<80 chars), was ${synopsis.length}: $synopsis",
+            )
+        }
+    }
+
+    @Test
+    fun `fetch_resource exposes the prompt alias and maps uri to the --uri flag`() {
+        assertTrue(fetchResource.cli.aliases.contains("prompt"), "fetch_resource should alias 'prompt'")
+        val uri = fetchResource.schema.asCliParams().single { it.name == "uri" }
+        assertFalse(uri.cliPositional, "fetch_resource uri must map to --uri, not a positional")
+        assertEquals("--uri", uri.cliFlag)
+    }
+
+    @Test
+    fun `asCliParams returns one spec per registered param for execute_code`() {
+        assertEquals(
+            listOf("project_name", "code", "task_id", "reason", "timeout", "modal"),
+            executeCode.schema.asCliParams().map { it.name },
+        )
+    }
+
+    @Test
+    fun `modal param carries its enum values for CLI help`() {
+        val modal = executeCode.schema.asCliParams().single { it.name == "modal" }
+        assertEquals(listOf("smart_non_modal", "non_modal", "unleashed"), modal.enumValues)
+    }
+
+    @Test
+    fun `project-scoped tools mark project_name CLI-optional but keep it MCP-required`() {
+        val projectScoped = listOf(executeCode, executeFeedback, takeScreenshot, input, fetchResource)
+        for (tool in projectScoped) {
+            val projectName = tool.schema.asCliParams().single { it.name == "project_name" }
+            assertTrue(projectName.cliOptional, "${tool.name}: project_name must be cliOptional")
+            assertTrue(projectName.required, "${tool.name}: project_name must stay MCP-required")
+            assertFalse(projectName.cliSynopsis.isNullOrBlank(), "${tool.name}: project_name needs a curated cliSynopsis")
+        }
+    }
+
+    @Test
+    fun `execute_code code is CLI-optional but remains MCP-required`() {
+        val code = executeCode.schema.asCliParams().single { it.name == "code" }
+        assertTrue(code.cliOptional)
+        assertTrue(code.required)
+        val required = executeCode.inputSchema["required"]!!.jsonArray.map { it.jsonPrimitive.content }
+        assertTrue(required.contains("code"), "code must stay in the MCP required list: $required")
+    }
+
+    @Test
+    fun `asMcpJson equals inputSchema and CLI hints never leak into the MCP schema`() {
+        for (tool in allTools) {
+            assertEquals(tool.inputSchema, tool.schema.asMcpJson(), "${tool.name}: asMcpJson must equal inputSchema")
+            val rendered = Json.encodeToString(JsonObject.serializer(), tool.inputSchema)
+            for (leak in listOf("cliFlag", "cliSynopsis", "cliPositional", "cliHidden", "cliOptional", "enumValues")) {
+                assertFalse(rendered.contains(leak), "${tool.name}: MCP schema leaked CLI hint '$leak'")
+            }
+        }
+    }
+}

--- a/mcp-steroid-server/src/test/kotlin/com/jonnyzzz/mcpSteroid/server/ToolSpecCliMetadataTest.kt
+++ b/mcp-steroid-server/src/test/kotlin/com/jonnyzzz/mcpSteroid/server/ToolSpecCliMetadataTest.kt
@@ -203,6 +203,8 @@ class ToolSpecCliMetadataTest {
 
     @Test
     fun `each devrig tool declares exactly its expected tool-level extra CLI options`() {
+        // Asserts both the option's name (its identity) and its flag (its CLI spelling) so a future
+        // flag rename shows up here as a flag-only diff rather than silently passing on the name alone.
         val expectedExtrasByTool = mapOf(
             "steroid_list_projects" to emptyList(),
             "steroid_list_windows" to emptyList(),
@@ -211,7 +213,7 @@ class ToolSpecCliMetadataTest {
             "steroid_take_screenshot" to emptyList(),
             "steroid_input" to emptyList(),
             "steroid_fetch_resource" to emptyList(),
-            "steroid_open_project" to listOf("--wait"),
+            "steroid_open_project" to listOf("wait" to "--wait"),
         )
 
         val tools = devrigToolSpecsForTest()
@@ -223,12 +225,13 @@ class ToolSpecCliMetadataTest {
         for (tool in tools) {
             assertEquals(
                 expectedExtrasByTool.getValue(tool.name),
-                tool.cli.extraOptions.map { it.flag },
-                "${tool.name}: declared tool-level extra CLI options",
+                tool.cli.extraOptions.map { it.name to it.flag },
+                "${tool.name}: declared tool-level extra CLI options (name to flag)",
             )
         }
 
         val wait = tools.single { it.name == "steroid_open_project" }.cli.extraOptions.single()
+        assertEquals("wait", wait.name, "the extra option's identity is its name, not its flag")
         assertEquals(CliOptionType.BOOLEAN, wait.type, "--wait is a boolean switch")
         assertFalse(wait.synopsis.isBlank(), "--wait needs help text")
         // An extra option is not a tool input: it must not appear among the parameters.

--- a/mcp-steroid-server/src/test/kotlin/com/jonnyzzz/mcpSteroid/server/ToolSpecSchemaAssertions.kt
+++ b/mcp-steroid-server/src/test/kotlin/com/jonnyzzz/mcpSteroid/server/ToolSpecSchemaAssertions.kt
@@ -1,6 +1,7 @@
 /* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
 package com.jonnyzzz.mcpSteroid.server
 
+import com.jonnyzzz.mcpSteroid.mcp.CliToolSpec
 import com.jonnyzzz.mcpSteroid.mcp.McpTool
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonArray
@@ -202,3 +203,20 @@ private fun assertJsonStringEquals(
 /** Convenience for `*ToolSpec` constructor lambdas that must never be invoked. */
 fun unreachableHandler(): Nothing =
     error("handler factory must not be invoked from an inputSchema test")
+
+/**
+ * A [McpSteroidTools] whose [McpSteroidTools.handler] throws — for tests that only need the
+ * [CliToolSpec] metadata (schema, `cli.*`) of the real, canonical tool list and must never actually
+ * resolve or invoke a handler.
+ */
+private class NoHandlerToolsForTest : McpSteroidTools() {
+    override fun <T> handler(type: Class<T>): T =
+        error("handler ${type.name} must not be resolved from a schema-only test")
+}
+
+/**
+ * The exact 8 tool specs `devrig` exposes (see [McpSteroidTools.devrigToolSpecs]), built fresh with
+ * handlers that must never be resolved. Tests that assert "every tool has X" should iterate this list
+ * rather than a hand-picked one, so a ninth tool added to the canonical list is covered automatically.
+ */
+fun devrigToolSpecsForTest(): List<CliToolSpec> = NoHandlerToolsForTest().devrigToolSpecs()

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/server/StubStdioMcpServer.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/server/StubStdioMcpServer.kt
@@ -9,8 +9,6 @@ import com.jonnyzzz.mcpSteroid.mcp.ServerInfo
 import com.jonnyzzz.mcpSteroid.mcp.ToolsCapability
 import com.jonnyzzz.mcpSteroid.devrig.DevrigServices
 import com.jonnyzzz.mcpSteroid.devrig.DevrigVersionMetadata
-import com.jonnyzzz.mcpSteroid.server.OpenProjectToolHandler
-import com.jonnyzzz.mcpSteroid.server.OpenProjectToolSpec
 import kotlinx.serialization.json.JsonObject
 
 /**
@@ -18,10 +16,11 @@ import kotlinx.serialization.json.JsonObject
  *
  * Wiring:
  *  - [McpServerCore] declares server identity and advertised capabilities.
- *  - [StubMcpSteroidTools.registerAll] registers every steroid_* tool spec onto
- *    the core. The handlers themselves are not yet implemented in devrig — see
- *    [StubMcpSteroidTools] — so calling a tool returns an error, but
- *    `tools/list` / `prompts/list` / `resources/list` describe the full surface.
+ *  - [StubMcpSteroidTools.devrigToolSpecs] is the canonical devrig tool list; every
+ *    spec from it is registered onto the core. The handlers themselves are not yet
+ *    implemented in devrig — see [StubMcpSteroidTools] — so calling a tool returns
+ *    an error, but `tools/list` / `prompts/list` / `resources/list` describe the
+ *    full surface.
  *  - [McpStdioServer] runs the transport on [DevrigServices.mcpStdin] /
  *    [DevrigServices.mcpStdout] (NDJSON or framed, auto-detected from the first
  *    inbound frame).
@@ -65,13 +64,11 @@ suspend fun runStubStdioMcpServer(
     onServerReady(server)
 
     val tools = StubMcpSteroidTools(services)
-    tools.registerAll(server)
-    // devrig routes to one of several discovered IDEs, so its steroid_open_project advertises the
-    // required `backend_name` routing param (includeBackendName = true). registerAll() no longer
-    // registers open_project; each surface registers its own spec.
-    server.toolRegistry.registerTool(
-        OpenProjectToolSpec(includeBackendName = true) { tools.handler<OpenProjectToolHandler>() }
-    )
+    // devrigToolSpecs() is the canonical devrig tool list — the common tools plus devrig's own
+    // steroid_open_project, which advertises the required `backend_name` routing param
+    // (includeBackendName = true) so calls route to one of the discovered IDE backends. The generated
+    // CLI consumes the same list, so registering from it keeps the two surfaces drift-free.
+    tools.devrigToolSpecs().forEach { server.toolRegistry.registerTool(it) }
 
     McpStdioServer(server, input = services.mcpStdin, output = services.mcpStdout).run()
 }

--- a/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/server/DevrigDescriptorParityTest.kt
+++ b/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/server/DevrigDescriptorParityTest.kt
@@ -97,12 +97,9 @@ class DevrigDescriptorParityTest {
                         mcpStdout = PrintStream(ByteArrayOutputStream(), true, Charsets.UTF_8),
                     )
                 )
-                tools.registerAll(server)
-                // Mirror the devrig StubStdioMcpServer callsite: the multi-backend surface registers
-                // its own open_project spec advertising the required backend_name routing param.
-                server.toolRegistry.registerTool(
-                    OpenProjectToolSpec(includeBackendName = true) { tools.handler<OpenProjectToolHandler>() }
-                )
+                // Mirror the devrig StubStdioMcpServer callsite: the canonical devrigToolSpecs() list,
+                // whose open_project advertises the required backend_name routing param.
+                tools.devrigToolSpecs().forEach { server.toolRegistry.registerTool(it) }
             }
         } finally {
             lifetime.closeAllStacks()


### PR DESCRIPTION
Rebased onto `main`.

Every `steroid_*` tool should also be a devrig subcommand generated from the tool's own metadata, instead of a hand-written Clikt command class per tool. Review ask on #272: "I can add a new MCP tool which will automatically (or at minimal cost) be registered to the CLI as well", and "the command parameters are easy to generate from the MCP Tool specification".

This PR is the `mcp-core` half of that: a typed CLI projection declared beside the MCP wire schema, plus the declarations filled in for every tool. **Declaration only** — no tool behavior changes, and no CLI library appears in either module. Clikt stays an implementation detail of the npx-kt frontend, which consumes these descriptors in follow-up work.

### What it adds

- A CLI projection on the tool spec, alongside (never replacing) the MCP wire schema. `devrigToolSpecs()` becomes the single tool-spec list, so later help, parsing, and runtime layers consume the same command descriptors without duplicating tool registration.
- Per parameter: a mandatory one-line `cliSynopsis`, so no help text is ever derived by clipping an MCP description; curated `cliMissingHint` wording; CLI-only `cliMinimum`/`cliMaximum` bounds, which exist because putting `minimum` in the schema's extra block would change the MCP wire; and `cliFileSource` for a flag that feeds file or stdin content into the parameter it belongs to.
- Per tool: `CliCommandSpec.extraOptions` for tool-scoped CLI options that are not tool inputs — currently `open_project`'s `--wait` polling toggle. `CliExtraOption` splits `name` (identity) from `flag` (presentation, defaulting to `--$name`), mirroring `InputSchemaParamSpec`, so downstream consumers key on the stable name instead of a literal flag string; construction-time validation matches the sibling `cliFileSource` builder.
- Declarations for all eight tools in `devrigToolSpecs()`.

### Why the three CLI-only flags have three different shapes

They are three unlike things. `--code-file` is an alternate source for `code`, so it is declared on `code` itself and exclusivity follows from having two sources for one parameter. `--wait` is per-tool orchestration, so it is a tool-level extra. `--out` is a render-path redirect applied after the tool has already returned, so it belongs to the CLI frontend and is declared nowhere here. The first two need no per-tool code in the generator that consumes this metadata.

One surface rule covers every CLI-only declaration: never gate it per surface, because it never reaches the MCP wire. Only wire-visible parameters, such as `open_project`'s `backend_name`, stay gated by `includeBackendName`.

### The MCP wire is unchanged

A golden test pins every tool's `inputSchema` byte-for-byte, with description values masked by a JSON-tree walk — so CLI metadata cannot leak into the wire, while routine prompt-copy edits do not churn the test. The test documents how to regenerate the constants legitimately.

`TODO.md` records the two behaviors the CLI frontend must now own.

### Size

18 files, +1301/−18 — of which production code is +400/−18 across 12 files (mostly one declarative block per tool); tests are +892 across 5 files, dominated by golden constants.
