### PR TITLE
fix: bump bundled kotlinc 2.3.20 → 2.4.10 for IDE 263 compatibility

### DIFF
--- a/kotlin-cli/build.gradle.kts
+++ b/kotlin-cli/build.gradle.kts
@@ -24,7 +24,11 @@ tasks.test {
 
 // --- kotlinc download and distribution ---
 
-val kotlincVersion = "2.3.20"
+// Must stay within 1 minor of the Kotlin bundled by the IDEs we attach to
+// (Kotlin reads metadata at most +1 minor ahead). IDE 263 bundles Kotlin
+// 2.5.0, so 2.3.x is 2 minors behind and fails to read plugins/Kotlin/lib.
+// 2.4.10 is the newest publicly released kotlinc and covers 2.3-2.5 IDEs.
+val kotlincVersion = "2.4.10"
 val kotlincUrl = "https://github.com/JetBrains/kotlin/releases/download/v${kotlincVersion}/kotlin-compiler-${kotlincVersion}.zip"
 val kotlincSha256Url = "$kotlincUrl.sha256"
 val kotlincDownloadDir = layout.buildDirectory.dir("kotlinc-zip/$kotlincVersion")


### PR DESCRIPTION
Fixes #357.

## What

One line: `kotlin-cli/build.gradle.kts` `kotlincVersion` `2.3.20` → `2.4.10`, plus a comment recording the constraint so the next bump has the rule in front of it.

## Why

IntelliJ IDEA 2026.3 EAP bundles Kotlin **2.5.0**. Kotlin reads class metadata at most **+1 minor** ahead, so the bundled 2.3.20 compiler cannot read a single module under `plugins/Kotlin/lib`. Every `steroid_execute_code` call fails before the script body runs, including a one-liner:

```
kotlin-plugin.jar!/META-INF/kotlin-script-runtime.kotlin_module:
error: module was compiled with an incompatible version of Kotlin.
The binary version of its metadata is 2.5.0, expected version is 2.3.0.
```

…repeated for ~200 modules. Observed on `IU-263.2180` and `IU-263.2289` with plugin `0.101.566-jb-90ac87b`. The same scripts run fine against 2026.1 (`IU-261.26222.65`) and 2026.2 (`IU-262.8665.337`) on the same machine.

This is the same failure #10 hit at 2.2 vs 2.4.

## Why 2.4.10

It is the newest publicly released kotlinc — there is no 2.5.x on GitHub releases or Maven Central yet; 2026.3 EAP ships a pre-release 2.5.0. 2.4.10 sits within one minor of **both** ends of the supported range, so a single bundled compiler spans every IDE the plugin targets:

| IDE line | Bundled Kotlin | 2.4.10 reads it |
|---|---|---|
| 261 / 262 | 2.3.20 | backwards, always fine |
| 263 EAP | 2.5.0 | one minor forward, inside the window |

`verifyBundledKotlinCompatibility` passes and independently agrees:

```
IDE Kotlin version: 2.3.20
Kotlin plugin version: 2.3.20
Bundled kotlinc version: 2.4.10
Kotlin plugin not newer than IDE: true
Bundled kotlinc compatible (major match, minor diff <= 1): true
Latest stable Kotlin release: 2.4.10 (bundled kotlinc is up to date)
```

The root `kotlin("jvm") version "2.3.20"` is deliberately untouched — that compiles the plugin itself, and older metadata is always readable by a newer runtime.

## Verification

Built and installed locally into a 2026.3 EAP (`IU-263.2289`), replacing `0.101.566-jb-90ac87b`. Before the change every script failed as above. After:

```kotlin
val app = com.intellij.openapi.application.ApplicationInfo.getInstance()
println("IDE=" + app.fullApplicationName + " build=" + app.build.asString())
```
```
IDE=IntelliJ IDEA 2026.3 EAP build=IU-263.2289
```

Full `steroid_execute_code` and the javaperf/Profiler script paths work again.

## On the missing test

CONTRIBUTING asks for a failing test with a bug fix, and I did not add one — flagging that rather than bolting on something that passes trivially.

The change is a build constant, and the check that *would* own this regression already exists: `VerifyBundledKotlinCompatibilityTask`. It cannot catch this case because it compares the bundled kotlinc against the Kotlin of the IDE the plugin **builds** against (261 → 2.3.20), not the IDE a user **attaches** to. That is why the build stayed green while every 263 user was broken, and it is why a pin bump alone will break again on the next IDE Kotlin bump.

#357 lays out the durable fixes — evaluate `KotlinVersionCompatibility.isCompatible` at runtime against the attached IDE and fail with one actionable line instead of the compiler dump, and/or resolve the compiler per-IDE. Both are larger than this PR and mix a fix with build-infra or shipped-runtime changes, so I kept this one to the unblock per the "one logical change per PR" guideline. Happy to follow up with either if you tell me which direction you prefer.
