### PR TITLE
Installers: report download progress and survive bad downloads (stack 1/6)

### DIFF
--- a/installer-gen/src/installerIntegrationTest/kotlin/com/jonnyzzz/mcpSteroid/installer/tests/InstallerBootstrapPs1Test.kt
+++ b/installer-gen/src/installerIntegrationTest/kotlin/com/jonnyzzz/mcpSteroid/installer/tests/InstallerBootstrapPs1Test.kt
@@ -2,6 +2,8 @@
 package com.jonnyzzz.mcpSteroid.installer.tests
 
 import com.jonnyzzz.mcpSteroid.installer.ALL_PLATFORMS
+import com.jonnyzzz.mcpSteroid.installer.ArchiveType
+import com.jonnyzzz.mcpSteroid.installer.archiveUnpackedSize
 import com.jonnyzzz.mcpSteroid.installer.DevrigEntry
 import com.jonnyzzz.mcpSteroid.installer.JdkScriptEntry
 import com.jonnyzzz.mcpSteroid.installer.writeInstallerScripts
@@ -74,8 +76,8 @@ class InstallerBootstrapPs1Test {
         //       javaHome="jdk" pointing at the top dir of the fixture zip. Non-Windows entries are
         //       required by validateScriptTable (all 5 platforms) but the ps1 script only reads its own
         //       $Platforms hashtable, which contains only windows-x64 + windows-arm64. ──
-        val jdkEntryWin = JdkScriptEntry("http://$nginxIp/jdk.zip", jdkSha, "zip", "jdk", jdkZip.length())
-        val jdkEntryPosix = JdkScriptEntry("http://$nginxIp/jdk.zip", jdkSha, "tar.gz", "jdk", jdkZip.length())
+        val jdkEntryWin = JdkScriptEntry("http://$nginxIp/jdk.zip", jdkSha, "zip", "jdk", jdkZip.length(), archiveUnpackedSize(jdkZip.readBytes(), ArchiveType.ZIP))
+        val jdkEntryPosix = JdkScriptEntry("http://$nginxIp/jdk.zip", jdkSha, "tar.gz", "jdk", jdkZip.length(), archiveUnpackedSize(jdkZip.readBytes(), ArchiveType.ZIP))
         val table = ALL_PLATFORMS.associateWith { key ->
             if (key.startsWith("windows-")) jdkEntryWin else jdkEntryPosix
         }
@@ -83,7 +85,7 @@ class InstallerBootstrapPs1Test {
         val devrig = DevrigEntry(
             url = "http://$nginxIp/devrig.zip", sha256 = devrigSha,
             launcherPosix = "devrig-$version/bin/devrig", launcherWindows = "devrig-$version/bin/devrig.bat",
-            size = devrigZip.length(),
+            size = devrigZip.length(), unpackedSize = archiveUnpackedSize(devrigZip.readBytes(), ArchiveType.ZIP),
         )
         val genDir = createInstallerWorkDir("installer-ps1-gen-out")
         writeInstallerScripts(genDir.toPath(), table, devrig, version)
@@ -180,13 +182,13 @@ class InstallerBootstrapPs1Test {
             )
             val nginxIp = nginx.queryContainerIp() ?: error("nginx side-car has no bridge IP")
 
-            val jdkEntryWin = JdkScriptEntry("http://$nginxIp/jdk.zip", jdkSha, "zip", "jdk", jdkZip.length())
-            val jdkEntryPosix = JdkScriptEntry("http://$nginxIp/jdk.zip", jdkSha, "tar.gz", "jdk", jdkZip.length())
+            val jdkEntryWin = JdkScriptEntry("http://$nginxIp/jdk.zip", jdkSha, "zip", "jdk", jdkZip.length(), archiveUnpackedSize(jdkZip.readBytes(), ArchiveType.ZIP))
+            val jdkEntryPosix = JdkScriptEntry("http://$nginxIp/jdk.zip", jdkSha, "tar.gz", "jdk", jdkZip.length(), archiveUnpackedSize(jdkZip.readBytes(), ArchiveType.ZIP))
             val table = ALL_PLATFORMS.associateWith { key -> if (key.startsWith("windows-")) jdkEntryWin else jdkEntryPosix }
             val devrig = DevrigEntry(
                 url = "http://$nginxIp/devrig.zip", sha256 = devrigSha,
                 launcherPosix = "devrig-$version/bin/devrig", launcherWindows = "devrig-$version/bin/devrig.bat",
-                size = devrigZip.length(),
+                size = devrigZip.length(), unpackedSize = archiveUnpackedSize(devrigZip.readBytes(), ArchiveType.ZIP),
             )
             val genDir = createInstallerWorkDir("installer-ps1-arch-gen")
             writeInstallerScripts(genDir.toPath(), table, devrig, version)
@@ -246,13 +248,13 @@ class InstallerBootstrapPs1Test {
             )
             val nginxIp = nginx.queryContainerIp() ?: error("nginx side-car has no bridge IP")
 
-            val jdkEntryWin = JdkScriptEntry("http://$nginxIp/jdk.zip", jdkSha, "zip", "jdk", jdkZip.length())
-            val jdkEntryPosix = JdkScriptEntry("http://$nginxIp/jdk.zip", jdkSha, "tar.gz", "jdk", jdkZip.length())
+            val jdkEntryWin = JdkScriptEntry("http://$nginxIp/jdk.zip", jdkSha, "zip", "jdk", jdkZip.length(), archiveUnpackedSize(jdkZip.readBytes(), ArchiveType.ZIP))
+            val jdkEntryPosix = JdkScriptEntry("http://$nginxIp/jdk.zip", jdkSha, "tar.gz", "jdk", jdkZip.length(), archiveUnpackedSize(jdkZip.readBytes(), ArchiveType.ZIP))
             val table = ALL_PLATFORMS.associateWith { key -> if (key.startsWith("windows-")) jdkEntryWin else jdkEntryPosix }
             val devrig = DevrigEntry(
                 url = "http://$nginxIp/devrig.zip", sha256 = devrigSha,
                 launcherPosix = "devrig-$version/bin/devrig", launcherWindows = "devrig-$version/bin/devrig.bat",
-                size = devrigZip.length(),
+                size = devrigZip.length(), unpackedSize = archiveUnpackedSize(devrigZip.readBytes(), ArchiveType.ZIP),
             )
             val genDir = createInstallerWorkDir("installer-ps1-stdin-gen")
             writeInstallerScripts(genDir.toPath(), table, devrig, version)

--- a/installer-gen/src/installerIntegrationTest/kotlin/com/jonnyzzz/mcpSteroid/installer/tests/InstallerBootstrapPs1Test.kt
+++ b/installer-gen/src/installerIntegrationTest/kotlin/com/jonnyzzz/mcpSteroid/installer/tests/InstallerBootstrapPs1Test.kt
@@ -34,9 +34,12 @@ import java.util.concurrent.TimeUnit
  * POSIX sibling covers.
  *
  * Windows-native runs of `install.ps1` need a Windows Docker host, which this repo's CI does not
- * provision; running pwsh under Linux instead exercises the same script (`Invoke-WebRequest`,
- * `Expand-Archive`, `Get-FileHash`, `Move-Item`, and — critically for jonnyzzz/mcp-steroid#274 —
- * `$ProgressPreference = 'SilentlyContinue'` at the top). The template already accepts a `bin/java`
+ * provision; running pwsh under Linux instead exercises the same script (`Expand-Archive`,
+ * `Get-FileHash`, `Move-Item`, and — critically for jonnyzzz/mcp-steroid#274 —
+ * `$ProgressPreference = 'SilentlyContinue'` at the top). The container installs `curl` before the
+ * script runs (step 4 below), so `Invoke-Download` takes its PRIMARY `curl` branch here — the same one
+ * real Windows takes via `curl.exe`, stall timeouts included — rather than the Invoke-WebRequest
+ * fallback. The template already accepts a `bin/java`
  * stub in place of `bin/java.exe` "so pwsh-on-Linux test runs without java.exe" — the design
  * anticipates this exact test.
  */

--- a/installer-gen/src/installerIntegrationTest/kotlin/com/jonnyzzz/mcpSteroid/installer/tests/InstallerBootstrapPs1Test.kt
+++ b/installer-gen/src/installerIntegrationTest/kotlin/com/jonnyzzz/mcpSteroid/installer/tests/InstallerBootstrapPs1Test.kt
@@ -74,8 +74,8 @@ class InstallerBootstrapPs1Test {
         //       javaHome="jdk" pointing at the top dir of the fixture zip. Non-Windows entries are
         //       required by validateScriptTable (all 5 platforms) but the ps1 script only reads its own
         //       $Platforms hashtable, which contains only windows-x64 + windows-arm64. ──
-        val jdkEntryWin = JdkScriptEntry("http://$nginxIp/jdk.zip", jdkSha, "zip", "jdk")
-        val jdkEntryPosix = JdkScriptEntry("http://$nginxIp/jdk.zip", jdkSha, "tar.gz", "jdk")
+        val jdkEntryWin = JdkScriptEntry("http://$nginxIp/jdk.zip", jdkSha, "zip", "jdk", jdkZip.length())
+        val jdkEntryPosix = JdkScriptEntry("http://$nginxIp/jdk.zip", jdkSha, "tar.gz", "jdk", jdkZip.length())
         val table = ALL_PLATFORMS.associateWith { key ->
             if (key.startsWith("windows-")) jdkEntryWin else jdkEntryPosix
         }
@@ -83,6 +83,7 @@ class InstallerBootstrapPs1Test {
         val devrig = DevrigEntry(
             url = "http://$nginxIp/devrig.zip", sha256 = devrigSha,
             launcherPosix = "devrig-$version/bin/devrig", launcherWindows = "devrig-$version/bin/devrig.bat",
+            size = devrigZip.length(),
         )
         val genDir = createInstallerWorkDir("installer-ps1-gen-out")
         writeInstallerScripts(genDir.toPath(), table, devrig, version)
@@ -179,12 +180,13 @@ class InstallerBootstrapPs1Test {
             )
             val nginxIp = nginx.queryContainerIp() ?: error("nginx side-car has no bridge IP")
 
-            val jdkEntryWin = JdkScriptEntry("http://$nginxIp/jdk.zip", jdkSha, "zip", "jdk")
-            val jdkEntryPosix = JdkScriptEntry("http://$nginxIp/jdk.zip", jdkSha, "tar.gz", "jdk")
+            val jdkEntryWin = JdkScriptEntry("http://$nginxIp/jdk.zip", jdkSha, "zip", "jdk", jdkZip.length())
+            val jdkEntryPosix = JdkScriptEntry("http://$nginxIp/jdk.zip", jdkSha, "tar.gz", "jdk", jdkZip.length())
             val table = ALL_PLATFORMS.associateWith { key -> if (key.startsWith("windows-")) jdkEntryWin else jdkEntryPosix }
             val devrig = DevrigEntry(
                 url = "http://$nginxIp/devrig.zip", sha256 = devrigSha,
                 launcherPosix = "devrig-$version/bin/devrig", launcherWindows = "devrig-$version/bin/devrig.bat",
+                size = devrigZip.length(),
             )
             val genDir = createInstallerWorkDir("installer-ps1-arch-gen")
             writeInstallerScripts(genDir.toPath(), table, devrig, version)
@@ -244,12 +246,13 @@ class InstallerBootstrapPs1Test {
             )
             val nginxIp = nginx.queryContainerIp() ?: error("nginx side-car has no bridge IP")
 
-            val jdkEntryWin = JdkScriptEntry("http://$nginxIp/jdk.zip", jdkSha, "zip", "jdk")
-            val jdkEntryPosix = JdkScriptEntry("http://$nginxIp/jdk.zip", jdkSha, "tar.gz", "jdk")
+            val jdkEntryWin = JdkScriptEntry("http://$nginxIp/jdk.zip", jdkSha, "zip", "jdk", jdkZip.length())
+            val jdkEntryPosix = JdkScriptEntry("http://$nginxIp/jdk.zip", jdkSha, "tar.gz", "jdk", jdkZip.length())
             val table = ALL_PLATFORMS.associateWith { key -> if (key.startsWith("windows-")) jdkEntryWin else jdkEntryPosix }
             val devrig = DevrigEntry(
                 url = "http://$nginxIp/devrig.zip", sha256 = devrigSha,
                 launcherPosix = "devrig-$version/bin/devrig", launcherWindows = "devrig-$version/bin/devrig.bat",
+                size = devrigZip.length(),
             )
             val genDir = createInstallerWorkDir("installer-ps1-stdin-gen")
             writeInstallerScripts(genDir.toPath(), table, devrig, version)

--- a/installer-gen/src/installerIntegrationTest/kotlin/com/jonnyzzz/mcpSteroid/installer/tests/InstallerBootstrapTest.kt
+++ b/installer-gen/src/installerIntegrationTest/kotlin/com/jonnyzzz/mcpSteroid/installer/tests/InstallerBootstrapTest.kt
@@ -52,10 +52,10 @@ class InstallerBootstrapTest {
     fun `generated install_sh refuses musl (alpine)`() = runWithCloseableStack { lifetime ->
         val genDir = createInstallerWorkDir("installer-musl-gen")
         // A minimal valid model (nothing is downloaded on the musl-reject path) → renders a real install.sh.
-        val table = ALL_PLATFORMS.associateWith { JdkScriptEntry("https://example.com/jdk.tar.gz", "a".repeat(64), "tar.gz", "jdk") }
+        val table = ALL_PLATFORMS.associateWith { JdkScriptEntry("https://example.com/jdk.tar.gz", "a".repeat(64), "tar.gz", "jdk", 1L) }
         writeInstallerScripts(
             genDir.toPath(), table,
-            DevrigEntry("https://example.com/devrig.zip", "b".repeat(64), "d/bin/devrig", "d/bin/devrig.bat"),
+            DevrigEntry("https://example.com/devrig.zip", "b".repeat(64), "d/bin/devrig", "d/bin/devrig.bat", 1L),
             version,
         )
         makeWorldReadable(genDir)
@@ -110,11 +110,12 @@ class InstallerBootstrapTest {
         // ── 3. render install.sh from a synthetic model: all 5 platforms point at the one fake jdk.tar.gz
         //       (javaHome="jdk"), served by the side-car. This is the new seam — no real JDK download. ──
         val genDir = createInstallerWorkDir("installer-gen-out")
-        val table = ALL_PLATFORMS.associateWith { JdkScriptEntry("http://$nginxIp/jdk.tar.gz", jdkSha, "tar.gz", "jdk") }
+        val table = ALL_PLATFORMS.associateWith { JdkScriptEntry("http://$nginxIp/jdk.tar.gz", jdkSha, "tar.gz", "jdk", jdkTarGz.length()) }
         // The fixture zip unpacks to devrig-<version>/, so that's the computed+asserted launcher subpath.
         val devrig = DevrigEntry(
             url = "http://$nginxIp/devrig.zip", sha256 = devrigSha,
             launcherPosix = "devrig-$version/bin/devrig", launcherWindows = "devrig-$version/bin/devrig.bat",
+            size = devrigZip.length(),
         )
         writeInstallerScripts(genDir.toPath(), table, devrig, version)
         require(File(genDir, "install.sh").isFile) { "did not produce install.sh in $genDir" }
@@ -172,6 +173,107 @@ class InstallerBootstrapTest {
         reRun.assertNoMessageInOutput("downloading devrig")
 
         log("ALL INSTALLER ASSERTIONS PASSED on ubuntu (glibc) — download + delegate to devrig install devrig")
+    }
+
+    /**
+     * Error resilience (#228), disk precheck: bake an ABSURD artifact size so the required space
+     * (size x3) exceeds any real disk. The generated install.sh must refuse BEFORE downloading, with a
+     * clear "insufficient disk space" message. No nginx/fixtures needed — the check fires pre-download.
+     * The download tools must still be present (preflight runs first), so we install curl+unzip.
+     */
+    @Test
+    @Timeout(value = 10, unit = TimeUnit.MINUTES)
+    fun `generated install_sh fails clearly when disk space is insufficient`() = runWithCloseableStack { lifetime ->
+        val genDir = createInstallerWorkDir("installer-disk-gen")
+        val huge = 10_000_000_000_000L // 10 TB each -> required (x3) dwarfs any CI disk
+        val table = ALL_PLATFORMS.associateWith { JdkScriptEntry("http://192.0.2.1/jdk.tar.gz", "a".repeat(64), "tar.gz", "jdk", huge) }
+        writeInstallerScripts(
+            genDir.toPath(), table,
+            DevrigEntry("http://192.0.2.1/devrig.zip", "b".repeat(64), "d/bin/devrig", "d/bin/devrig.bat", huge),
+            version,
+        )
+        makeWorldReadable(genDir)
+
+        val install = startDockerContainerAndDispose(
+            lifetime,
+            StartContainerRequest()
+                .image(installImage)
+                .logPrefix("installer-disk")
+                .volumes(ContainerVolume(genDir, "/gen", "ro"))
+                .entryPoint(
+                    "sh", "-c",
+                    "apt-get update -qq && apt-get install -y -qq curl unzip >/dev/null 2>&1; mkdir -p \"$homeDir\"; sleep 3000",
+                ),
+        )
+        awaitToolsInstalled(install)
+
+        val r = install.startProcessInContainer {
+            args("sh", "/gen/install.sh").timeoutSeconds(120).description("install.sh with absurd disk need")
+                .extraEnv(mapOf("HOME" to homeDir, "DEVRIG_OS" to "linux", "DEVRIG_CPU" to "x64"))
+        }.awaitForProcessFinish()
+
+        require(r.exitCode != 0) { "install.sh must FAIL when disk is insufficient, but exited 0:\n$r" }
+        r.assertOutputContains("insufficient disk space", message = "must explain the disk-space shortfall")
+        r.assertNoMessageInOutput("downloading") // refused before any download (TEST-NET url never dialed)
+        log("insufficient-disk rejection verified (exit ${r.exitCode})")
+    }
+
+    /**
+     * Error resilience (#228), retry + backoff + cleanup: point the artifact URLs at an nginx side-car
+     * that 404s every path. The generated install.sh must RETRY the download DL_ATTEMPTS times with
+     * backoff, then fail cleanly with a final message — and the cleanup trap must leave no .tmp.* staging
+     * behind. Sizes are tiny (1) so the disk check passes and we reach the download.
+     */
+    @Test
+    @Timeout(value = 12, unit = TimeUnit.MINUTES)
+    fun `generated install_sh retries a failing download then fails cleanly and cleans up staging`() = runWithCloseableStack { lifetime ->
+        val emptyHtml = createInstallerWorkDir("installer-404-html") // nginx serves this; every artifact path 404s
+        makeWorldReadable(emptyHtml)
+        val nginx = startDockerContainerAndDispose(
+            lifetime,
+            StartContainerRequest()
+                .image(NGINX_IMAGE)
+                .logPrefix("installer-404-nginx")
+                .volumes(ContainerVolume(emptyHtml, "/usr/share/nginx/html", "ro")),
+        )
+        val nginxIp = nginx.queryContainerIp() ?: error("nginx side-car has no bridge IP")
+
+        val genDir = createInstallerWorkDir("installer-404-gen")
+        val table = ALL_PLATFORMS.associateWith { JdkScriptEntry("http://$nginxIp/missing-jdk.tar.gz", "a".repeat(64), "tar.gz", "jdk", 1L) }
+        writeInstallerScripts(
+            genDir.toPath(), table,
+            DevrigEntry("http://$nginxIp/missing-devrig.zip", "b".repeat(64), "d/bin/devrig", "d/bin/devrig.bat", 1L),
+            version,
+        )
+        makeWorldReadable(genDir)
+
+        val install = startDockerContainerAndDispose(
+            lifetime,
+            StartContainerRequest()
+                .image(installImage)
+                .logPrefix("installer-404")
+                .volumes(ContainerVolume(genDir, "/gen", "ro"))
+                .entryPoint(
+                    "sh", "-c",
+                    "apt-get update -qq && apt-get install -y -qq curl unzip >/dev/null 2>&1; mkdir -p \"$homeDir\"; sleep 3000",
+                ),
+        )
+        awaitToolsInstalled(install)
+
+        val r = install.startProcessInContainer {
+            args("sh", "/gen/install.sh").timeoutSeconds(180).description("install.sh against 404 artifacts")
+                .extraEnv(mapOf("HOME" to homeDir, "DEVRIG_OS" to "linux", "DEVRIG_CPU" to "x64"))
+        }.awaitForProcessFinish()
+
+        require(r.exitCode != 0) { "install.sh must FAIL when the download 404s, but exited 0:\n$r" }
+        r.assertOutputContains("downloading devrig", message = "must attempt the download")
+        r.assertOutputContains("attempt 1/3 failed", "attempt 2/3 failed", message = "must retry the download with backoff")
+        r.assertOutputContains("after 3 attempts", message = "must give up with a clear final error after DL_ATTEMPTS")
+
+        // the cleanup trap removed THIS run's staging: no .tmp.* left in binaries/
+        val leftovers = sh(install, "ls -A \"$homeDir/.mcp-steroid/binaries\" 2>/dev/null | grep -c '^[.]tmp[.]' || true")
+        leftovers.assertOutputContains("0", message = "cleanup trap must remove this run's .tmp.* staging on failure")
+        log("permanent-failure retry + staging cleanup verified (exit ${r.exitCode})")
     }
 
     // ── helpers ──────────────────────────────────────────────────────────────────────────────────

--- a/installer-gen/src/installerIntegrationTest/kotlin/com/jonnyzzz/mcpSteroid/installer/tests/InstallerBootstrapTest.kt
+++ b/installer-gen/src/installerIntegrationTest/kotlin/com/jonnyzzz/mcpSteroid/installer/tests/InstallerBootstrapTest.kt
@@ -2,6 +2,8 @@
 package com.jonnyzzz.mcpSteroid.installer.tests
 
 import com.jonnyzzz.mcpSteroid.installer.ALL_PLATFORMS
+import com.jonnyzzz.mcpSteroid.installer.ArchiveType
+import com.jonnyzzz.mcpSteroid.installer.archiveUnpackedSize
 import com.jonnyzzz.mcpSteroid.installer.DevrigEntry
 import com.jonnyzzz.mcpSteroid.installer.JdkScriptEntry
 import com.jonnyzzz.mcpSteroid.installer.writeInstallerScripts
@@ -52,10 +54,10 @@ class InstallerBootstrapTest {
     fun `generated install_sh refuses musl (alpine)`() = runWithCloseableStack { lifetime ->
         val genDir = createInstallerWorkDir("installer-musl-gen")
         // A minimal valid model (nothing is downloaded on the musl-reject path) → renders a real install.sh.
-        val table = ALL_PLATFORMS.associateWith { JdkScriptEntry("https://example.com/jdk.tar.gz", "a".repeat(64), "tar.gz", "jdk", 1L) }
+        val table = ALL_PLATFORMS.associateWith { JdkScriptEntry("https://example.com/jdk.tar.gz", "a".repeat(64), "tar.gz", "jdk", 1L, 2L) }
         writeInstallerScripts(
             genDir.toPath(), table,
-            DevrigEntry("https://example.com/devrig.zip", "b".repeat(64), "d/bin/devrig", "d/bin/devrig.bat", 1L),
+            DevrigEntry("https://example.com/devrig.zip", "b".repeat(64), "d/bin/devrig", "d/bin/devrig.bat", 1L, 2L),
             version,
         )
         makeWorldReadable(genDir)
@@ -110,12 +112,12 @@ class InstallerBootstrapTest {
         // ── 3. render install.sh from a synthetic model: all 5 platforms point at the one fake jdk.tar.gz
         //       (javaHome="jdk"), served by the side-car. This is the new seam — no real JDK download. ──
         val genDir = createInstallerWorkDir("installer-gen-out")
-        val table = ALL_PLATFORMS.associateWith { JdkScriptEntry("http://$nginxIp/jdk.tar.gz", jdkSha, "tar.gz", "jdk", jdkTarGz.length()) }
+        val table = ALL_PLATFORMS.associateWith { JdkScriptEntry("http://$nginxIp/jdk.tar.gz", jdkSha, "tar.gz", "jdk", jdkTarGz.length(), archiveUnpackedSize(jdkTarGz.readBytes(), ArchiveType.TAR_GZ)) }
         // The fixture zip unpacks to devrig-<version>/, so that's the computed+asserted launcher subpath.
         val devrig = DevrigEntry(
             url = "http://$nginxIp/devrig.zip", sha256 = devrigSha,
             launcherPosix = "devrig-$version/bin/devrig", launcherWindows = "devrig-$version/bin/devrig.bat",
-            size = devrigZip.length(),
+            size = devrigZip.length(), unpackedSize = archiveUnpackedSize(devrigZip.readBytes(), ArchiveType.ZIP),
         )
         writeInstallerScripts(genDir.toPath(), table, devrig, version)
         require(File(genDir, "install.sh").isFile) { "did not produce install.sh in $genDir" }
@@ -185,11 +187,11 @@ class InstallerBootstrapTest {
     @Timeout(value = 10, unit = TimeUnit.MINUTES)
     fun `generated install_sh fails clearly when disk space is insufficient`() = runWithCloseableStack { lifetime ->
         val genDir = createInstallerWorkDir("installer-disk-gen")
-        val huge = 10_000_000_000_000L // 10 TB each -> required (x3) dwarfs any CI disk
-        val table = ALL_PLATFORMS.associateWith { JdkScriptEntry("http://192.0.2.1/jdk.tar.gz", "a".repeat(64), "tar.gz", "jdk", huge) }
+        val huge = 10_000_000_000_000L // 10 TB per number -> the required total dwarfs any CI disk
+        val table = ALL_PLATFORMS.associateWith { JdkScriptEntry("http://192.0.2.1/jdk.tar.gz", "a".repeat(64), "tar.gz", "jdk", huge, huge) }
         writeInstallerScripts(
             genDir.toPath(), table,
-            DevrigEntry("http://192.0.2.1/devrig.zip", "b".repeat(64), "d/bin/devrig", "d/bin/devrig.bat", huge),
+            DevrigEntry("http://192.0.2.1/devrig.zip", "b".repeat(64), "d/bin/devrig", "d/bin/devrig.bat", huge, huge),
             version,
         )
         makeWorldReadable(genDir)
@@ -239,10 +241,10 @@ class InstallerBootstrapTest {
         val nginxIp = nginx.queryContainerIp() ?: error("nginx side-car has no bridge IP")
 
         val genDir = createInstallerWorkDir("installer-404-gen")
-        val table = ALL_PLATFORMS.associateWith { JdkScriptEntry("http://$nginxIp/missing-jdk.tar.gz", "a".repeat(64), "tar.gz", "jdk", 1L) }
+        val table = ALL_PLATFORMS.associateWith { JdkScriptEntry("http://$nginxIp/missing-jdk.tar.gz", "a".repeat(64), "tar.gz", "jdk", 1L, 2L) }
         writeInstallerScripts(
             genDir.toPath(), table,
-            DevrigEntry("http://$nginxIp/missing-devrig.zip", "b".repeat(64), "d/bin/devrig", "d/bin/devrig.bat", 1L),
+            DevrigEntry("http://$nginxIp/missing-devrig.zip", "b".repeat(64), "d/bin/devrig", "d/bin/devrig.bat", 1L, 2L),
             version,
         )
         makeWorldReadable(genDir)

--- a/installer-gen/src/main/kotlin/com/jonnyzzz/mcpSteroid/installer/AzulJdk.kt
+++ b/installer-gen/src/main/kotlin/com/jonnyzzz/mcpSteroid/installer/AzulJdk.kt
@@ -77,6 +77,7 @@ internal fun resolveAzulJdk(cache: Cache, http: HttpFetcher, keyFingerprint: Str
         url = detail.downloadUrl,
         fileName = fileNameOf(detail.downloadUrl),
         size = bytes.size.toLong(),
+        unpackedSize = archiveUnpackedSize(bytes, ArchiveType.ZIP),
         sha256 = detail.sha256Hash.lowercase(),
         javaHome = findJavaHome(bytes, ArchiveType.ZIP),
     )

--- a/installer-gen/src/main/kotlin/com/jonnyzzz/mcpSteroid/installer/CorrettoJdk.kt
+++ b/installer-gen/src/main/kotlin/com/jonnyzzz/mcpSteroid/installer/CorrettoJdk.kt
@@ -61,6 +61,7 @@ private fun resolveCorretto(
         url = versionedUrl,
         fileName = fileNameOf(versionedUrl),
         size = bytes.size.toLong(),
+        unpackedSize = archiveUnpackedSize(bytes, spec.archive),
         sha256 = sha256Hex(bytes),
         javaHome = findJavaHome(bytes, spec.archive),
     )

--- a/installer-gen/src/main/kotlin/com/jonnyzzz/mcpSteroid/installer/InstallerGenerator.kt
+++ b/installer-gen/src/main/kotlin/com/jonnyzzz/mcpSteroid/installer/InstallerGenerator.kt
@@ -27,9 +27,17 @@ val ALL_PLATFORMS = POSIX_PLATFORMS + WINDOWS_PLATFORMS
 
 /**
  * The per-platform values baked into the scripts (derived from a [JdkArtifact]). [size] is the archive
- * byte length; the scripts use it (plus devrig's) for the pre-download disk-space check (#228).
+ * byte length and [unpackedSize] the length of its extracted tree; the scripts use both (plus devrig's)
+ * for the pre-download disk-space check (#228).
  */
-data class JdkScriptEntry(val url: String, val sha256: String, val format: String, val javaHome: String, val size: Long)
+data class JdkScriptEntry(
+    val url: String,
+    val sha256: String,
+    val format: String,
+    val javaHome: String,
+    val size: Long,
+    val unpackedSize: Long,
+)
 
 data class DevrigEntry(
     val url: String,
@@ -43,6 +51,8 @@ data class DevrigEntry(
     val launcherWindows: String,
     /** The devrig-dist zip byte length; baked into the scripts for the disk-space check (#228). */
     val size: Long,
+    /** The devrig-dist zip's UNPACKED byte length; the other half of the disk-space check (#228). */
+    val unpackedSize: Long,
     val format: String = "zip",
 )
 
@@ -64,7 +74,8 @@ internal fun JdkPlatform.scriptKey(): String {
 /** Adapt the resolved [JdkModel] into the platform-keyed table the scripts bake in, and validate it. */
 internal fun jdkScriptTable(model: JdkModel): Map<String, JdkScriptEntry> {
     val table = model.jdks.associate {
-        it.platform.scriptKey() to JdkScriptEntry(it.url, it.sha256, it.archive.extension, it.javaHome, it.size)
+        it.platform.scriptKey() to
+                JdkScriptEntry(it.url, it.sha256, it.archive.extension, it.javaHome, it.size, it.unpackedSize)
     }
     validateScriptTable(table)
     return table
@@ -85,9 +96,10 @@ internal fun validateScriptTable(table: Map<String, JdkScriptEntry>) {
             "$key: bad javaHome (must be non-blank, no leading/trailing slash): '${e.javaHome}'"
         }
         require(e.url.startsWith("https://") || e.url.startsWith("http://")) { "$key: url must be absolute http(s), got '${e.url}'" }
-        // size feeds the scripts' pre-download disk-space check (#228); a non-positive value would make
-        // the check meaningless (need ~0 MB), so reject it at generation time.
+        // size + unpackedSize feed the scripts' pre-download disk-space check (#228); a non-positive value
+        // would make the check meaningless (need ~0 MB), so reject it at generation time.
         require(e.size > 0) { "$key: size must be a positive byte count, got ${e.size}" }
+        require(e.unpackedSize > 0) { "$key: unpackedSize must be a positive byte count, got ${e.unpackedSize}" }
         requireShellSafe("$key url", e.url)
         requireShellSafe("$key javaHome", e.javaHome)
     }
@@ -115,6 +127,7 @@ internal fun validateDevrig(e: DevrigEntry) {
     require(e.sha256.matches(Regex("[0-9a-f]{64}"))) { "devrig sha256 must be 64 lowercase hex, got '${e.sha256}'" }
     require(e.format == "zip") { "devrig: unexpected format '${e.format}'" }
     require(e.size > 0) { "devrig size must be a positive byte count, got ${e.size}" }
+    require(e.unpackedSize > 0) { "devrig unpackedSize must be a positive byte count, got ${e.unpackedSize}" }
     requireShellSafe("devrig url", e.url)
     // The launcher subpaths are derived from devrig-zip ENTRY NAMES (attacker-controlled if the zip is
     // crafted) and baked into the single-quoted DEVRIG_BINSUB assignment in both scripts — validate them
@@ -137,6 +150,7 @@ private fun renderShCase(table: Map<String, JdkScriptEntry>): String = buildStri
         appendLine("    jdk_format='${j.format}'")
         appendLine("    jdk_javahome='${j.javaHome}'")
         appendLine("    jdk_size='${j.size}'")
+        appendLine("    jdk_unpacked_size='${j.unpackedSize}'")
         appendLine("    ;;")
     }
 }.trimEnd('\n')
@@ -151,6 +165,7 @@ private fun renderPsTable(table: Map<String, JdkScriptEntry>): String = buildStr
         appendLine("    JdkFormat = '${j.format}'")
         appendLine("    JdkJavaHome = '${j.javaHome}'")
         appendLine("    JdkSize = ${j.size}")
+        appendLine("    JdkUnpackedSize = ${j.unpackedSize}")
         appendLine("  }")
     }
 }.trimEnd('\n')
@@ -240,7 +255,7 @@ internal fun resolveDevrig(flags: Map<String, List<String>>, http: HttpFetcher, 
     }
     return DevrigEntry(
         url = url, sha256 = sha256Hex(bytes), launcherPosix = posix, launcherWindows = win,
-        size = bytes.size.toLong(),
+        size = bytes.size.toLong(), unpackedSize = archiveUnpackedSize(bytes, ArchiveType.ZIP),
     )
 }
 
@@ -293,6 +308,7 @@ internal fun renderInstallerScripts(table: Map<String, JdkScriptEntry>, devrig: 
         "DEVRIG_SHA256" to devrig.sha256,
         "DEVRIG_FORMAT" to devrig.format,
         "DEVRIG_SIZE" to devrig.size.toString(),
+        "DEVRIG_UNPACKED_SIZE" to devrig.unpackedSize.toString(),
     )
     // DEVRIG_BINSUB differs per OS (POSIX `…/bin/devrig` vs Windows `…/bin/devrig.bat`), so it is injected
     // per-template from the computed+asserted launcher subpaths.

--- a/installer-gen/src/main/kotlin/com/jonnyzzz/mcpSteroid/installer/InstallerGenerator.kt
+++ b/installer-gen/src/main/kotlin/com/jonnyzzz/mcpSteroid/installer/InstallerGenerator.kt
@@ -25,8 +25,11 @@ val POSIX_PLATFORMS = listOf("macos-arm64", "linux-arm64", "linux-x64")
 val WINDOWS_PLATFORMS = listOf("windows-x64", "windows-arm64")
 val ALL_PLATFORMS = POSIX_PLATFORMS + WINDOWS_PLATFORMS
 
-/** The per-platform values baked into the scripts (derived from a [JdkArtifact]). */
-data class JdkScriptEntry(val url: String, val sha256: String, val format: String, val javaHome: String)
+/**
+ * The per-platform values baked into the scripts (derived from a [JdkArtifact]). [size] is the archive
+ * byte length; the scripts use it (plus devrig's) for the pre-download disk-space check (#228).
+ */
+data class JdkScriptEntry(val url: String, val sha256: String, val format: String, val javaHome: String, val size: Long)
 
 data class DevrigEntry(
     val url: String,
@@ -38,6 +41,8 @@ data class DevrigEntry(
      */
     val launcherPosix: String,
     val launcherWindows: String,
+    /** The devrig-dist zip byte length; baked into the scripts for the disk-space check (#228). */
+    val size: Long,
     val format: String = "zip",
 )
 
@@ -59,7 +64,7 @@ internal fun JdkPlatform.scriptKey(): String {
 /** Adapt the resolved [JdkModel] into the platform-keyed table the scripts bake in, and validate it. */
 internal fun jdkScriptTable(model: JdkModel): Map<String, JdkScriptEntry> {
     val table = model.jdks.associate {
-        it.platform.scriptKey() to JdkScriptEntry(it.url, it.sha256, it.archive.extension, it.javaHome)
+        it.platform.scriptKey() to JdkScriptEntry(it.url, it.sha256, it.archive.extension, it.javaHome, it.size)
     }
     validateScriptTable(table)
     return table
@@ -80,6 +85,9 @@ internal fun validateScriptTable(table: Map<String, JdkScriptEntry>) {
             "$key: bad javaHome (must be non-blank, no leading/trailing slash): '${e.javaHome}'"
         }
         require(e.url.startsWith("https://") || e.url.startsWith("http://")) { "$key: url must be absolute http(s), got '${e.url}'" }
+        // size feeds the scripts' pre-download disk-space check (#228); a non-positive value would make
+        // the check meaningless (need ~0 MB), so reject it at generation time.
+        require(e.size > 0) { "$key: size must be a positive byte count, got ${e.size}" }
         requireShellSafe("$key url", e.url)
         requireShellSafe("$key javaHome", e.javaHome)
     }
@@ -106,6 +114,7 @@ internal fun validateDevrig(e: DevrigEntry) {
     }
     require(e.sha256.matches(Regex("[0-9a-f]{64}"))) { "devrig sha256 must be 64 lowercase hex, got '${e.sha256}'" }
     require(e.format == "zip") { "devrig: unexpected format '${e.format}'" }
+    require(e.size > 0) { "devrig size must be a positive byte count, got ${e.size}" }
     requireShellSafe("devrig url", e.url)
     // The launcher subpaths are derived from devrig-zip ENTRY NAMES (attacker-controlled if the zip is
     // crafted) and baked into the single-quoted DEVRIG_BINSUB assignment in both scripts — validate them
@@ -127,6 +136,7 @@ private fun renderShCase(table: Map<String, JdkScriptEntry>): String = buildStri
         appendLine("    jdk_sha256='${j.sha256}'")
         appendLine("    jdk_format='${j.format}'")
         appendLine("    jdk_javahome='${j.javaHome}'")
+        appendLine("    jdk_size='${j.size}'")
         appendLine("    ;;")
     }
 }.trimEnd('\n')
@@ -140,6 +150,7 @@ private fun renderPsTable(table: Map<String, JdkScriptEntry>): String = buildStr
         appendLine("    JdkSha256 = '${j.sha256}'")
         appendLine("    JdkFormat = '${j.format}'")
         appendLine("    JdkJavaHome = '${j.javaHome}'")
+        appendLine("    JdkSize = ${j.size}")
         appendLine("  }")
     }
 }.trimEnd('\n')
@@ -227,7 +238,10 @@ internal fun resolveDevrig(flags: Map<String, List<String>>, http: HttpFetcher, 
     require(topDir.startsWith("devrig-$version-")) {
         "devrig binary version in '$topDir' does not match repo VERSION '$version' — install scripts would ship a mismatched devrig"
     }
-    return DevrigEntry(url = url, sha256 = sha256Hex(bytes), launcherPosix = posix, launcherWindows = win)
+    return DevrigEntry(
+        url = url, sha256 = sha256Hex(bytes), launcherPosix = posix, launcherWindows = win,
+        size = bytes.size.toLong(),
+    )
 }
 
 /**
@@ -278,6 +292,7 @@ internal fun renderInstallerScripts(table: Map<String, JdkScriptEntry>, devrig: 
         "DEVRIG_URL" to devrig.url,
         "DEVRIG_SHA256" to devrig.sha256,
         "DEVRIG_FORMAT" to devrig.format,
+        "DEVRIG_SIZE" to devrig.size.toString(),
     )
     // DEVRIG_BINSUB differs per OS (POSIX `…/bin/devrig` vs Windows `…/bin/devrig.bat`), so it is injected
     // per-template from the computed+asserted launcher subpaths.

--- a/installer-gen/src/main/kotlin/com/jonnyzzz/mcpSteroid/installer/JdkModel.kt
+++ b/installer-gen/src/main/kotlin/com/jonnyzzz/mcpSteroid/installer/JdkModel.kt
@@ -3,8 +3,9 @@ package com.jonnyzzz.mcpSteroid.installer
 
 import kotlinx.serialization.Serializable
 import org.apache.commons.compress.archivers.tar.TarArchiveInputStream
-import org.apache.commons.compress.archivers.zip.ZipArchiveInputStream
+import org.apache.commons.compress.archivers.zip.ZipFile
 import org.apache.commons.compress.compressors.gzip.GzipCompressorInputStream
+import org.apache.commons.compress.utils.SeekableInMemoryByteChannel
 import java.io.ByteArrayInputStream
 
 /**
@@ -37,6 +38,9 @@ data class JdkPlatform(val os: JdkOs, val arch: JdkArch)
  *                       followed to its versioned resource).
  *  - [fileName]       — the archive's file name (the [url] basename), e.g. for `curl -o <fileName>`.
  *  - [size]           — the byte length of the downloaded archive.
+ *  - [unpackedSize]   — the byte length of the archive's contents once extracted, summed from the real
+ *                       entries (see [archiveUnpackedSize]). Together with [size] it gives the installers
+ *                       an exact pre-download disk-space requirement instead of a multiple-of-archive guess.
  *  - [sha256]         — lowercase hex over the downloaded bytes (Azul also cross-checks the published hash).
  *  - [javaHome]       — the path to `JAVA_HOME` (the directory whose `bin/` holds `java`), discovered by
  *                       scanning the archive entries, so macOS's `…/Contents/Home` and the Linux/Windows
@@ -54,6 +58,7 @@ data class JdkArtifact(
     val url: String,
     val fileName: String,
     val size: Long,
+    val unpackedSize: Long,
     val sha256: String,
     val javaHome: String,
 )
@@ -67,15 +72,48 @@ internal fun fileNameOf(url: String): String = url.substringAfterLast('/').subst
 
 // ── archive scanning: compute JAVA_HOME (shared by the vendor resolvers) ─────────────────────────
 
-internal fun archiveEntryNames(bytes: ByteArray, archive: ArchiveType): List<String> = when (archive) {
+/**
+ * One archive entry: its `/`-separated [name] and the UNPACKED byte length of its content
+ * ([unpackedSize]; 0 for directories, symlinks and other non-regular entries).
+ */
+data class ArchiveEntry(val name: String, val unpackedSize: Long)
+
+/**
+ * Every entry of [bytes], with its unpacked length. ZIPs are read through [ZipFile] (the CENTRAL
+ * DIRECTORY) rather than streamed: a streaming reader reports size `-1` for entries whose sizes live in
+ * a trailing data descriptor, which is exactly how `java.util.zip.ZipOutputStream` writes them.
+ */
+fun archiveEntries(bytes: ByteArray, archive: ArchiveType): List<ArchiveEntry> = when (archive) {
     ArchiveType.TAR_GZ ->
         TarArchiveInputStream(GzipCompressorInputStream(ByteArrayInputStream(bytes))).use { tis ->
-            generateSequence { tis.nextEntry }.map { it.name }.toList()
+            generateSequence { tis.nextEntry }.map { ArchiveEntry(it.name, it.size) }.toList()
         }
     ArchiveType.ZIP ->
-        ZipArchiveInputStream(ByteArrayInputStream(bytes)).use { zis ->
-            generateSequence { zis.nextEntry }.map { it.name }.toList()
+        ZipFile.builder().setSeekableByteChannel(SeekableInMemoryByteChannel(bytes)).get().use { zf ->
+            zf.entries.asSequence().map { ArchiveEntry(it.name, it.size) }.toList()
         }
+}
+
+internal fun archiveEntryNames(bytes: ByteArray, archive: ArchiveType): List<String> =
+    archiveEntries(bytes, archive).map { it.name }
+
+/**
+ * The REAL byte length of [bytes] once unpacked — the sum of every entry's content length. Bakes an exact
+ * number into the installers' pre-download disk-space check instead of the old `archive x 3` guess (#228):
+ * an already-compressed JDK unpacks to well under 2x its archive, a text-heavy one to well over it.
+ *
+ * Sizes must be KNOWN (never `-1`): both readers above are central-directory / header based, so a missing
+ * size means a malformed archive — fail generation rather than bake a too-small disk requirement.
+ */
+fun archiveUnpackedSize(bytes: ByteArray, archive: ArchiveType): Long {
+    val entries = archiveEntries(bytes, archive)
+    val unsized = entries.filter { it.unpackedSize < 0 }
+    require(unsized.isEmpty()) {
+        "archive has entries with an unknown unpacked size: ${unsized.take(5).map { it.name }}"
+    }
+    val total = entries.sumOf { it.unpackedSize }
+    require(total > 0) { "archive unpacks to 0 bytes (${entries.size} entries) - refusing to bake it" }
+    return total
 }
 
 /**

--- a/installer-gen/src/main/resources/templates/install.ps1.tmpl
+++ b/installer-gen/src/main/resources/templates/install.ps1.tmpl
@@ -10,6 +10,10 @@
 
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
+# Invoke-WebRequest renders a per-chunk progress bar by default, which is extremely slow on Windows
+# (repeated console redraws). The "downloading $kind (...)..." log line below is the textual progress
+# instead; disabling the built-in bar restores normal download throughput.
+$ProgressPreference = 'SilentlyContinue'
 [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 # PowerShell's default progress bar redraws on every byte read (Invoke-WebRequest) and every entry
 # unpacked (Expand-Archive), turning a multi-hundred-MB download + JDK unpack into a UI-bound crawl

--- a/installer-gen/src/main/resources/templates/install.ps1.tmpl
+++ b/installer-gen/src/main/resources/templates/install.ps1.tmpl
@@ -28,6 +28,11 @@ $Version      = '@@VERSION@@'
 $DevrigUrl    = '@@DEVRIG_URL@@'
 $DevrigSha256 = '@@DEVRIG_SHA256@@'
 $DevrigFormat = '@@DEVRIG_FORMAT@@'
+# devrig-dist archive byte length - used (with the per-platform JDK size) for the pre-download
+# disk-space check, so a full disk fails early and clearly instead of mid-stream.
+$DevrigSize   = @@DEVRIG_SIZE@@
+# Download resilience (#228): re-download a failed OR corrupted (sha-mismatch) artifact this many times.
+$DlAttempts   = 3
 # The devrig launcher subpath INSIDE the unpacked dist (computed + asserted by the generator from the
 # real zip - `devrig-<version>-<hash>\bin\devrig.bat`). The script runs this and lets devrig register
 # itself (`devrig install devrig`), so the script never writes the launcher/PATH.
@@ -39,7 +44,17 @@ $Platforms = @{
 }
 
 function Write-Log([string]$m) { [Console]::Error.WriteLine("[mcp-steroid] $m") }
-function Fail([string]$m) { Write-Log "ERROR: $m"; exit 1 }
+# Remove THIS run's staging so a broken download never leaks hundreds of MB. Guard the $BinariesDir
+# lookup: Fail (which calls this) can run before $BinariesDir is defined, and StrictMode errors on an
+# undefined variable. PowerShell does not reliably run finally{} on `exit`, so cleanup lives here.
+function Remove-Staging {
+  $bd = Get-Variable -Name BinariesDir -ValueOnly -ErrorAction SilentlyContinue
+  if ($bd) {
+    Get-ChildItem -Path $bd -Filter ".tmp.$PID.*" -ErrorAction SilentlyContinue |
+      ForEach-Object { Remove-Item -Recurse -Force $_.FullName -ErrorAction SilentlyContinue }
+  }
+}
+function Fail([string]$m) { Remove-Staging; Write-Log "ERROR: $m"; exit 1 }
 
 # Home resolution: USERPROFILE -> HOME -> GetFolderPath (so pwsh-on-Linux tests can locate it too).
 $InstallRoot = $env:USERPROFILE
@@ -91,6 +106,18 @@ Get-ChildItem -Path $BinariesDir -Filter '.tmp.*' -ErrorAction SilentlyContinue 
   Where-Object { $_.LastWriteTime -lt (Get-Date).AddDays(-1) } |
   ForEach-Object { Remove-Item -Recurse -Force $_.FullName -ErrorAction SilentlyContinue }
 
+# -- preflight: disk space (#228) --
+# Fail early + clearly if the volume backing ~\.mcp-steroid cannot hold the download + unpack, rather
+# than dying mid-stream. Estimate the need as (devrig + jdk) archive bytes x3 (archive + unpacked tree
+# + slack).
+$needBytes = ([long]$DevrigSize + [long]$p.JdkSize) * 3
+$driveRoot = [System.IO.Path]::GetPathRoot((Resolve-Path $BinariesDir).Path)
+$availBytes = (New-Object System.IO.DriveInfo($driveRoot)).AvailableFreeSpace
+if ($availBytes -lt $needBytes) {
+  Fail ("insufficient disk space in {0}: need ~{1} MB (download + unpack), have ~{2} MB free - free up space and re-run" -f `
+    $BinariesDir, [long]($needBytes / 1MB), [long]($availBytes / 1MB))
+}
+
 function Install-Artifact([string]$kind, [string]$url, [string]$sha, [string]$fmt) {
   $sha12  = $sha.Substring(0, 12)
   $name   = "$kind-$key-$Version-$sha12"
@@ -104,10 +131,29 @@ function Install-Artifact([string]$kind, [string]$url, [string]$sha, [string]$fm
   Remove-Item -Recurse -Force $tmpZip, $tmpUnpack -ErrorAction SilentlyContinue
 
   Write-Log "downloading $kind ($url)..."
-  Invoke-WebRequest -Uri $url -OutFile $tmpZip -UseBasicParsing
-  $actual = (Get-FileHash -Algorithm SHA256 -Path $tmpZip).Hash.ToLowerInvariant()
-  if ($actual -ne $sha) { Fail "SHA-256 mismatch for ${kind}: expected $sha, got $actual" }
-  Write-Log "SHA-256 verified: $sha"
+  # Retry download+verify as a unit (transient network failure OR sha mismatch both re-download), with
+  # growing backoff; only the final failure is fatal. -TimeoutSec is a generous hard ceiling: PowerShell
+  # has no stall-only timeout (unlike curl's --speed-time), so a very slow link relies on this ceiling.
+  # install.sh is the primary macOS/Linux path.
+  $attempt = 1
+  $backoff = 2
+  while ($true) {
+    $err = $null
+    try {
+      Invoke-WebRequest -Uri $url -OutFile $tmpZip -UseBasicParsing -TimeoutSec 1800
+      $actual = (Get-FileHash -Algorithm SHA256 -Path $tmpZip).Hash.ToLowerInvariant()
+      if ($actual -eq $sha) { Write-Log "SHA-256 verified: $sha"; break }
+      $err = "SHA-256 mismatch for ${kind}: expected $sha, got $actual"
+    } catch {
+      $err = "download failed: $url ($($_.Exception.Message))"
+    }
+    Remove-Item -Force $tmpZip -ErrorAction SilentlyContinue
+    if ($attempt -ge $DlAttempts) { Fail "$err (after $DlAttempts attempts)" }
+    Write-Log "attempt $attempt/$DlAttempts failed ($err); retrying in ${backoff}s..."
+    Start-Sleep -Seconds $backoff
+    $attempt++
+    $backoff = $backoff * 3
+  }
 
   New-Item -ItemType Directory -Force -Path $tmpUnpack | Out-Null
   Expand-Archive -Path $tmpZip -DestinationPath $tmpUnpack -Force

--- a/installer-gen/src/main/resources/templates/install.ps1.tmpl
+++ b/installer-gen/src/main/resources/templates/install.ps1.tmpl
@@ -10,10 +10,6 @@
 
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
-# Invoke-WebRequest renders a per-chunk progress bar by default, which is extremely slow on Windows
-# (repeated console redraws). The "downloading $kind (...)..." log line below is the textual progress
-# instead; disabling the built-in bar restores normal download throughput.
-$ProgressPreference = 'SilentlyContinue'
 [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 # PowerShell's default progress bar redraws on every byte read (Invoke-WebRequest) and every entry
 # unpacked (Expand-Archive), turning a multi-hundred-MB download + JDK unpack into a UI-bound crawl

--- a/installer-gen/src/main/resources/templates/install.ps1.tmpl
+++ b/installer-gen/src/main/resources/templates/install.ps1.tmpl
@@ -28,9 +28,11 @@ $Version      = '@@VERSION@@'
 $DevrigUrl    = '@@DEVRIG_URL@@'
 $DevrigSha256 = '@@DEVRIG_SHA256@@'
 $DevrigFormat = '@@DEVRIG_FORMAT@@'
-# devrig-dist archive byte length - used (with the per-platform JDK size) for the pre-download
+# devrig-dist archive byte length, and the byte length of the tree it unpacks to (both computed by the
+# generator from the real archive) - used with the per-platform JDK numbers for the pre-download
 # disk-space check, so a full disk fails early and clearly instead of mid-stream.
 $DevrigSize   = @@DEVRIG_SIZE@@
+$DevrigUnpackedSize = @@DEVRIG_UNPACKED_SIZE@@
 # Download resilience (#228): re-download a failed OR corrupted (sha-mismatch) artifact this many times.
 $DlAttempts   = 3
 # The devrig launcher subpath INSIDE the unpacked dist (computed + asserted by the generator from the
@@ -108,9 +110,11 @@ Get-ChildItem -Path $BinariesDir -Filter '.tmp.*' -ErrorAction SilentlyContinue 
 
 # -- preflight: disk space (#228) --
 # Fail early + clearly if the volume backing ~\.mcp-steroid cannot hold the download + unpack, rather
-# than dying mid-stream. Estimate the need as (devrig + jdk) archive bytes x3 (archive + unpacked tree
-# + slack).
-$needBytes = ([long]$DevrigSize + [long]$p.JdkSize) * 3
+# than dying mid-stream. The four numbers are EXACT (the generator sums the real archive entries), so the
+# requirement is archive + unpacked tree for each artifact, plus 10% for filesystem overhead - not a
+# multiple-of-archive guess. Same formula as install.sh.
+# (PowerShell integer division yields a double when it does not divide evenly - cast back to [long].)
+$needBytes = [long]((([long]$DevrigSize + [long]$DevrigUnpackedSize + [long]$p.JdkSize + [long]$p.JdkUnpackedSize) * 11) / 10)
 $driveRoot = [System.IO.Path]::GetPathRoot((Resolve-Path $BinariesDir).Path)
 $availBytes = (New-Object System.IO.DriveInfo($driveRoot)).AvailableFreeSpace
 if ($availBytes -lt $needBytes) {

--- a/installer-gen/src/main/resources/templates/install.ps1.tmpl
+++ b/installer-gen/src/main/resources/templates/install.ps1.tmpl
@@ -58,6 +58,39 @@ function Remove-Staging {
 }
 function Fail([string]$m) { Remove-Staging; Write-Log "ERROR: $m"; exit 1 }
 
+# -- the downloader (#228) --
+# curl.exe is the PRIMARY path. It ships with Windows 10 1803+ / Server 2019+, and gives the same STALL
+# detection install.sh relies on: --speed-limit/--speed-time abort a transfer whose average rate stays
+# under 1 KB/s for 30s (a dead connection, a proxy that accepted and went silent, a suspended laptop),
+# while a legitimately slow but PROGRESSING ~600 MB download runs to completion. That is what lets the
+# retry loop below actually fire instead of hanging forever.
+#
+# Invoke-WebRequest has no stall-only timeout. Its -TimeoutSec bounds the WHOLE operation on PowerShell 7
+# (HttpClient) but only the request initiation on Windows PowerShell 5.1 (WebRequest.Timeout) - so the
+# same script behaves differently per host, and any ceiling short enough to catch a dead connection also
+# kills a slow-but-working download. The retry then restarts it from byte 0 and it can never finish.
+#
+# -CommandType Application matters: in Windows PowerShell 5.1 `curl` is an ALIAS for Invoke-WebRequest,
+# and this filters to real executables. Bare `curl` is listed second so the pwsh-on-Linux test containers
+# exercise the same code path Windows takes.
+$CurlExe = Get-Command curl.exe, curl -CommandType Application -ErrorAction SilentlyContinue |
+  Select-Object -First 1
+
+function Invoke-Download([string]$url, [string]$outFile) {
+  if ($CurlExe) {
+    # Same flags as install.sh, deliberately.
+    & $CurlExe.Source -fL --progress-bar -S --connect-timeout 30 --speed-limit 1024 --speed-time 30 -o $outFile $url
+    # PowerShell 7.4+ already throws on a non-zero native exit ($PSNativeCommandUseErrorActionPreference);
+    # 5.1 does not, so check explicitly and let the caller's catch turn it into a retry.
+    if ($LASTEXITCODE -ne 0) { throw "curl.exe exited with code $LASTEXITCODE" }
+    return
+  }
+  # No curl.exe (pre-1803 Windows). -TimeoutSec here is a last-resort HANG guard, not a stall detector,
+  # so it is deliberately generous: it bounds the entire transfer, and ~600 MB in 2h is ~0.7 Mbit/s.
+  # Anything tighter would abort working downloads on slow links.
+  Invoke-WebRequest -Uri $url -OutFile $outFile -UseBasicParsing -TimeoutSec 7200
+}
+
 # Home resolution: USERPROFILE -> HOME -> GetFolderPath (so pwsh-on-Linux tests can locate it too).
 $InstallRoot = $env:USERPROFILE
 if (-not $InstallRoot) { $InstallRoot = $env:HOME }
@@ -138,15 +171,14 @@ function Install-Artifact([string]$kind, [string]$url, [string]$sha, [string]$fm
   # fraction while it installs devrig for the user (InstallerProgress.parseInstallerLine).
   Write-Log ("downloading {0} (~{1} MB) from {2} ..." -f $kind, [long]($size / 1MB), $url)
   # Retry download+verify as a unit (transient network failure OR sha mismatch both re-download), with
-  # growing backoff; only the final failure is fatal. -TimeoutSec is a generous hard ceiling: PowerShell
-  # has no stall-only timeout (unlike curl's --speed-time), so a very slow link relies on this ceiling.
-  # install.sh is the primary macOS/Linux path.
+  # growing backoff; only the final failure is fatal. Invoke-Download carries the connect + stall
+  # timeouts (see above) so a dead connection fails - and thus retries - instead of hanging forever.
   $attempt = 1
   $backoff = 2
   while ($true) {
     $err = $null
     try {
-      Invoke-WebRequest -Uri $url -OutFile $tmpZip -UseBasicParsing -TimeoutSec 1800
+      Invoke-Download $url $tmpZip
       $actual = (Get-FileHash -Algorithm SHA256 -Path $tmpZip).Hash.ToLowerInvariant()
       if ($actual -eq $sha) { Write-Log "SHA-256 verified: $sha"; break }
       $err = "SHA-256 mismatch for ${kind}: expected $sha, got $actual"

--- a/installer-gen/src/main/resources/templates/install.ps1.tmpl
+++ b/installer-gen/src/main/resources/templates/install.ps1.tmpl
@@ -122,7 +122,7 @@ if ($availBytes -lt $needBytes) {
     $BinariesDir, [long]($needBytes / 1MB), [long]($availBytes / 1MB))
 }
 
-function Install-Artifact([string]$kind, [string]$url, [string]$sha, [string]$fmt) {
+function Install-Artifact([string]$kind, [string]$url, [string]$sha, [string]$fmt, [long]$size) {
   $sha12  = $sha.Substring(0, 12)
   $name   = "$kind-$key-$Version-$sha12"
   $target = Join-Path $BinariesDir $name
@@ -134,7 +134,9 @@ function Install-Artifact([string]$kind, [string]$url, [string]$sha, [string]$fm
   $tmpUnpack = Join-Path $BinariesDir ".tmp.$pid_.$kind.unpack"
   Remove-Item -Recurse -Force $tmpZip, $tmpUnpack -ErrorAction SilentlyContinue
 
-  Write-Log "downloading $kind ($url)..."
+  # Same wording as install.sh on purpose: the IDE plugin parses this line to show a real progress
+  # fraction while it installs devrig for the user (InstallerProgress.parseInstallerLine).
+  Write-Log ("downloading {0} (~{1} MB) from {2} ..." -f $kind, [long]($size / 1MB), $url)
   # Retry download+verify as a unit (transient network failure OR sha mismatch both re-download), with
   # growing backoff; only the final failure is fatal. -TimeoutSec is a generous hard ceiling: PowerShell
   # has no stall-only timeout (unlike curl's --speed-time), so a very slow link relies on this ceiling.
@@ -177,8 +179,8 @@ function Install-Artifact([string]$kind, [string]$url, [string]$sha, [string]$fm
   return $target
 }
 
-$devrigTarget = Install-Artifact 'devrig' $DevrigUrl $DevrigSha256 $DevrigFormat
-$jdkTarget    = Install-Artifact 'jdk'    $p.JdkUrl  $p.JdkSha256  $p.JdkFormat
+$devrigTarget = Install-Artifact 'devrig' $DevrigUrl $DevrigSha256 $DevrigFormat $DevrigSize
+$jdkTarget    = Install-Artifact 'jdk'    $p.JdkUrl  $p.JdkSha256  $p.JdkFormat  $p.JdkSize
 
 # -- locate the unpacked launcher + the bundled JAVA_HOME --
 # $DevrigBinSub is the generator-computed, asserted subpath (devrig-<version>-<hash>\bin\devrig.bat).

--- a/installer-gen/src/main/resources/templates/install.sh.tmpl
+++ b/installer-gen/src/main/resources/templates/install.sh.tmpl
@@ -18,6 +18,9 @@ VERSION='@@VERSION@@'
 DEVRIG_URL='@@DEVRIG_URL@@'
 DEVRIG_SHA256='@@DEVRIG_SHA256@@'
 DEVRIG_FORMAT='@@DEVRIG_FORMAT@@'
+# devrig-dist archive byte length -- used (with the per-platform JDK size) for the pre-download
+# disk-space check, so a full disk fails early and clearly instead of mid-stream.
+DEVRIG_SIZE='@@DEVRIG_SIZE@@'
 # The devrig launcher subpath INSIDE the unpacked dist (computed + asserted by the generator from the
 # real zip - `devrig-<version>-<hash>/bin/devrig`). The script runs this launcher and lets devrig itself
 # register `~/.mcp-steroid/bin` + PATH (`devrig install devrig`), so the script never writes the wrapper.
@@ -26,6 +29,10 @@ DEVRIG_BINSUB='@@DEVRIG_BINSUB@@'
 STEROID_HOME="$HOME/.mcp-steroid"
 BIN_DIR="$STEROID_HOME/bin"
 BINARIES_DIR="$STEROID_HOME/binaries"
+
+# Download resilience (#228): re-download a failed OR corrupted (sha-mismatch) artifact this many times,
+# with growing backoff, before giving up. A transient network blip no longer aborts the whole install.
+DL_ATTEMPTS=3
 
 log()  { printf '%s\n' "[mcp-steroid] $*" >&2; }
 fail() { log "ERROR: $*"; exit 1; }
@@ -43,9 +50,9 @@ promote_tree() {
   fi
 }
 
-# install_artifact <kind> <url> <sha256> <format>  -> prints the target dir on stdout
+# install_artifact <kind> <url> <sha256> <format> <size_bytes>  -> prints the target dir on stdout
 install_artifact() {
-  ia_kind="$1"; ia_url="$2"; ia_sha="$3"; ia_fmt="$4"
+  ia_kind="$1"; ia_url="$2"; ia_sha="$3"; ia_fmt="$4"; ia_size="${5:-0}"
   ia_sha12=$(printf '%s' "$ia_sha" | cut -c1-12)
   ia_target="$BINARIES_DIR/${ia_kind}-${key}-${VERSION}-${ia_sha12}"
   if [ -d "$ia_target" ]; then
@@ -56,11 +63,31 @@ install_artifact() {
   ia_tmp="$BINARIES_DIR/.tmp.$$.${ia_kind}.${ia_ext}"
   ia_unpack="$BINARIES_DIR/.tmp.$$.${ia_kind}.unpack"
   rm -rf "$ia_tmp" "$ia_unpack"
-  log "downloading ${ia_kind} ($ia_url)..."
-  fetch "$ia_url" "$ia_tmp" || fail "download failed: $ia_url"
-  actual=$($sha_tool "$ia_tmp" | awk '{print $1}')
-  [ "$actual" = "$ia_sha" ] || fail "SHA-256 mismatch for ${ia_kind}: expected $ia_sha, got $actual"
-  log "SHA-256 verified: $ia_sha"
+  log "downloading ${ia_kind} (~$((ia_size / 1024 / 1024)) MB) from $ia_url ..."
+  # Retry the download+verify as a unit: a transient network failure OR a corrupted (sha-mismatch)
+  # transfer both re-download, up to $DL_ATTEMPTS times with growing backoff. Only the final failure is
+  # fatal. `fetch` carries connect + stall timeouts (below) so a dead connection fails -- and thus
+  # retries -- instead of hanging forever.
+  ia_attempt=1
+  ia_backoff=2
+  while : ; do
+    if fetch "$ia_url" "$ia_tmp"; then
+      actual=$($sha_tool "$ia_tmp" | awk '{print $1}')
+      if [ "$actual" = "$ia_sha" ]; then
+        log "SHA-256 verified: $ia_sha"
+        break
+      fi
+      ia_err="SHA-256 mismatch for ${ia_kind}: expected $ia_sha, got $actual"
+    else
+      ia_err="download failed: $ia_url"
+    fi
+    rm -f "$ia_tmp"
+    [ "$ia_attempt" -ge "$DL_ATTEMPTS" ] && fail "$ia_err (after $DL_ATTEMPTS attempts)"
+    log "attempt $ia_attempt/$DL_ATTEMPTS failed ($ia_err); retrying in ${ia_backoff}s..."
+    sleep "$ia_backoff"
+    ia_attempt=$((ia_attempt + 1))
+    ia_backoff=$((ia_backoff * 3))
+  done
   mkdir -p "$ia_unpack"
   case "$ia_fmt" in
     zip)    unzip -q "$ia_tmp" -d "$ia_unpack" ;;   # unzip presence guaranteed by the preflight below
@@ -107,7 +134,7 @@ main() {
   fi
 
   # -- BAKED-IN per-platform JDK table (devrig coordinates are universal, set above) --
-  jdk_url=''; jdk_sha256=''; jdk_format=''; jdk_javahome=''
+  jdk_url=''; jdk_sha256=''; jdk_format=''; jdk_javahome=''; jdk_size=''
   case "$key" in
 @@PLATFORM_CASE_SH@@
     macos-x64) fail "Intel macOS (x86_64) is not supported - MCP Steroid ships an Apple-silicon (arm64) JDK only. Use an arm64 Mac." ;;
@@ -143,20 +170,38 @@ main() {
   fi
 
   # Bind the concrete download + checksum tools now that the preflight proved one of each exists.
+  # Both carry timeouts so the retry loop above can actually fire: --connect-timeout caps a dead-host
+  # connect, and --speed-limit/--speed-time (curl) / --timeout (wget read timeout) abort a STALLED
+  # transfer without capping a legitimately slow -- but progressing -- ~600 MB download.
   if command -v curl >/dev/null 2>&1; then
-    fetch() { curl -fsSL "$1" -o "$2"; }
+    fetch() { curl -fL --progress-bar -S --connect-timeout 30 --speed-limit 1024 --speed-time 30 "$1" -o "$2"; }
   else
-    fetch() { wget -q "$1" -O "$2"; }
+    fetch() { wget -q --timeout=30 --tries=1 "$1" -O "$2"; }
   fi
   if command -v sha256sum >/dev/null 2>&1; then sha_tool="sha256sum"; else sha_tool="shasum -a 256"; fi
 
   mkdir -p "$BIN_DIR" "$BINARIES_DIR"
+  # Clean up THIS run's staging on any exit (success or failure/interrupt) so a broken download never
+  # leaks hundreds of MB. Complements the next-run stale-.tmp sweep below. $$ is the (stable) parent
+  # shell PID -- the same value install_artifact uses to name its .tmp.$$.* staging, so the glob matches.
+  trap 'rm -rf "$BINARIES_DIR"/.tmp.$$.* 2>/dev/null || true' EXIT
   # Sweep orphaned staging from runs killed before cleanup (different $$ each run).
   find "$BINARIES_DIR" -maxdepth 1 -name '.tmp.*' -mtime +0 -exec rm -rf {} + 2>/dev/null \
     || log "WARNING: could not sweep stale .tmp.* entries"
 
-  devrig_target=$(install_artifact devrig "$DEVRIG_URL" "$DEVRIG_SHA256" "$DEVRIG_FORMAT")
-  jdk_target=$(install_artifact jdk "$jdk_url" "$jdk_sha256" "$jdk_format")
+  # -- preflight: disk space (#228) --
+  # Fail early + clearly if the volume backing ~/.mcp-steroid cannot hold the download + unpack, rather
+  # than dying mid-stream. Estimate the need as (devrig + jdk) archive bytes x3 (archive + unpacked tree
+  # + slack). `df -Pk` reports POSIX 1024-byte-block availability; compare in KiB to avoid byte overflow.
+  # If df output is unparseable we do NOT block the install (only fail when we positively know it won't fit).
+  need_kib=$(( (DEVRIG_SIZE + jdk_size) * 3 / 1024 ))
+  avail_kib=$(df -Pk "$BINARIES_DIR" 2>/dev/null | awk 'NR==2 {print $4}')
+  if [ -n "$avail_kib" ] && [ "$avail_kib" -lt "$need_kib" ]; then
+    fail "insufficient disk space in $BINARIES_DIR: need ~$((need_kib / 1024)) MB (download + unpack), have ~$((avail_kib / 1024)) MB free -- free up space and re-run"
+  fi
+
+  devrig_target=$(install_artifact devrig "$DEVRIG_URL" "$DEVRIG_SHA256" "$DEVRIG_FORMAT" "$DEVRIG_SIZE")
+  jdk_target=$(install_artifact jdk "$jdk_url" "$jdk_sha256" "$jdk_format" "$jdk_size")
 
   # -- locate the unpacked launcher + the bundled JAVA_HOME --
   # DEVRIG_BINSUB is the generator-computed, asserted subpath (devrig-<version>-<hash>/bin/devrig).

--- a/installer-gen/src/main/resources/templates/install.sh.tmpl
+++ b/installer-gen/src/main/resources/templates/install.sh.tmpl
@@ -18,9 +18,11 @@ VERSION='@@VERSION@@'
 DEVRIG_URL='@@DEVRIG_URL@@'
 DEVRIG_SHA256='@@DEVRIG_SHA256@@'
 DEVRIG_FORMAT='@@DEVRIG_FORMAT@@'
-# devrig-dist archive byte length -- used (with the per-platform JDK size) for the pre-download
+# devrig-dist archive byte length, and the byte length of the tree it unpacks to (both computed by the
+# generator from the real archive) -- used with the per-platform JDK numbers for the pre-download
 # disk-space check, so a full disk fails early and clearly instead of mid-stream.
 DEVRIG_SIZE='@@DEVRIG_SIZE@@'
+DEVRIG_UNPACKED_SIZE='@@DEVRIG_UNPACKED_SIZE@@'
 # The devrig launcher subpath INSIDE the unpacked dist (computed + asserted by the generator from the
 # real zip - `devrig-<version>-<hash>/bin/devrig`). The script runs this launcher and lets devrig itself
 # register `~/.mcp-steroid/bin` + PATH (`devrig install devrig`), so the script never writes the wrapper.
@@ -52,7 +54,10 @@ promote_tree() {
 
 # install_artifact <kind> <url> <sha256> <format> <size_bytes>  -> prints the target dir on stdout
 install_artifact() {
-  ia_kind="$1"; ia_url="$2"; ia_sha="$3"; ia_fmt="$4"; ia_size="${5:-0}"
+  # No defaults: every argument is supplied by the two call sites in main(), and the generator asserts
+  # every baked value is present and positive. Under `set -u` a missing argument fails loudly here,
+  # rather than silently logging "~0 MB".
+  ia_kind="$1"; ia_url="$2"; ia_sha="$3"; ia_fmt="$4"; ia_size="$5"
   ia_sha12=$(printf '%s' "$ia_sha" | cut -c1-12)
   ia_target="$BINARIES_DIR/${ia_kind}-${key}-${VERSION}-${ia_sha12}"
   if [ -d "$ia_target" ]; then
@@ -134,7 +139,7 @@ main() {
   fi
 
   # -- BAKED-IN per-platform JDK table (devrig coordinates are universal, set above) --
-  jdk_url=''; jdk_sha256=''; jdk_format=''; jdk_javahome=''; jdk_size=''
+  jdk_url=''; jdk_sha256=''; jdk_format=''; jdk_javahome=''; jdk_size=''; jdk_unpacked_size=''
   case "$key" in
 @@PLATFORM_CASE_SH@@
     macos-x64) fail "Intel macOS (x86_64) is not supported - MCP Steroid ships an Apple-silicon (arm64) JDK only. Use an arm64 Mac." ;;
@@ -191,10 +196,10 @@ main() {
 
   # -- preflight: disk space (#228) --
   # Fail early + clearly if the volume backing ~/.mcp-steroid cannot hold the download + unpack, rather
-  # than dying mid-stream. Estimate the need as (devrig + jdk) archive bytes x3 (archive + unpacked tree
-  # + slack). `df -Pk` reports POSIX 1024-byte-block availability; compare in KiB to avoid byte overflow.
-  # If df output is unparseable we do NOT block the install (only fail when we positively know it won't fit).
-  need_kib=$(( (DEVRIG_SIZE + jdk_size) * 3 / 1024 ))
+  # than dying mid-stream. The four numbers are EXACT (the generator sums the real archive entries), so
+  # the requirement is archive + unpacked tree for each artifact, plus 10% for filesystem extras.
+  # The devrig archive is deleted before the JDK download starts, so both archives never coexist.
+  need_kib=$(( ((DEVRIG_SIZE + DEVRIG_UNPACKED_SIZE + jdk_size + jdk_unpacked_size) / 1024) * 11 / 10 ))
   avail_kib=$(df -Pk "$BINARIES_DIR" 2>/dev/null | awk 'NR==2 {print $4}')
   if [ -n "$avail_kib" ] && [ "$avail_kib" -lt "$need_kib" ]; then
     fail "insufficient disk space in $BINARIES_DIR: need ~$((need_kib / 1024)) MB (download + unpack), have ~$((avail_kib / 1024)) MB free -- free up space and re-run"

--- a/installer-gen/src/test/kotlin/com/jonnyzzz/mcpSteroid/installer/InstallerGeneratorTest.kt
+++ b/installer-gen/src/test/kotlin/com/jonnyzzz/mcpSteroid/installer/InstallerGeneratorTest.kt
@@ -282,6 +282,33 @@ class InstallerGeneratorTest {
         assertTrue(scripts.ps.contains("function Remove-Staging"), "install.ps1 missing staging cleanup")
     }
 
+    @Test
+    fun `both scripts announce the artifact size in the downloading line (parsed by the IDE plugin)`() {
+        // The IDE plugin installs devrig for the user and shows a real progress fraction by parsing this
+        // line (ij-plugin InstallerProgress.parseInstallerLine): the "(~N MB)" is the denominator. Both
+        // scripts must therefore log the size in the SAME shape — install.ps1 used to omit it, which left
+        // Windows users with an indeterminate bar for a ~611 MB download.
+        val scripts = renderInstallerScripts(jdkScriptTable(fullModel()), devrig, "1.2.3")
+
+        assertTrue(
+            scripts.sh.contains("""log "downloading ${'$'}{ia_kind} (~${'$'}((ia_size / 1024 / 1024)) MB) from ${'$'}ia_url ...""""),
+            "install.sh must log the artifact size in the downloading line",
+        )
+        assertTrue(
+            scripts.ps.contains("""Write-Log ("downloading {0} (~{1} MB) from {2} ..." -f ${'$'}kind, [long](${'$'}size / 1MB), ${'$'}url)"""),
+            "install.ps1 must log the artifact size in the downloading line",
+        )
+        // The size has to reach the function that logs it, for both artifacts.
+        assertTrue(
+            scripts.ps.contains("Install-Artifact 'devrig' \$DevrigUrl \$DevrigSha256 \$DevrigFormat \$DevrigSize"),
+            "install.ps1 must pass DevrigSize to Install-Artifact",
+        )
+        assertTrue(
+            scripts.ps.contains("\$p.JdkSize"),
+            "install.ps1 must pass the per-platform JdkSize to Install-Artifact",
+        )
+    }
+
     // ── devrig resolution: local override path (no network) ──────────────────────────────────────
 
     @Test

--- a/installer-gen/src/test/kotlin/com/jonnyzzz/mcpSteroid/installer/InstallerGeneratorTest.kt
+++ b/installer-gen/src/test/kotlin/com/jonnyzzz/mcpSteroid/installer/InstallerGeneratorTest.kt
@@ -55,10 +55,18 @@ class InstallerGeneratorTest {
 
     @Test
     fun `validateScriptTable rejects a non-hex sha256 and an absolute javaHome`() {
-        val badSha = mapOf(*ALL_PLATFORMS.map { it to JdkScriptEntry("https://x", "ZZZ", "zip", "h") }.toTypedArray())
+        val badSha = mapOf(*ALL_PLATFORMS.map { it to JdkScriptEntry("https://x", "ZZZ", "zip", "h", 1L) }.toTypedArray())
         assertFailsWith<IllegalArgumentException> { validateScriptTable(badSha) }
-        val absHome = mapOf(*ALL_PLATFORMS.map { it to JdkScriptEntry("https://x", "a".repeat(64), "zip", "/abs") }.toTypedArray())
+        val absHome = mapOf(*ALL_PLATFORMS.map { it to JdkScriptEntry("https://x", "a".repeat(64), "zip", "/abs", 1L) }.toTypedArray())
         assertFailsWith<IllegalArgumentException> { validateScriptTable(absHome) }
+    }
+
+    @Test
+    fun `validateScriptTable rejects a non-positive size`() {
+        // size feeds the pre-download disk-space check (#228); a 0/negative size would make it meaningless.
+        val zeroSize = mapOf(*ALL_PLATFORMS.map { it to JdkScriptEntry("https://x", "a".repeat(64), "zip", "h", 0L) }.toTypedArray())
+        val ex = assertFailsWith<IllegalArgumentException> { validateScriptTable(zeroSize) }
+        assertTrue(ex.message!!.contains("size must be a positive byte count"), ex.message!!)
     }
 
     // ── render pipeline: scripts bake the table + carry the musl guard, no leftover placeholders ─
@@ -67,6 +75,7 @@ class InstallerGeneratorTest {
     private val devrig = DevrigEntry(
         url = "https://example.com/devrig-1.0.zip", sha256 = "b".repeat(64),
         launcherPosix = "devrig-1.0-abc1234/bin/devrig", launcherWindows = "devrig-1.0-abc1234/bin/devrig.bat",
+        size = 233_000_000L,
     )
 
     @Test
@@ -237,6 +246,42 @@ class InstallerGeneratorTest {
         assertTrue(failure.message!!.contains("must be ASCII-only"), failure.message!!)
     }
 
+    @Test
+    fun `rendered scripts carry the error-resilience machinery (disk precheck, retry+backoff, timeouts)`() {
+        // Issue #228: the generated installers must precheck disk space, retry transient failures with
+        // backoff, and bound the network with timeouts. Assert the machinery is baked into both scripts.
+        val table = jdkScriptTable(fullModel()) // art() has size=1 → every arm bakes jdk_size='1'
+        val scripts = renderInstallerScripts(table, devrig, "1.2.3")
+
+        // -- install.sh --
+        // sizes threaded through for the disk check
+        assertTrue(scripts.sh.contains("DEVRIG_SIZE='233000000'"), "install.sh missing baked DEVRIG_SIZE")
+        assertTrue(scripts.sh.contains("jdk_size='1'"), "install.sh missing per-platform jdk_size")
+        // disk precheck: computes need vs df availability and fails with a clear message
+        assertTrue(scripts.sh.contains("df -Pk"), "install.sh missing df-based disk check")
+        assertTrue(scripts.sh.contains("insufficient disk space"), "install.sh missing clear disk-space error")
+        // retry loop + growing backoff + final give-up
+        assertTrue(scripts.sh.contains("DL_ATTEMPTS=3"), "install.sh missing retry-attempts config")
+        assertTrue(scripts.sh.contains("attempt \$ia_attempt/\$DL_ATTEMPTS failed"), "install.sh missing retry log")
+        assertTrue(scripts.sh.contains("after \$DL_ATTEMPTS attempts"), "install.sh missing final give-up message")
+        // network timeouts / stall detection (so the retry loop can fire instead of hanging)
+        assertTrue(scripts.sh.contains("--connect-timeout 30"), "install.sh curl missing connect timeout")
+        assertTrue(scripts.sh.contains("--speed-limit 1024 --speed-time 30"), "install.sh curl missing stall detection")
+        assertTrue(scripts.sh.contains("wget -q --timeout=30 --tries=1"), "install.sh wget missing timeout")
+        // cleanup-on-exit trap for this run's staging
+        assertTrue(scripts.sh.contains("trap 'rm -rf \"\$BINARIES_DIR\"/.tmp.\$\$.*"), "install.sh missing cleanup trap")
+
+        // -- install.ps1 (ASCII-only) --
+        assertTrue(scripts.ps.contains("\$DevrigSize   = 233000000"), "install.ps1 missing baked DevrigSize")
+        assertTrue(scripts.ps.contains("JdkSize = 1"), "install.ps1 missing per-platform JdkSize")
+        assertTrue(scripts.ps.contains("AvailableFreeSpace"), "install.ps1 missing DriveInfo disk check")
+        assertTrue(scripts.ps.contains("insufficient disk space"), "install.ps1 missing clear disk-space error")
+        assertTrue(scripts.ps.contains("\$DlAttempts   = 3"), "install.ps1 missing retry-attempts config")
+        assertTrue(scripts.ps.contains("-TimeoutSec 1800"), "install.ps1 missing request timeout")
+        assertTrue(scripts.ps.contains("after \$DlAttempts attempts"), "install.ps1 missing final give-up message")
+        assertTrue(scripts.ps.contains("function Remove-Staging"), "install.ps1 missing staging cleanup")
+    }
+
     // ── devrig resolution: local override path (no network) ──────────────────────────────────────
 
     @Test
@@ -256,6 +301,7 @@ class InstallerGeneratorTest {
         val devrig = resolveDevrig(flags, noNetwork, version = "1.0")
         assertEquals("https://example.com/devrig-1.0.zip", devrig.url)
         assertEquals(sha256Hex(Files.readAllBytes(zip)), devrig.sha256)
+        assertEquals(Files.readAllBytes(zip).size.toLong(), devrig.size) // size computed from the bytes (#228)
         // Computed + asserted from the real zip (NOT assumed devrig-<version>).
         assertEquals("devrig-1.0-abc1234/bin/devrig", devrig.launcherPosix)
         assertEquals("devrig-1.0-abc1234/bin/devrig.bat", devrig.launcherWindows)
@@ -328,8 +374,19 @@ class InstallerGeneratorTest {
         assertFailsWith<IllegalArgumentException> {
             validateDevrig(DevrigEntry(
                 url = "https://example.com/PLACEHOLDER.zip", sha256 = "b".repeat(64),
-                launcherPosix = "d/bin/devrig", launcherWindows = "d/bin/devrig.bat",
+                launcherPosix = "d/bin/devrig", launcherWindows = "d/bin/devrig.bat", size = 1L,
             ))
         }
+    }
+
+    @Test
+    fun `validateDevrig rejects a non-positive size`() {
+        val ex = assertFailsWith<IllegalArgumentException> {
+            validateDevrig(DevrigEntry(
+                url = "https://example.com/devrig-1.0.zip", sha256 = "b".repeat(64),
+                launcherPosix = "d/bin/devrig", launcherWindows = "d/bin/devrig.bat", size = 0L,
+            ))
+        }
+        assertTrue(ex.message!!.contains("size must be a positive byte count"), ex.message!!)
     }
 }

--- a/installer-gen/src/test/kotlin/com/jonnyzzz/mcpSteroid/installer/InstallerGeneratorTest.kt
+++ b/installer-gen/src/test/kotlin/com/jonnyzzz/mcpSteroid/installer/InstallerGeneratorTest.kt
@@ -298,7 +298,25 @@ class InstallerGeneratorTest {
         assertTrue(scripts.ps.contains("AvailableFreeSpace"), "install.ps1 missing DriveInfo disk check")
         assertTrue(scripts.ps.contains("insufficient disk space"), "install.ps1 missing clear disk-space error")
         assertTrue(scripts.ps.contains("\$DlAttempts   = 3"), "install.ps1 missing retry-attempts config")
-        assertTrue(scripts.ps.contains("-TimeoutSec 1800"), "install.ps1 missing request timeout")
+        // Windows downloads go through curl.exe, which has the SAME stall detection as install.sh's curl.
+        // Invoke-WebRequest has no stall-only timeout, so it is only the fallback for hosts without
+        // curl.exe (pre-1803 Windows) and its -TimeoutSec is a generous hang guard, not a stall detector.
+        assertTrue(
+            scripts.ps.contains("--connect-timeout 30 --speed-limit 1024 --speed-time 30"),
+            "install.ps1 curl.exe missing connect timeout + stall detection",
+        )
+        assertTrue(
+            scripts.ps.contains("Get-Command curl.exe, curl -CommandType Application"),
+            "install.ps1 must resolve curl.exe as an Application (5.1 aliases `curl` to Invoke-WebRequest)",
+        )
+        assertTrue(
+            scripts.ps.contains("Invoke-WebRequest -Uri \$url -OutFile \$outFile -UseBasicParsing -TimeoutSec 7200"),
+            "install.ps1 missing the no-curl.exe fallback",
+        )
+        assertTrue(
+            scripts.ps.contains("if (\$LASTEXITCODE -ne 0) { throw"),
+            "install.ps1 must turn a non-zero curl.exe exit into a retry (5.1 does not throw on its own)",
+        )
         assertTrue(scripts.ps.contains("after \$DlAttempts attempts"), "install.ps1 missing final give-up message")
         assertTrue(scripts.ps.contains("function Remove-Staging"), "install.ps1 missing staging cleanup")
     }

--- a/installer-gen/src/test/kotlin/com/jonnyzzz/mcpSteroid/installer/InstallerGeneratorTest.kt
+++ b/installer-gen/src/test/kotlin/com/jonnyzzz/mcpSteroid/installer/InstallerGeneratorTest.kt
@@ -28,7 +28,7 @@ class InstallerGeneratorTest {
     private fun art(platform: JdkPlatform, archive: ArchiveType, javaHome: String) = JdkArtifact(
         platform = platform, vendor = "v", version = "25.0.3.9.1", featureVersion = 25, archive = archive,
         url = "https://example.com/jdk.${archive.extension}", fileName = "jdk.${archive.extension}",
-        size = 1, sha256 = "a".repeat(64), javaHome = javaHome,
+        size = 1, unpackedSize = 2, sha256 = "a".repeat(64), javaHome = javaHome,
     )
 
     private fun fullModel() = JdkModel(
@@ -55,18 +55,26 @@ class InstallerGeneratorTest {
 
     @Test
     fun `validateScriptTable rejects a non-hex sha256 and an absolute javaHome`() {
-        val badSha = mapOf(*ALL_PLATFORMS.map { it to JdkScriptEntry("https://x", "ZZZ", "zip", "h", 1L) }.toTypedArray())
+        val badSha = mapOf(*ALL_PLATFORMS.map { it to JdkScriptEntry("https://x", "ZZZ", "zip", "h", 1L, 2L) }.toTypedArray())
         assertFailsWith<IllegalArgumentException> { validateScriptTable(badSha) }
-        val absHome = mapOf(*ALL_PLATFORMS.map { it to JdkScriptEntry("https://x", "a".repeat(64), "zip", "/abs", 1L) }.toTypedArray())
+        val absHome = mapOf(*ALL_PLATFORMS.map { it to JdkScriptEntry("https://x", "a".repeat(64), "zip", "/abs", 1L, 2L) }.toTypedArray())
         assertFailsWith<IllegalArgumentException> { validateScriptTable(absHome) }
     }
 
     @Test
     fun `validateScriptTable rejects a non-positive size`() {
         // size feeds the pre-download disk-space check (#228); a 0/negative size would make it meaningless.
-        val zeroSize = mapOf(*ALL_PLATFORMS.map { it to JdkScriptEntry("https://x", "a".repeat(64), "zip", "h", 0L) }.toTypedArray())
+        val zeroSize = mapOf(*ALL_PLATFORMS.map { it to JdkScriptEntry("https://x", "a".repeat(64), "zip", "h", 0L, 2L) }.toTypedArray())
         val ex = assertFailsWith<IllegalArgumentException> { validateScriptTable(zeroSize) }
         assertTrue(ex.message!!.contains("size must be a positive byte count"), ex.message!!)
+    }
+
+    @Test
+    fun `validateScriptTable rejects a non-positive unpackedSize`() {
+        // unpackedSize is the other half of the disk-space check — an exact number, not a guess.
+        val zero = mapOf(*ALL_PLATFORMS.map { it to JdkScriptEntry("https://x", "a".repeat(64), "zip", "h", 1L, 0L) }.toTypedArray())
+        val ex = assertFailsWith<IllegalArgumentException> { validateScriptTable(zero) }
+        assertTrue(ex.message!!.contains("unpackedSize must be a positive byte count"), ex.message!!)
     }
 
     // ── render pipeline: scripts bake the table + carry the musl guard, no leftover placeholders ─
@@ -75,7 +83,7 @@ class InstallerGeneratorTest {
     private val devrig = DevrigEntry(
         url = "https://example.com/devrig-1.0.zip", sha256 = "b".repeat(64),
         launcherPosix = "devrig-1.0-abc1234/bin/devrig", launcherWindows = "devrig-1.0-abc1234/bin/devrig.bat",
-        size = 233_000_000L,
+        size = 233_000_000L, unpackedSize = 470_000_000L,
     )
 
     @Test
@@ -256,8 +264,15 @@ class InstallerGeneratorTest {
         // -- install.sh --
         // sizes threaded through for the disk check
         assertTrue(scripts.sh.contains("DEVRIG_SIZE='233000000'"), "install.sh missing baked DEVRIG_SIZE")
+        assertTrue(scripts.sh.contains("DEVRIG_UNPACKED_SIZE='470000000'"), "install.sh missing baked DEVRIG_UNPACKED_SIZE")
         assertTrue(scripts.sh.contains("jdk_size='1'"), "install.sh missing per-platform jdk_size")
-        // disk precheck: computes need vs df availability and fails with a clear message
+        assertTrue(scripts.sh.contains("jdk_unpacked_size='2'"), "install.sh missing per-platform jdk_unpacked_size")
+        // disk precheck: computes need vs df availability and fails with a clear message. The requirement
+        // is the EXACT archive + unpacked bytes (generator-computed) + 10% slack, never a guessed multiple.
+        assertTrue(
+            scripts.sh.contains("need_kib=\$(( ((DEVRIG_SIZE + DEVRIG_UNPACKED_SIZE + jdk_size + jdk_unpacked_size) / 1024) * 11 / 10 ))"),
+            "install.sh disk check must use the exact archive+unpacked sizes",
+        )
         assertTrue(scripts.sh.contains("df -Pk"), "install.sh missing df-based disk check")
         assertTrue(scripts.sh.contains("insufficient disk space"), "install.sh missing clear disk-space error")
         // retry loop + growing backoff + final give-up
@@ -273,7 +288,13 @@ class InstallerGeneratorTest {
 
         // -- install.ps1 (ASCII-only) --
         assertTrue(scripts.ps.contains("\$DevrigSize   = 233000000"), "install.ps1 missing baked DevrigSize")
+        assertTrue(scripts.ps.contains("\$DevrigUnpackedSize = 470000000"), "install.ps1 missing baked DevrigUnpackedSize")
         assertTrue(scripts.ps.contains("JdkSize = 1"), "install.ps1 missing per-platform JdkSize")
+        assertTrue(scripts.ps.contains("JdkUnpackedSize = 2"), "install.ps1 missing per-platform JdkUnpackedSize")
+        assertTrue(
+            scripts.ps.contains("[long]\$DevrigSize + [long]\$DevrigUnpackedSize + [long]\$p.JdkSize + [long]\$p.JdkUnpackedSize"),
+            "install.ps1 disk check must use the exact archive+unpacked sizes",
+        )
         assertTrue(scripts.ps.contains("AvailableFreeSpace"), "install.ps1 missing DriveInfo disk check")
         assertTrue(scripts.ps.contains("insufficient disk space"), "install.ps1 missing clear disk-space error")
         assertTrue(scripts.ps.contains("\$DlAttempts   = 3"), "install.ps1 missing retry-attempts config")
@@ -329,6 +350,10 @@ class InstallerGeneratorTest {
         assertEquals("https://example.com/devrig-1.0.zip", devrig.url)
         assertEquals(sha256Hex(Files.readAllBytes(zip)), devrig.sha256)
         assertEquals(Files.readAllBytes(zip).size.toLong(), devrig.size) // size computed from the bytes (#228)
+        // Unpacked size is summed from the real entries ("#!/bin/sh" + "@echo off" = 9 + 9). Note the zip
+        // is written by java.util.zip.ZipOutputStream, which records sizes in a trailing data descriptor —
+        // reading the central directory (not streaming) is what makes this number correct rather than -1.
+        assertEquals(18L, devrig.unpackedSize)
         // Computed + asserted from the real zip (NOT assumed devrig-<version>).
         assertEquals("devrig-1.0-abc1234/bin/devrig", devrig.launcherPosix)
         assertEquals("devrig-1.0-abc1234/bin/devrig.bat", devrig.launcherWindows)
@@ -401,7 +426,7 @@ class InstallerGeneratorTest {
         assertFailsWith<IllegalArgumentException> {
             validateDevrig(DevrigEntry(
                 url = "https://example.com/PLACEHOLDER.zip", sha256 = "b".repeat(64),
-                launcherPosix = "d/bin/devrig", launcherWindows = "d/bin/devrig.bat", size = 1L,
+                launcherPosix = "d/bin/devrig", launcherWindows = "d/bin/devrig.bat", size = 1L, unpackedSize = 2L,
             ))
         }
     }
@@ -411,9 +436,20 @@ class InstallerGeneratorTest {
         val ex = assertFailsWith<IllegalArgumentException> {
             validateDevrig(DevrigEntry(
                 url = "https://example.com/devrig-1.0.zip", sha256 = "b".repeat(64),
-                launcherPosix = "d/bin/devrig", launcherWindows = "d/bin/devrig.bat", size = 0L,
+                launcherPosix = "d/bin/devrig", launcherWindows = "d/bin/devrig.bat", size = 0L, unpackedSize = 2L,
             ))
         }
         assertTrue(ex.message!!.contains("size must be a positive byte count"), ex.message!!)
+    }
+
+    @Test
+    fun `validateDevrig rejects a non-positive unpackedSize`() {
+        val ex = assertFailsWith<IllegalArgumentException> {
+            validateDevrig(DevrigEntry(
+                url = "https://example.com/devrig-1.0.zip", sha256 = "b".repeat(64),
+                launcherPosix = "d/bin/devrig", launcherWindows = "d/bin/devrig.bat", size = 1L, unpackedSize = 0L,
+            ))
+        }
+        assertTrue(ex.message!!.contains("unpackedSize must be a positive byte count"), ex.message!!)
     }
 }

--- a/installer-gen/src/test/kotlin/com/jonnyzzz/mcpSteroid/installer/JdkArtifactsTest.kt
+++ b/installer-gen/src/test/kotlin/com/jonnyzzz/mcpSteroid/installer/JdkArtifactsTest.kt
@@ -1,7 +1,15 @@
 /* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
 package com.jonnyzzz.mcpSteroid.installer
 
+import org.apache.commons.compress.archivers.ArchiveInputStream
+import org.apache.commons.compress.archivers.tar.TarArchiveInputStream
+import org.apache.commons.compress.archivers.zip.ZipArchiveInputStream
+import org.apache.commons.compress.compressors.gzip.GzipCompressorInputStream
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.ByteArrayInputStream
+import java.nio.file.Files
+import java.nio.file.Path
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
@@ -42,6 +50,49 @@ class JdkArtifactsTest {
             )
         )
         assertEquals("jdk-25", findJavaHome(bytes, ArchiveType.TAR_GZ))
+    }
+
+    // ── archiveUnpackedSize: the disk-space number the installers bake in (#228) ─────────────────
+
+    /**
+     * The computed number must equal what REALLY lands on disk. Both archives are extracted for real and
+     * the resulting files measured — so this checks against extraction, not against the same entry
+     * metadata the computation reads.
+     */
+    @Test
+    fun `archiveUnpackedSize equals the byte total of a real extraction`(@TempDir dir: Path) {
+        val files = linkedMapOf(
+            "jdk-25/bin/java" to ByteArray(4_096) { 1 },
+            "jdk-25/lib/modules" to ByteArray(1_048_576) { 2 },
+            "jdk-25/release" to "JAVA_VERSION=25".encodeToByteArray(),
+        )
+        val expected = files.values.sumOf { it.size.toLong() }
+
+        for ((archive, bytes) in listOf(ArchiveType.TAR_GZ to tarGz(files), ArchiveType.ZIP to zip(files))) {
+            val computed = archiveUnpackedSize(bytes, archive)
+            val onDisk = extractAndMeasure(bytes, archive, dir.resolve(archive.name))
+            println("[$archive] computed=$computed extracted=$onDisk expected=$expected (archive itself=${bytes.size})")
+            assertEquals(expected, computed, "$archive: computed unpacked size")
+            assertEquals(expected, onDisk, "$archive: bytes actually written by an extraction")
+        }
+    }
+
+    /** Extract [bytes] into [into] for real and return the total byte length of the files written. */
+    private fun extractAndMeasure(bytes: ByteArray, archive: ArchiveType, into: Path): Long {
+        val input: ArchiveInputStream<*> = when (archive) {
+            ArchiveType.TAR_GZ -> TarArchiveInputStream(GzipCompressorInputStream(ByteArrayInputStream(bytes)))
+            ArchiveType.ZIP -> ZipArchiveInputStream(ByteArrayInputStream(bytes))
+        }
+        input.use { ais ->
+            generateSequence { ais.nextEntry }.filterNot { it.isDirectory }.forEach { entry ->
+                val target = into.resolve(entry.name)
+                Files.createDirectories(target.parent)
+                Files.newOutputStream(target).use { ais.copyTo(it) }
+            }
+        }
+        return Files.walk(into).use { paths ->
+            paths.filter { Files.isRegularFile(it) }.mapToLong { Files.size(it) }.sum()
+        }
     }
 
     // ── resolveAllJdks: full model assembly, hermetic (synthetic archives + fake HTTP) ───────────

--- a/test-integration-agent-launch/src/test/kotlin/com/jonnyzzz/mcpSteroid/agentlaunch/InstallerPs1ExecutionTest.kt
+++ b/test-integration-agent-launch/src/test/kotlin/com/jonnyzzz/mcpSteroid/agentlaunch/InstallerPs1ExecutionTest.kt
@@ -103,8 +103,8 @@ class InstallerPs1ExecutionTest {
             // Render install.ps1 through the SHIPPING code path (writeInstallerScripts). All 5
             // platforms must be present in the table (installer-gen contract), but install.ps1
             // reads only its own Windows platform hashtable at runtime.
-            val jdkEntryWin = JdkScriptEntry("$baseUrl/jdk.zip", jdkSha, "zip", "jdk")
-            val jdkEntryPosix = JdkScriptEntry("$baseUrl/jdk.zip", jdkSha, "tar.gz", "jdk")
+            val jdkEntryWin = JdkScriptEntry("$baseUrl/jdk.zip", jdkSha, "zip", "jdk", Files.size(jdkZip))
+            val jdkEntryPosix = JdkScriptEntry("$baseUrl/jdk.zip", jdkSha, "tar.gz", "jdk", Files.size(jdkZip))
             val table = ALL_PLATFORMS.associateWith { key ->
                 if (key.startsWith("windows-")) jdkEntryWin else jdkEntryPosix
             }
@@ -112,6 +112,7 @@ class InstallerPs1ExecutionTest {
                 url = "$baseUrl/devrig.zip", sha256 = devrigSha,
                 launcherPosix = "devrig-$VERSION/bin/devrig",
                 launcherWindows = "devrig-$VERSION/bin/devrig.bat",
+                size = Files.size(devrigZip),
             )
             writeInstallerScripts(genDir, table, devrig, VERSION)
             val ps1 = genDir.resolve("install.ps1")

--- a/test-integration-agent-launch/src/test/kotlin/com/jonnyzzz/mcpSteroid/agentlaunch/InstallerScriptTest.kt
+++ b/test-integration-agent-launch/src/test/kotlin/com/jonnyzzz/mcpSteroid/agentlaunch/InstallerScriptTest.kt
@@ -24,25 +24,34 @@ class InstallerScriptTest {
     private val isWindows = System.getProperty("os.name").lowercase().contains("win")
     private val sha = "a".repeat(64)
 
+    /** Stand-in for a real artifact byte length; the script is parsed, never executed. */
+    private val FAKE_SIZE = 123_456_789L
+
     private fun renderPs1(): String {
         val tmpl = Path.of(System.getProperty("installer.ps1.template")).readText()
-        val table = "\$Platforms = @{ 'win32-x64' = @{ url = 'https://example.invalid/j.zip'; sha256 = '$sha'; binsub = 'jdk\\bin' } }"
+        // JdkSize mirrors what renderPsTable emits: the scripts read it for the pre-download
+        // disk-space check, so a table without it would not represent a real generated installer.
+        val table = "\$Platforms = @{ 'win32-x64' = @{ url = 'https://example.invalid/j.zip'; " +
+            "sha256 = '$sha'; binsub = 'jdk\\bin'; JdkSize = $FAKE_SIZE } }"
         return tmpl
             .replace("@@VERSION@@", "0.0.0-test")
             .replace("@@DEVRIG_URL@@", "https://example.invalid/devrig.zip")
             .replace("@@DEVRIG_SHA256@@", sha)
             .replace("@@DEVRIG_FORMAT@@", "zip")
+            .replace("@@DEVRIG_SIZE@@", FAKE_SIZE.toString())
             .replace("@@DEVRIG_BINSUB@@", "devrig\\bin\\devrig.bat")
             .replace("@@PLATFORM_TABLE_PS@@", table)
     }
 
     private fun renderSh(): String {
         val tmpl = Path.of(System.getProperty("installer.sh.template")).readText()
-        val case = "    linux-x64) jdk_url='https://example.invalid/j.tgz'; jdk_sha256='$sha'; jdk_format='tar.gz'; jdk_javahome='jdk';;"
+        val case = "    linux-x64) jdk_url='https://example.invalid/j.tgz'; jdk_sha256='$sha'; " +
+            "jdk_format='tar.gz'; jdk_javahome='jdk'; jdk_size='$FAKE_SIZE';;"
         return tmpl
             .replace("@@VERSION@@", "0.0.0-test")
             .replace("@@DEVRIG_URL@@", "https://example.invalid/devrig.tgz")
             .replace("@@DEVRIG_FORMAT@@", "tar.gz")
+            .replace("@@DEVRIG_SIZE@@", FAKE_SIZE.toString())
             .replace("@@DEVRIG_BINSUB@@", "devrig/bin/devrig")
             .replace("@@PLATFORM_CASE_SH@@", case)
     }


### PR DESCRIPTION
A ~611 MB install previously gave the user no feedback and no second chance: a single transient network blip or truncated transfer aborted the whole thing, and a full disk failed opaquely mid-stream.

- Bake each artifact's byte length into the scripts and announce it in a `downloading <kind> (~N MB) from <url>` line. **The wording is identical in `install.sh` and `install.ps1` on purpose** — the IDE plugin (PR 5) parses this line to render a real progress fraction.
- Retry download+verify as a unit with growing backoff, so a failed *or* sha-mismatched transfer re-downloads. Only the final attempt is fatal.
- Pre-check free disk space against `(devrig + jdk) × 3` and fail early with the numbers.
- Clean up this run's staging on failure, so a broken download cannot leak hundreds of megabytes.