### PR TITLE
Add `devrig connect` to wire an agent and an IDE together (stack 3/6)

### DIFF
--- a/ai-agents/src/main/kotlin/com/jonnyzzz/mcpSteroid/aiAgents/McpServerConfig.kt
+++ b/ai-agents/src/main/kotlin/com/jonnyzzz/mcpSteroid/aiAgents/McpServerConfig.kt
@@ -3,7 +3,7 @@ package com.jonnyzzz.mcpSteroid.aiAgents
 
 import kotlin.collections.plus
 
-const val DEFAULT_SERVER_NAME = "mcp-steroid"
+const val DEFAULT_SERVER_NAME = "devrig"
 
 /**
  * Structured model of the MCP server connection info.

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/ClaudePluginConnect.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/ClaudePluginConnect.kt
@@ -1,0 +1,73 @@
+/* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
+package com.jonnyzzz.mcpSteroid.devrig
+
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import kotlinx.serialization.json.putJsonObject
+
+/** Marketplace name Claude registers our plugin under, in `extraKnownMarketplaces`. */
+const val CLAUDE_MARKETPLACE_NAME = "mcp-steroid"
+
+/** GitHub `owner/repo` hosting `.claude-plugin/marketplace.json` for the marketplace above. */
+const val CLAUDE_MARKETPLACE_REPO = "jonnyzzz/mcp-steroid"
+
+/** The `enabledPlugins` key that turns the devrig plugin on: `<plugin>@<marketplace>`. */
+const val CLAUDE_DEVRIG_PLUGIN_KEY = "devrig@$CLAUDE_MARKETPLACE_NAME"
+
+private val prettyJson = Json { prettyPrint = true }
+private val laxJson = Json { ignoreUnknownKeys = true; isLenient = true }
+
+private fun parseRootObject(currentJson: String?): JsonObject {
+    val text = currentJson?.takeIf { it.isNotBlank() } ?: return JsonObject(emptyMap())
+    val element: JsonElement = laxJson.parseToJsonElement(text)
+    return element as? JsonObject
+        ?: error("~/.claude/settings.json root is not a JSON object")
+}
+
+/** True iff `enabledPlugins["devrig@mcp-steroid"]` is present and is exactly the JSON boolean `true`. */
+fun isClaudePluginEnabled(currentJson: String?): Boolean {
+    val root = parseRootObject(currentJson)
+    val plugins = root["enabledPlugins"] as? JsonObject ?: return false
+    val flag = plugins[CLAUDE_DEVRIG_PLUGIN_KEY] as? JsonPrimitive ?: return false
+    // A JSON boolean primitive is non-string with content "true"/"false"; a quoted "true" is a string.
+    return !flag.isString && flag.content == "true"
+}
+
+/**
+ * Return a pretty-printed settings.json that has our marketplace + enabled-plugin entries merged in.
+ * Additive and idempotent: every existing top-level key, marketplace, and enabled plugin is preserved;
+ * only our two keys are inserted/overwritten with their canonical value.
+ */
+fun enableClaudePluginInSettings(currentJson: String?): String {
+    val root = parseRootObject(currentJson)
+
+    val existingMarketplaces = root["extraKnownMarketplaces"] as? JsonObject ?: JsonObject(emptyMap())
+    val existingPlugins = root["enabledPlugins"] as? JsonObject ?: JsonObject(emptyMap())
+
+    val mergedMarketplaces = buildJsonObject {
+        existingMarketplaces.forEach { (k, v) -> put(k, v) }
+        putJsonObject(CLAUDE_MARKETPLACE_NAME) {
+            putJsonObject("source") {
+                put("source", "github")
+                put("repo", CLAUDE_MARKETPLACE_REPO)
+            }
+        }
+    }
+    val mergedPlugins = buildJsonObject {
+        existingPlugins.forEach { (k, v) -> put(k, v) }
+        put(CLAUDE_DEVRIG_PLUGIN_KEY, true)
+    }
+
+    val mergedRoot = buildJsonObject {
+        root.forEach { (k, v) ->
+            if (k != "extraKnownMarketplaces" && k != "enabledPlugins") put(k, v)
+        }
+        put("extraKnownMarketplaces", mergedMarketplaces)
+        put("enabledPlugins", mergedPlugins)
+    }
+    return prettyJson.encodeToString(JsonObject.serializer(), mergedRoot) + "\n"
+}

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/ClaudePluginConnect.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/ClaudePluginConnect.kt
@@ -9,8 +9,15 @@ import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
 import kotlinx.serialization.json.putJsonObject
 
-/** Marketplace name Claude registers our plugin under, in `extraKnownMarketplaces`. */
-const val CLAUDE_MARKETPLACE_NAME = "mcp-steroid"
+/**
+ * Marketplace name Claude registers our plugin under, in `extraKnownMarketplaces`.
+ *
+ * Claude keys a marketplace by the `name` DECLARED in its `.claude-plugin/marketplace.json` — not by the
+ * repo it was added from (see `~/.claude/plugins/known_marketplaces.json`). So this must stay equal to
+ * that field, and the plugin id below must be `devrig@<that name>`; a mismatch makes `connect claude`
+ * write an entry that corresponds to no real plugin. Enforced by the `validateMarketplaceJson` build check.
+ */
+const val CLAUDE_MARKETPLACE_NAME = "jonnyzzz"
 
 /** GitHub `owner/repo` hosting `.claude-plugin/marketplace.json` for the marketplace above. */
 const val CLAUDE_MARKETPLACE_REPO = "jonnyzzz/mcp-steroid"

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/Cli.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/Cli.kt
@@ -80,6 +80,18 @@ sealed interface DevrigCommand {
         override val json: Boolean = false,
     ) : DevrigCommand
 
