### PR TITLE
bin launcher: version header + never overwrite a newer launcher

### DIFF
--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/BinLauncher.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/BinLauncher.kt
@@ -1,6 +1,7 @@
 /* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
 package com.jonnyzzz.mcpSteroid.devrig
 
+import com.jonnyzzz.mcpSteroid.util.text.DevrigVersion
 import java.io.File
 import java.nio.file.Files
 import java.nio.file.Path
@@ -82,7 +83,9 @@ private fun parseBinAutoRegisterOptOut(value: String?): Boolean? = when (value?.
  * The launcher is rewritten ONLY when its content actually changed (normalized comparison), never on
  * every launch — and writes are atomic (temp file + atomic move), so a concurrent agent that is mid-read
  * of the file (the contract: it can change WHILE the binary runs) never sees a torn launcher. When the
- * content already matches, a lost executable bit is still repaired.
+ * content already matches, a lost executable bit is still repaired. An existing launcher whose stamped
+ * header version is strictly newer than this binary is never overwritten at all — see
+ * [shouldKeepNewerLauncher] (#373).
  *
  * [force] = an explicit `devrig install`: write regardless of the SNAPSHOT/dev passive-start default
  * (but still honoring an explicit opt-out), so install never registers a wrapper it didn't write.
@@ -146,27 +149,38 @@ internal fun ensureBinLauncherCore(
     userHome: Path,
     pathDirs: List<String>,
     registerWindowsPath: Boolean = true,
+    buildVersion: DevrigVersion = DevrigVersionMetadata.getBuildVersion(),
 ) {
     if (isWin) {
         // CMD-only launcher: a single self-contained devrig.cmd. No PowerShell at launch — PS is only
         // needed by the install SCRIPT, not the launcher.
         val cmd = home.binDir.resolve("devrig.cmd")
-        writeIfChanged(home.binDir, cmd, renderWindowsCmd(ownBin, jdkHome), executable = false, ownBin = ownBin)
+        writeIfChanged(home.binDir, cmd, renderWindowsCmd(ownBin, jdkHome, buildVersion.value), executable = false, ownBin = ownBin, buildVersion = buildVersion)
         // PATH registration spawns PowerShell, so skip it on the `devrig mcp` hot path (registerWindowsPath
         // = false) — it would block the first serve until the marker exists. Interactive/install pass true.
         if (registerWindowsPath) ensureWindowsPathEntry(home.binDir)
     } else {
         val devrig = home.binDir.resolve("devrig")
-        writeIfChanged(home.binDir, devrig, renderPosixLauncher(ownBin, jdkHome), executable = true, ownBin = ownBin)
+        writeIfChanged(home.binDir, devrig, renderPosixLauncher(ownBin, jdkHome, buildVersion.value), executable = true, ownBin = ownBin, buildVersion = buildVersion)
         ensurePosixPathSymlink(home.binDir, devrig, userHome, pathDirs)
     }
 }
 
-/** The POSIX wrapper: pins the JDK devrig runs under via DEVRIG_JAVA_HOME, then execs the install-tree launcher. */
-internal fun renderPosixLauncher(launcher: Path, jdkHome: Path): String {
+/**
+ * The POSIX wrapper: pins the JDK devrig runs under via DEVRIG_JAVA_HOME, then execs the install-tree
+ * launcher. The header stamps the generating devrig [version] and the source install tree — the version
+ * line is machine-parseable (see [parseLauncherVersion]) and drives the regeneration guard (#373).
+ */
+internal fun renderPosixLauncher(
+    launcher: Path,
+    jdkHome: Path,
+    version: String = DevrigVersionMetadata.getDevrigVersion(),
+): String {
     val launcherStr = launcher.toString().replace('\\', '/')
     val jdkStr = jdkHome.toString().replace('\\', '/')
     return "#!/bin/sh\n" +
+        "# devrig launcher version: ${headerSafe(version)}\n" +
+        "# devrig launcher source: ${headerSafe(launcherStr)}\n" +
         "# devrig launcher — managed by the devrig binary. Writes nothing to stdout (MCP stdio channel).\n" +
         "# Pins the JDK devrig runs under via DEVRIG_JAVA_HOME (its supported runtime), then hands off to\n" +
         "# the install-tree devrig launcher.\n" +
@@ -181,12 +195,48 @@ internal fun renderPosixLauncher(launcher: Path, jdkHome: Path): String {
  * the inner devrig.bat → java does. The agent invokes this via `cmd.exe /d /c` — see
  * [DevrigUserLauncher.invocation].
  */
-internal fun renderWindowsCmd(launcher: Path, jdkHome: Path): String =
+internal fun renderWindowsCmd(
+    launcher: Path,
+    jdkHome: Path,
+    version: String = DevrigVersionMetadata.getDevrigVersion(),
+): String =
+    // The header sits AFTER `@echo off`: anything before it would echo to stdout — the MCP JSON-RPC channel.
+    // The source path is QUOTED: `rem` does not neutralize batch metacharacters, so an unquoted install
+    // path containing `&` would terminate the rem and execute the rest as a command.
     "@echo off\r\n" +
+        "rem devrig launcher version: ${headerSafe(version)}\r\n" +
+        "rem devrig launcher source: \"${headerSafe(launcher.toString())}\"\r\n" +
         "set \"DEVRIG_JAVA_HOME=$jdkHome\"\r\n" +
         "call \"$launcher\" %*\r\n"
 
-private fun writeIfChanged(dir: Path, target: Path, desired: String, executable: Boolean, ownBin: Path) {
+/** Header fields must stay on their own comment line: CR/LF in interpolated values become spaces. */
+private fun headerSafe(value: String): String = value.replace('\r', ' ').replace('\n', ' ')
+
+/**
+ * Matches the machine-parseable version header stamped into generated launchers — POSIX
+ * (`# devrig launcher version: …`) and Windows (`rem devrig launcher version: …`).
+ */
+private val LAUNCHER_VERSION_HEADER =
+    Regex("""^(?:#|rem)\s+devrig launcher version:\s*(\S+)""", setOf(RegexOption.MULTILINE, RegexOption.IGNORE_CASE))
+
+/** Version stamped in a launcher's header, or null when the header is absent (pre-#373 launchers). */
+fun parseLauncherVersion(content: String): DevrigVersion? =
+    LAUNCHER_VERSION_HEADER.find(content)?.let { DevrigVersion.parse(it.groupValues[1]) }
+
+/**
+ * The regeneration guard (#373): an existing launcher stamped with a STRICTLY NEWER version than the
+ * running binary must not be overwritten — an older devrig process never clobbers a newer launcher.
+ * Snapshot rule (from [DevrigVersion]): a SNAPSHOT-stamped launcher counts as newer than any release,
+ * so a release binary never overwrites a deliberately installed dev launcher. A missing or headerless
+ * launcher never blocks regeneration (migration + corrupt-file self-heal keep working).
+ */
+fun shouldKeepNewerLauncher(existingContent: String?, currentVersion: DevrigVersion): Boolean {
+    val existing = existingContent?.let { parseLauncherVersion(it) } ?: return false
+    return existing > currentVersion
+}
+
+private fun writeIfChanged(dir: Path, target: Path, desired: String, executable: Boolean, ownBin: Path, buildVersion: DevrigVersion) {
+    Files.createDirectories(dir)
     // An unreadable existing launcher (non-UTF-8 bytes, wrong file type, transient IO) counts as
     // "changed" so a corrupt launcher self-heals rather than being left in place.
     val current = if (!target.exists()) null else try {
@@ -194,6 +244,26 @@ private fun writeIfChanged(dir: Path, target: Path, desired: String, executable:
     } catch (e: Exception) {
         System.err.println("[mcp-steroid] existing launcher $target is unreadable ($e); rewriting it")
         null
+    }
+    // The #373 guard: never overwrite a launcher stamped with a strictly newer version — an older
+    // devrig start (a stale install still registered somewhere) must not re-register itself over a
+    // newer launcher. No cross-process lock around read→check→write: replacement is an atomic
+    // same-directory move (see replaceLauncherFile), so a concurrent racing start can at worst make a
+    // stale-read guard decision — never a torn file — and the newer devrig re-heals the launcher on
+    // its next start anyway.
+    if (shouldKeepNewerLauncher(current, buildVersion)) {
+        val existing = current?.let { parseLauncherVersion(it) }
+        System.err.println(
+            "[mcp-steroid] keeping $target: its launcher version ${existing?.value} " +
+                "is newer than this devrig ${buildVersion.value}",
+        )
+        // Content-neutral healing still applies: a kept NEWER launcher that lost its executable bit
+        // would otherwise stay unusable forever (no devrig would ever rewrite it).
+        if (executable && !Files.isExecutable(target)) {
+            setExecutable(target)
+            System.err.println("[mcp-steroid] restored the executable bit on $target")
+        }
+        return
     }
     if (current != null && normalizeLauncher(current) == normalizeLauncher(desired)) {
         // Content already correct — but a launcher that lost its executable bit (e.g. a copy that dropped

--- a/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/BinLauncherTest.kt
+++ b/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/BinLauncherTest.kt
@@ -9,10 +9,12 @@ import java.io.IOException
 import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.attribute.PosixFilePermission
+import com.jonnyzzz.mcpSteroid.util.text.DevrigVersion
 import kotlin.io.path.readText
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 class BinLauncherTest {
@@ -116,6 +118,9 @@ class BinLauncherTest {
         assertTrue(text.contains("exec \"/tmp/devrig/bin/devrig\" \"\$@\""), text)
         assertFalse(text.contains("\r\n"), "POSIX launcher must be LF-only")
         assertFalse(text.contains("\$HOME"), "wrapper records absolute paths, not \$HOME-relative")
+        // #373 header: version + source stamped as comments
+        assertTrue(text.contains("# devrig launcher version: ${DevrigVersionMetadata.getDevrigVersion()}"), text)
+        assertTrue(text.contains("# devrig launcher source: /tmp/devrig/bin/devrig"), text)
     }
 
     @Test
@@ -125,11 +130,136 @@ class BinLauncherTest {
         assertTrue(text.contains("set \"DEVRIG_JAVA_HOME=C:\\devrig\\jdk-25\"\r\n"), text)
         assertTrue(text.contains("call \"C:\\devrig\\bin\\devrig.bat\" %*\r\n"), text)
         assertFalse(text.contains("powershell", ignoreCase = true), "windows launcher must not invoke PowerShell")
+        // #373 header: AFTER `@echo off` (anything before it would echo to stdout — the MCP channel)
+        assertTrue(text.contains("rem devrig launcher version: ${DevrigVersionMetadata.getDevrigVersion()}\r\n"), text)
+        assertTrue(text.contains("rem devrig launcher source: \"C:\\devrig\\bin\\devrig.bat\"\r\n"), text)
+        assertTrue(text.indexOf("@echo off") < text.indexOf("rem devrig launcher version:"), text)
     }
 
     @Test
     fun `normalizeLauncher is tolerant of CRLF and trailing newlines`() {
         assertEquals(normalizeLauncher("a\nb\n"), normalizeLauncher("a\r\nb\r\n\n"))
+    }
+
+    // ── launcher version header + regeneration guard (#373) ────────────────────────────────────
+
+    @Test
+    fun `parseLauncherVersion reads the posix and windows headers`() {
+        val posix = renderPosixLauncher(Path.of("/tmp/devrig/bin/devrig"), Path.of("/tmp/jdk-25"), version = "0.102-abc1234")
+        assertEquals("0.102-abc1234", parseLauncherVersion(posix)?.value)
+
+        val cmd = renderWindowsCmd(Path.of("C:\\devrig\\bin\\devrig.bat"), Path.of("C:\\jdk"), version = "0.101.442-jb-fedcba9")
+        assertEquals("0.101.442-jb-fedcba9", parseLauncherVersion(cmd)?.value)
+
+        // hand-edited uppercase REM still parses
+        assertEquals("0.99", parseLauncherVersion("@echo off\r\nREM devrig launcher version: 0.99\r\n")?.value)
+
+        // pre-#373 launchers carry no header
+        assertNull(parseLauncherVersion("#!/bin/sh\nexec \"/tmp/devrig/bin/devrig\" \"\$@\"\n"))
+    }
+
+    @Test
+    fun `shouldKeepNewerLauncher keeps only strictly newer launchers`() {
+        val current = DevrigVersion.parse("0.101-abc1234")
+        fun launcherStamped(v: String) = renderPosixLauncher(Path.of("/x/bin/devrig"), Path.of("/x/jdk"), version = v)
+
+        assertFalse(shouldKeepNewerLauncher(null, current), "missing launcher never blocks regeneration")
+        assertFalse(shouldKeepNewerLauncher("#!/bin/sh\nexec x\n", current), "headerless launcher never blocks")
+        assertFalse(shouldKeepNewerLauncher(launcherStamped("0.100-fff0000"), current), "older launcher is replaced")
+        assertFalse(shouldKeepNewerLauncher(launcherStamped("0.101-fff0000"), current), "same version (different hash) is replaced")
+        assertTrue(shouldKeepNewerLauncher(launcherStamped("0.102-fff0000"), current), "newer launcher is kept")
+
+        // snapshot rules from DevrigVersion: a SNAPSHOT-stamped launcher outranks any release binary...
+        assertTrue(shouldKeepNewerLauncher(launcherStamped("0.100.19999-SNAPSHOT-fff0000"), current))
+        // ...while a SNAPSHOT binary replaces even a much larger release launcher
+        val snapshotBinary = DevrigVersion.parse("0.100.19999-SNAPSHOT-fff0000")
+        assertFalse(shouldKeepNewerLauncher(launcherStamped("999.0-abc1234"), snapshotBinary))
+    }
+
+    @DisabledOnOs(OS.WINDOWS)
+    @Test
+    fun `an older devrig never overwrites a newer launcher - a newer one regenerates it`(@TempDir tmp: Path) {
+        val userHome = tmp.resolve("home")
+        val home = HomePaths(userHome.resolve(".mcp-steroid"))
+        fun run(ownBin: Path, version: String) = ensureBinLauncherCore(
+            home, isWin = false, ownBin = ownBin, jdkHome = tmp.resolve("jdk"),
+            userHome = userHome, pathDirs = emptyList(),
+            buildVersion = DevrigVersion.parse(version),
+        )
+
+        run(tmp.resolve("opt/devrig-0.102/bin/devrig"), "0.102-abc1234")
+        val launcher = home.binDir.resolve("devrig")
+        val written = launcher.readText()
+        assertTrue(written.contains("# devrig launcher version: 0.102-abc1234"), written)
+
+        // an older binary starts: the newer launcher must be left byte-identical
+        run(tmp.resolve("opt/devrig-0.101/bin/devrig"), "0.101-fff0000")
+        assertEquals(written, launcher.readText())
+
+        // a newer binary starts: the launcher is regenerated to point at it
+        val newest = tmp.resolve("opt/devrig-0.103/bin/devrig")
+        run(newest, "0.103-0123abc")
+        val regenerated = launcher.readText()
+        assertTrue(regenerated.contains("# devrig launcher version: 0.103-0123abc"), regenerated)
+        assertTrue(regenerated.contains(newest.toString()), regenerated)
+    }
+
+    @Test
+    fun `windows header quotes the source path so batch metacharacters stay inert`() {
+        // `rem` does not neutralize `&` — an unquoted path would execute the tail as a command
+        val text = renderWindowsCmd(Path.of("C:\\tools & extras\\devrig\\bin\\devrig.bat"), Path.of("C:\\jdk"), version = "0.101")
+        assertTrue(text.contains("rem devrig launcher source: \"C:\\tools & extras\\devrig\\bin\\devrig.bat\"\r\n"), text)
+    }
+
+    @DisabledOnOs(OS.WINDOWS)
+    @Test
+    fun `header interpolation strips newlines so a value cannot escape its comment line`() {
+        val evil = Path.of("/tmp/evil\ndir/devrig") // POSIX file names may legally contain a newline
+        val text = renderPosixLauncher(evil, Path.of("/tmp/jdk"), version = "0.101")
+        assertTrue(text.contains("# devrig launcher source: /tmp/evil dir/devrig\n"), text)
+    }
+
+    @DisabledOnOs(OS.WINDOWS)
+    @Test
+    fun `keeping a newer launcher still repairs a lost executable bit`(@TempDir tmp: Path) {
+        val userHome = tmp.resolve("home")
+        val home = HomePaths(userHome.resolve(".mcp-steroid"))
+        fun run(version: String) = ensureBinLauncherCore(
+            home, isWin = false, ownBin = tmp.resolve("opt/devrig/bin/devrig"), jdkHome = tmp.resolve("jdk"),
+            userHome = userHome, pathDirs = emptyList(),
+            buildVersion = DevrigVersion.parse(version),
+        )
+
+        run("0.102-abc1234")
+        val launcher = home.binDir.resolve("devrig")
+        val written = launcher.readText()
+        val perms = Files.getPosixFilePermissions(launcher).toMutableSet()
+        perms.removeAll(setOf(PosixFilePermission.OWNER_EXECUTE, PosixFilePermission.GROUP_EXECUTE, PosixFilePermission.OTHERS_EXECUTE))
+        Files.setPosixFilePermissions(launcher, perms)
+
+        // an OLDER binary keeps the newer launcher byte-identical, but must still restore +x
+        run("0.101-fff0000")
+        assertEquals(written, launcher.readText(), "newer launcher must not be rewritten")
+        assertTrue(Files.isExecutable(launcher), "kept launcher must be usable again")
+    }
+
+    @DisabledOnOs(OS.WINDOWS)
+    @Test
+    fun `a headerless pre-existing launcher is regenerated`(@TempDir tmp: Path) {
+        val userHome = tmp.resolve("home")
+        val home = HomePaths(userHome.resolve(".mcp-steroid"))
+        Files.createDirectories(home.binDir)
+        val launcher = home.binDir.resolve("devrig")
+        Files.writeString(launcher, "#!/bin/sh\nexec \"/somewhere/else/devrig\" \"\$@\"\n")
+
+        ensureBinLauncherCore(
+            home, isWin = false, ownBin = tmp.resolve("opt/devrig/bin/devrig"), jdkHome = tmp.resolve("jdk"),
+            userHome = userHome, pathDirs = emptyList(),
+            buildVersion = DevrigVersion.parse("0.101-abc1234"),
+        )
+        val text = launcher.readText()
+        assertTrue(text.contains("# devrig launcher version: 0.101-abc1234"), text)
+        assertTrue(Files.isExecutable(launcher), "regenerated launcher must be executable")
     }
 
     // ── core self-heal (POSIX) ──────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Fixes #373.

## What

- The generated `~/.mcp-steroid/bin/devrig` (POSIX) / `devrig.cmd` (Windows) launchers now carry a machine-parseable header: `# devrig launcher version: <version>` + `# devrig launcher source: <install-tree launcher>` (`rem` equivalents after `@echo off` on Windows).
- Before regenerating, the self-heal parses the existing launcher's header and **skips the write when its version is strictly newer** than the running binary — an older devrig never re-registers itself over a newer launcher. Comparison is `DevrigVersion` (snapshot always outranks a release; build metadata after the first `-` carries no precedence). Headerless (pre-#373) or unreadable launchers regenerate as before.

## Design notes

- **No cross-process lock.** Launcher replacement is an atomic same-directory move (`writeAtomically`: temp file + `ATOMIC_MOVE`), so concurrent starts can never produce a torn file. The worst case without serialization is a stale-read guard decision by a racing process, which the newer devrig self-heals on its next start — not worth a lock on the latency-sensitive `devrig mcp` start path.
- A kept newer launcher still gets a lost executable bit repaired (otherwise no devrig would ever fix it).
- The cmd header **quotes** the source path — `rem` does not neutralize `&`, so an unquoted install path like `C:\tools & extras\…` would execute the tail; header interpolations strip CR/LF so a value cannot escape its comment line.

## Testing

`:npx-kt:test` green — 21 BinLauncherTest cases including: header rendering on both OSes, parse round-trip (`#`/`rem`/`REM`, headerless → null), guard truth table (older/equal/newer + both snapshot directions), end-to-end older-never-overwrites / newer-regenerates temp-dir flows, metacharacter + newline sanitization, and +x repair on a kept launcher.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
