### PR TITLE
Auto-detect the target project from the agent's working directory (stack 2/6)

### DIFF
--- a/mcp-core/src/main/kotlin/com/jonnyzzz/mcpSteroid/mcp/McpSchema.kt
+++ b/mcp-core/src/main/kotlin/com/jonnyzzz/mcpSteroid/mcp/McpSchema.kt
@@ -164,6 +164,10 @@ fun InputSchemaElement<Nothing>.array(items: JsonObjectBuilder.() -> Unit) = Inp
     }
 )
 
+/** Marks a parameter required in the emitted schema without changing its parsed (nullable) type. */
+fun <R> InputSchemaElement<R>.markRequired(): InputSchemaElement<R> =
+    copy(spec = spec.copy(required = true))
+
 fun <R : Any> InputSchemaElement<R?>.required(): InputSchemaElement<R> {
     val that = this
     return InputSchemaElement(

--- a/mcp-steroid-server/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/CommonToolParams.kt
+++ b/mcp-steroid-server/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/CommonToolParams.kt
@@ -2,6 +2,7 @@ package com.jonnyzzz.mcpSteroid.server
 
 import com.jonnyzzz.mcpSteroid.mcp.InputSchemaElement
 import com.jonnyzzz.mcpSteroid.mcp.description
+import com.jonnyzzz.mcpSteroid.mcp.markRequired
 import com.jonnyzzz.mcpSteroid.mcp.param
 import com.jonnyzzz.mcpSteroid.mcp.required
 import com.jonnyzzz.mcpSteroid.mcp.string
@@ -12,16 +13,26 @@ import com.jonnyzzz.mcpSteroid.mcp.string
  * `.registerToSchema()` to attach it to their tool's input schema.
  */
 object CommonToolParams {
-    /** Required `project_name` used to dispatch a tool call to an already-open IDE project. */
-    fun projectName() =
-        InputSchemaElement.param("project_name")
+    /**
+     * `project_name` used to dispatch a tool call to an already-open IDE project. Required by default
+     * (in-IDE surface). devrig registers it with [requiredInSchema] = false so the agent can omit it and
+     * have the project auto-detected from the working directory (task #226).
+     */
+    fun projectName(requiredInSchema: Boolean = true): InputSchemaElement<String?> {
+        val base = InputSchemaElement.param("project_name")
             .description(
-                "the `project_name` from steroid_list_projects (a unique routing key, NOT the raw " +
-                        "folder name). steroid_list_projects returns both `project_name` (the unique key " +
-                        "to pass here) and `name` (the raw folder name, informational only); they are not equal."
+                if (requiredInSchema)
+                    "the `project_name` from steroid_list_projects (a unique routing key, NOT the raw " +
+                            "folder name). steroid_list_projects returns both `project_name` (the unique key " +
+                            "to pass here) and `name` (the raw folder name, informational only); they are not equal."
+                else
+                    "Project name. Omit to auto-detect from your working directory; pass it only to " +
+                            "disambiguate or override. When passed, it is the `project_name` from " +
+                            "steroid_list_projects (a unique routing key, NOT the raw folder name)."
             )
             .string()
-            .required()
+        return if (requiredInSchema) base.markRequired() else base
+    }
 
     /** Required `task_id` used to group related executions in audit logs. */
     fun taskId() =

--- a/mcp-steroid-server/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/ExecuteCodeTool.kt
+++ b/mcp-steroid-server/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/ExecuteCodeTool.kt
@@ -75,11 +75,14 @@ data class ExecCodeParams(
 /**
  * Handler for the steroid_execute_code MCP tool.
  */
-class ExecuteCodeToolSpec(val handler: () -> ExecuteCodeToolHandler) : McpToolBase() {
+class ExecuteCodeToolSpec(
+    val projectNameRequired: Boolean = true,
+    val handler: () -> ExecuteCodeToolHandler,
+) : McpToolBase() {
     override val name = "steroid_execute_code"
     override val description get() = ExecuteCodeToolDescriptionPromptArticle().readPayload(PromptsContext.Generic)
 
-    val projectName = CommonToolParams.projectName().registerToSchema()
+    val projectName = CommonToolParams.projectName(projectNameRequired).registerToSchema()
 
     val code = InputSchemaElement.param("code")
         .description("Kotlin suspend method body")
@@ -123,7 +126,7 @@ class ExecuteCodeToolSpec(val handler: () -> ExecuteCodeToolHandler) : McpToolBa
         .registerToSchema()
 
     override suspend fun call(context: ToolCallContext): ToolCallResult {
-        val projectName = context[projectName]
+        val projectName = context[projectName].orEmpty()
         val code = context[code]
         val taskId = context[taskId]
         val reason = context[reason]

--- a/mcp-steroid-server/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/ExecuteFeedbackTool.kt
+++ b/mcp-steroid-server/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/ExecuteFeedbackTool.kt
@@ -23,7 +23,10 @@ import kotlinx.serialization.Serializable
  * - Explanation of the rating
  * - Association with a task_id
  */
-class ExecuteFeedbackToolSpec(val handler: () -> ExecuteFeedbackToolHandler) : McpToolBase() {
+class ExecuteFeedbackToolSpec(
+    val projectNameRequired: Boolean = true,
+    val handler: () -> ExecuteFeedbackToolHandler,
+) : McpToolBase() {
     override val name = "steroid_execute_feedback"
     override val description = """
             Provide feedback on the result of a steroid_execute_code call and suggestions to improve the service.
@@ -45,7 +48,7 @@ class ExecuteFeedbackToolSpec(val handler: () -> ExecuteFeedbackToolHandler) : M
             Feedback helps track execution history and identify patterns for improvement.
         """.trimIndent()
 
-    val projectName = CommonToolParams.projectName().registerToSchema()
+    val projectName = CommonToolParams.projectName(projectNameRequired).registerToSchema()
 
     val taskId = CommonToolParams.taskId().registerToSchema()
 
@@ -74,8 +77,8 @@ class ExecuteFeedbackToolSpec(val handler: () -> ExecuteFeedbackToolHandler) : M
         .registerToSchema()
 
     override suspend fun call(context: ToolCallContext): ToolCallResult {
-        val projectName = context[projectName]
-        if (projectName.isBlank()) {
+        val projectName = context[projectName].orEmpty()
+        if (projectNameRequired && projectName.isBlank()) {
             return ToolCallResult.errorResult("project_name is required (from steroid_list_projects)")
         }
         val taskId = context[taskId]

--- a/mcp-steroid-server/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/FetchResourceToolHandler.kt
+++ b/mcp-steroid-server/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/FetchResourceToolHandler.kt
@@ -28,6 +28,7 @@ import com.jonnyzzz.mcpSteroid.thisLogger
  * because [project_name] is needed to render IDE-conditional content correctly.
  */
 class FetchResourceToolHandler(
+    val projectNameRequired: Boolean = true,
     private val handler: () -> PromptsContextHandler,
 ) : McpToolBase() {
 
@@ -57,11 +58,11 @@ class FetchResourceToolHandler(
         .required()
         .registerToSchema()
 
-    val projectName = CommonToolParams.projectName().registerToSchema()
+    val projectName = CommonToolParams.projectName(projectNameRequired).registerToSchema()
 
     override suspend fun call(context: ToolCallContext): ToolCallResult {
         val uri = context[uri]
-        val projectName = context[projectName]
+        val projectName = context[projectName].orEmpty()
 
         log.info("steroid_fetch_resource: $uri")
 

--- a/mcp-steroid-server/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/McpSteroidTools.kt
+++ b/mcp-steroid-server/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/McpSteroidTools.kt
@@ -11,16 +11,16 @@ abstract class McpSteroidTools {
      * routing param). Each caller registers its own `OpenProjectToolSpec(...)` after this call,
      * using the public [handler] accessor to resolve the [OpenProjectToolHandler].
      */
-    fun registerAll(server: McpServerCore) {
+    fun registerAll(server: McpServerCore, projectNameRequired: Boolean = true) {
         val tools = server.toolRegistry
 
         tools.registerTool(ListProjectsToolSpec { handler<ListProjectsToolHandler>() })
         tools.registerTool(ListWindowsToolSpec { handler<ListWindowsToolHandler>() })
-        tools.registerTool(ExecuteCodeToolSpec { handler<ExecuteCodeToolHandler>() })
-        tools.registerTool(ExecuteFeedbackToolSpec { handler<ExecuteFeedbackToolHandler>() })
-        tools.registerTool(VisionScreenshotToolSpec { handler<VisionScreenshotToolHandler>() })
-        tools.registerTool(VisionInputToolSpec { handler<VisionInputToolHandler>() })
-        tools.registerTool(FetchResourceToolHandler { handler<PromptsContextHandler>() })
+        tools.registerTool(ExecuteCodeToolSpec(projectNameRequired) { handler<ExecuteCodeToolHandler>() })
+        tools.registerTool(ExecuteFeedbackToolSpec(projectNameRequired) { handler<ExecuteFeedbackToolHandler>() })
+        tools.registerTool(VisionScreenshotToolSpec(projectNameRequired) { handler<VisionScreenshotToolHandler>() })
+        tools.registerTool(VisionInputToolSpec(projectNameRequired) { handler<VisionInputToolHandler>() })
+        tools.registerTool(FetchResourceToolHandler(projectNameRequired) { handler<PromptsContextHandler>() })
     }
 
     inline fun <reified T : Any> handler(): T = handler(T::class.java)

--- a/mcp-steroid-server/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/VisionInputTool.kt
+++ b/mcp-steroid-server/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/VisionInputTool.kt
@@ -17,7 +17,10 @@ import kotlinx.serialization.Serializable
 /**
  * Handler for the steroid_input MCP tool.
  */
-class VisionInputToolSpec(val handler: () -> VisionInputToolHandler) : McpToolBase() {
+class VisionInputToolSpec(
+    val projectNameRequired: Boolean = true,
+    val handler: () -> VisionInputToolHandler,
+) : McpToolBase() {
     override val name = "steroid_input"
 
     override val description = """
@@ -43,7 +46,7 @@ class VisionInputToolSpec(val handler: () -> VisionInputToolHandler) : McpToolBa
         Click coordinates with the screenshot target (e.g. @120,200) are interpreted relative to the window as reported by steroid_list_windows / steroid_take_screenshot.
     """.trimIndent()
 
-    val projectName = CommonToolParams.projectName().registerToSchema()
+    val projectName = CommonToolParams.projectName(projectNameRequired).registerToSchema()
 
     val taskId = CommonToolParams.taskId().registerToSchema()
 
@@ -60,7 +63,7 @@ class VisionInputToolSpec(val handler: () -> VisionInputToolHandler) : McpToolBa
         .registerToSchema()
 
     override suspend fun call(context: ToolCallContext): ToolCallResult {
-        val projectName = context[projectName]
+        val projectName = context[projectName].orEmpty()
         val taskId = context[taskId]
         val reason = context[reason]
         val windowId = context[windowId]

--- a/mcp-steroid-server/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/VisionScreenshotTool.kt
+++ b/mcp-steroid-server/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/VisionScreenshotTool.kt
@@ -9,7 +9,10 @@ import kotlinx.serialization.Serializable
 /**
  * Handler for the steroid_take_screenshot MCP tool.
  */
-class VisionScreenshotToolSpec(val handler: () -> VisionScreenshotToolHandler) : McpToolBase() {
+class VisionScreenshotToolSpec(
+    val projectNameRequired: Boolean = true,
+    val handler: () -> VisionScreenshotToolHandler,
+) : McpToolBase() {
     override val name = "steroid_take_screenshot"
 
     override val description = """
@@ -33,7 +36,7 @@ class VisionScreenshotToolSpec(val handler: () -> VisionScreenshotToolHandler) :
         After execution, call steroid_execute_feedback to log your feedback.
     """.trimIndent()
 
-    val projectName = CommonToolParams.projectName().registerToSchema()
+    val projectName = CommonToolParams.projectName(projectNameRequired).registerToSchema()
 
     val taskId = CommonToolParams.taskId().registerToSchema()
 
@@ -43,7 +46,7 @@ class VisionScreenshotToolSpec(val handler: () -> VisionScreenshotToolHandler) :
         .registerToSchema()
 
     override suspend fun call(context: ToolCallContext): ToolCallResult {
-        val projectName = context[projectName]
+        val projectName = context[projectName].orEmpty()
         val taskId = context[taskId]
         val reason = context[reason]
         val windowId = context[windowId]

--- a/mcp-steroid-server/src/test/kotlin/com/jonnyzzz/mcpSteroid/server/ExecuteCodeToolSpecSchemaTest.kt
+++ b/mcp-steroid-server/src/test/kotlin/com/jonnyzzz/mcpSteroid/server/ExecuteCodeToolSpecSchemaTest.kt
@@ -18,4 +18,12 @@ class ExecuteCodeToolSpecSchemaTest {
         assertIntegerProperty(schema, "timeout")
         assertEnumProperty(schema, "modal", "smart_non_modal", "non_modal", "unleashed")
     }
+
+    @Test
+    fun `project_name is optional when not required`() {
+        val spec = ExecuteCodeToolSpec(projectNameRequired = false) { unreachableHandler() }
+        val schema = spec.inputSchema
+        assertRequiredExactly(schema, "code", "reason", "task_id") // project_name absent
+        assertStringProperty(schema, "project_name")               // still advertised
+    }
 }

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/DevrigServices.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/DevrigServices.kt
@@ -4,7 +4,11 @@ import com.jonnyzzz.mcpSteroid.devrig.monitor.IdePidDiscoveryService
 import com.jonnyzzz.mcpSteroid.devrig.monitor.IdeProjectMonitorService
 import com.jonnyzzz.mcpSteroid.devrig.monitor.IntelliJPortDiscovery
 import com.jonnyzzz.mcpSteroid.devrig.server.DevrigBackendService
+import com.jonnyzzz.mcpSteroid.devrig.server.DevrigProjectResolver
 import com.jonnyzzz.mcpSteroid.devrig.server.DevrigProjectRoutingService
+import com.jonnyzzz.mcpSteroid.devrig.server.DevrigWorkspaceRoots
+import com.jonnyzzz.mcpSteroid.mcp.McpRootsService
+import com.jonnyzzz.mcpSteroid.mcp.McpSession
 import com.jonnyzzz.mcpSteroid.server.NPX_STREAM_IDLE_TIMEOUT_MILLIS
 import com.jonnyzzz.mcpSteroid.testHelper.CloseableStack
 import io.ktor.client.HttpClient
@@ -17,6 +21,7 @@ import kotlinx.coroutines.CoroutineName
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.withTimeoutOrNull
 
 class DevrigServices(
     private val lifetime: CloseableStack,
@@ -88,6 +93,30 @@ class DevrigServices(
         DevrigProjectRoutingService(
             stateProvider = { ideMonitor.stateSnapshot() },
         )
+    }
+
+    /** The single MCP client session for this devrig stdio process; set at initialize. */
+    @Volatile
+    var mcpClientSession: McpSession? = null
+
+    val mcpRootsService: McpRootsService by lazy { McpRootsService() }
+
+    /**
+     * Candidate working directories for `project_name`-less tool calls: the MCP client's advertised
+     * workspace roots (queried with a short timeout so a slow/absent reply degrades to the cwd fallback),
+     * plus the devrig process cwd. See [DevrigWorkspaceRoots] and task #226.
+     */
+    val workspaceRoots: DevrigWorkspaceRoots by lazy {
+        DevrigWorkspaceRoots(
+            rootsProvider = rp@{
+                val session = mcpClientSession ?: return@rp null
+                withTimeoutOrNull(3_000) { mcpRootsService.getRoots(session) }
+            },
+        )
+    }
+
+    val projectResolver: DevrigProjectResolver by lazy {
+        DevrigProjectResolver(routing = projectRouting, workspaceRoots = workspaceRoots)
     }
 
     val portDiscovery: IntelliJPortDiscovery by lazy {

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/server/DevrigExecuteCodeToolHandler.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/server/DevrigExecuteCodeToolHandler.kt
@@ -10,7 +10,7 @@ import kotlinx.serialization.json.put
 
 class DevrigExecuteCodeToolHandler(
     private val bridge: DevrigToolBridgeClient,
-    private val routing: DevrigProjectRoutingService,
+    private val resolver: DevrigProjectResolver,
     private val beacon: DevrigBeacon,
 ) : ExecuteCodeToolHandler {
     override suspend fun executeCode(
@@ -18,7 +18,7 @@ class DevrigExecuteCodeToolHandler(
         execCodeParams: ExecCodeParams,
         callProgress: McpProgressReporter,
     ): ToolCallResult {
-        val route = routing.requireProject(projectName)
+        val route = resolver.resolve(projectName)
         // Version-base skew check on every routed exec_code call (devrig scenario only; stderr).
         BackendVersionSkew.warnOnExecCode(pid = route.route.pid, pluginVersion = route.route.plugin.version)
         val result = bridge.callProjectTool(route, "steroid_execute_code", callProgress) {

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/server/DevrigExecuteFeedbackToolHandler.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/server/DevrigExecuteFeedbackToolHandler.kt
@@ -8,11 +8,11 @@ import kotlinx.serialization.json.put
 
 class DevrigExecuteFeedbackToolHandler(
     private val bridge: DevrigToolBridgeClient,
-    private val routing: DevrigProjectRoutingService,
+    private val resolver: DevrigProjectResolver,
     private val beacon: DevrigBeacon,
 ) : ExecuteFeedbackToolHandler {
     override suspend fun handleFeedback(projectName: String, params: FeedbackParams): ToolCallResult {
-        val route = routing.requireProject(projectName)
+        val route = resolver.resolve(projectName)
         val result = bridge.callProjectTool(route, "steroid_execute_feedback") {
             put("task_id", params.taskId)
             put("success_rating", params.successRating)

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/server/DevrigProjectDetection.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/server/DevrigProjectDetection.kt
@@ -1,0 +1,46 @@
+/* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
+package com.jonnyzzz.mcpSteroid.devrig.server
+
+import java.nio.file.Path
+
+/** Outcome of matching the agent's working directory against the open projects. */
+sealed interface ProjectDetection {
+    data class Unique(val route: ProjectRoute) : ProjectDetection
+    data class Ambiguous(val matches: List<ProjectRoute>) : ProjectDetection
+    data object NoMatch : ProjectDetection
+    data object NoBackends : ProjectDetection
+}
+
+/**
+ * Selects the project a working directory belongs to. A route matches when its (canonical) project path
+ * equals or is an ancestor of a candidate dir (the agent may run from a subdirectory). Among matches,
+ * the deepest project in a single ancestor chain wins; two matches that are not in an ancestor relation
+ * are [ProjectDetection.Ambiguous].
+ */
+fun selectProjectByCwd(routes: List<ProjectRoute>, dirs: List<Path>): ProjectDetection {
+    if (routes.isEmpty()) return ProjectDetection.NoBackends
+
+    val canonicalDirs = dirs.map { Path.of(DevrigProjectRoutingService.canonicalProjectHome(it.toString())) }
+
+    val matched = routes
+        .filter { route ->
+            val projectPath = Path.of(route.projectPath)
+            canonicalDirs.any { dir -> dir == projectPath || dir.startsWith(projectPath) }
+        }
+        .distinctBy { it.projectPath }
+
+    if (matched.isEmpty()) return ProjectDetection.NoMatch
+
+    // A match is a "leaf" when no other match sits strictly beneath it. A nested chain (/repo, /repo/sub)
+    // has exactly one leaf (/repo/sub → deepest wins); unrelated matches (/a, /b) have several → ambiguous.
+    val leaves = matched.filter { candidate ->
+        val candidatePath = Path.of(candidate.projectPath)
+        matched.none { other ->
+            other !== candidate &&
+                Path.of(other.projectPath).let { it != candidatePath && it.startsWith(candidatePath) }
+        }
+    }
+
+    return if (leaves.size == 1) ProjectDetection.Unique(leaves.single())
+    else ProjectDetection.Ambiguous(leaves)
+}

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/server/DevrigProjectResolver.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/server/DevrigProjectResolver.kt
@@ -1,0 +1,39 @@
+/* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
+package com.jonnyzzz.mcpSteroid.devrig.server
+
+import com.jonnyzzz.mcpSteroid.mcp.ToolCallErrorException
+
+/**
+ * Resolves the [ProjectRoute] for a project-scoped devrig tool call. An explicit, non-blank
+ * `project_name` always wins (delegates to [DevrigProjectRoutingService.requireProject]); otherwise the
+ * project is auto-detected from the agent's working directory. Detection failures surface as
+ * [ToolCallErrorException] with an actionable, case-specific message (task #226).
+ */
+class DevrigProjectResolver(
+    private val routing: DevrigProjectRoutingService,
+    private val workspaceRoots: DevrigWorkspaceRoots,
+) {
+    suspend fun resolve(projectName: String?): ProjectRoute {
+        if (!projectName.isNullOrBlank()) return routing.requireProject(projectName)
+
+        val dirs = workspaceRoots.candidateDirs()
+        val primaryDir = dirs.firstOrNull()?.toString() ?: "(unknown)"
+
+        return when (val detection = routing.detectProject(dirs)) {
+            is ProjectDetection.Unique -> detection.route
+            is ProjectDetection.Ambiguous -> throw ToolCallErrorException(
+                "Multiple open projects match your working directory ($primaryDir): " +
+                    detection.matches.joinToString(", ") { it.exposedProjectName } +
+                    ". Pass project_name to choose one — see steroid_list_projects."
+            )
+            ProjectDetection.NoMatch -> throw ToolCallErrorException(
+                "No open project matches your working directory ($primaryDir). " +
+                    "Open it in IntelliJ, or pass project_name explicitly — see steroid_list_projects."
+            )
+            ProjectDetection.NoBackends -> throw ToolCallErrorException(
+                "No IntelliJ IDE with the MCP Steroid plugin is running. " +
+                    "Open your project in IntelliJ, then retry."
+            )
+        }
+    }
+}

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/server/DevrigProjectRoutingService.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/server/DevrigProjectRoutingService.kt
@@ -44,6 +44,12 @@ class DevrigProjectRoutingService(
         routeProject(exposedProjectName) ?: throw ProjectRouteNotFoundException(exposedProjectName)
 
     /**
+     * Detects which open project the agent's working directory belongs to. See [selectProjectByCwd].
+     * Used by devrig to resolve a tool call that omits `project_name` (task #226).
+     */
+    fun detectProject(dirs: List<Path>): ProjectDetection = selectProjectByCwd(routes(), dirs)
+
+    /**
      * All discovered backends as (backend_name, ide) pairs, for list_projects summaries and error
      * messages. De-duped by backend_name (keep-first + WARN), mirroring `backendRowsWithStableIds`.
      */

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/server/DevrigPromptsContextHandler.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/server/DevrigPromptsContextHandler.kt
@@ -5,10 +5,10 @@ import com.jonnyzzz.mcpSteroid.prompts.PromptsContext
 import com.jonnyzzz.mcpSteroid.server.PromptsContextHandler
 
 class DevrigPromptsContextHandler(
-    private val routing: DevrigProjectRoutingService,
+    private val resolver: DevrigProjectResolver,
 ) : PromptsContextHandler {
     override suspend fun buildPromptsContext(projectName: String): PromptsContext {
-        val route = routing.requireProject(projectName)
+        val route = resolver.resolve(projectName)
         return promptsContextFromBuild(route.route.ide.build)
     }
 

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/server/DevrigVisionInputToolHandler.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/server/DevrigVisionInputToolHandler.kt
@@ -8,10 +8,10 @@ import kotlinx.serialization.json.put
 
 class DevrigVisionInputToolHandler(
     private val bridge: DevrigToolBridgeClient,
-    private val routing: DevrigProjectRoutingService,
+    private val resolver: DevrigProjectResolver,
 ) : VisionInputToolHandler {
     override suspend fun handleInputSequence(projectName: String, inputParams: InputParams): ToolCallResult {
-        val route = routing.requireProject(projectName)
+        val route = resolver.resolve(projectName)
         val rawSequence = inputParams.rawSequence
             ?: return ToolCallResult.errorResult("Input sequence cannot be forwarded without the original sequence string")
         return bridge.callProjectTool(route, "steroid_input") {

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/server/DevrigVisionScreenshotToolHandler.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/server/DevrigVisionScreenshotToolHandler.kt
@@ -8,14 +8,14 @@ import kotlinx.serialization.json.put
 
 class DevrigVisionScreenshotToolHandler(
     private val bridge: DevrigToolBridgeClient,
-    private val routing: DevrigProjectRoutingService,
+    private val resolver: DevrigProjectResolver,
 ) : VisionScreenshotToolHandler {
     override suspend fun screenshotWindow(
         projectName: String,
         screenshotParams: ScreenshotParams,
         mcpProgressReporter: McpProgressReporter,
     ): ToolCallResult {
-        val route = routing.requireProject(projectName)
+        val route = resolver.resolve(projectName)
         return bridge.callProjectTool(route, "steroid_take_screenshot", mcpProgressReporter) {
             put("task_id", screenshotParams.taskId)
             put("reason", screenshotParams.reason)

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/server/DevrigWorkspaceRoots.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/server/DevrigWorkspaceRoots.kt
@@ -1,0 +1,67 @@
+/* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
+package com.jonnyzzz.mcpSteroid.devrig.server
+
+import com.jonnyzzz.mcpSteroid.mcp.Root
+import com.jonnyzzz.mcpSteroid.thisLogger
+import java.net.URI
+import java.nio.file.Path
+import java.nio.file.Paths
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+/**
+ * Supplies the candidate directories devrig matches against open projects when a tool call omits
+ * `project_name`. Prefers the MCP client's advertised workspace roots (via [rootsProvider]); always
+ * appends the devrig process working directory ([processCwd]) as a fallback so a client that advertises
+ * no roots still gets cwd-based detection. Result is cached for the (single, per-process) session.
+ */
+class DevrigWorkspaceRoots(
+    private val rootsProvider: suspend () -> List<Root>?,
+    private val processCwd: () -> String = { System.getProperty("user.dir") },
+) {
+    private val log = thisLogger()
+    private val mutex = Mutex()
+
+    @Volatile
+    private var cached: List<Path>? = null
+
+    suspend fun candidateDirs(): List<Path> {
+        cached?.let { return it }
+        return mutex.withLock {
+            cached ?: computeDirs().also { cached = it }
+        }
+    }
+
+    /** Clears the cache; a subsequent [candidateDirs] re-queries the client. */
+    fun invalidate() {
+        cached = null
+    }
+
+    private suspend fun computeDirs(): List<Path> {
+        val roots = try {
+            rootsProvider()
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            log.warn("Failed to fetch MCP roots; falling back to process cwd", e)
+            null
+        }
+
+        val rootDirs = roots.orEmpty().mapNotNull { rootUriToPath(it.uri) }
+        val cwd = try {
+            Path.of(processCwd())
+        } catch (e: Exception) {
+            log.warn("Invalid process cwd", e)
+            null
+        }
+        return (rootDirs + listOfNotNull(cwd)).distinct()
+    }
+
+    private fun rootUriToPath(uri: String): Path? = try {
+        Paths.get(URI(uri))
+    } catch (e: Exception) {
+        log.warn("Ignoring non-file MCP root uri: $uri", e)
+        null
+    }
+}

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/server/StubMcpSteroidTools.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/server/StubMcpSteroidTools.kt
@@ -34,14 +34,14 @@ class StubMcpSteroidTools(
 
     private val promptsContext by lazy {
         DevrigPromptsContextHandler(
-            routing = services.projectRouting
+            resolver = services.projectResolver
         )
     }
 
     private val executeCode by lazy {
         DevrigExecuteCodeToolHandler(
             bridge = bridge,
-            routing = services.projectRouting,
+            resolver = services.projectResolver,
             beacon = services.beacon
         )
     }
@@ -49,7 +49,7 @@ class StubMcpSteroidTools(
     private val executeFeedback by lazy {
         DevrigExecuteFeedbackToolHandler(
             bridge = bridge,
-            routing = services.projectRouting,
+            resolver = services.projectResolver,
             beacon = services.beacon
         )
     }
@@ -57,14 +57,14 @@ class StubMcpSteroidTools(
     private val visionScreenshot by lazy {
         DevrigVisionScreenshotToolHandler(
             bridge = bridge,
-            routing = services.projectRouting
+            resolver = services.projectResolver
         )
     }
 
     private val visionInput by lazy {
         DevrigVisionInputToolHandler(
             bridge = bridge,
-            routing = services.projectRouting,
+            resolver = services.projectResolver,
         )
     }
 

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/server/StubStdioMcpServer.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/server/StubStdioMcpServer.kt
@@ -48,6 +48,8 @@ suspend fun runStubStdioMcpServer(
         ),
         // Fire a once-per-session analytics beacon recording client (agent) + server versions.
         onSessionInitialized = { session, serverInfo, clientProtocolVersion ->
+            // Capture the single stdio session so cwd auto-detection can query the client's MCP roots (#226).
+            services.mcpClientSession = session
             services.beacon.capture(
                 event = "session_initialized",
                 properties = mapOf(
@@ -65,7 +67,9 @@ suspend fun runStubStdioMcpServer(
     onServerReady(server)
 
     val tools = StubMcpSteroidTools(services)
-    tools.registerAll(server)
+    // devrig auto-detects the project from the agent's working directory (#226), so project_name is
+    // advertised as optional on this surface.
+    tools.registerAll(server, projectNameRequired = false)
     // devrig routes to one of several discovered IDEs, so its steroid_open_project advertises the
     // required `backend_name` routing param (includeBackendName = true). registerAll() no longer
     // registers open_project; each surface registers its own spec.

--- a/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/server/DevrigProjectDetectionTest.kt
+++ b/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/server/DevrigProjectDetectionTest.kt
@@ -1,0 +1,77 @@
+/* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
+package com.jonnyzzz.mcpSteroid.devrig.server
+
+import com.jonnyzzz.mcpSteroid.IdeInfo
+import com.jonnyzzz.mcpSteroid.PluginInfo
+import com.jonnyzzz.mcpSteroid.devrig.monitor.DiscoveredIde
+import com.jonnyzzz.mcpSteroid.devrig.monitor.IdeProjectState
+import com.jonnyzzz.mcpSteroid.devrig.testDevrigEndpoint
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import org.junit.jupiter.api.io.TempDir
+
+class DevrigProjectDetectionTest {
+    @TempDir lateinit var tempDir: Path
+
+    private fun route(name: String, path: String): ProjectRoute {
+        val ide = DiscoveredIde(
+            pid = 0L,
+            rpcBaseUrl = testDevrigEndpoint("http://127.0.0.1:65000/mcp").rpcBaseUrl,
+            bridgeHeaders = emptyMap(),
+            ide = IdeInfo(name = name, version = "1", build = "IU-261.1"),
+            plugin = PluginInfo(id = "com.jonnyzzz.mcp-steroid", name = "MCP Steroid", version = "0.0.0-test"),
+            backendName = "backend-$name",
+        )
+        val canonical = DevrigProjectRoutingService.canonicalProjectHome(path)
+        return ProjectRoute(
+            route = ide,
+            projectInfo = IdeProjectState(name = name, projectPath = path),
+            exposedProjectName = "$name-hash",
+            projectPath = canonical,
+        )
+    }
+
+    @Test fun `no routes yields NoBackends`() {
+        assertEquals(ProjectDetection.NoBackends, selectProjectByCwd(emptyList(), listOf(tempDir)))
+    }
+
+    @Test fun `exact cwd equals project root matches uniquely`() {
+        val repo = Files.createDirectories(tempDir.resolve("repo"))
+        val d = selectProjectByCwd(listOf(route("repo", repo.toString())), listOf(repo))
+        assertTrue(d is ProjectDetection.Unique && d.route.originalProjectName == "repo")
+    }
+
+    @Test fun `cwd inside a subdirectory of the project matches the project`() {
+        val repo = Files.createDirectories(tempDir.resolve("repo"))
+        val sub = Files.createDirectories(repo.resolve("src").resolve("app"))
+        val d = selectProjectByCwd(listOf(route("repo", repo.toString())), listOf(sub))
+        assertTrue(d is ProjectDetection.Unique && d.route.originalProjectName == "repo")
+    }
+
+    @Test fun `nested projects pick the deepest match`() {
+        val outer = Files.createDirectories(tempDir.resolve("repo"))
+        val inner = Files.createDirectories(outer.resolve("sub"))
+        val cwd = Files.createDirectories(inner.resolve("x"))
+        val routes = listOf(route("outer", outer.toString()), route("inner", inner.toString()))
+        val d = selectProjectByCwd(routes, listOf(cwd))
+        assertTrue(d is ProjectDetection.Unique && d.route.originalProjectName == "inner")
+    }
+
+    @Test fun `unrelated matches across dirs are ambiguous`() {
+        val a = Files.createDirectories(tempDir.resolve("a"))
+        val b = Files.createDirectories(tempDir.resolve("b"))
+        val routes = listOf(route("a", a.toString()), route("b", b.toString()))
+        val d = selectProjectByCwd(routes, listOf(a, b))
+        assertTrue(d is ProjectDetection.Ambiguous && d.matches.size == 2)
+    }
+
+    @Test fun `dirs matching no project yields NoMatch`() {
+        val repo = Files.createDirectories(tempDir.resolve("repo"))
+        val elsewhere = Files.createDirectories(tempDir.resolve("elsewhere"))
+        val d = selectProjectByCwd(listOf(route("repo", repo.toString())), listOf(elsewhere))
+        assertEquals(ProjectDetection.NoMatch, d)
+    }
+}

--- a/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/server/DevrigProjectResolverTest.kt
+++ b/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/server/DevrigProjectResolverTest.kt
@@ -1,0 +1,89 @@
+/* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
+package com.jonnyzzz.mcpSteroid.devrig.server
+
+import com.jonnyzzz.mcpSteroid.IdeInfo
+import com.jonnyzzz.mcpSteroid.PluginInfo
+import com.jonnyzzz.mcpSteroid.devrig.monitor.DiscoveredIde
+import com.jonnyzzz.mcpSteroid.devrig.monitor.IdeMonitorState
+import com.jonnyzzz.mcpSteroid.devrig.monitor.IdeProjectState
+import com.jonnyzzz.mcpSteroid.devrig.testDevrigEndpoint
+import com.jonnyzzz.mcpSteroid.mcp.Root
+import com.jonnyzzz.mcpSteroid.mcp.ToolCallErrorException
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.io.TempDir
+
+class DevrigProjectResolverTest {
+    @TempDir lateinit var tempDir: Path
+
+    private fun ide(pid: Long) = DiscoveredIde(
+        pid = pid,
+        rpcBaseUrl = testDevrigEndpoint("http://127.0.0.1:6500$pid/mcp").rpcBaseUrl,
+        bridgeHeaders = emptyMap(),
+        ide = IdeInfo(name = "IDEA-$pid", version = "1", build = "IU-261.1"),
+        plugin = PluginInfo(id = "com.jonnyzzz.mcp-steroid", name = "MCP Steroid", version = "0.0.0-test"),
+        backendName = "backend-$pid",
+    )
+
+    private fun routing(vararg states: IdeMonitorState) =
+        DevrigProjectRoutingService(stateProvider = { states.toList() })
+
+    private fun resolver(routing: DevrigProjectRoutingService, dirs: List<Path>): DevrigProjectResolver =
+        DevrigProjectResolver(
+            routing = routing,
+            workspaceRoots = DevrigWorkspaceRoots(
+                rootsProvider = { dirs.map { Root(uri = it.toUri().toString()) } },
+                processCwd = { tempDir.toString() },
+            ),
+        )
+
+    @Test fun `explicit project_name wins over cwd`() = runTest {
+        val repo = Files.createDirectories(tempDir.resolve("repo"))
+        val routing = routing(IdeMonitorState(ide(1), listOf(IdeProjectState("repo", repo.toString()))))
+        val exposed = routing.routes().single().exposedProjectName
+        val route = resolver(routing, dirs = listOf(tempDir)).resolve(exposed)
+        assertEquals("repo", route.originalProjectName)
+    }
+
+    @Test fun `blank name auto-detects from cwd`() = runTest {
+        val repo = Files.createDirectories(tempDir.resolve("repo"))
+        val routing = routing(IdeMonitorState(ide(1), listOf(IdeProjectState("repo", repo.toString()))))
+        val route = resolver(routing, dirs = listOf(repo)).resolve("")
+        assertEquals("repo", route.originalProjectName)
+    }
+
+    @Test fun `no backends yields friendly message`() = runTest {
+        val ex = assertFailsWith<ToolCallErrorException> {
+            resolver(routing(), dirs = listOf(tempDir)).resolve(null)
+        }
+        assertTrue(ex.message.contains("No IntelliJ IDE with the MCP Steroid plugin is running"))
+    }
+
+    @Test fun `no match yields friendly message`() = runTest {
+        val repo = Files.createDirectories(tempDir.resolve("repo"))
+        val elsewhere = Files.createDirectories(tempDir.resolve("elsewhere"))
+        val routing = routing(IdeMonitorState(ide(1), listOf(IdeProjectState("repo", repo.toString()))))
+        val ex = assertFailsWith<ToolCallErrorException> {
+            resolver(routing, dirs = listOf(elsewhere)).resolve(null)
+        }
+        assertTrue(ex.message.contains("No open project matches your working directory"))
+    }
+
+    @Test fun `ambiguous match yields friendly message`() = runTest {
+        val a = Files.createDirectories(tempDir.resolve("a"))
+        val b = Files.createDirectories(tempDir.resolve("b"))
+        val routing = routing(
+            IdeMonitorState(ide(1), listOf(IdeProjectState("a", a.toString()))),
+            IdeMonitorState(ide(2), listOf(IdeProjectState("b", b.toString()))),
+        )
+        val ex = assertFailsWith<ToolCallErrorException> {
+            resolver(routing, dirs = listOf(a, b)).resolve(null)
+        }
+        assertTrue(ex.message.contains("Multiple open projects match"))
+    }
+}

--- a/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/server/DevrigProjectRoutingServiceTest.kt
+++ b/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/server/DevrigProjectRoutingServiceTest.kt
@@ -13,6 +13,7 @@ import java.nio.file.Path
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.io.TempDir
 
@@ -185,6 +186,24 @@ class DevrigProjectRoutingServiceTest {
             assertEquals("Generic", context.productCode, build)
             assertEquals(253, context.baselineVersion, build)
         }
+    }
+
+    @Test
+    fun `detectProject matches the project owning the cwd subdirectory`() {
+        val repo = Files.createDirectories(tempDir.resolve("repo"))
+        val sub = Files.createDirectories(repo.resolve("module"))
+        val service = routingService(
+            state(pid = 7, projects = listOf(IdeProjectState("repo", repo.toString())))
+        )
+        val detection = service.detectProject(listOf(sub))
+        assertTrue(detection is ProjectDetection.Unique)
+        assertEquals("repo", detection.route.originalProjectName)
+    }
+
+    @Test
+    fun `detectProject returns NoBackends when nothing is discovered`() {
+        val service = routingService() // no states -> routes() is empty
+        assertEquals(ProjectDetection.NoBackends, service.detectProject(listOf(tempDir)))
     }
 
     private fun routingService(vararg states: IdeMonitorState): DevrigProjectRoutingService =

--- a/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/server/DevrigProjectRoutingServiceTest.kt
+++ b/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/server/DevrigProjectRoutingServiceTest.kt
@@ -134,7 +134,7 @@ class DevrigProjectRoutingServiceTest {
         )
         val route = routing.routes().single()
 
-        val context = DevrigPromptsContextHandler(routing).buildPromptsContext(route.exposedProjectName)
+        val context = DevrigPromptsContextHandler(testProjectResolver(routing)).buildPromptsContext(route.exposedProjectName)
 
         assertEquals("IU", context.productCode)
         assertEquals(261, context.baselineVersion)
@@ -143,7 +143,7 @@ class DevrigProjectRoutingServiceTest {
     @Test
     fun `prompt context for a stale project name surfaces the route-not-found error`() = runTest {
         assertFailsWith<ProjectRouteNotFoundException> {
-            DevrigPromptsContextHandler(routingService()).buildPromptsContext("missing-project-abcdefgh")
+            DevrigPromptsContextHandler(testProjectResolver(routingService())).buildPromptsContext("missing-project-abcdefgh")
         }
     }
 

--- a/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/server/DevrigToolBridgeClientTest.kt
+++ b/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/server/DevrigToolBridgeClientTest.kt
@@ -184,7 +184,7 @@ class DevrigToolBridgeClientTest {
             )
         )
         val route = routing.routes().single()
-        val handler = DevrigExecuteCodeToolHandler(DevrigToolBridgeClient(httpClient), routing, testBeacon(tempDir))
+        val handler = DevrigExecuteCodeToolHandler(DevrigToolBridgeClient(httpClient), testProjectResolver(routing), testBeacon(tempDir))
 
         val result = handler.executeCode(
             projectName = route.exposedProjectName,
@@ -224,7 +224,7 @@ class DevrigToolBridgeClientTest {
             )
         )
         val route = routing.routes().single()
-        val handler = DevrigExecuteFeedbackToolHandler(DevrigToolBridgeClient(httpClient),routing, testBeacon(tempDir))
+        val handler = DevrigExecuteFeedbackToolHandler(DevrigToolBridgeClient(httpClient), testProjectResolver(routing), testBeacon(tempDir))
 
         val result = handler.handleFeedback(
             projectName = route.exposedProjectName,
@@ -259,7 +259,7 @@ class DevrigToolBridgeClientTest {
             )
         )
         val route = routing.routes().single()
-        val handler = DevrigVisionScreenshotToolHandler(DevrigToolBridgeClient(httpClient), routing)
+        val handler = DevrigVisionScreenshotToolHandler(DevrigToolBridgeClient(httpClient), testProjectResolver(routing))
 
         val result = handler.screenshotWindow(
             projectName = route.exposedProjectName,
@@ -299,7 +299,7 @@ class DevrigToolBridgeClientTest {
             ),
         )
         val route = routing.routes().single { it.route.pid == 43L }
-        val handler = DevrigVisionInputToolHandler(DevrigToolBridgeClient(httpClient), routing)
+        val handler = DevrigVisionInputToolHandler(DevrigToolBridgeClient(httpClient), testProjectResolver(routing))
 
         val result = handler.handleInputSequence(
             projectName = route.exposedProjectName,
@@ -551,7 +551,7 @@ class DevrigToolBridgeClientTest {
         )
         val route = routing.routes().single()
         val progressMessages = mutableListOf<String>()
-        val handler = DevrigExecuteCodeToolHandler(DevrigToolBridgeClient(httpClient), routing, testBeacon(tempDir))
+        val handler = DevrigExecuteCodeToolHandler(DevrigToolBridgeClient(httpClient), testProjectResolver(routing), testBeacon(tempDir))
 
         val result = handler.executeCode(
             projectName = route.exposedProjectName,

--- a/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/server/DevrigWorkspaceRootsTest.kt
+++ b/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/server/DevrigWorkspaceRootsTest.kt
@@ -1,0 +1,46 @@
+/* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
+package com.jonnyzzz.mcpSteroid.devrig.server
+
+import com.jonnyzzz.mcpSteroid.mcp.Root
+import java.nio.file.Path
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlinx.coroutines.test.runTest
+
+class DevrigWorkspaceRootsTest {
+    @Test fun `maps file uri roots to paths and appends cwd`() = runTest {
+        val roots = DevrigWorkspaceRoots(
+            rootsProvider = { listOf(Root(uri = "file:///tmp/ws-a"), Root(uri = "file:///tmp/ws-b")) },
+            processCwd = { "/tmp/cwd" },
+        )
+        val dirs = roots.candidateDirs().map { it.toString() }
+        assertTrue(dirs.contains("/tmp/ws-a"))
+        assertTrue(dirs.contains("/tmp/ws-b"))
+        assertTrue(dirs.contains("/tmp/cwd"))
+        assertEquals("/tmp/ws-a", dirs.first()) // roots first, cwd fallback last
+    }
+
+    @Test fun `falls back to cwd when client advertises no roots`() = runTest {
+        val roots = DevrigWorkspaceRoots(rootsProvider = { null }, processCwd = { "/tmp/only-cwd" })
+        assertEquals(listOf(Path.of("/tmp/only-cwd")), roots.candidateDirs())
+    }
+
+    @Test fun `falls back to cwd when roots provider throws`() = runTest {
+        val roots = DevrigWorkspaceRoots(
+            rootsProvider = { error("boom") },
+            processCwd = { "/tmp/cwd2" },
+        )
+        assertEquals(listOf(Path.of("/tmp/cwd2")), roots.candidateDirs())
+    }
+
+    @Test fun `caches the first result`() = runTest {
+        var calls = 0
+        val roots = DevrigWorkspaceRoots(
+            rootsProvider = { calls++; emptyList() },
+            processCwd = { "/tmp/c" },
+        )
+        roots.candidateDirs(); roots.candidateDirs()
+        assertEquals(1, calls)
+    }
+}

--- a/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/server/TestProjectResolver.kt
+++ b/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/server/TestProjectResolver.kt
@@ -1,0 +1,12 @@
+/* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
+package com.jonnyzzz.mcpSteroid.devrig.server
+
+/**
+ * A [DevrigProjectResolver] over [routing] whose workspace-roots seam is inert (no roots, cwd `/`).
+ * For tests that always resolve an explicit `project_name`, so cwd auto-detection is never consulted.
+ */
+fun testProjectResolver(routing: DevrigProjectRoutingService): DevrigProjectResolver =
+    DevrigProjectResolver(
+        routing = routing,
+        workspaceRoots = DevrigWorkspaceRoots(rootsProvider = { null }, processCwd = { "/" }),
+    )


### PR DESCRIPTION
Every devrig tool call required an explicit `project_name`, which the agent had to fetch from `steroid_list_projects` first — an extra round trip on every call, and a routing key it frequently guessed wrong.

`project_name` becomes **optional on the devrig surface**: when omitted, the project owning the agent's working directory is used. The in-IDE surface is unchanged.

- **`DevrigWorkspaceRoots`** — candidate directories from the MCP client's advertised roots, queried with a short timeout so a slow or absent reply degrades to the process cwd rather than hanging.
- **`DevrigProjectDetection`** — matches a candidate directory against open projects, including when the cwd is a *subdirectory* of the project root.
- **`DevrigProjectResolver`** — joins the two and reports actionable errors: nothing discovered, no match, ambiguous match.
- **`markRequired()`** — lets one schema element be emitted as required in-IDE and optional on the devrig surface, so relaxing it doesn't fork the schema.