### PR TITLE
execute_code result carries only the execution_id header + script output — progress moves to logs/notifications

### DIFF
--- a/docs/dialog-killer-modality-hang.md
+++ b/docs/dialog-killer-modality-hang.md
@@ -55,8 +55,8 @@ residual write-intent stall fails fast instead of hanging:
 6. **Stage markers** (`[PRE] …`, `[RUN] script`, `[POST] …`) are logged on entry to each stage, so if
    anything ever stalls the last marker pinpoints the exact stuck stage. *Updated for issue #154:* the
    markers originally went into the tool result, which broke machine parsing of script output; they now
-   go to **idea.log only**, and a pre-flight failure instead names its step + modality profile in the
-   returned error itself (`pre-flight '<step>' (modal=<profile>): …`).
+   go to **idea.log only** — a failing stage propagates its own error untouched, and the last `[PRE]`
+   line in idea.log pinpoints a stuck stage.
 
 New `exec_code` parameter **`allow_modal: Boolean = false`** drives step 4 (threaded through
 `ExecCodeParams` + the tool schema, and forwarded by the devrig stdio bridge in

--- a/docs/dialog-killer-modality-hang.md
+++ b/docs/dialog-killer-modality-hang.md
@@ -52,8 +52,11 @@ residual write-intent stall fails fast instead of hanging:
    otherwise enumerate via `DialogWindowsLookup.withModalityCheck` and **hard-fail only on a real modal
    dialog** (not on mere indexing/progress, which also elevates `ModalityState`).
 5. **Post-flight commit** re-checks `isModalEdt()` (current modality) before committing.
-6. **Stage markers** (`[PRE] …`, `[RUN] script`, `[POST] …`) are logged to the result on entry to each
-   stage, so if anything ever stalls the last marker pinpoints the exact stuck stage.
+6. **Stage markers** (`[PRE] …`, `[RUN] script`, `[POST] …`) are logged on entry to each stage, so if
+   anything ever stalls the last marker pinpoints the exact stuck stage. *Updated for issue #154:* the
+   markers originally went into the tool result, which broke machine parsing of script output; they now
+   go to **idea.log only**, and a pre-flight failure instead names its step + modality profile in the
+   returned error itself (`pre-flight '<step>' (modal=<profile>): …`).
 
 New `exec_code` parameter **`allow_modal: Boolean = false`** drives step 4 (threaded through
 `ExecCodeParams` + the tool schema, and forwarded by the devrig stdio bridge in

--- a/ij-plugin/CLAUDE.md
+++ b/ij-plugin/CLAUDE.md
@@ -343,9 +343,8 @@ lines on anomalies, so a JSON-printing script stays machine-parseable after stri
 The same separation applies to ALL in-flight progress (`progress(...)`, indexing/compile waits,
 multi-block progress): `ExecutionManager.logProgress` delivers it via MCP progress notifications
 (when the client passed a `progressToken`) + idea.log + the execution event storage — never the
-result content. A pre-flight failure instead names its step + profile in the returned error
-(`pre-flight '<step>' (modal=<profile>): …` via `ScriptExecutor.preFlight`, original exception
-chained as cause), so a stall is still localizable from the error alone or from idea.log.
+result content. A failing pre-flight step propagates the context API's own error untouched;
+a stall is localized via the per-step `[PRE]` lines in idea.log.
 
 **Tests:** unit `ModalModeTest` (wire/default/parse) + `ExecutionManagerTest` profile-pipeline cases;
 integration `DialogKillerIntegrationTest` (Docker) — Step-1 opens a modal with `modal=unleashed` (no

--- a/ij-plugin/CLAUDE.md
+++ b/ij-plugin/CLAUDE.md
@@ -338,10 +338,14 @@ cancels it for the rest of the run), `syncDocuments()` (commit+save+VFS; asserts
 (asserts non-modal; **bounded** by `WAIT_FOR_SMART_MODE_TIMEOUT`). All bounded EDT ops use
 `withTimeout → ToolCallErrorException` so a stuck modal fails fast with a thread dump instead of hanging.
 Stage markers (`[PRE]`/`[RUN]`/`[POST]`) go to **idea.log only** — never into the tool result (#154: the
-result is the `execution_id:` header plus the script's own output, so a JSON-printing script stays
-machine-parseable after stripping that header). A pre-flight failure instead names its step + profile in
-the returned error (`pre-flight '<step>' (modal=<profile>): …` via `ScriptExecutor.preFlight`), so a
-stall is still localizable from the error alone or from idea.log.
+result is the `execution_id:` header plus the script's own output, plus explicit WARNING/ERROR/HINT
+lines on anomalies, so a JSON-printing script stays machine-parseable after stripping that header).
+The same separation applies to ALL in-flight progress (`progress(...)`, indexing/compile waits,
+multi-block progress): `ExecutionManager.logProgress` delivers it via MCP progress notifications
+(when the client passed a `progressToken`) + idea.log + the execution event storage — never the
+result content. A pre-flight failure instead names its step + profile in the returned error
+(`pre-flight '<step>' (modal=<profile>): …` via `ScriptExecutor.preFlight`, original exception
+chained as cause), so a stall is still localizable from the error alone or from idea.log.
 
 **Tests:** unit `ModalModeTest` (wire/default/parse) + `ExecutionManagerTest` profile-pipeline cases;
 integration `DialogKillerIntegrationTest` (Docker) — Step-1 opens a modal with `modal=unleashed` (no

--- a/ij-plugin/CLAUDE.md
+++ b/ij-plugin/CLAUDE.md
@@ -99,9 +99,10 @@ Get services: `project.service<MyService>()` or `service<AppService>()`. Use `ch
   was driven by this rule being violated; A0's boundary catch-all
   (`McpHttpTransport.handlePost`, commit `3a4e7c13`) plus the A2b
   rethrows form the complete fix.
-- One exception: `ScriptExecutor.kt:150` deliberately catches
+- One exception: `ScriptExecutor.executeCodeBlocks` deliberately catches
   `TimeoutCancellationException` BEFORE the generic `CancellationException`
-  catch and calls `reportFailed("Execution timed out after $timeout seconds")`.
+  catch and calls `reportFailed("Execution timed out after $timeout seconds
+  while running the script body (modal=…; pre-flight completed)")`.
   TCE is a CE subclass; the script-timeout case is a domain error that
   needs to surface to the agent, not a control-flow signal to propagate.
 - Use `Logger.getInstance(MyClass::class.java)` for logging.
@@ -336,7 +337,11 @@ thread-dump+screenshot side effects, **skipped on an empty sweep**; does not fai
 cancels it for the rest of the run), `syncDocuments()` (commit+save+VFS; asserts non-modal), `waitForSmartMode()`
 (asserts non-modal; **bounded** by `WAIT_FOR_SMART_MODE_TIMEOUT`). All bounded EDT ops use
 `withTimeout → ToolCallErrorException` so a stuck modal fails fast with a thread dump instead of hanging.
-Stage markers (`[PRE]`/`[RUN]`/`[POST]`) localize a stall.
+Stage markers (`[PRE]`/`[RUN]`/`[POST]`) go to **idea.log only** — never into the tool result (#154: the
+result is the `execution_id:` header plus the script's own output, so a JSON-printing script stays
+machine-parseable after stripping that header). A pre-flight failure instead names its step + profile in
+the returned error (`pre-flight '<step>' (modal=<profile>): …` via `ScriptExecutor.preFlight`), so a
+stall is still localizable from the error alone or from idea.log.
 
 **Tests:** unit `ModalModeTest` (wire/default/parse) + `ExecutionManagerTest` profile-pipeline cases;
 integration `DialogKillerIntegrationTest` (Docker) — Step-1 opens a modal with `modal=unleashed` (no

--- a/ij-plugin/src/main/kotlin/com/jonnyzzz/mcpSteroid/execution/CodeEvalManager.kt
+++ b/ij-plugin/src/main/kotlin/com/jonnyzzz/mcpSteroid/execution/CodeEvalManager.kt
@@ -106,7 +106,9 @@ class CodeEvalManager(
                 val compilerError = wrappedCode.lineMapping.remapCompilerOutput(rawCompilerError)
 
                 if (compilerOutput.isNotEmpty()) {
-                    resultBuilder.logProgress("Compiler Output:\n$compilerOutput")
+                    // Real content, not progress (#154): kotlinc stdout is empty on a clean
+                    // compile, so when it IS present the agent must see it in the result.
+                    resultBuilder.logMessage("Compiler Output:\n$compilerOutput")
                 }
 
                 if (compilerError.isNotEmpty()) {

--- a/ij-plugin/src/main/kotlin/com/jonnyzzz/mcpSteroid/execution/ExecutionManager.kt
+++ b/ij-plugin/src/main/kotlin/com/jonnyzzz/mcpSteroid/execution/ExecutionManager.kt
@@ -30,6 +30,11 @@ interface ExecutionResultBuilder {
      */
     val userOutputCount: Int
     fun logMessage(message: String)
+    /**
+     * Report in-flight progress. Progress is diagnostic, not payload (#154): implementations
+     * must NOT add it to the tool result content — deliver via MCP progress notifications,
+     * logs, and/or the execution event storage instead.
+     */
     fun logProgress(message: String)
     fun logImage(mimeType: String, data: String, fileName: String)
     fun logException(message: String, throwable: Throwable)
@@ -183,7 +188,12 @@ class ExecutionManager(
         }
 
         override fun logProgress(message: String) {
-            responseBuilder.addTextContent(message)
+            // #154: progress is diagnostic, NOT payload — it must never enter the tool result
+            // content (a script printing one JSON document must stay machine-parseable after
+            // stripping the execution_id header). Delivery channels: MCP progress notifications
+            // (sent when the client passed a progressToken), the Demo Mode broadcaster, and the
+            // execution storage event log. Every producer also logs the same line to idea.log
+            // at its call site.
             mcpProgress.report(message)
             // Broadcast progress event for Demo Mode
             executionEventBroadcaster.onProgress(executionId, message)

--- a/ij-plugin/src/main/kotlin/com/jonnyzzz/mcpSteroid/execution/ScriptExecutor.kt
+++ b/ij-plugin/src/main/kotlin/com/jonnyzzz/mcpSteroid/execution/ScriptExecutor.kt
@@ -140,20 +140,20 @@ class ScriptExecutor(
         // script that prints a single JSON document stays machine-parseable after stripping the
         // execution_id line. The same holds for ALL in-flight progress (indexing waits, compile
         // waits, multi-block progress): ExecutionManager.logProgress delivers it via MCP progress
-        // notifications + idea.log + event storage, never the result content. Because the framing
-        // no longer localizes a failure in the output, every stage failure names its step and
-        // modality profile in the error itself (see [preFlight]).
+        // notifications + idea.log + event storage, never the result content. A failing step
+        // propagates its own error untouched; the per-step [PRE] lines in idea.log localize a stall.
         when (exec.modal) {
             ModalMode.SMART_NON_MODAL -> {
-                preFlight(executionId, exec.modal, "close modal dialogs") { context.closeModalDialogs() }
+                log.info("[$executionId] [PRE] close modal dialogs (modal=${exec.modal.wire})")
+                context.closeModalDialogs()
                 log.info("[$executionId] [PRE] require non-modal (modal=${exec.modal.wire})")
                 requireNonModalOrFail(executionId, exec.modal)
-                preFlight(executionId, exec.modal, "sync documents") { context.syncDocuments() }
-                // Step name deliberately avoids the "smart mode" substring: the hint engine
-                // (ExecutionSuggestionService) matches it and would append a smartReadAction TIP
-                // to the INDEXING IN PROGRESS error, whose own instruction is "just keep polling".
-                preFlight(executionId, exec.modal, "wait for indexing") { context.waitForSmartMode() }
-                preFlight(executionId, exec.modal, "start modal-dialog monitor") { context.monitorAndCloseModalDialogs() }
+                log.info("[$executionId] [PRE] sync documents (modal=${exec.modal.wire})")
+                context.syncDocuments()
+                log.info("[$executionId] [PRE] wait for smart mode (modal=${exec.modal.wire})")
+                context.waitForSmartMode()
+                log.info("[$executionId] [PRE] start modal-dialog monitor (modal=${exec.modal.wire})")
+                context.monitorAndCloseModalDialogs()
             }
 
             ModalMode.NON_MODAL -> {
@@ -187,40 +187,6 @@ class ScriptExecutor(
                     "WARNING: post-flight 'sync documents' (modal=${exec.modal.wire}) was skipped: ${e.message}"
                 )
             }
-        }
-    }
-
-    /**
-     * Runs one pre-flight step of the `modal` profile. The step's progress is logged to the IDE log
-     * only — never added to the tool result (#154). When the step fails, it is rethrown with the
-     * step name and modality profile prefixed, so the returned error is self-sufficient now that no
-     * `[PRE]` framing in the output localizes the failing step. The original exception is chained
-     * as the cause, so the stack trace logged upstream (ExecutionManager) still points at the real
-     * throw site inside the step. Cancellation (CE/PCE) propagates untouched.
-     */
-    private suspend fun preFlight(
-        executionId: ExecutionId,
-        modal: ModalMode,
-        step: String,
-        action: suspend () -> Unit,
-    ) {
-        log.info("[$executionId] [PRE] $step (modal=${modal.wire})")
-        try {
-            action()
-        } catch (e: ToolCallErrorException) {
-            throw ToolCallErrorException("pre-flight '$step' (modal=${modal.wire}): ${e.message}")
-                .apply { initCause(e) }
-        } catch (e: CancellationException) {
-            throw e
-        } catch (e: ProcessCanceledException) {
-            // Explicit defense for any PCE that does not extend CancellationException
-            // (mirrors executeCodeBlocks): control-flow exceptions propagate untouched.
-            throw e
-        } catch (t: Throwable) {
-            // Unexpected failures (e.g. a RuntimeException out of commitAllDocuments) must also
-            // name the failing step + profile — ExecutionManager's generic handler reports the
-            // wrapper's message and stack (with this cause chain) in the result.
-            throw RuntimeException("pre-flight '$step' (modal=${modal.wire}): ${t.message}", t)
         }
     }
 

--- a/ij-plugin/src/main/kotlin/com/jonnyzzz/mcpSteroid/execution/ScriptExecutor.kt
+++ b/ij-plugin/src/main/kotlin/com/jonnyzzz/mcpSteroid/execution/ScriptExecutor.kt
@@ -134,44 +134,73 @@ class ScriptExecutor(
         // Pre-flight per `modal` profile. Each profile is sugar over the context APIs
         // (closeModalDialogs / syncDocuments / waitForSmartMode / monitorAndCloseModalDialogs),
         // which a script in any mode can also call on demand.
+        //
+        // Stage progress ([PRE]/[RUN]/[POST]) goes to the IDE log ONLY, never into the tool result
+        // (#154): the result carries just the execution_id header plus the script's own output, so a
+        // script that prints a single JSON document stays machine-parseable after stripping the
+        // execution_id line. Because the framing no longer localizes a failure in the output, every
+        // stage failure names its step and modality profile in the error itself (see [preFlight]).
         when (exec.modal) {
             ModalMode.SMART_NON_MODAL -> {
-                resultBuilder.logMessage("[PRE] close modal dialogs")
-                context.closeModalDialogs()
+                preFlight(executionId, exec.modal, "close modal dialogs") { context.closeModalDialogs() }
+                log.info("[$executionId] [PRE] require non-modal (modal=${exec.modal.wire})")
                 requireNonModalOrFail(executionId, exec.modal)
-                resultBuilder.logMessage("[PRE] sync documents")
-                context.syncDocuments()
-                resultBuilder.logMessage("[PRE] wait for smart mode")
-                context.waitForSmartMode()
-                resultBuilder.logMessage("[PRE] start modal-dialog monitor")
-                context.monitorAndCloseModalDialogs()
+                preFlight(executionId, exec.modal, "sync documents") { context.syncDocuments() }
+                preFlight(executionId, exec.modal, "wait for smart mode") { context.waitForSmartMode() }
+                preFlight(executionId, exec.modal, "start modal-dialog monitor") { context.monitorAndCloseModalDialogs() }
             }
 
             ModalMode.NON_MODAL -> {
-                resultBuilder.logMessage("[PRE] require non-modal")
+                log.info("[$executionId] [PRE] require non-modal (modal=${exec.modal.wire})")
                 requireNonModalOrFail(executionId, exec.modal)
             }
 
             ModalMode.UNLEASHED -> {
-                resultBuilder.logMessage("[PRE] unleashed — no modality checks")
+                log.info("[$executionId] [PRE] unleashed — no modality checks")
             }
         }
 
         monitorExceptions(context, executionDisposable)
 
-        resultBuilder.logMessage("[RUN] script")
+        log.info("[$executionId] [RUN] script (modal=${exec.modal.wire}, timeout=${exec.timeout}s)")
         executeCodeBlocks(exec, context, evalResult, executionId, resultBuilder)
 
         // Post-flight: re-sync to disk only for `smart_non_modal`, whose profile owns the document-
         // consistency contract. `non_modal` is intentionally start-gate-only and `unleashed` does nothing —
         // neither re-syncs (a fresh isModalEdt() read, since the body may have changed modality).
         if (exec.modal == ModalMode.SMART_NON_MODAL && !isModalEdt()) {
-            resultBuilder.logMessage("[POST] sync documents")
+            log.info("[$executionId] [POST] sync documents (modal=${exec.modal.wire})")
             try {
                 context.syncDocuments()
             } catch (e: ToolCallErrorException) {
-                resultBuilder.logMessage("[POST] sync skipped: ${e.message}")
+                // Non-fatal by design — the script itself succeeded. But this is an anomaly the agent
+                // must see (its edits may not have reached disk), not progress framing, so it stays in
+                // the result as an explicit warning that names the step and profile.
+                log.warn("[$executionId] [POST] sync documents skipped: ${e.message}")
+                resultBuilder.logMessage(
+                    "WARNING: post-flight 'sync documents' (modal=${exec.modal.wire}) was skipped: ${e.message}"
+                )
             }
+        }
+    }
+
+    /**
+     * Runs one pre-flight step of the `modal` profile. The step's progress is logged to the IDE log
+     * only — never added to the tool result (#154). When the step fails with a [ToolCallErrorException],
+     * it is rethrown with the step name and modality profile prefixed, so the returned error is
+     * self-sufficient now that no `[PRE]` framing in the output localizes the failing step.
+     */
+    private suspend fun preFlight(
+        executionId: ExecutionId,
+        modal: ModalMode,
+        step: String,
+        action: suspend () -> Unit,
+    ) {
+        log.info("[$executionId] [PRE] $step (modal=${modal.wire})")
+        try {
+            action()
+        } catch (e: ToolCallErrorException) {
+            throw ToolCallErrorException("pre-flight '$step' (modal=${modal.wire}): ${e.message}")
         }
     }
 
@@ -251,7 +280,12 @@ class ScriptExecutor(
             // Timeout - report as error (must be caught before CancellationException since it's a subclass)
             log.warn("Execution $executionId timed out: ${e.message}")
             resultBuilder.logRemappedException("Execution timed out", e, evalResult.lineMapping)
-            resultBuilder.reportFailed("Execution timed out after ${exec.timeout} seconds")
+            // Name the phase explicitly: with the [RUN] framing gone from the result (#154), the
+            // error itself must say the timeout hit the script body after pre-flight completed.
+            resultBuilder.reportFailed(
+                "Execution timed out after ${exec.timeout} seconds while running the script body " +
+                    "(modal=${exec.modal.wire}; pre-flight completed)"
+            )
         } catch (e: CancellationException) {
             throw e
         } catch (e: ProcessCanceledException) {

--- a/ij-plugin/src/main/kotlin/com/jonnyzzz/mcpSteroid/execution/ScriptExecutor.kt
+++ b/ij-plugin/src/main/kotlin/com/jonnyzzz/mcpSteroid/execution/ScriptExecutor.kt
@@ -138,15 +138,21 @@ class ScriptExecutor(
         // Stage progress ([PRE]/[RUN]/[POST]) goes to the IDE log ONLY, never into the tool result
         // (#154): the result carries just the execution_id header plus the script's own output, so a
         // script that prints a single JSON document stays machine-parseable after stripping the
-        // execution_id line. Because the framing no longer localizes a failure in the output, every
-        // stage failure names its step and modality profile in the error itself (see [preFlight]).
+        // execution_id line. The same holds for ALL in-flight progress (indexing waits, compile
+        // waits, multi-block progress): ExecutionManager.logProgress delivers it via MCP progress
+        // notifications + idea.log + event storage, never the result content. Because the framing
+        // no longer localizes a failure in the output, every stage failure names its step and
+        // modality profile in the error itself (see [preFlight]).
         when (exec.modal) {
             ModalMode.SMART_NON_MODAL -> {
                 preFlight(executionId, exec.modal, "close modal dialogs") { context.closeModalDialogs() }
                 log.info("[$executionId] [PRE] require non-modal (modal=${exec.modal.wire})")
                 requireNonModalOrFail(executionId, exec.modal)
                 preFlight(executionId, exec.modal, "sync documents") { context.syncDocuments() }
-                preFlight(executionId, exec.modal, "wait for smart mode") { context.waitForSmartMode() }
+                // Step name deliberately avoids the "smart mode" substring: the hint engine
+                // (ExecutionSuggestionService) matches it and would append a smartReadAction TIP
+                // to the INDEXING IN PROGRESS error, whose own instruction is "just keep polling".
+                preFlight(executionId, exec.modal, "wait for indexing") { context.waitForSmartMode() }
                 preFlight(executionId, exec.modal, "start modal-dialog monitor") { context.monitorAndCloseModalDialogs() }
             }
 
@@ -186,9 +192,11 @@ class ScriptExecutor(
 
     /**
      * Runs one pre-flight step of the `modal` profile. The step's progress is logged to the IDE log
-     * only — never added to the tool result (#154). When the step fails with a [ToolCallErrorException],
-     * it is rethrown with the step name and modality profile prefixed, so the returned error is
-     * self-sufficient now that no `[PRE]` framing in the output localizes the failing step.
+     * only — never added to the tool result (#154). When the step fails, it is rethrown with the
+     * step name and modality profile prefixed, so the returned error is self-sufficient now that no
+     * `[PRE]` framing in the output localizes the failing step. The original exception is chained
+     * as the cause, so the stack trace logged upstream (ExecutionManager) still points at the real
+     * throw site inside the step. Cancellation (CE/PCE) propagates untouched.
      */
     private suspend fun preFlight(
         executionId: ExecutionId,
@@ -201,6 +209,18 @@ class ScriptExecutor(
             action()
         } catch (e: ToolCallErrorException) {
             throw ToolCallErrorException("pre-flight '$step' (modal=${modal.wire}): ${e.message}")
+                .apply { initCause(e) }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: ProcessCanceledException) {
+            // Explicit defense for any PCE that does not extend CancellationException
+            // (mirrors executeCodeBlocks): control-flow exceptions propagate untouched.
+            throw e
+        } catch (t: Throwable) {
+            // Unexpected failures (e.g. a RuntimeException out of commitAllDocuments) must also
+            // name the failing step + profile — ExecutionManager's generic handler reports the
+            // wrapper's message and stack (with this cause chain) in the result.
+            throw RuntimeException("pre-flight '$step' (modal=${modal.wire}): ${t.message}", t)
         }
     }
 

--- a/ij-plugin/src/test/kotlin/com/jonnyzzz/mcpSteroid/McpServerIntegrationTest.kt
+++ b/ij-plugin/src/test/kotlin/com/jonnyzzz/mcpSteroid/McpServerIntegrationTest.kt
@@ -935,8 +935,9 @@ class McpServerIntegrationTest : BasePlatformTestCase() {
      * The synthetic script blocks via `kotlinx.coroutines.delay` (cancellation-
      * cooperative) for far longer than the requested timeout, so `withTimeout`
      * inside `ScriptExecutor` fires its `TimeoutCancellationException` path
-     * and `resultBuilder.reportFailed("Execution timed out after $timeout seconds")`
-     * is the user-visible signal.
+     * and `resultBuilder.reportFailed("Execution timed out after $timeout seconds
+     * while running the script body (modal=…; pre-flight completed)")` is the
+     * user-visible signal.
      */
     fun testExecuteCodeTimeoutReturnsCleanErrorNotHttp500(): Unit = timeoutRunBlocking(60.seconds) {
         val server = SteroidsMcpServer.getInstance()

--- a/ij-plugin/src/test/kotlin/com/jonnyzzz/mcpSteroid/McpServerIntegrationTest.kt
+++ b/ij-plugin/src/test/kotlin/com/jonnyzzz/mcpSteroid/McpServerIntegrationTest.kt
@@ -1061,13 +1061,14 @@ class McpServerIntegrationTest : BasePlatformTestCase() {
     }
 
     /**
-     * Tests that progress reporting works correctly over the MCP protocol.
-     * When code calls progress(), the messages should be included in the response.
+     * Tests that progress() output stays OUT of the tool result content (#154).
      *
      * Per MCP 2025-11-25 spec:
      * - Client can pass _meta.progressToken in tool call arguments
      * - Server sends notifications/progress with that token
-     * - Progress messages are also accumulated in the final response
+     * - Without a token, progress is delivered to idea.log and the execution event storage only —
+     *   the result content carries just the execution_id header plus the script's own output, so
+     *   programmatic consumers can strip the header and parse the rest.
      */
     fun testProgressReportingInResponse(): Unit = timeoutRunBlocking(60.seconds) {
         val server = SteroidsMcpServer.getInstance()
@@ -1132,10 +1133,13 @@ class McpServerIntegrationTest : BasePlatformTestCase() {
             execOutput.contains("DONE: All steps completed")
         )
 
-        // Output should contain progress messages (they may be throttled, so check for at least one)
-        assertTrue(
-            "Output should contain at least one progress indicator, got: $execOutput",
-            execOutput.contains("Step") || execOutput.contains("PROGRESS:")
+        // #154: progress() messages are diagnostic, not payload — they must NOT appear in the
+        // tool result content (delivery is via notifications/progress when a token is present).
+        assertFalse(
+            "progress() messages must not leak into the tool result (#154), got: $execOutput",
+            execOutput.contains("Step 1: Initializing")
+                    || execOutput.contains("Step 2: Processing data")
+                    || execOutput.contains("Step 3: Completing task")
         )
     }
 
@@ -1211,10 +1215,11 @@ class McpServerIntegrationTest : BasePlatformTestCase() {
             execOutput.contains("COMPLETED: Task with progress token")
         )
 
-        // Progress messages from progress() calls are added to the tool result via logProgress().
-        // This is the delivery mechanism for HTTP clients (streaming clients get separate notifications).
-        assertTrue(
-            "Output should contain progress messages from script, got: $execOutput",
+        // #154: progress() messages are diagnostic, not payload — they must NOT appear in the
+        // tool result content. With a progressToken, notifications/progress is the delivery
+        // mechanism (asserted below).
+        assertFalse(
+            "progress() messages must not leak into the tool result (#154), got: $execOutput",
             execOutput.contains("Starting with progress token")
                     || execOutput.contains("Middle step")
                     || execOutput.contains("Final step")
@@ -1323,11 +1328,11 @@ class McpServerIntegrationTest : BasePlatformTestCase() {
             execOutput.contains("FINISHED: Processed 5 items")
         )
 
-        // Should contain at least some progress messages
-        // Note: progress is throttled to 1 message per second, so not all may appear
-        assertTrue(
-            "Output should contain progress messages, got: $execOutput",
-            execOutput.contains("Processing item") || execOutput.contains("PROGRESS:")
+        // #154: progress() messages are diagnostic, not payload — the long-running loop's
+        // progress must NOT leak into the tool result content.
+        assertFalse(
+            "progress() messages must not leak into the tool result (#154), got: $execOutput",
+            execOutput.contains("Processing item")
         )
     }
 
@@ -1830,8 +1835,8 @@ class McpServerIntegrationTest : BasePlatformTestCase() {
     /**
      * Tests that compilation errors are included in the tool result content items even
      * when a progress token is provided. The tool result is the delivery mechanism for
-     * HTTP clients — all logMessage/logProgress/reportFailed content is added to it
-     * synchronously before the HTTP response is sent.
+     * HTTP clients — all logMessage/reportFailed content is added to it synchronously
+     * before the HTTP response is sent (logProgress deliberately is not — #154).
      */
     fun testCompilationErrorWithProgressToken(): Unit = timeoutRunBlocking(60.seconds) {
         val server = SteroidsMcpServer.getInstance()

--- a/ij-plugin/src/test/kotlin/com/jonnyzzz/mcpSteroid/execution/ExecutionManagerTest.kt
+++ b/ij-plugin/src/test/kotlin/com/jonnyzzz/mcpSteroid/execution/ExecutionManagerTest.kt
@@ -14,6 +14,10 @@ import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
 import kotlin.time.Duration.Companion.seconds
 
 /**
@@ -53,6 +57,40 @@ class ExecutionManagerTest : BasePlatformTestCase() {
         )
         assertFalse("non_modal should pass the non-modal gate headless: ${getTextContent(result)}", result.isError)
         assertTrue("Should have output", getTextContent(result).contains("hi non_modal"))
+    }
+
+    /**
+     * #154: the tool result must be machine-parseable. A script that prints a single JSON document
+     * yields exactly the `execution_id:` header plus the script's own stdout — no `[PRE]`/`[RUN]`/
+     * `[POST]` modal-mode framing interleaved (that progress goes to the IDE log only). A consumer
+     * that strips the execution_id line and JSON-parses the rest must succeed.
+     */
+    fun testJsonScriptOutputIsParseableAfterStrippingExecutionId(): Unit = timeoutRunBlocking(60.seconds) {
+        val manager = project.service<ExecutionManager>()
+        val result = manager.executeWithProgress(
+            testExecParams(
+                """printJson(mapOf("leaf" to "Show line numbers", "matches" to listOf(1, 2, 3)))""",
+                modal = ModalMode.SMART_NON_MODAL,
+            ),
+            NoOpProgressReporter,
+        )
+        val text = getTextContent(result)
+        assertFalse("Script must succeed: $text", result.isError)
+
+        val lines = text.lines()
+        assertTrue("First line must be the execution_id header, got: $text", lines.first().startsWith("execution_id: "))
+        lines.forEach { line ->
+            assertFalse(
+                "Stage framing must never appear in the tool result (#154), got: $line",
+                line.startsWith("[PRE]") || line.startsWith("[RUN]") || line.startsWith("[POST]")
+            )
+        }
+
+        // The contract from the issue: strip the execution_id line, parse the rest as JSON.
+        val payload = lines.drop(1).joinToString("\n")
+        val json = Json.parseToJsonElement(payload).jsonObject
+        assertEquals("Show line numbers", json.getValue("leaf").jsonPrimitive.content)
+        assertEquals(3, json.getValue("matches").jsonArray.size)
     }
 
     fun testParentCoroutineCancellationUnwindsExecution(): Unit = timeoutRunBlocking(60.seconds) {

--- a/ij-plugin/src/test/kotlin/com/jonnyzzz/mcpSteroid/execution/ScriptExecutorTest.kt
+++ b/ij-plugin/src/test/kotlin/com/jonnyzzz/mcpSteroid/execution/ScriptExecutorTest.kt
@@ -143,8 +143,9 @@ class ScriptExecutorTest : BasePlatformTestCase() {
         // Either SUCCESS (if engine is available) or ERROR (if not).
         // #154: the executor's pre-flight/run/post-flight stage progress goes to the IDE log only —
         // the result must contain the user-script output verbatim, with NO `[PRE]`/`[RUN]`/`[POST]`
-        // framing interleaved. Pin that contract here.
-        builder.messages.forEach { message ->
+        // framing interleaved. Scan the progress channel too: it must never carry framing either
+        // (production delivers logProgress via MCP notifications, never the result content).
+        (builder.messages + builder.progressMessages).forEach { message ->
             assertFalse(
                 "Stage framing must never appear in the tool result (#154), got: $message",
                 message.startsWith("[PRE]") || message.startsWith("[RUN]") || message.startsWith("[POST]")

--- a/ij-plugin/src/test/kotlin/com/jonnyzzz/mcpSteroid/execution/ScriptExecutorTest.kt
+++ b/ij-plugin/src/test/kotlin/com/jonnyzzz/mcpSteroid/execution/ScriptExecutorTest.kt
@@ -140,19 +140,21 @@ class ScriptExecutorTest : BasePlatformTestCase() {
         val builder = TestResultBuilder()
         executor.executeWithProgress(nextExecutionId(), testExecParams(multiCode), builder)
 
-        // Either SUCCESS (if engine is available) or ERROR (if not)
-        // If successful, verify FIFO order in output. Drop the pre-flight/run/
-        // post-flight stage markers (`[PRE] …`, `[RUN] …`, `[POST] …`) the
-        // executor emits around the script body so we assert only on the
-        // user-script println output.
-        val scriptOutput = builder.messages.filterNot {
-            it.startsWith("[PRE]") || it.startsWith("[RUN]") || it.startsWith("[POST]")
+        // Either SUCCESS (if engine is available) or ERROR (if not).
+        // #154: the executor's pre-flight/run/post-flight stage progress goes to the IDE log only —
+        // the result must contain the user-script output verbatim, with NO `[PRE]`/`[RUN]`/`[POST]`
+        // framing interleaved. Pin that contract here.
+        builder.messages.forEach { message ->
+            assertFalse(
+                "Stage framing must never appear in the tool result (#154), got: $message",
+                message.startsWith("[PRE]") || message.startsWith("[RUN]") || message.startsWith("[POST]")
+            )
         }
-        if (!builder.isFailed && scriptOutput.isNotEmpty()) {
-            assertTrue("Should have 3 messages", scriptOutput.size >= 3)
-            assertEquals("First message", "First", scriptOutput[0])
-            assertEquals("Second message", "Second", scriptOutput[1])
-            assertEquals("Third message", "Third", scriptOutput[2])
+        if (!builder.isFailed && builder.messages.isNotEmpty()) {
+            assertTrue("Should have 3 messages", builder.messages.size >= 3)
+            assertEquals("First message", "First", builder.messages[0])
+            assertEquals("Second message", "Second", builder.messages[1])
+            assertEquals("Third message", "Third", builder.messages[2])
         }
     }
 

--- a/test-integration/src/test/kotlin/com/jonnyzzz/mcpSteroid/integration/infra/IndexingInProgressDetectionTest.kt
+++ b/test-integration/src/test/kotlin/com/jonnyzzz/mcpSteroid/integration/infra/IndexingInProgressDetectionTest.kt
@@ -18,7 +18,7 @@ class IndexingInProgressDetectionTest {
         // FAILED line that names the step and modality profile, with the marker inside it.
         val text = """
             execution_id: eid_x-integration-test
-            FAILED: pre-flight 'wait for smart mode' (modal=smart_non_modal): $INDEXING_IN_PROGRESS_MARKER: the IDE is
+            FAILED: pre-flight 'wait for indexing' (modal=smart_non_modal): $INDEXING_IN_PROGRESS_MARKER: the IDE is
             still indexing this project, so it is not ready yet. This is normal and expected … just keep
             polling: call this tool again to continue waiting.
         """.trimIndent()

--- a/test-integration/src/test/kotlin/com/jonnyzzz/mcpSteroid/integration/infra/IndexingInProgressDetectionTest.kt
+++ b/test-integration/src/test/kotlin/com/jonnyzzz/mcpSteroid/integration/infra/IndexingInProgressDetectionTest.kt
@@ -14,18 +14,21 @@ class IndexingInProgressDetectionTest {
 
     @Test
     fun `detects the still-indexing message the server emits while indexing`() {
+        // #154: the result carries no [PRE]/[RUN]/[POST] framing; a pre-flight failure is a single
+        // FAILED line that names the step and modality profile, with the marker inside it.
         val text = """
             execution_id: eid_x-integration-test
-            [PRE] wait for smart mode
-            ERROR: $INDEXING_IN_PROGRESS_MARKER: the IDE is still indexing this project, so it is not ready
-            yet. This is normal and expected … just keep polling: call this tool again to continue waiting.
+            FAILED: pre-flight 'wait for smart mode' (modal=smart_non_modal): $INDEXING_IN_PROGRESS_MARKER: the IDE is
+            still indexing this project, so it is not ready yet. This is normal and expected … just keep
+            polling: call this tool again to continue waiting.
         """.trimIndent()
         assertTrue(isIndexingInProgress(text))
     }
 
     @Test
     fun `a normal successful result is not still-indexing`() {
-        assertFalse(isIndexingInProgress("execution_id: eid_x\n[RUN] script\nJDKs registered\ndone"))
+        // #154: a successful result is just the execution_id header plus the script's own output.
+        assertFalse(isIndexingInProgress("execution_id: eid_x\nJDKs registered\ndone"))
     }
 
     @Test

--- a/test-integration/src/test/kotlin/com/jonnyzzz/mcpSteroid/integration/infra/IndexingInProgressDetectionTest.kt
+++ b/test-integration/src/test/kotlin/com/jonnyzzz/mcpSteroid/integration/infra/IndexingInProgressDetectionTest.kt
@@ -14,13 +14,12 @@ class IndexingInProgressDetectionTest {
 
     @Test
     fun `detects the still-indexing message the server emits while indexing`() {
-        // #154: the result carries no [PRE]/[RUN]/[POST] framing; a pre-flight failure is a single
-        // FAILED line that names the step and modality profile, with the marker inside it.
+        // #154: the result carries no [PRE]/[RUN]/[POST] framing; the still-indexing failure is the
+        // context API's own error, propagated untouched, with the marker inside it.
         val text = """
             execution_id: eid_x-integration-test
-            FAILED: pre-flight 'wait for indexing' (modal=smart_non_modal): $INDEXING_IN_PROGRESS_MARKER: the IDE is
-            still indexing this project, so it is not ready yet. This is normal and expected … just keep
-            polling: call this tool again to continue waiting.
+            ERROR: $INDEXING_IN_PROGRESS_MARKER: the IDE is still indexing this project, so it is not ready
+            yet. This is normal and expected … just keep polling: call this tool again to continue waiting.
         """.trimIndent()
         assertTrue(isIndexingInProgress(text))
     }


### PR DESCRIPTION
Fixes #154 (canonical; #159 was closed as its duplicate).

## Contract change

`steroid_execute_code`'s result text no longer interleaves modal-mode progress framing (`[PRE] …`, `[RUN] script`, `[POST] …`) or any in-flight progress lines ("Waiting for indexing to complete…") with the script's output. The result is now exactly:

```
execution_id: eid_…
<script stdout, verbatim>
```

so a script that prints a single JSON document is machine-parseable after stripping the first line — the exact consumer break reported in #154 (Settings-path resolution, JFR/thread-dump analysis pipelines).

Where the progress went, instead of being deleted:

- **idea.log** — every stage gets a `[PRE]`/`[RUN]`/`[POST]` line at its call site, prefixed with the executionId and the modality profile, so the last marker still pinpoints a stuck stage.
- **MCP progress notifications** — `ExecutionManager.logProgress` reports through `mcpProgress` (sent when the client passed a `progressToken`).
- **Demo Mode broadcaster + execution event storage** — unchanged channels, still fed.

`ExecutionResultBuilder.logProgress` is now documented as diagnostic-only: implementations must never add it to result content.

## Error behavior

Pre-flight failures propagate each context API's **original exception untouched** — no wrapping, no message rewriting (per review feedback; an earlier revision had a `preFlight` wrapper that prefixed step names onto errors, now removed). The pre-flight steps are plain inlined calls again, each preceded only by an idea.log line.

Two result-content refinements that are payload, not progress:

- Compiler output is result content (`logMessage`): kotlinc stdout is empty on a clean compile, so when present the agent must see it.
- The script-body timeout message names its phase (`…while running the script body (modal=…; pre-flight completed)`) — this is our own generated error, not a wrap.

## Review

3-reviewer adversarial quorum (correctness of removal / error-context quality / contract+consumers). The must-fix both leak-hunting reviewers converged on — `waitForSmartMode` progress still reaching the result via `logProgress` — is fixed by the `ExecutionManager` change above. Repo-wide grep confirms no remaining producer/consumer/parser depends on the markers; the survivors are negative-contract test assertions and historical docs.

## Tests

- New `ExecutionManagerTest` case: a script printing one JSON document yields parseable output after stripping the `execution_id` header.
- `ScriptExecutorTest` pins "no framing in result" across the result *and* progress channels.
- `IndexingInProgressDetectionTest` (test-integration infra) asserts the propagated still-indexing error (no framing, original message) is still detected.
- `./gradlew :ij-plugin:test` after the final revision: 274 tests, 0 failures, 1 skipped (pre-existing). `:test-integration:test --tests '*IndexingInProgressDetectionTest'`: green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)