### PR TITLE
Document the two ways to connect an agent (stack 6/6)

### DIFF
--- a/release/release-instructions.md
+++ b/release/release-instructions.md
@@ -204,6 +204,21 @@ echo "0.92.0" > VERSION
 git add VERSION && git commit -m "release: bump version to 0.92.0"
 ```
 
+**Then sync the Claude plugin manifest** so marketplace users receive the update. The `devrig`
+Claude plugin is published from the committed tree (`.claude-plugin/marketplace.json` →
+`source: "./claude-plugin"`), and Claude Code only offers `/plugin update` when the manifest
+`version` string changes. Run:
+
+```bash
+./gradlew :claude-plugin:syncClaudePluginVersion
+git add claude-plugin/.claude-plugin/plugin.json
+git commit --amend --no-edit   # fold into the version-bump commit
+```
+
+`syncClaudePluginVersion` rewrites `claude-plugin/.claude-plugin/plugin.json`'s `version` to the
+new `VERSION` (normalized to semver). Forgetting it fails CI: `validatePluginJson` asserts the
+manifest version matches the VERSION-derived semver.
+
 ### Stage 4: Website Release Page + Homepage Update
 
 **4a. Release page** — create `website/content/releases/<version>.md` following the

--- a/release/release-instructions.md
+++ b/release/release-instructions.md
@@ -219,6 +219,13 @@ git commit --amend --no-edit   # fold into the version-bump commit
 new `VERSION` (normalized to semver). Forgetting it fails CI: `validatePluginJson` asserts the
 manifest version matches the VERSION-derived semver.
 
+**Go toolchain requirement**: any build that touches `:claude-plugin` (e.g.
+`./gradlew :claude-plugin:claudePluginZip`) now **requires the Go toolchain** (Go 1.23+, matching
+the `go` directive in `devrig-bootstrap/go.mod`). The 6 `bin/bootstrap-*` binaries are cross-compiled
+at build time by `:devrig-bootstrap:buildBootstrapBinaries` and consumed by
+`:claude-plugin:preparePluginFiles` — they are **not** committed to the repo. If Go is missing or
+too old, `buildBootstrapBinaries` fails loudly rather than silently skipping the binaries.
+
 ### Stage 4: Website Release Page + Homepage Update
 
 **4a. Release page** — create `website/content/releases/<version>.md` following the

--- a/release/release-instructions.md
+++ b/release/release-instructions.md
@@ -219,12 +219,8 @@ git commit --amend --no-edit   # fold into the version-bump commit
 new `VERSION` (normalized to semver). Forgetting it fails CI: `validatePluginJson` asserts the
 manifest version matches the VERSION-derived semver.
 
-**Go toolchain requirement**: any build that touches `:claude-plugin` (e.g.
-`./gradlew :claude-plugin:claudePluginZip`) now **requires the Go toolchain** (Go 1.23+, matching
-the `go` directive in `devrig-bootstrap/go.mod`). The 6 `bin/bootstrap-*` binaries are cross-compiled
-at build time by `:devrig-bootstrap:buildBootstrapBinaries` and consumed by
-`:claude-plugin:preparePluginFiles` — they are **not** committed to the repo. If Go is missing or
-too old, `buildBootstrapBinaries` fails loudly rather than silently skipping the binaries.
+The Claude plugin is pure scripts (`claude-plugin/bin/*`) — no native binary is built or bundled
+for it, so `:claude-plugin:claudePluginZip` needs no Go toolchain or other extra build tooling.
 
 ### Stage 4: Website Release Page + Homepage Update
 


### PR DESCRIPTION
Documentation only — no behavior change.

- Restructures the README around the choice a new user actually faces — *"I have an IDE open"* vs *"I have Claude Code in a terminal"* — with a table routing to each path, instead of describing components and leaving the reader to assemble a route.
- **`ij-plugin/README.md`** documents the plugin's user-facing surface: every notification, popup and widget state. Reviewing the copy as a whole is much easier than one string at a time (see PR 5).
- Records the **rejected spike** of bundling devrig inside the IDE plugin, with measurements and reasoning, so the question isn't reopened from scratch.
- Notes the release step that keeps `plugin.json`'s version tied to releases.