### PR TITLE
Release version becomes <base>.0-r-<hash> so IDE version comparison is hash-free

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -72,12 +72,15 @@ if (providedBuildVersion != null) {
     // The CI-computed version keeps the VERSION file content (all components) intact
     // and appends the CI counter plus the -<ci>-<hash> suffix.
     // e.g. VERSION=0.92.0 + counter=441 + hash=abcdef1 → 0.92.0.441-jb-abcdef1
+    // Counter 0 is rejected: `<base>.0` is reserved for the release lane (`<base>.0-r-<hash>`,
+    // see #360) — a zero CI counter would tie with the release and leave the ordering to the
+    // lane word and hash tokens.
     val expected = Regex(
-        "^" + Regex.escape(baseVersion) + "\\.\\d+-(gh|jb)-" + Regex.escape(gitHash) + "$"
+        "^" + Regex.escape(baseVersion) + "\\.[1-9]\\d*-(gh|jb)-" + Regex.escape(gitHash) + "$"
     )
     require(expected.matches(providedBuildVersion)) {
         "mcp.build.version='$providedBuildVersion' does not match expected format " +
-            "'${baseVersion}.<counter>-(gh|jb)-${gitHash}'. " +
+            "'${baseVersion}.<counter>-(gh|jb)-${gitHash}' (counter >= 1; 0 is reserved for the release lane). " +
             "The build number must be composed upstream (GitHub Actions run_number or " +
             "TeamCity buildNumber service message) and passed in unchanged — this build " +
             "does not rewrite it."
@@ -92,8 +95,14 @@ if (providedBuildVersion != null) {
 // compileKotlin is only re-run when sources actually change.
 // The git hash is the only freshness signal.
 val localBuildCounter = "19999-SNAPSHOT"
+// Release lane `<base>.0-r-<hash>` (#360): all lanes share the `<base>.<counter>-<lane>-<hash>`
+// token layout, so IntelliJ's VersionComparatorUtil (the raw comparator behind Marketplace and
+// custom-repository update checks) never reaches the git hash. Counter `0` is an all-zero digit
+// run, ranking below every non-zero CI counter — any gh/jb build of the same base is an update
+// over the release. The `r` lane word is the comparator's own RELEASE keyword, shielding a hash
+// that would otherwise tokenize as the ALPHA/BETA/MILESTONE marker (a/b/m…) or as a number.
 version = when {
-    isReleaseBuild -> "$baseVersion-$gitHash"
+    isReleaseBuild -> "$baseVersion.0-r-$gitHash"
     providedBuildVersion != null -> providedBuildVersion
     else -> "$baseVersion.$localBuildCounter-$gitHash"
 }

--- a/installer-gen/src/main/kotlin/com/jonnyzzz/mcpSteroid/installer/InstallerGenerator.kt
+++ b/installer-gen/src/main/kotlin/com/jonnyzzz/mcpSteroid/installer/InstallerGenerator.kt
@@ -17,7 +17,8 @@ import kotlin.io.path.writeText
  * artifact), a pinned `--devrig-version`, or — by default — the devrig zip on the `v<VERSION>` GitHub
  * release (NOT "latest": "latest" can drift ahead/behind the `--version` the generator runs with, baking
  * a mismatched devrig into the install scripts). Whatever the source, the resolved zip's top dir is
- * ASSERTED to be `devrig-<version>-…` so a mismatch fails generation instead of shipping silently.
+ * ASSERTED to start with `devrig-<version>-` or `devrig-<version>.` (the 0.102+ `.0-r-` release lane,
+ * #360) so a mismatch fails generation instead of shipping silently.
  */
 
 /** The five supported platforms, keyed `<os>-<cpu>`. The script split is by OS. */
@@ -204,7 +205,8 @@ private fun resolveDevrigZipUrlForRelease(version: String, http: HttpFetcher): S
  * Resolve devrig coordinates and ASSERT the binary version matches [version]. Local override (a pre-built
  * / fixture zip): `--devrig-zip <file>` + `--devrig-url <public url>`. Otherwise download a published
  * release — pinned `--devrig-version <v>` or, by default, the `v<version>` release (NOT "latest") — and
- * compute sha from the bytes. Whatever the source, the zip's top dir must be `devrig-<version>-…`.
+ * compute sha from the bytes. Whatever the source, the zip's top dir must start with
+ * `devrig-<version>-` or `devrig-<version>.` (0.102+ release lane, #360).
  */
 internal fun resolveDevrig(flags: Map<String, List<String>>, http: HttpFetcher, version: String): DevrigEntry {
     val (url, bytes) = flags["devrig-zip"]?.firstOrNull()?.let { zip ->
@@ -229,11 +231,12 @@ internal fun resolveDevrig(flags: Map<String, List<String>>, http: HttpFetcher, 
         u to http.getBytes(u)
     }
     val (posix, win) = devrigLaunchers(bytes)
-    // The launcher subpath is `<topDir>/bin/devrig`; the top dir is `devrig-<version>-<hash>`. Assert it
-    // matches --version regardless of how devrig was resolved (release / pinned / local zip) — a mismatch
-    // means the install scripts would ship a devrig whose version disagrees with the repo VERSION.
+    // The launcher subpath is `<topDir>/bin/devrig`; the top dir is `devrig-<version>-<hash>` (pre-0.102
+    // releases) or `devrig-<version>.<counter>-<lane>-<hash>` (0.102+, e.g. the `.0-r-` release lane, #360).
+    // Assert it matches --version regardless of how devrig was resolved (release / pinned / local zip) — a
+    // mismatch means the install scripts would ship a devrig whose version disagrees with the repo VERSION.
     val topDir = posix.substringBefore('/')
-    require(topDir.startsWith("devrig-$version-")) {
+    require(topDir.startsWith("devrig-$version-") || topDir.startsWith("devrig-$version.")) {
         "devrig binary version in '$topDir' does not match repo VERSION '$version' — install scripts would ship a mismatched devrig"
     }
     return DevrigEntry(url = url, sha256 = sha256Hex(bytes), launcherPosix = posix, launcherWindows = win)

--- a/installer-gen/src/test/kotlin/com/jonnyzzz/mcpSteroid/installer/InstallerGeneratorTest.kt
+++ b/installer-gen/src/test/kotlin/com/jonnyzzz/mcpSteroid/installer/InstallerGeneratorTest.kt
@@ -376,6 +376,27 @@ class InstallerGeneratorTest {
     }
 
     @Test
+    fun `resolveDevrig accepts the 0-102-plus release top-dir shape`(@TempDir dir: Path) {
+        val zip = dir.resolve("devrig.zip")
+        // 0.102+ release zips use the uniform lane layout: devrig-<version>.0-r-<hash> (#360)
+        ZipOutputStream(Files.newOutputStream(zip)).use { z ->
+            z.putNextEntry(ZipEntry("devrig-0.102.0-r-abc1234/bin/devrig")); z.write("#!/bin/sh".encodeToByteArray()); z.closeEntry()
+            z.putNextEntry(ZipEntry("devrig-0.102.0-r-abc1234/bin/devrig.bat")); z.write("@echo off".encodeToByteArray()); z.closeEntry()
+        }
+        val flags = mapOf("devrig-zip" to listOf(zip.toString()), "devrig-url" to listOf("https://example.com/devrig-0.102.0-r-abc1234.zip"))
+        val http = object : HttpFetcher {
+            override fun head(url: String) = error("no network")
+            override fun getBytes(url: String) = error("no network")
+        }
+        val devrig = resolveDevrig(flags, http, version = "0.102")
+        assertEquals("devrig-0.102.0-r-abc1234/bin/devrig", devrig.launcherPosix)
+
+        // a differing base still fails fast — and "0.10" must not prefix-match "0.102"
+        val ex = assertFailsWith<IllegalArgumentException> { resolveDevrig(flags, http, version = "0.10") }
+        assertTrue(ex.message!!.contains("does not match repo VERSION '0.10'"), ex.message!!)
+    }
+
+    @Test
     fun `validateDevrig rejects a placeholder url`() {
         assertFailsWith<IllegalArgumentException> {
             validateDevrig(DevrigEntry(

--- a/mcp-core/src/test/kotlin/com/jonnyzzz/mcpSteroid/util/text/DevrigVersionTest.kt
+++ b/mcp-core/src/test/kotlin/com/jonnyzzz/mcpSteroid/util/text/DevrigVersionTest.kt
@@ -68,4 +68,21 @@ class DevrigVersionTest {
     assertFalse(updateAvailable("0.102", "0.101.19999-SNAPSHOT-5d18a187"))
     assertFalse(updateAvailable("999.0", "0.101.19999-SNAPSHOT-5d18a187"))
   }
+
+  @Test
+  fun releaseLaneWithCounterAndLaneMarker() {
+    // 0.102+ release lane <base>.0-r-<hash> (#360): the uniform <base>.<counter>-<lane>-<hash>
+    // layout; everything after the first `-` is still build metadata
+    val release = DevrigVersion.parse("0.102.0-r-40690055")
+    assertFalse(release.isSnapshotBuild)
+    assertEquals("0.102.0", release.comparableVersion)
+
+    // no self-nag: the promoted base is not an update over its own release build
+    assertFalse(DevrigVersion.isUpdateAvailable(current = release, promoted = DevrigVersion.parse("0.102")))
+    assertTrue(DevrigVersion.isUpdateAvailable(current = release, promoted = DevrigVersion.parse("0.103")))
+
+    // a CI build of the same base is newer than the release; hash spelling carries no precedence
+    assertTrue(DevrigVersion.parse("0.102.441-jb-abcdef1") > release)
+    assertEquals(0, DevrigVersion.parse("0.102.0-r-a1b2c3d").compareTo(DevrigVersion.parse("0.102.0-r-f9e8d7c")))
+  }
 }

--- a/mcp-core/src/test/kotlin/com/jonnyzzz/mcpSteroid/util/text/VersionComparatorUtilTest.kt
+++ b/mcp-core/src/test/kotlin/com/jonnyzzz/mcpSteroid/util/text/VersionComparatorUtilTest.kt
@@ -114,4 +114,34 @@ class VersionComparatorUtilTest {
     // the bare SNAPSHOT marker (no counter) still sorts before its release, as in Maven
     assertTrue(VersionComparatorUtil.compare("0.101-SNAPSHOT", "0.101") < 0)
   }
+
+  @Test
+  fun releaseLaneOrdersHashFreeAcrossLanes() {
+    // 0.102+ release shape from the root build script: <VERSION>.0-r-<hash> (#360). The IDE's
+    // plugin manager compares the raw strings with this comparator, so the ordering must hold
+    // for every hash spelling: a hash starting with a/b/m would otherwise read as the
+    // ALPHA/BETA/MILESTONE keyword, and a leading digit as a number.
+    val hashes = listOf("40690055", "a1b2c3d", "b1c2d3e", "m1n2o3p", "f9e8d7c", "0abc123", "9999999")
+    for (releaseHash in hashes) {
+      val release = "0.102.0-r-$releaseHash"
+      for (ciHash in hashes) {
+        // any CI build of the base is an update over the release: the release counter 0 is an
+        // all-zero digit run (_WS) and loses to every non-zero CI counter before the
+        // comparison can reach the lane word or the hash
+        assertTrue(VersionComparatorUtil.compare(release, "0.102.1-jb-$ciHash") < 0)
+        assertTrue(VersionComparatorUtil.compare(release, "0.102.566-jb-$ciHash") < 0)
+        assertTrue(VersionComparatorUtil.compare(release, "0.102.566-gh-$ciHash") < 0)
+        // the local snapshot band stays the newest of the base
+        assertTrue(VersionComparatorUtil.compare("0.102.19999-SNAPSHOT-$ciHash", release) > 0)
+      }
+      // already-shipped 0.101 strings (old release + CI shapes) order below every 0.102 artifact
+      assertTrue(VersionComparatorUtil.compare("0.101-40690055", release) < 0)
+      assertTrue(VersionComparatorUtil.compare("0.101.566-jb-90ac87b", release) < 0)
+      // the `r` lane word ranks as the RELEASE keyword, so the release never sinks below its
+      // own promoted base, whatever the hash spelling
+      assertTrue(VersionComparatorUtil.compare(release, "0.102") > 0)
+    }
+    // a release of the NEXT base outranks every artifact of the previous base
+    assertTrue(VersionComparatorUtil.compare("0.103.0-r-a1b2c3d", "0.102.999-jb-40690055") > 0)
+  }
 }

--- a/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/BackendVersionSkewTest.kt
+++ b/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/BackendVersionSkewTest.kt
@@ -30,6 +30,7 @@ class BackendVersionSkewTest {
     fun `versionBase extracts the leading major-minor prefix`() {
         assertEquals("0.100", BackendVersionSkew.versionBase("0.100-409f23a2"))
         assertEquals("0.100", BackendVersionSkew.versionBase("0.100.19999-SNAPSHOT-9b6783a6"))
+        assertEquals("0.102", BackendVersionSkew.versionBase("0.102.0-r-40690055")) // 0.102+ release lane (#360)
         assertEquals("0.101", BackendVersionSkew.versionBase("0.101"))
         assertEquals("1.2", BackendVersionSkew.versionBase(" 1.2.3 "))
         assertNull(BackendVersionSkew.versionBase(""))
@@ -42,6 +43,7 @@ class BackendVersionSkewTest {
         // The exact strings that made the old exact-match scheme warn spuriously.
         assertFalse(BackendVersionSkew.isSkewed("0.100.19999-SNAPSHOT-9b6783a6", "0.100-409f23a2"))
         assertFalse(BackendVersionSkew.isSkewed("0.101", "0.101"))
+        assertFalse(BackendVersionSkew.isSkewed("0.102.0-r-40690055", "0.102.566-jb-90ac87b"))
     }
 
     @Test

--- a/release/release-instructions.md
+++ b/release/release-instructions.md
@@ -279,14 +279,17 @@ flag needed). Every artifact in the release ZIPs is compiled from source by this
 very invocation; nothing is assembled from cache entries. Expect the build to
 take correspondingly longer than a regular dev build.
 
-The resulting plugin ZIP is in `ij-plugin/build/distributions/mcp-steroid-<version>-<gitHash>.zip`.
-The devrig CLI ZIP is in `npx-kt/build/distributions/devrig-<version>-<gitHash>.zip`.
+The resulting plugin ZIP is in `ij-plugin/build/distributions/mcp-steroid-<version>.0-r-<gitHash>.zip`.
+The devrig CLI ZIP is in `npx-kt/build/distributions/devrig-<version>.0-r-<gitHash>.zip`.
 The `<gitHash>` must match the current HEAD (the version bump commit) for both — building
 them in one Gradle invocation guarantees the same hash.
 
 **devrig zip naming.** `:npx-kt:distZip` sets only `archiveBaseName = "devrig"`, so the
-release archive is Gradle's default `devrig-<version>-<gitHash>.zip`, matching the plugin
-zip's `mcp-steroid-<version>-<gitHash>.zip` convention. Local/dev builds (without
+release archive is Gradle's default `devrig-<version>.0-r-<gitHash>.zip`, matching the plugin
+zip's `mcp-steroid-<version>.0-r-<gitHash>.zip` convention. The `.0-r-` infix is the release
+lane of the uniform `<base>.<counter>-<lane>-<hash>` version layout (#360): counter `0` ranks
+below every CI counter and the `r` lane word keeps the git hash out of IntelliJ's version
+comparison. Local/dev builds (without
 `-Pmcp.release.build=true`) carry the SNAPSHOT counter:
 `devrig-<version>.19999-SNAPSHOT-<gitHash>.zip`. Only the non-SNAPSHOT name is a release
 artifact; ignore SNAPSHOT zips left over from dev builds.
@@ -318,8 +321,8 @@ the tag already exists on the remote — drop `--target` from the `gh` command.
 
 ```bash
 gh release create "v<version>" \
-  "ij-plugin/build/distributions/mcp-steroid-<version>-<gitHash>.zip" \
-  "npx-kt/build/distributions/devrig-<version>-<gitHash>.zip" \
+  "ij-plugin/build/distributions/mcp-steroid-<version>.0-r-<gitHash>.zip" \
+  "npx-kt/build/distributions/devrig-<version>.0-r-<gitHash>.zip" \
   EULA \
   --repo jonnyzzz/mcp-steroid \
   --notes-file "release/notes/<version>.md" \
@@ -330,7 +333,7 @@ gh release create "v<version>" \
 it with HTTP 422. The release attaches to the existing tag automatically.
 
 **Assets**: The `gh` CLI uses each source filename as the asset name, so the release page
-carries `mcp-steroid-<version>-<gitHash>.zip` (plugin), `devrig-<version>-<gitHash>.zip`
+carries `mcp-steroid-<version>.0-r-<gitHash>.zip` (plugin), `devrig-<version>.0-r-<gitHash>.zip`
 (devrig CLI), and `EULA`.
 
 **EULA**: The root `EULA` file is uploaded directly. The `gh` CLI uses the source
@@ -363,7 +366,7 @@ the Pages workflow; the deploy + verification happen in Stage 9.
 ### Stage 8: Upload to JetBrains Marketplace
 
 ```bash
-release/scripts/publish-marketplace.sh "ij-plugin/build/distributions/mcp-steroid-<version>-<gitHash>.zip"
+release/scripts/publish-marketplace.sh "ij-plugin/build/distributions/mcp-steroid-<version>.0-r-<gitHash>.zip"
 ```
 
 Requires `~/.marketplace` (one-line JetBrains permanent token).
@@ -454,7 +457,7 @@ The website template automatically renders an obsolete banner on older release p
 | `CONTRIBUTORS.md` | Contributor acknowledgements (update each release) |
 | `VERSION` | Current plugin version (`X.Y.Z`) |
 | `EULA` | End User License Agreement (uploaded to GitHub releases) |
-| `npx-kt/build/distributions/devrig-<version>-<gitHash>.zip` | devrig CLI archive (`:npx-kt:distZip`); uploaded to GitHub releases |
+| `npx-kt/build/distributions/devrig-<version>.0-r-<gitHash>.zip` | devrig CLI archive (`:npx-kt:distZip`); uploaded to GitHub releases |
 | `release/notes/<version>.md` | Release notes (used as GitHub release body) |
 | `release/scripts/bump-version.sh` | Version bump with rerun guard |
 | `release/scripts/publish-marketplace.sh` | JetBrains Marketplace upload (Stable channel) |


### PR DESCRIPTION
Fixes #360.

## Problem

The release lane emits `<base>-<hash>` while CI emits `<base>.<counter>-(gh|jb)-<hash>`. IntelliJ's `VersionComparatorUtil` (used raw by `PluginDownloader.compareVersionsSkipBrokenAndIncompatible`, `UpdateChecker`, `RepositoryHelper` — no preprocessing) then pits the release git hash against the CI counter: `0.101-40690055` outranks every CI build of 0.101 because the hash happens to be all digits, while a hash starting with `a`/`b`/`m` reads as the alpha/beta/milestone keyword and loses hardest. Which artifact "is an update" flips on hash spelling.

## Fix

All lanes now share the `<base>.<counter>-<lane>-<hash>` token layout; only the release lane changes:

| Lane | Before | After |
|---|---|---|
| Release | `0.102-40690055` | `0.102.0-r-40690055` |
| jb / gh CI | `0.102.566-jb-90ac87b` | unchanged |
| Local | `0.102.19999-SNAPSHOT-…` | unchanged |

- The release counter `0` is an all-zero digit run (`_WS`) — it ranks below every non-zero CI counter, so any jb/gh build of the same base is an update over the release, decided before the comparison can reach the lane word or hash.
- The `r` lane word is the comparator's own RELEASE keyword — it shields the hash so hash tokens are only compared when base+counter+lane all tie, i.e. never between distinct artifacts.
- The CI version guard now rejects counter `0` (reserved for the release lane).
- installer-gen's devrig top-dir assertion accepts `devrig-<version>.0-r-<hash>` alongside the pre-0.102 `devrig-<version>-<hash>` shape (with a prefix-safety check: `--version 0.10` does not match `0.102`).
- Release instructions updated to the new artifact names. website-gen needs no change (it reads the version from the artifact's own `plugin.xml`).

Ordering within a base: `release(.0-r) < CI(.N-gh/jb, by counter) < local(.19999-SNAPSHOT)`; the next base outranks everything of the previous one. Shipped `0.101-40690055` / `0.101.566-jb-90ac87b` strings order below every new-format `0.102.*` artifact, so the upgrade path from published versions is safe. `DevrigVersion` (#369) parses the new release string to `0.102.0`, which compares equal to the promoted base `0.102` — no self-nag.

Full comparator research and the empirically verified ordering table (run against the real `util_rt.jar`): https://github.com/jonnyzzz/mcp-steroid/issues/360#issuecomment-5131277123

## Tests

- `:mcp-core:test` — `VersionComparatorUtilTest.releaseLaneOrdersHashFreeAcrossLanes` pins the raw-comparator ordering across 7 hash spellings on both sides of every cross-lane pair; `DevrigVersionTest.releaseLaneWithCounterAndLaneMarker` covers the update-notification gate.
- `:npx-kt:test` — `BackendVersionSkewTest` covers `versionBase`/`isSkewed` for the new shape.
- `:installer-gen:test` — new-format top dir accepted, version mismatch still fails fast (test written first; failed on the old assertion, passes now).
- Manual: `gradlew properties -Pmcp.release.build=true` emits `0.101.0-r-c7dd5934`; `-Pmcp.build.version=0.101.0-jb-c7dd5934` is rejected (counter 0), `0.101.566-jb-c7dd5934` accepted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)