+    /** `devrig connect claude` — enable the marketplace devrig plugin in ~/.claude/settings.json. */
+    data class DevrigCommandConnectClaude(
+        override val debug: Boolean = false,
+        override val json: Boolean = false,
+    ) : DevrigCommand
+
+    /** `devrig connect ide` — offer to install the MCP Steroid plugin into a running JetBrains IDE. */
+    data class DevrigCommandConnectIde(
+        override val debug: Boolean = false,
+        override val json: Boolean = false,
+    ) : DevrigCommand
+
     data class DevrigCommandHelp(
         override val debug: Boolean = false,
         override val json: Boolean = false,
@@ -183,6 +195,7 @@ private class DevrigRootCommand(
             backend,
             ProjectCommand(selected, this),
             InstallCommand(selected, this),
+            ConnectCommand(selected, this),
             HelpCommand(selected, this),
             VersionCommand(selected, this),
         )
@@ -269,6 +282,45 @@ private class VersionCommand(
     override fun run() {
         val options = options()
         select(DevrigCommand.DevrigCommandVersion(debug = options.debug, json = options.json))
+    }
+}
+
+private class ConnectCommand(
+    selected: SelectedDevrigCommand,
+    parent: DevrigCliktCommand,
+) : DevrigCliktCommand("connect", selected, parent, invokeWithoutSubcommand = true) {
+    init {
+        subcommands(
+            ConnectClaudeCommand(selected, this),
+            ConnectIdeCommand(selected, this),
+        )
+    }
+
+    override fun run() {
+        // `connect` with no subcommand is a usage error surfaced as help; select nothing here so the
+        // parser reports the missing subcommand rather than silently doing nothing.
+        val options = options()
+        if (options.help) select(DevrigCommand.DevrigCommandHelp(debug = options.debug, json = options.json))
+    }
+}
+
+private class ConnectClaudeCommand(
+    selected: SelectedDevrigCommand,
+    parent: DevrigCliktCommand,
+) : DevrigCliktCommand("claude", selected, parent) {
+    override fun run() {
+        val options = options()
+        select(DevrigCommand.DevrigCommandConnectClaude(debug = options.debug, json = options.json))
+    }
+}
+
+private class ConnectIdeCommand(
+    selected: SelectedDevrigCommand,
+    parent: DevrigCliktCommand,
+) : DevrigCliktCommand("ide", selected, parent) {
+    override fun run() {
+        val options = options()
+        select(DevrigCommand.DevrigCommandConnectIde(debug = options.debug, json = options.json))
     }
 }
 
@@ -360,6 +412,8 @@ fun DevrigServices.runCli(command: DevrigCommand): Int {
             is DevrigCommand.DevrigCommandProject -> runProjectCommand(command)
             is DevrigCommand.DevrigCommandInstall -> runInstallCommand(command)
             is DevrigCommand.DevrigCommandInstallDevrig -> runInstallDevrigCommand(command)
+            is DevrigCommand.DevrigCommandConnectClaude -> runConnectClaudeCommand(command)
+            is DevrigCommand.DevrigCommandConnectIde -> runConnectIdeCommand(command)
         }
     } catch (e: ManagedBackendLockException) {
         System.err.println(e.message)

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/ConnectCommand.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/ConnectCommand.kt
@@ -50,6 +50,8 @@ fun runConnectClaude(settingsPath: Path, out: PrintStream, err: PrintStream): In
 fun DevrigServices.runConnectIdeCommand(command: DevrigCommand.DevrigCommandConnectIde): Int =
     runBlocking(Dispatchers.IO) {
         val discovered = portDiscovery.stateSnapshot()
+        // Marker count = IDEs already advertising the MCP Steroid plugin; >0 means the bridge works.
+        val pluginMarkerCount = collectIdeReachability().discovered
         val client = InstallPluginClient { url ->
             val response = commandHttpClient.get(url) {
                 // /api/installPlugin trusts localhost callers (RestService.isHostTrusted -> isLocalhost);
@@ -63,11 +65,13 @@ fun DevrigServices.runConnectIdeCommand(command: DevrigCommand.DevrigCommandConn
             try {
                 ProcessBuilder(browserOpenArgv(detectHostOs(System.getProperty("os.name") ?: ""), url)).start()
                 true
+            } catch (e: kotlinx.coroutines.CancellationException) {
+                throw e
             } catch (e: Exception) {
                 System.err.println("[devrig] failed to open browser: ${e.message ?: e::class.simpleName}")
                 false
             }
         }
-        val outcome = runConnectIde(discovered, pluginMarkerCount = 0, client, browser, mcpStdout, System.err)
-        if (outcome == ConnectIdeOutcome.NO_IDE) 1 else 0
+        val outcome = runConnectIde(discovered, pluginMarkerCount, client, browser, mcpStdout, System.err)
+        connectIdeExitCode(outcome)
     }

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/ConnectCommand.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/ConnectCommand.kt
@@ -50,8 +50,8 @@ fun runConnectClaude(settingsPath: Path, out: PrintStream, err: PrintStream): In
 fun DevrigServices.runConnectIdeCommand(command: DevrigCommand.DevrigCommandConnectIde): Int =
     runBlocking(Dispatchers.IO) {
         val discovered = portDiscovery.stateSnapshot()
-        // Marker count = IDEs already advertising the MCP Steroid plugin; >0 means the bridge works.
-        val pluginMarkerCount = collectIdeReachability().discovered
+        // Count of live plugin-bearing IDEs (marker-based, no network probe); >0 means the bridge already works.
+        val pluginMarkerCount = ideDiscovery.stateSnapshot().size
         val client = InstallPluginClient { url ->
             val response = commandHttpClient.get(url) {
                 // /api/installPlugin trusts localhost callers (RestService.isHostTrusted -> isLocalhost);

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/ConnectCommand.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/ConnectCommand.kt
@@ -2,7 +2,9 @@
 package com.jonnyzzz.mcpSteroid.devrig
 
 import io.ktor.client.request.get
+import io.ktor.client.request.header
 import io.ktor.client.statement.bodyAsText
+import io.ktor.http.HttpHeaders
 import java.io.PrintStream
 import java.nio.file.Files
 import java.nio.file.Path
@@ -49,7 +51,12 @@ fun DevrigServices.runConnectIdeCommand(command: DevrigCommand.DevrigCommandConn
     runBlocking(Dispatchers.IO) {
         val discovered = portDiscovery.stateSnapshot()
         val client = InstallPluginClient { url ->
-            val response = commandHttpClient.get(url)
+            val response = commandHttpClient.get(url) {
+                // /api/installPlugin trusts localhost callers (RestService.isHostTrusted -> isLocalhost);
+                // devrig is a localhost tool, so we declare our real localhost origin rather than spoof a
+                // marketplace one. Without any Origin the endpoint blocks on an "unknown host" dialog.
+                header(HttpHeaders.Origin, "http://127.0.0.1")
+            }
             InstallPluginResponse(response.status.value, response.bodyAsText())
         }
         runConnectIde(discovered, client, mcpStdout, System.err)

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/ConnectCommand.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/ConnectCommand.kt
@@ -42,7 +42,7 @@ fun runConnectClaude(settingsPath: Path, out: PrintStream, err: PrintStream): In
         err.println("[devrig] atomic move unavailable (${e.message}); falling back to a plain replace.")
         Files.move(tmp, settingsPath, StandardCopyOption.REPLACE_EXISTING)
     }
-    out.println("enabled the devrig plugin for Claude Code in $settingsPath.")
+    out.println("Claude Code plugin now enabled in $settingsPath.")
     out.println("Restart Claude Code (or start a new session) to load it.")
     return 0
 }

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/ConnectCommand.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/ConnectCommand.kt
@@ -1,12 +1,16 @@
 /* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
 package com.jonnyzzz.mcpSteroid.devrig
 
+import io.ktor.client.request.get
+import io.ktor.client.statement.bodyAsText
 import java.io.PrintStream
 import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.StandardCopyOption
 import kotlin.io.path.isRegularFile
 import kotlin.io.path.readText
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runBlocking
 
 /** Absolute path to the user's Claude Code settings file. */
 fun claudeSettingsPath(): Path =
@@ -41,8 +45,12 @@ fun runConnectClaude(settingsPath: Path, out: PrintStream, err: PrintStream): In
     return 0
 }
 
-// Temporary stub — Task 4 replaces this with the real "connect ide" implementation (live IDE discovery
-// + installPlugin). Kept in the same file so the two `connect` dispatch extensions live together.
-fun DevrigServices.runConnectIdeCommand(command: DevrigCommand.DevrigCommandConnectIde): Int {
-    TODO("Task 4")
-}
+fun DevrigServices.runConnectIdeCommand(command: DevrigCommand.DevrigCommandConnectIde): Int =
+    runBlocking(Dispatchers.IO) {
+        val discovered = portDiscovery.stateSnapshot()
+        val client = InstallPluginClient { url ->
+            val response = commandHttpClient.get(url)
+            InstallPluginResponse(response.status.value, response.bodyAsText())
+        }
+        runConnectIde(discovered, client, mcpStdout, System.err)
+    }

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/ConnectCommand.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/ConnectCommand.kt
@@ -59,5 +59,15 @@ fun DevrigServices.runConnectIdeCommand(command: DevrigCommand.DevrigCommandConn
             }
             InstallPluginResponse(response.status.value, response.bodyAsText())
         }
-        runConnectIde(discovered, client, mcpStdout, System.err)
+        val browser = BrowserLauncher { url ->
+            try {
+                ProcessBuilder(browserOpenArgv(detectHostOs(System.getProperty("os.name") ?: ""), url)).start()
+                true
+            } catch (e: Exception) {
+                System.err.println("[devrig] failed to open browser: ${e.message ?: e::class.simpleName}")
+                false
+            }
+        }
+        val outcome = runConnectIde(discovered, pluginMarkerCount = 0, client, browser, mcpStdout, System.err)
+        if (outcome == ConnectIdeOutcome.NO_IDE) 1 else 0
     }

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/ConnectCommand.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/ConnectCommand.kt
@@ -1,0 +1,48 @@
+/* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
+package com.jonnyzzz.mcpSteroid.devrig
+
+import java.io.PrintStream
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.StandardCopyOption
+import kotlin.io.path.isRegularFile
+import kotlin.io.path.readText
+
+/** Absolute path to the user's Claude Code settings file. */
+fun claudeSettingsPath(): Path =
+    Path.of(System.getProperty("user.home"), ".claude", "settings.json")
+
+fun DevrigServices.runConnectClaudeCommand(command: DevrigCommand.DevrigCommandConnectClaude): Int =
+    runConnectClaude(claudeSettingsPath(), mcpStdout, System.err)
+
+/**
+ * Enable the marketplace devrig plugin in Claude Code by merging our two keys into [settingsPath]
+ * (idempotent — see [enableClaudePluginInSettings]). Writes atomically (temp file + ATOMIC_MOVE) so a
+ * concurrent Claude read never sees a torn file. Best-effort narration to [out]; failures throw.
+ */
+fun runConnectClaude(settingsPath: Path, out: PrintStream, err: PrintStream): Int {
+    val current = if (settingsPath.isRegularFile()) settingsPath.readText() else null
+    if (isClaudePluginEnabled(current)) {
+        out.println("Claude Code plugin '$CLAUDE_DEVRIG_PLUGIN_KEY' is already enabled in $settingsPath.")
+        return 0
+    }
+    val updated = enableClaudePluginInSettings(current)
+    Files.createDirectories(settingsPath.parent)
+    val tmp = Files.createTempFile(settingsPath.parent, "settings", ".json.tmp")
+    Files.writeString(tmp, updated)
+    try {
+        Files.move(tmp, settingsPath, StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING)
+    } catch (e: java.nio.file.AtomicMoveNotSupportedException) {
+        err.println("[devrig] atomic move unavailable (${e.message}); falling back to a plain replace.")
+        Files.move(tmp, settingsPath, StandardCopyOption.REPLACE_EXISTING)
+    }
+    out.println("enabled the devrig plugin for Claude Code in $settingsPath.")
+    out.println("Restart Claude Code (or start a new session) to load it.")
+    return 0
+}
+
+// Temporary stub — Task 4 replaces this with the real "connect ide" implementation (live IDE discovery
+// + installPlugin). Kept in the same file so the two `connect` dispatch extensions live together.
+fun DevrigServices.runConnectIdeCommand(command: DevrigCommand.DevrigCommandConnectIde): Int {
+    TODO("Task 4")
+}

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/ConnectIde.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/ConnectIde.kt
@@ -1,0 +1,63 @@
+/* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
+package com.jonnyzzz.mcpSteroid.devrig
+
+import com.jonnyzzz.mcpSteroid.devrig.monitor.DiscoveredIdeByPort
+import java.io.PrintStream
+
+/** Plugin id of the MCP Steroid IntelliJ plugin (matches plugin.xml `<id>`). */
+const val MCP_STEROID_PLUGIN_ID = "com.jonnyzzz.mcpSteroid"
+
+/**
+ * The IntelliJ Platform built-in Netty server picks the first free port starting at 63342 (19 fallbacks).
+ * `/api/installPlugin` lives on THIS server — not on the MCP plugin's 64342 range — so only these ports
+ * are valid `installPlugin` targets.
+ */
+val BUILTIN_SERVER_PORTS: IntRange = 63342..63361
+
+/** Discovered IDEs answering on a built-in-server port, sorted by port for deterministic ordering. */
+fun builtInServerCandidates(discovered: Set<DiscoveredIdeByPort>): List<DiscoveredIdeByPort> =
+    discovered.filter { it.port in BUILTIN_SERVER_PORTS }.sortedBy { it.port }
+
+/** Build an `/api/installPlugin` URL for [baseUrl] with the given [action] and [pluginId]. */
+fun installPluginUrl(baseUrl: String, action: String, pluginId: String): String =
+    "${baseUrl.trimEnd('/')}/api/installPlugin?action=$action&pluginId=$pluginId"
+
+data class InstallPluginResponse(val statusCode: Int, val body: String)
+
+/** HTTP seam so tests inject a fake instead of a live Ktor client. */
+fun interface InstallPluginClient {
+    suspend fun request(url: String): InstallPluginResponse
+}
+
+/**
+ * For every reachable IDE on a built-in-server port, ask its `installPlugin` endpoint to install the
+ * MCP Steroid plugin. The endpoint forces a user confirmation dialog by design (ASK_CONFIRMATION), so
+ * this only *offers* the install; the user approves it in the IDE. `checkCompatibility` is queried first
+ * for a helpful log line. Returns 0 when at least one IDE was offered the install, 1 when none reachable.
+ */
+suspend fun runConnectIde(
+    discovered: Set<DiscoveredIdeByPort>,
+    client: InstallPluginClient,
+    out: PrintStream,
+    err: PrintStream,
+    pluginId: String = MCP_STEROID_PLUGIN_ID,
+): Int {
+    val candidates = builtInServerCandidates(discovered)
+    if (candidates.isEmpty()) {
+        out.println("No running JetBrains IDE with a built-in server was found (probed ports $BUILTIN_SERVER_PORTS).")
+        out.println("Start your IDE and re-run 'devrig connect ide'.")
+        return 1
+    }
+    for (ide in candidates) {
+        val label = ide.productFullName ?: ide.productName ?: ide.baseUrl
+        val compat = client.request(installPluginUrl(ide.baseUrl, "checkCompatibility", pluginId))
+        if (compat.statusCode !in 200..299) {
+            err.println("[devrig] $label: compatibility check returned HTTP ${compat.statusCode}; offering install anyway.")
+        }
+        client.request(installPluginUrl(ide.baseUrl, "install", pluginId))
+        out.println("Requested the MCP Steroid plugin install in $label (port ${ide.port}).")
+    }
+    out.println()
+    out.println(">>> Open your JetBrains IDE and approve the MCP Steroid plugin install dialog. <<<")
+    return 0
+}

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/ConnectIde.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/ConnectIde.kt
@@ -33,7 +33,7 @@ fun interface InstallPluginClient {
 const val MARKETPLACE_INSTALL_URL = "https://plugins.jetbrains.com/embeddable/install/$MCP_STEROID_PLUGIN_ID"
 
 /** Custom plugin repository URL for the manual last-resort instructions. */
-const val CUSTOM_REPO_URL = "https://mcp-steroid.jonnyzzz.com/updatePlugins.xml"
+const val CUSTOM_REPO_URL = "https://devrig.dev/updatePlugins.xml"
 
 /** Outcome of a connect-ide attempt, for the caller to narrate/decide on. */
 enum class ConnectIdeOutcome { ALREADY_CONNECTED, NO_IDE, OFFERED_VIA_HTTP, OFFERED_VIA_BROWSER, MANUAL_INSTRUCTIONS }

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/ConnectIde.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/ConnectIde.kt
@@ -39,12 +39,15 @@ const val CUSTOM_REPO_URL = "https://mcp-steroid.jonnyzzz.com/updatePlugins.xml"
 enum class ConnectIdeOutcome { ALREADY_CONNECTED, NO_IDE, OFFERED_VIA_HTTP, OFFERED_VIA_BROWSER, MANUAL_INSTRUCTIONS }
 
 /**
- * Process exit code for a [ConnectIdeOutcome]: 1 when no IDE was found or the caller was left with
- * manual instructions (nothing was actually offered/connected automatically), 0 otherwise.
+ * Process exit code for a [ConnectIdeOutcome]: 2 when no IDE was found at all (nothing to act on yet —
+ * callers like the onboarding hook should retry later without burning a one-shot offer), 1 when the
+ * caller was left with manual instructions (an IDE was found but nothing could be offered
+ * automatically), 0 otherwise.
  */
 fun connectIdeExitCode(outcome: ConnectIdeOutcome): Int =
     when (outcome) {
-        ConnectIdeOutcome.NO_IDE, ConnectIdeOutcome.MANUAL_INSTRUCTIONS -> 1
+        ConnectIdeOutcome.NO_IDE -> 2
+        ConnectIdeOutcome.MANUAL_INSTRUCTIONS -> 1
         ConnectIdeOutcome.ALREADY_CONNECTED, ConnectIdeOutcome.OFFERED_VIA_HTTP, ConnectIdeOutcome.OFFERED_VIA_BROWSER -> 0
     }
 

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/ConnectIde.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/ConnectIde.kt
@@ -29,35 +29,101 @@ fun interface InstallPluginClient {
     suspend fun request(url: String): InstallPluginResponse
 }
 
+/** Canonical Marketplace one-click install deep link (browser fallback). */
+const val MARKETPLACE_INSTALL_URL = "https://plugins.jetbrains.com/embeddable/install/$MCP_STEROID_PLUGIN_ID"
+
+/** Custom plugin repository URL for the manual last-resort instructions. */
+const val CUSTOM_REPO_URL = "https://mcp-steroid.jonnyzzz.com/updatePlugins.xml"
+
+/** Outcome of a connect-ide attempt, for the caller to narrate/decide on. */
+enum class ConnectIdeOutcome { ALREADY_CONNECTED, NO_IDE, OFFERED_VIA_HTTP, OFFERED_VIA_BROWSER, MANUAL_INSTRUCTIONS }
+
+enum class HostOs { MAC, WINDOWS, LINUX }
+
+/** Map a `System.getProperty("os.name")` value to a HostOs (defaults to LINUX for unknown/unix). */
+fun detectHostOs(osName: String): HostOs {
+    val n = osName.lowercase()
+    return when {
+        n.contains("mac") || n.contains("darwin") -> HostOs.MAC
+        n.contains("win") -> HostOs.WINDOWS
+        else -> HostOs.LINUX
+    }
+}
+
+/** Argv to open [url] in the OS default browser. Windows `start` needs an empty title arg first. */
+fun browserOpenArgv(os: HostOs, url: String): List<String> = when (os) {
+    HostOs.MAC -> listOf("open", url)
+    HostOs.WINDOWS -> listOf("cmd", "/c", "start", "", url)
+    HostOs.LINUX -> listOf("xdg-open", url)
+}
+
+/** Seam for opening a URL in the browser; returns false if the launch failed. */
+fun interface BrowserLauncher {
+    fun open(url: String): Boolean
+}
+
 /**
- * For every reachable IDE on a built-in-server port, ask its `installPlugin` endpoint to install the
- * MCP Steroid plugin. The endpoint forces a user confirmation dialog by design (ASK_CONFIRMATION), so
- * this only *offers* the install; the user approves it in the IDE. `checkCompatibility` is queried first
- * for a helpful log line. Returns 0 when at least one IDE was offered the install, 1 when none reachable.
+ * Offer to install the MCP Steroid plugin into a running JetBrains IDE.
+ *
+ * - If any IDE already advertises the plugin ([pluginMarkerCount] > 0), the bridge already works →
+ *   [ConnectIdeOutcome.ALREADY_CONNECTED], nothing offered.
+ * - Else, for each built-in-server IDE, try the in-IDE install dialog via `installPlugin` ("B"). If any
+ *   returns 2xx → [OFFERED_VIA_HTTP].
+ * - If B is rejected for all candidates, open the Marketplace install page in the browser ("A") →
+ *   [OFFERED_VIA_BROWSER]; the browser carries the trusted jetbrains origin, so the IDE shows its dialog.
+ * - If the browser cannot be launched, print manual instructions ("text") → [MANUAL_INSTRUCTIONS].
  */
 suspend fun runConnectIde(
     discovered: Set<DiscoveredIdeByPort>,
+    pluginMarkerCount: Int,
     client: InstallPluginClient,
+    browser: BrowserLauncher,
     out: PrintStream,
     err: PrintStream,
     pluginId: String = MCP_STEROID_PLUGIN_ID,
-): Int {
+): ConnectIdeOutcome {
+    if (pluginMarkerCount > 0) {
+        out.println("A running JetBrains IDE already has the MCP Steroid plugin — devrig is connected.")
+        return ConnectIdeOutcome.ALREADY_CONNECTED
+    }
     val candidates = builtInServerCandidates(discovered)
     if (candidates.isEmpty()) {
-        out.println("No running JetBrains IDE with a built-in server was found (probed ports $BUILTIN_SERVER_PORTS).")
-        out.println("Start your IDE and re-run 'devrig connect ide'.")
-        return 1
+        out.println("No running JetBrains IDE was found (probed built-in-server ports $BUILTIN_SERVER_PORTS).")
+        return ConnectIdeOutcome.NO_IDE
     }
+
+    var httpOffered = false
     for (ide in candidates) {
         val label = ide.productFullName ?: ide.productName ?: ide.baseUrl
-        val compat = client.request(installPluginUrl(ide.baseUrl, "checkCompatibility", pluginId))
-        if (compat.statusCode !in 200..299) {
-            err.println("[devrig] $label: compatibility check returned HTTP ${compat.statusCode}; offering install anyway.")
+        try {
+            client.request(installPluginUrl(ide.baseUrl, "checkCompatibility", pluginId))
+            val install = client.request(installPluginUrl(ide.baseUrl, "install", pluginId))
+            if (install.statusCode in 200..299) {
+                httpOffered = true
+                out.println("Requested the MCP Steroid plugin install in $label (port ${ide.port}).")
+            } else {
+                err.println("[devrig] $label: install request returned HTTP ${install.statusCode}.")
+            }
+        } catch (e: Exception) {
+            err.println("[devrig] $label: install request failed: ${e.message ?: e::class.simpleName}")
         }
-        client.request(installPluginUrl(ide.baseUrl, "install", pluginId))
-        out.println("Requested the MCP Steroid plugin install in $label (port ${ide.port}).")
     }
-    out.println()
-    out.println(">>> Open your JetBrains IDE and approve the MCP Steroid plugin install dialog. <<<")
-    return 0
+    if (httpOffered) {
+        out.println()
+        out.println(">>> Open your JetBrains IDE and approve the MCP Steroid plugin install dialog. <<<")
+        return ConnectIdeOutcome.OFFERED_VIA_HTTP
+    }
+
+    // B rejected for all candidates → A: open the Marketplace install page in the browser.
+    out.println("Opening the MCP Steroid plugin page in your browser to install it…")
+    if (browser.open(MARKETPLACE_INSTALL_URL)) {
+        out.println("Approve the install in the page (and the IDE dialog it triggers).")
+        return ConnectIdeOutcome.OFFERED_VIA_BROWSER
+    }
+
+    // A failed → text last-resort.
+    out.println("Could not offer the install automatically.")
+    out.println("Install \"MCP Steroid\" via Settings > Plugins (Marketplace),")
+    out.println("or add this plugin repository: $CUSTOM_REPO_URL")
+    return ConnectIdeOutcome.MANUAL_INSTRUCTIONS
 }

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/ConnectIde.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/ConnectIde.kt
@@ -38,6 +38,16 @@ const val CUSTOM_REPO_URL = "https://mcp-steroid.jonnyzzz.com/updatePlugins.xml"
 /** Outcome of a connect-ide attempt, for the caller to narrate/decide on. */
 enum class ConnectIdeOutcome { ALREADY_CONNECTED, NO_IDE, OFFERED_VIA_HTTP, OFFERED_VIA_BROWSER, MANUAL_INSTRUCTIONS }
 
+/**
+ * Process exit code for a [ConnectIdeOutcome]: 1 when no IDE was found or the caller was left with
+ * manual instructions (nothing was actually offered/connected automatically), 0 otherwise.
+ */
+fun connectIdeExitCode(outcome: ConnectIdeOutcome): Int =
+    when (outcome) {
+        ConnectIdeOutcome.NO_IDE, ConnectIdeOutcome.MANUAL_INSTRUCTIONS -> 1
+        ConnectIdeOutcome.ALREADY_CONNECTED, ConnectIdeOutcome.OFFERED_VIA_HTTP, ConnectIdeOutcome.OFFERED_VIA_BROWSER -> 0
+    }
+
 enum class HostOs { MAC, WINDOWS, LINUX }
 
 /** Map a `System.getProperty("os.name")` value to a HostOs (defaults to LINUX for unknown/unix). */
@@ -96,7 +106,10 @@ suspend fun runConnectIde(
     for (ide in candidates) {
         val label = ide.productFullName ?: ide.productName ?: ide.baseUrl
         try {
-            client.request(installPluginUrl(ide.baseUrl, "checkCompatibility", pluginId))
+            val compat = client.request(installPluginUrl(ide.baseUrl, "checkCompatibility", pluginId))
+            if (compat.statusCode !in 200..299) {
+                err.println("[devrig] $label: compatibility check returned HTTP ${compat.statusCode}; offering install anyway.")
+            }
             val install = client.request(installPluginUrl(ide.baseUrl, "install", pluginId))
             if (install.statusCode in 200..299) {
                 httpOffered = true
@@ -104,8 +117,10 @@ suspend fun runConnectIde(
             } else {
                 err.println("[devrig] $label: install request returned HTTP ${install.statusCode}.")
             }
+        } catch (e: kotlinx.coroutines.CancellationException) {
+            throw e
         } catch (e: Exception) {
-            err.println("[devrig] $label: install request failed: ${e.message ?: e::class.simpleName}")
+            err.println("[devrig] $label: install offer failed: ${e.message ?: e::class.simpleName}")
         }
     }
     if (httpOffered) {

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/ConnectIde.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/ConnectIde.kt
@@ -5,7 +5,7 @@ import com.jonnyzzz.mcpSteroid.devrig.monitor.DiscoveredIdeByPort
 import java.io.PrintStream
 
 /** Plugin id of the MCP Steroid IntelliJ plugin (matches plugin.xml `<id>`). */
-const val MCP_STEROID_PLUGIN_ID = "com.jonnyzzz.mcpSteroid"
+const val MCP_STEROID_PLUGIN_ID = "com.jonnyzzz.mcp-steroid"
 
 /**
  * The IntelliJ Platform built-in Netty server picks the first free port starting at 63342 (19 fallbacks).

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/DevrigBeacon.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/DevrigBeacon.kt
@@ -72,6 +72,8 @@ class DevrigBeacon(
             is DevrigCommand.DevrigCommandProject -> "project"
             is DevrigCommand.DevrigCommandInstall -> "install"
             is DevrigCommand.DevrigCommandInstallDevrig -> "install"
+            is DevrigCommand.DevrigCommandConnectClaude,
+            is DevrigCommand.DevrigCommandConnectIde -> "connect"
             is DevrigCommand.DevrigCommandHelp -> null
             is DevrigCommand.DevrigCommandVersion -> null
             is DevrigCommand.DevrigCommandParseError -> null

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/InstallCommand.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/InstallCommand.kt
@@ -317,7 +317,9 @@ fun runInstallCheckCommand(
     // install would register. Anything else — stale launcher/subcommand, duplicates, a custom name, no
     // entry, or an unreadable list — is drift.
     val canonical = listReadable &&
-        detected.singleOrNull()?.let { it.name == DEVRIG_MCP_SERVER_NAME && it.commandLine == renderedCommand } == true
+        detected.singleOrNull()?.let {
+            it.name == DEVRIG_MCP_SERVER_NAME && mcpCommandLinesEquivalent(it.commandLine, renderedCommand)
+        } == true
 
     out.println("What 'devrig install ${agent.binary}' would change:")
     if (canonical) {

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/InstallCommand.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/InstallCommand.kt
@@ -179,6 +179,24 @@ fun runInstallCommand(
         removed.forEach { out.println("  - removed '$it'") }
     }
 
+    // The devrig Claude plugin registers this server from its own .mcp.json — it shows up as
+    // 'plugin:devrig:devrig'. Adding a user-scope entry on top would start a SECOND devrig server, so stop
+    // here: the duplicates cleared above are gone and the plugin's registration stands as the canonical one.
+    val pluginProvided = detected.filter { it.isPluginProvided() }
+    if (pluginProvided.isNotEmpty()) {
+        out.println(
+            "Step 3/3: skipped — ${agent.displayName}'s devrig plugin already provides this server " +
+                "(${pluginProvided.joinToString(", ") { "'${it.name}'" }}).",
+        )
+        out.println()
+        out.println(
+            "Done — devrig is registered for ${agent.displayName} by its plugin; nothing to add " +
+                "(a user-scope entry would duplicate the server).",
+        )
+        out.println("  Verify with: ${agent.binary} mcp list")
+        return 0
+    }
+
     // Step 3 — add the single canonical registration.
     out.println("Step 3/3: registering '$DEVRIG_MCP_SERVER_NAME' with ${agent.displayName}…")
     val addInvocation = mcpAddStdioInvocation(agent, mcpCommand, DEVRIG_MCP_SERVER_NAME)
@@ -214,10 +232,14 @@ private fun emitAgentOutput(result: AiAgentCliResult, err: PrintStream) {
  * never drift from what install actually does: every detected devrig-owned entry, the canonical name
  * (always, so the re-add is clean even if the listing missed it), plus the legacy name when the agent's
  * list could not be read.
+ *
+ * Plugin-provided entries (`plugin:devrig:devrig`) are EXCLUDED: they are owned by the plugin's own
+ * `.mcp.json`, `claude mcp remove` cannot delete them, and they are the canonical registration in a
+ * plugin install — see [McpServerRef.isPluginProvided].
  */
 internal fun installRemovalNames(detected: List<McpServerRef>, listReadable: Boolean): Set<String> {
     val names = LinkedHashSet<String>()
-    detected.forEach { names += it.name }
+    detected.filterNot { it.isPluginProvided() }.forEach { names += it.name }
     names += DEVRIG_MCP_SERVER_NAME
     if (!listReadable) names += DEVRIG_LEGACY_SERVER_NAME
     return names
@@ -258,7 +280,9 @@ fun DevrigServices.collectIdeReachability(): IdeReachabilityReport {
  *
  * Returns 0 when the registration is already canonical (re-running install would change nothing) and
  * [INSTALL_CHECK_DRIFT_EXIT_CODE] when install would change anything — including when the agent's server
- * list cannot be read, since the state cannot be verified then.
+ * list cannot be read, since the state cannot be verified then. A registration contributed by the agent's
+ * own devrig PLUGIN ([McpServerRef.isPluginProvided]) counts as canonical: it is a working server that
+ * install must neither remove nor duplicate.
  *
  * Stateless by design (Tenet 3): the only agent CLI invocation is the read-only `mcp list`, the IDE probe
  * reads markers/ports on demand, and the check writes nothing — two concurrent `--check` runs are safe.
@@ -313,13 +337,33 @@ fun runInstallCheckCommand(
     }
     out.println()
 
-    // Canonical = exactly one devrig-owned entry, under the canonical name, launching the exact command
-    // install would register. Anything else — stale launcher/subcommand, duplicates, a custom name, no
-    // entry, or an unreadable list — is drift.
-    val canonical = listReadable &&
-        detected.singleOrNull()?.let {
+    // A devrig entry contributed by the agent's PLUGIN (`plugin:devrig:devrig`) is already canonical: the
+    // plugin's .mcp.json owns it and launches devrig through ${CLAUDE_PLUGIN_ROOT}/bin/devrig-mcp. Install
+    // neither can nor should touch it — registering a second user-scope 'devrig' would only duplicate the
+    // server — so in that case the only thing left to reconcile is a stale user-scope duplicate.
+    val pluginProvided = detected.filter { it.isPluginProvided() }
+    val userScope = detected.filterNot { it.isPluginProvided() }
+
+    // Canonical = the plugin provides it and there is no user-scope duplicate; or (no plugin entry)
+    // exactly one user-scope entry, under the canonical name, launching the exact command install would
+    // register. Anything else — stale launcher/subcommand, duplicates, a custom name, no entry, or an
+    // unreadable list — is drift.
+    val canonical = listReadable && if (pluginProvided.isNotEmpty()) {
+        userScope.isEmpty()
+    } else {
+        userScope.singleOrNull()?.let {
             it.name == DEVRIG_MCP_SERVER_NAME && mcpCommandLinesEquivalent(it.commandLine, renderedCommand)
         } == true
+    }
+
+    if (pluginProvided.isNotEmpty()) {
+        out.println(
+            "The ${agent.displayName} devrig plugin provides this server " +
+                "(${pluginProvided.joinToString(", ") { "'${it.name}'" }}) — its .mcp.json owns the " +
+                "registration, so devrig does not add a second, user-scope one.",
+        )
+        out.println()
+    }
 
     out.println("What 'devrig install ${agent.binary}' would change:")
     if (canonical) {
@@ -327,11 +371,12 @@ fun runInstallCheckCommand(
     } else {
         // The EXACT removal set install would issue (shared via installRemovalNames) — names install
         // clears defensively even when not detected are annotated "if present".
-        val detectedNames = detected.map { it.name }.toSet()
+        val detectedNames = userScope.map { it.name }.toSet()
         for (name in installRemovalNames(detected, listReadable)) {
             out.println("  - remove '$name'" + if (name in detectedNames) "" else ", if present")
         }
-        out.println("  - add '$DEVRIG_MCP_SERVER_NAME' → $renderedCommand")
+        // With a plugin-provided entry present, install stops after the cleanup — it never re-adds.
+        if (pluginProvided.isEmpty()) out.println("  - add '$DEVRIG_MCP_SERVER_NAME' → $renderedCommand")
     }
     out.println()
 
@@ -339,7 +384,11 @@ fun runInstallCheckCommand(
     out.println()
 
     return if (canonical) {
-        out.println("No drift — '$DEVRIG_MCP_SERVER_NAME' is registered canonically for ${agent.displayName}.")
+        if (pluginProvided.isNotEmpty()) {
+            out.println("No drift — devrig is provided by the ${agent.displayName} plugin.")
+        } else {
+            out.println("No drift — '$DEVRIG_MCP_SERVER_NAME' is registered canonically for ${agent.displayName}.")
+        }
         0
     } else {
         out.println("Drift detected — run 'devrig install ${agent.binary}' to repair.")

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/InstallCommand.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/InstallCommand.kt
@@ -12,8 +12,8 @@ import java.io.PrintStream
 import java.nio.file.Path
 import kotlin.io.path.isRegularFile
 
-private const val DEVRIG_MCP_SERVER_NAME = "mcp-steroid"
-private const val DEVRIG_LEGACY_SERVER_NAME = "devrig"
+private const val DEVRIG_MCP_SERVER_NAME = "devrig"
+private const val DEVRIG_LEGACY_SERVER_NAME = "mcp-steroid"
 
 /** Exit code of `devrig install <agent> --check` when install would change anything (drift detected). */
 const val INSTALL_CHECK_DRIFT_EXIT_CODE = 1
@@ -38,7 +38,7 @@ const val INSTALL_CHECK_DRIFT_EXIT_CODE = 1
 fun DevrigServices.runInstallDevrigCommand(command: DevrigCommand.DevrigCommandInstallDevrig): Int {
     val installScript = command.installScript
     if (installScript.isNullOrBlank()) {
-        System.err.println("[mcp-steroid] 'devrig install devrig' requires --install-script=<full path>")
+        System.err.println("[devrig] 'devrig install devrig' requires --install-script=<full path>")
         return 64
     }
     // --jdk-home is what the wrapper pins as DEVRIG_JAVA_HOME; fall back to the JDK we run under.
@@ -49,12 +49,12 @@ fun DevrigServices.runInstallDevrigCommand(command: DevrigCommand.DevrigCommandI
     val launcher = DevrigUserLauncher.path(homePaths)
     if (!launcher.isRegularFile()) {
         System.err.println(
-            "[mcp-steroid] ERROR: 'devrig install devrig' did not create the launcher $launcher " +
+            "[devrig] ERROR: 'devrig install devrig' did not create the launcher $launcher " +
                 "(DEVRIG_BIN_NO_AUTO_REGISTER may opt out of writing it).",
         )
         return 64
     }
-    System.err.println("[mcp-steroid] devrig is on PATH via $launcher")
+    System.err.println("[devrig] devrig is on PATH via $launcher")
     return 0
 }
 
@@ -85,7 +85,7 @@ fun DevrigServices.runInstallCommand(
     val launcher = DevrigUserLauncher.path(homePaths)
     if (!launcher.isRegularFile()) {
         System.err.println(
-            "[mcp-steroid] ERROR: cannot register the MCP server — the launcher $launcher was not created.",
+            "[devrig] ERROR: cannot register the MCP server — the launcher $launcher was not created.",
         )
         System.err.println(
             "  This usually means DEVRIG_BIN_NO_AUTO_REGISTER opts out of writing it. Unset that " +
@@ -103,14 +103,14 @@ fun DevrigServices.runInstallCommand(
 }
 
 /**
- * Registers devrig as the `mcp-steroid` stdio MCP server in [command]'s agent, narrating each step so
+ * Registers devrig as the `devrig` stdio MCP server in [command]'s agent, narrating each step so
  * the user understands exactly what is being changed.
  *
  * The registration is an **idempotent, consolidating upsert**:
  *  1. it reviews the agent's currently registered MCP servers;
  *  2. it removes every devrig-owned entry it finds — any named `mcp-steroid` or `devrig`, or whose
  *     launch command runs the devrig binary — collapsing duplicates/stale variants into one;
- *  3. it adds a single canonical `mcp-steroid` entry.
+ *  3. it adds a single canonical `devrig` entry.
  *
  * That is what makes re-running `devrig install` safe and self-healing: it repairs a stale entry (old
  * launcher path or subcommand) and merges stray duplicates instead of failing with "already exists",

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/Main.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/Main.kt
@@ -149,7 +149,9 @@ private fun DevrigCommand.runsTool(): Boolean = when (this) {
     is DevrigCommand.DevrigCommandBackendProvision,
     is DevrigCommand.DevrigCommandProject,
     is DevrigCommand.DevrigCommandInstall,
-    is DevrigCommand.DevrigCommandInstallDevrig -> true
+    is DevrigCommand.DevrigCommandInstallDevrig,
+    is DevrigCommand.DevrigCommandConnectClaude,
+    is DevrigCommand.DevrigCommandConnectIde -> true
     is DevrigCommand.DevrigCommandHelp,
     is DevrigCommand.DevrigCommandVersion,
     is DevrigCommand.DevrigCommandParseError -> false

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/McpServerListReview.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/McpServerListReview.kt
@@ -40,6 +40,23 @@ fun McpServerRef.devrigMatchReason(): String = when {
 }
 
 /**
+ * True when two rendered launch command lines are equivalent for canonical-registration purposes —
+ * tolerant of differences that do not change what is executed.
+ *
+ * The motivating case (Windows): [DevrigUserLauncher.invocation] double-quotes the `cmd.exe` launcher
+ * path so it survives a `%USERPROFILE%` with spaces, so the command devrig REGISTERS (and the canonical
+ * form it compares against) is `cmd.exe /d /c "<path>" mcp`. But `claude mcp list` echoes the stored
+ * command back WITHOUT those quotes (`cmd.exe /d /c <path> mcp`). An exact string compare then reports
+ * permanent false "drift" that re-running install can never fix. Normalizing away the quotes — and
+ * collapsing runs of whitespace — makes the compare reflect the actual launch, not its cosmetic quoting.
+ */
+fun mcpCommandLinesEquivalent(a: String, b: String): Boolean =
+    normalizeMcpCommandLine(a) == normalizeMcpCommandLine(b)
+
+private fun normalizeMcpCommandLine(commandLine: String): String =
+    commandLine.replace("\"", "").trim().replace(Regex("\\s+"), " ")
+
+/**
  * Parse the output of `<agent> mcp list` into the registered servers. codex emits a JSON array
  * (`--json`); claude and gemini emit a line-oriented `name: <command> - <status>` listing. Parsing is
  * best-effort: a format we can't read yields an empty list (the caller falls back to reconciling the

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/McpServerListReview.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/McpServerListReview.kt
@@ -31,6 +31,18 @@ fun McpServerRef.matchesDevrigCommand(): Boolean = commandLine.contains("devrig"
  */
 fun McpServerRef.isDevrigOwned(): Boolean = matchesDevrigName() || matchesDevrigCommand()
 
+/**
+ * True when this registration comes from an installed Claude Code **plugin** — a `.mcp.json` inside the
+ * plugin — rather than from user/project scope. `claude mcp list` reports those under a
+ * `plugin:<plugin>:<server>` name.
+ *
+ * This matters because the devrig Claude plugin registers devrig exactly that way
+ * (`plugin:devrig:devrig` → `${'$'}{CLAUDE_PLUGIN_ROOT}/bin/devrig-mcp`). Such an entry is a WORKING,
+ * canonical registration that `claude mcp remove` cannot delete, so it must never be reported as drift,
+ * scheduled for removal, or shadowed by a second user-scope `devrig` entry (issue #253).
+ */
+fun McpServerRef.isPluginProvided(): Boolean = name.startsWith("plugin:")
+
 /** Human-readable reason this entry was detected, naming which signal(s) matched — for install narration. */
 fun McpServerRef.devrigMatchReason(): String = when {
     matchesDevrigName() && matchesDevrigCommand() -> "name + config"

--- a/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/ClaudePluginConnectTest.kt
+++ b/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/ClaudePluginConnectTest.kt
@@ -55,6 +55,10 @@ class ClaudePluginConnectTest {
         assertFalse(isClaudePluginEnabled("{}"))
         assertFalse(isClaudePluginEnabled("""{"enabledPlugins":{"foo@other":true}}"""))
         assertTrue(isClaudePluginEnabled(enableClaudePluginInSettings(null)))
-        assertFalse(isClaudePluginEnabled("""{"enabledPlugins":{"devrig@mcp-steroid":false}}"""))
+        assertFalse(isClaudePluginEnabled("""{"enabledPlugins":{"devrig@jonnyzzz":false}}"""))
+        // The marketplace name must be the one declared in .claude-plugin/marketplace.json, so the
+        // pre-fix `devrig@mcp-steroid` key names no real plugin and must not read as enabled.
+        assertEquals("devrig@jonnyzzz", CLAUDE_DEVRIG_PLUGIN_KEY)
+        assertFalse(isClaudePluginEnabled("""{"enabledPlugins":{"devrig@mcp-steroid":true}}"""))
     }
 }

--- a/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/ClaudePluginConnectTest.kt
+++ b/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/ClaudePluginConnectTest.kt
@@ -1,0 +1,60 @@
+/* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
+package com.jonnyzzz.mcpSteroid.devrig
+
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class ClaudePluginConnectTest {
+    private fun parse(s: String) = Json.parseToJsonElement(s).jsonObject
+
+    @Test
+    fun `enable on null produces the marketplace and enabled plugin`() {
+        val out = parse(enableClaudePluginInSettings(null))
+        val marketplaces = out["extraKnownMarketplaces"]!!.jsonObject
+        val source = marketplaces[CLAUDE_MARKETPLACE_NAME]!!.jsonObject["source"]!!.jsonObject
+        assertEquals("github", source["source"]!!.jsonPrimitive.content)
+        assertEquals(CLAUDE_MARKETPLACE_REPO, source["repo"]!!.jsonPrimitive.content)
+        assertTrue(out["enabledPlugins"]!!.jsonObject[CLAUDE_DEVRIG_PLUGIN_KEY]!!.jsonPrimitive.content == "true")
+    }
+
+    @Test
+    fun `enable preserves unrelated keys and other marketplaces`() {
+        val input = """
+            {
+              "model": "opus",
+              "extraKnownMarketplaces": { "other": { "source": { "source": "github", "repo": "a/b" } } },
+              "enabledPlugins": { "foo@other": true }
+            }
+        """.trimIndent()
+        val out = parse(enableClaudePluginInSettings(input))
+        assertEquals("opus", out["model"]!!.jsonPrimitive.content)
+        val mk = out["extraKnownMarketplaces"]!!.jsonObject
+        assertTrue(mk.containsKey("other"), "existing marketplace preserved")
+        assertTrue(mk.containsKey(CLAUDE_MARKETPLACE_NAME), "ours added")
+        val plugins = out["enabledPlugins"]!!.jsonObject
+        assertTrue(plugins.containsKey("foo@other"), "existing plugin preserved")
+        assertTrue(plugins.containsKey(CLAUDE_DEVRIG_PLUGIN_KEY), "ours added")
+    }
+
+    @Test
+    fun `enable is idempotent`() {
+        val once = enableClaudePluginInSettings(null)
+        val twice = enableClaudePluginInSettings(once)
+        assertEquals(once, twice)
+    }
+
+    @Test
+    fun `detection reflects state`() {
+        assertFalse(isClaudePluginEnabled(null))
+        assertFalse(isClaudePluginEnabled("{}"))
+        assertFalse(isClaudePluginEnabled("""{"enabledPlugins":{"foo@other":true}}"""))
+        assertTrue(isClaudePluginEnabled(enableClaudePluginInSettings(null)))
+        assertFalse(isClaudePluginEnabled("""{"enabledPlugins":{"devrig@mcp-steroid":false}}"""))
+    }
+}

--- a/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/ConnectClaudeCommandTest.kt
+++ b/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/ConnectClaudeCommandTest.kt
@@ -1,0 +1,65 @@
+/* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
+package com.jonnyzzz.mcpSteroid.devrig
+
+import java.io.ByteArrayOutputStream
+import java.io.PrintStream
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.io.path.readText
+import kotlin.io.path.writeText
+import kotlin.test.Test
+import kotlin.test.assertContains
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class ConnectClaudeCommandTest {
+    private fun capture(): Pair<PrintStream, ByteArrayOutputStream> {
+        val buf = ByteArrayOutputStream()
+        return PrintStream(buf, true, "UTF-8") to buf
+    }
+
+    @Test
+    fun `writes settings when file is absent`() {
+        val dir = Files.createTempDirectory("claude-home")
+        val settings = dir.resolve(".claude").resolve("settings.json")
+        val (out, outBuf) = capture()
+        val (err, _) = capture()
+
+        val code = runConnectClaude(settings, out, err)
+
+        assertEquals(0, code)
+        assertTrue(isClaudePluginEnabled(settings.readText()))
+        assertContains(outBuf.toString("UTF-8"), "enabled")
+    }
+
+    @Test
+    fun `is idempotent and does not error when already enabled`() {
+        val dir = Files.createTempDirectory("claude-home")
+        val settings = dir.resolve(".claude").resolve("settings.json")
+        Files.createDirectories(settings.parent)
+        settings.writeText(enableClaudePluginInSettings(null))
+        val (out, outBuf) = capture()
+        val (err, _) = capture()
+
+        val code = runConnectClaude(settings, out, err)
+
+        assertEquals(0, code)
+        assertTrue(isClaudePluginEnabled(settings.readText()))
+        assertContains(outBuf.toString("UTF-8"), "already")
+    }
+
+    @Test
+    fun `preserves existing unrelated settings`() {
+        val dir = Files.createTempDirectory("claude-home")
+        val settings = dir.resolve(".claude").resolve("settings.json")
+        Files.createDirectories(settings.parent)
+        settings.writeText("""{"model":"opus"}""")
+        val (out, _) = capture()
+        val (err, _) = capture()
+
+        runConnectClaude(settings, out, err)
+
+        assertContains(settings.readText(), "\"model\": \"opus\"")
+        assertTrue(isClaudePluginEnabled(settings.readText()))
+    }
+}

--- a/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/ConnectIdeTest.kt
+++ b/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/ConnectIdeTest.kt
@@ -12,66 +12,78 @@ import kotlin.test.assertTrue
 
 class ConnectIdeTest {
     private fun ide(port: Int) = DiscoveredIdeByPort(
-        port = port,
-        baseUrl = "http://127.0.0.1:$port",
-        productName = "IDEA",
-        productFullName = "IntelliJ IDEA",
-        edition = "IU",
-        baselineVersion = 261,
-        buildNumber = "261.1",
+        port = port, baseUrl = "http://127.0.0.1:$port", productName = "IDEA",
+        productFullName = "IntelliJ IDEA", edition = "IU", baselineVersion = 261, buildNumber = "261.1",
     )
-
     private fun capture(): Pair<PrintStream, ByteArrayOutputStream> {
         val buf = ByteArrayOutputStream()
         return PrintStream(buf, true, "UTF-8") to buf
     }
+    private val okClient = InstallPluginClient { InstallPluginResponse(200, "{\"compatible\":true}") }
+    private val failClient = InstallPluginClient { InstallPluginResponse(403, "nope") }
+    private val browserOk = BrowserLauncher { true }
+    private val browserFail = BrowserLauncher { false }
 
-    @Test
-    fun `only built-in-server ports are candidates`() {
-        val candidates = builtInServerCandidates(setOf(ide(63342), ide(64342), ide(63350), ide(70000)))
-        assertEquals(listOf(63342, 63350), candidates.map { it.port })
+    @Test fun `only built-in-server ports are candidates`() {
+        assertEquals(listOf(63342, 63350), builtInServerCandidates(setOf(ide(63342), ide(64342), ide(63350), ide(70000))).map { it.port })
     }
 
-    @Test
-    fun `install url is well formed`() {
+    @Test fun `install url is well formed`() {
         assertEquals(
             "http://127.0.0.1:63342/api/installPlugin?action=install&pluginId=com.jonnyzzz.mcp-steroid",
             installPluginUrl("http://127.0.0.1:63342/", "install", MCP_STEROID_PLUGIN_ID),
         )
     }
 
-    @Test
-    fun `run issues checkCompatibility then install per candidate and prints the nudge`() {
-        val urls = mutableListOf<String>()
-        val client = InstallPluginClient { url -> urls += url; InstallPluginResponse(200, "{\"compatible\":true}") }
-        val (out, outBuf) = capture()
-        val (err, _) = capture()
-
-        val code = runBlocking { runConnectIde(setOf(ide(63342)), client, out, err, MCP_STEROID_PLUGIN_ID) }
-
-        assertEquals(0, code)
-        assertEquals(2, urls.size)
-        assertContains(urls[0], "action=checkCompatibility")
-        assertContains(urls[1], "action=install")
-        assertContains(outBuf.toString("UTF-8"), "approve")
+    @Test fun `browser open argv is per-OS`() {
+        assertEquals(listOf("open", "u"), browserOpenArgv(HostOs.MAC, "u"))
+        assertEquals(listOf("xdg-open", "u"), browserOpenArgv(HostOs.LINUX, "u"))
+        assertEquals(listOf("cmd", "/c", "start", "", "u"), browserOpenArgv(HostOs.WINDOWS, "u"))
     }
 
-    @Test
-    fun `run reports when no IDE is reachable`() {
+    @Test fun `detectHostOs maps os name`() {
+        assertEquals(HostOs.MAC, detectHostOs("Mac OS X"))
+        assertEquals(HostOs.WINDOWS, detectHostOs("Windows 11"))
+        assertEquals(HostOs.LINUX, detectHostOs("Linux"))
+    }
+
+    @Test fun `already-connected when a plugin marker exists — no offer`() {
+        val (out, buf) = capture(); val (err, _) = capture()
         val client = InstallPluginClient { error("must not be called") }
-        val (out, outBuf) = capture()
-        val (err, _) = capture()
-
-        val code = runBlocking { runConnectIde(emptySet(), client, out, err, MCP_STEROID_PLUGIN_ID) }
-
-        assertEquals(1, code)
-        assertTrue(outBuf.toString("UTF-8").contains("No running JetBrains IDE"))
+        val browser = BrowserLauncher { error("must not be called") }
+        val outcome = runBlocking { runConnectIde(setOf(ide(63342)), pluginMarkerCount = 1, client, browser, out, err) }
+        assertEquals(ConnectIdeOutcome.ALREADY_CONNECTED, outcome)
+        assertContains(buf.toString("UTF-8"), "already")
     }
 
-    @Test
-    fun `install plugin response carries status and body`() {
-        val r = InstallPluginResponse(404, "nope")
-        assertEquals(404, r.statusCode)
-        assertEquals("nope", r.body)
+    @Test fun `no IDE reachable`() {
+        val (out, buf) = capture(); val (err, _) = capture()
+        val outcome = runBlocking { runConnectIde(emptySet(), 0, okClient, browserOk, out, err) }
+        assertEquals(ConnectIdeOutcome.NO_IDE, outcome)
+        assertTrue(buf.toString("UTF-8").contains("No running JetBrains IDE"))
+    }
+
+    @Test fun `B succeeds — offered via http, browser untouched`() {
+        val (out, buf) = capture(); val (err, _) = capture()
+        val browser = BrowserLauncher { error("must not be called") }
+        val outcome = runBlocking { runConnectIde(setOf(ide(63342)), 0, okClient, browser, out, err) }
+        assertEquals(ConnectIdeOutcome.OFFERED_VIA_HTTP, outcome)
+        assertContains(buf.toString("UTF-8"), "approve")
+    }
+
+    @Test fun `B fails then browser opens — offered via browser`() {
+        val (out, buf) = capture(); val (err, _) = capture()
+        val outcome = runBlocking { runConnectIde(setOf(ide(63342)), 0, failClient, browserOk, out, err) }
+        assertEquals(ConnectIdeOutcome.OFFERED_VIA_BROWSER, outcome)
+        assertContains(buf.toString("UTF-8"), "browser")
+    }
+
+    @Test fun `B fails and browser fails — manual instructions`() {
+        val (out, buf) = capture(); val (err, _) = capture()
+        val outcome = runBlocking { runConnectIde(setOf(ide(63342)), 0, failClient, browserFail, out, err) }
+        assertEquals(ConnectIdeOutcome.MANUAL_INSTRUCTIONS, outcome)
+        val s = buf.toString("UTF-8")
+        assertContains(s, "Settings")
+        assertContains(s, CUSTOM_REPO_URL)
     }
 }

--- a/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/ConnectIdeTest.kt
+++ b/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/ConnectIdeTest.kt
@@ -35,7 +35,7 @@ class ConnectIdeTest {
     @Test
     fun `install url is well formed`() {
         assertEquals(
-            "http://127.0.0.1:63342/api/installPlugin?action=install&pluginId=com.jonnyzzz.mcpSteroid",
+            "http://127.0.0.1:63342/api/installPlugin?action=install&pluginId=com.jonnyzzz.mcp-steroid",
             installPluginUrl("http://127.0.0.1:63342/", "install", MCP_STEROID_PLUGIN_ID),
         )
     }

--- a/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/ConnectIdeTest.kt
+++ b/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/ConnectIdeTest.kt
@@ -1,0 +1,70 @@
+/* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
+package com.jonnyzzz.mcpSteroid.devrig
+
+import com.jonnyzzz.mcpSteroid.devrig.monitor.DiscoveredIdeByPort
+import java.io.ByteArrayOutputStream
+import java.io.PrintStream
+import kotlinx.coroutines.runBlocking
+import kotlin.test.Test
+import kotlin.test.assertContains
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class ConnectIdeTest {
+    private fun ide(port: Int) = DiscoveredIdeByPort(
+        port = port,
+        baseUrl = "http://127.0.0.1:$port",
+        productName = "IDEA",
+        productFullName = "IntelliJ IDEA",
+        edition = "IU",
+        baselineVersion = 261,
+        buildNumber = "261.1",
+    )
+
+    private fun capture(): Pair<PrintStream, ByteArrayOutputStream> {
+        val buf = ByteArrayOutputStream()
+        return PrintStream(buf, true, "UTF-8") to buf
+    }
+
+    @Test
+    fun `only built-in-server ports are candidates`() {
+        val candidates = builtInServerCandidates(setOf(ide(63342), ide(64342), ide(63350), ide(70000)))
+        assertEquals(listOf(63342, 63350), candidates.map { it.port })
+    }
+
+    @Test
+    fun `install url is well formed`() {
+        assertEquals(
+            "http://127.0.0.1:63342/api/installPlugin?action=install&pluginId=com.jonnyzzz.mcpSteroid",
+            installPluginUrl("http://127.0.0.1:63342/", "install", MCP_STEROID_PLUGIN_ID),
+        )
+    }
+
+    @Test
+    fun `run issues checkCompatibility then install per candidate and prints the nudge`() {
+        val urls = mutableListOf<String>()
+        val client = InstallPluginClient { url -> urls += url; InstallPluginResponse(200, "{\"compatible\":true}") }
+        val (out, outBuf) = capture()
+        val (err, _) = capture()
+
+        val code = runBlocking { runConnectIde(setOf(ide(63342)), client, out, err, MCP_STEROID_PLUGIN_ID) }
+
+        assertEquals(0, code)
+        assertEquals(2, urls.size)
+        assertContains(urls[0], "action=checkCompatibility")
+        assertContains(urls[1], "action=install")
+        assertContains(outBuf.toString("UTF-8"), "approve")
+    }
+
+    @Test
+    fun `run reports when no IDE is reachable`() {
+        val client = InstallPluginClient { error("must not be called") }
+        val (out, outBuf) = capture()
+        val (err, _) = capture()
+
+        val code = runBlocking { runConnectIde(emptySet(), client, out, err, MCP_STEROID_PLUGIN_ID) }
+
+        assertEquals(1, code)
+        assertTrue(outBuf.toString("UTF-8").contains("No running JetBrains IDE"))
+    }
+}

--- a/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/ConnectIdeTest.kt
+++ b/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/ConnectIdeTest.kt
@@ -88,7 +88,7 @@ class ConnectIdeTest {
     }
 
     @Test fun `exit code maps outcome to process exit status`() {
-        assertEquals(1, connectIdeExitCode(ConnectIdeOutcome.NO_IDE))
+        assertEquals(2, connectIdeExitCode(ConnectIdeOutcome.NO_IDE))
         assertEquals(1, connectIdeExitCode(ConnectIdeOutcome.MANUAL_INSTRUCTIONS))
         assertEquals(0, connectIdeExitCode(ConnectIdeOutcome.ALREADY_CONNECTED))
         assertEquals(0, connectIdeExitCode(ConnectIdeOutcome.OFFERED_VIA_HTTP))

--- a/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/ConnectIdeTest.kt
+++ b/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/ConnectIdeTest.kt
@@ -86,4 +86,12 @@ class ConnectIdeTest {
         assertContains(s, "Settings")
         assertContains(s, CUSTOM_REPO_URL)
     }
+
+    @Test fun `exit code maps outcome to process exit status`() {
+        assertEquals(1, connectIdeExitCode(ConnectIdeOutcome.NO_IDE))
+        assertEquals(1, connectIdeExitCode(ConnectIdeOutcome.MANUAL_INSTRUCTIONS))
+        assertEquals(0, connectIdeExitCode(ConnectIdeOutcome.ALREADY_CONNECTED))
+        assertEquals(0, connectIdeExitCode(ConnectIdeOutcome.OFFERED_VIA_HTTP))
+        assertEquals(0, connectIdeExitCode(ConnectIdeOutcome.OFFERED_VIA_BROWSER))
+    }
 }

--- a/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/ConnectIdeTest.kt
+++ b/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/ConnectIdeTest.kt
@@ -67,4 +67,11 @@ class ConnectIdeTest {
         assertEquals(1, code)
         assertTrue(outBuf.toString("UTF-8").contains("No running JetBrains IDE"))
     }
+
+    @Test
+    fun `install plugin response carries status and body`() {
+        val r = InstallPluginResponse(404, "nope")
+        assertEquals(404, r.statusCode)
+        assertEquals("nope", r.body)
+    }
 }

--- a/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/DevrigCommandTest.kt
+++ b/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/DevrigCommandTest.kt
@@ -118,6 +118,13 @@ class DevrigCommandTest {
         assertIs<DevrigCommand.DevrigCommandParseError>(command("install", "devrig", "--check"))
     }
 
+    @Test
+    fun `connect claude and connect ide select their commands`() {
+        assertIs<DevrigCommand.DevrigCommandConnectClaude>(command("connect", "claude"))
+        assertIs<DevrigCommand.DevrigCommandConnectIde>(command("connect", "ide"))
+        assertIs<DevrigCommand.DevrigCommandParseError>(command("connect", "bogus"))
+    }
+
     private fun command(vararg args: String): DevrigCommand =
         parseDevrigCommand(args.toList().toTypedArray())
 }

--- a/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/InstallCommandTest.kt
+++ b/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/InstallCommandTest.kt
@@ -39,12 +39,12 @@ class InstallCommandTest {
         ]
     """.trimIndent()
 
-    // A CANONICAL claude listing: exactly one 'mcp-steroid' entry whose command is the stable wrapper
+    // A CANONICAL claude listing: exactly one 'devrig' entry whose command is the stable wrapper
     // install would register ("$launcherPath mcp"). Re-running install would change nothing.
     private val claudeCanonicalList = """
         Checking MCP server health…
 
-        mcp-steroid: $launcherPath mcp - ✓ Connected
+        devrig: $launcherPath mcp - ✓ Connected
         playwright: npx @playwright/mcp@latest - ✓ Connected
     """.trimIndent()
 
@@ -53,7 +53,7 @@ class InstallCommandTest {
     // not valid unescaped inside a JSON string.
     private val codexCanonicalJson = """
         [
-          {"name":"mcp-steroid","transport":{"type":"stdio","command":"$launcherPathJsonEscaped","args":["mcp"]}},
+          {"name":"devrig","transport":{"type":"stdio","command":"$launcherPathJsonEscaped","args":["mcp"]}},
           {"name":"playwright","transport":{"type":"stdio","command":"npx","args":["@playwright/mcp@latest"]}}
         ]
     """.trimIndent()
@@ -72,8 +72,8 @@ class InstallCommandTest {
         val result = runInstall(AiAgentCli.CLAUDE, RecordingRunner())
         assertEquals(0, result.exitCode)
         assertEquals(
-            listOf("mcp", "add", "--scope", "user", "mcp-steroid", "--", launcherPath, "mcp"),
-            result.addInvocation.args,
+            listOf("mcp", "add", "--scope", "user", "devrig", "--", launcherPath, "mcp"),
+            result.addInvocation?.args,
         )
     }
 
@@ -81,17 +81,17 @@ class InstallCommandTest {
     fun `install add invocation per agent (codex, gemini)`() {
         val codex = runInstall(AiAgentCli.CODEX, RecordingRunner())
         assertEquals(
-            listOf("mcp", "add", "mcp-steroid", "--", launcherPath, "mcp"),
-            codex.addInvocation.args,
+            listOf("mcp", "add", "devrig", "--", launcherPath, "mcp"),
+            codex.addInvocation?.args,
         )
 
         val gemini = runInstall(AiAgentCli.GEMINI, RecordingRunner())
         assertEquals(
             listOf(
-                "mcp", "add", "--type", "stdio", "--scope", "user", "--trust", "mcp-steroid",
+                "mcp", "add", "--type", "stdio", "--scope", "user", "--trust", "devrig",
                 launcherPath, "mcp",
             ),
-            gemini.addInvocation.args,
+            gemini.addInvocation?.args,
         )
     }
 
@@ -290,7 +290,7 @@ class InstallCommandTest {
         // Detected by its command (not name) → removed WITHOUT the "if present" qualifier.
         assertContains(r.stdout, "remove 'old-steroid'")
         assertFalse(r.stdout.contains("remove 'old-steroid', if present"), r.stdout)
-        assertContains(r.stdout, "add 'mcp-steroid'")
+        assertContains(r.stdout, "add 'devrig'")
     }
 
     @Test
@@ -325,7 +325,7 @@ class InstallCommandTest {
         assertEquals(INSTALL_CHECK_DRIFT_EXIT_CODE, r.exitCode)
         assertContains(r.stdout, "Drift detected")
         assertContains(r.stdout, "remove 'mcp-steroid'")
-        assertContains(r.stdout, "add 'mcp-steroid' → $launcherPath mcp")
+        assertContains(r.stdout, "add 'devrig' → $launcherPath mcp")
     }
 
     @Test
@@ -336,7 +336,7 @@ class InstallCommandTest {
         )
         assertEquals(INSTALL_CHECK_DRIFT_EXIT_CODE, r.exitCode)
         assertTrue(r.stdout.contains("no existing", ignoreCase = true), r.stdout)
-        assertContains(r.stdout, "add 'mcp-steroid'")
+        assertContains(r.stdout, "add 'devrig'")
     }
 
     @Test
@@ -347,8 +347,8 @@ class InstallCommandTest {
         )
         assertEquals(INSTALL_CHECK_DRIFT_EXIT_CODE, r.exitCode)
         assertTrue(r.stdout.contains("could not read", ignoreCase = true), r.stdout)
-        // Unreadable → install would defensively clear the legacy 'devrig' name too (shared installRemovalNames).
-        assertContains(r.stdout, "remove 'devrig'")
+        // Unreadable → install would defensively clear the legacy 'mcp-steroid' name too (shared installRemovalNames).
+        assertContains(r.stdout, "remove 'mcp-steroid'")
     }
 
     @Test
@@ -361,6 +361,83 @@ class InstallCommandTest {
         assertEquals(INSTALL_CHECK_DRIFT_EXIT_CODE, r.exitCode)
         assertContains(r.stderr, "IDE discovery failed")
         assertContains(r.stdout, "discovery failed")
+    }
+
+    // ── plugin-provided registration (the devrig Claude plugin's own .mcp.json, issue #253) ──
+
+    // What `claude mcp list` shows when the devrig Claude PLUGIN registers the server: a
+    // `plugin:<plugin>:<server>` name whose command is the plugin's bin/devrig-mcp launcher. `claude mcp
+    // remove` cannot delete it, and it is a working registration — so it must read as canonical.
+    private val claudePluginProvidedList = """
+        Checking MCP server health…
+
+        plugin:devrig:devrig: /Users/me/.claude/plugins/marketplaces/jonnyzzz/claude-plugin/bin/devrig-mcp - ✓ Connected
+        playwright: npx @playwright/mcp@latest - ✓ Connected
+    """.trimIndent()
+
+    @Test
+    fun `check reports no drift when the Claude plugin provides devrig, exit 0`() {
+        val r = runCheck(
+            AiAgentCli.CLAUDE,
+            RecordingRunner(listResult = AiAgentCliResult(0, claudePluginProvidedList)),
+        )
+        assertEquals(0, r.exitCode)
+        assertContains(r.stdout, "plugin:devrig:devrig")
+        assertContains(r.stdout, "plugin provides this server")
+        assertContains(r.stdout, "already canonical")
+        assertContains(r.stdout, "No drift")
+        // It must never propose removing (impossible) or duplicating (harmful) the plugin's entry.
+        assertFalse(r.stdout.contains("remove 'plugin:devrig:devrig'"), r.stdout)
+        assertFalse(r.stdout.contains("add 'devrig'"), r.stdout)
+    }
+
+    @Test
+    fun `check flags a user-scope duplicate alongside the plugin entry, removing only the duplicate`() {
+        val listing = """
+            Checking MCP server health…
+
+            plugin:devrig:devrig: /Users/me/.claude/plugins/marketplaces/jonnyzzz/claude-plugin/bin/devrig-mcp - ✓ Connected
+            devrig: $launcherPath mcp - ✓ Connected
+        """.trimIndent()
+
+        val r = runCheck(AiAgentCli.CLAUDE, RecordingRunner(listResult = AiAgentCliResult(0, listing)))
+
+        assertEquals(INSTALL_CHECK_DRIFT_EXIT_CODE, r.exitCode)
+        assertContains(r.stdout, "remove 'devrig'")
+        assertFalse(r.stdout.contains("remove 'plugin:devrig:devrig'"), r.stdout)
+        // The plugin already provides the server, so the plan must not re-add a user-scope entry.
+        assertFalse(r.stdout.contains("add 'devrig'"), r.stdout)
+    }
+
+    @Test
+    fun `install skips the add when the Claude plugin already provides devrig`() {
+        val result = runInstall(
+            AiAgentCli.CLAUDE,
+            RecordingRunner(listResult = AiAgentCliResult(0, claudePluginProvidedList)),
+        )
+
+        assertEquals(0, result.exitCode)
+        assertFalse(
+            result.invocations.any { it.args.contains("add") },
+            "install must not register a second devrig server: ${result.invocations}",
+        )
+        assertFalse(
+            result.removeNames.contains("plugin:devrig:devrig"),
+            "the plugin's own entry cannot be removed by 'claude mcp remove': ${result.removeNames}",
+        )
+        assertContains(result.stdout, "plugin already provides this server")
+    }
+
+    @Test
+    fun `installRemovalNames never schedules a plugin-provided entry for removal`() {
+        val names = installRemovalNames(
+            detected = listOf(
+                McpServerRef("plugin:devrig:devrig", "/plugins/devrig/bin/devrig-mcp"),
+                McpServerRef("mcp-steroid", "/old/devrig mpc"),
+            ),
+            listReadable = true,
+        )
+        assertEquals(setOf("mcp-steroid", "devrig"), names)
     }
 
     @Test
@@ -423,7 +500,8 @@ class InstallCommandTest {
             invocations = runner.invocations,
             removeNames = removeInvocations.map { it.args.last() },
             removedNames = runner.removed,
-            addInvocation = runner.invocations.last { it.args.contains("add") },
+            // Null when install deliberately skipped the add (the agent's plugin already provides devrig).
+            addInvocation = runner.invocations.lastOrNull { it.args.contains("add") },
             stdout = stdout.toString(Charsets.UTF_8).replace("\r\n", "\n"),
             stderr = stderr.toString(Charsets.UTF_8).replace("\r\n", "\n"),
         )
@@ -460,7 +538,7 @@ class InstallCommandTest {
         val invocations: List<AiAgentCliInvocation>,
         val removeNames: List<String>,
         val removedNames: List<String>,
-        val addInvocation: AiAgentCliInvocation,
+        val addInvocation: AiAgentCliInvocation?,
         val stdout: String,
         val stderr: String,
     )

--- a/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/InstallCommandTest.kt
+++ b/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/InstallCommandTest.kt
@@ -5,6 +5,7 @@ import com.jonnyzzz.mcpSteroid.aiAgents.AiAgentCli
 import com.jonnyzzz.mcpSteroid.aiAgents.AiAgentCliInvocation
 import com.jonnyzzz.mcpSteroid.aiAgents.AiAgentCliResult
 import com.jonnyzzz.mcpSteroid.aiAgents.AiAgentCliRunner
+import com.jonnyzzz.mcpSteroid.aiAgents.StdioMcpCommand
 import java.io.ByteArrayOutputStream
 import java.io.PrintStream
 import java.nio.file.Path
@@ -248,6 +249,31 @@ class InstallCommandTest {
     }
 
     @Test
+    fun `check treats the Windows cmd-exe launcher as canonical despite mcp list dropping the path quotes`() {
+        // On Windows the launcher path is double-quoted so cmd.exe survives a path with spaces
+        // (DevrigUserLauncher.invocation), but `claude mcp list` echoes the stored command back WITHOUT
+        // those quotes. An exact string compare then reports permanent false "drift" that re-running
+        // install can never fix — the real Windows bug. The canonical check must tolerate the quoting.
+        val winCommand = DevrigUserLauncher.invocation(home, listOf("mcp"), windows = true)
+        val winLauncher = "/home/user/.mcp-steroid/bin/devrig.cmd"
+        val claudeWinList = """
+            Checking MCP server health…
+
+            devrig: cmd.exe /d /c $winLauncher mcp - ✓ Connected
+            playwright: npx @playwright/mcp@latest - ✓ Connected
+        """.trimIndent()
+
+        val r = runCheck(
+            AiAgentCli.CLAUDE,
+            RecordingRunner(listResult = AiAgentCliResult(0, claudeWinList)),
+            mcpCommand = winCommand,
+        )
+        assertEquals(0, r.exitCode)
+        assertContains(r.stdout, "already canonical")
+        assertContains(r.stdout, "No drift")
+    }
+
+    @Test
     fun `check reports no drift for a canonical codex (--json) registration and exits 0`() {
         val r = runCheck(AiAgentCli.CODEX, RecordingRunner(listResult = AiAgentCliResult(0, codexCanonicalJson)))
         assertEquals(0, r.exitCode)
@@ -353,6 +379,7 @@ class InstallCommandTest {
         reachability: IdeReachabilityReport = IdeReachabilityReport(reachable = 0, discovered = 0),
         reachabilityThrows: Boolean = false,
         missingLauncherPath: Path? = null,
+        mcpCommand: StdioMcpCommand = this.mcpCommand,
     ): CheckRunResult {
         val stdout = ByteArrayOutputStream()
         val stderr = ByteArrayOutputStream()


### PR DESCRIPTION
Connecting an agent to MCP Steroid was a manual, error-prone sequence: register an MCP server by hand, find the plugin, install it into the right IDE. Two subcommands automate the two directions.

- **`devrig connect claude`** — enables the marketplace plugin through an *idempotent* `~/.claude/settings.json` merge, so re-running is a no-op.
- **`devrig connect ide`** — discovers running IDEs over their live ports and asks one to install the plugin, cascading **install dialog → browser → manual instructions** so the user is never left at a dead end. Skips already-connected IDEs, and returns a distinct `NO_IDE` exit code so callers can tell *failed* from *nothing to do*.
- The canonical MCP server name becomes **`devrig`**, with `mcp-steroid` retained as the legacy name so existing registrations are recognized and consolidated rather than duplicated.
- MCP command comparison is normalized before the canonical check, so Windows quoting differences no longer look like drift and trigger a redundant re-registration.