### PR TITLE
steroid_list_windows: rename projectName/projectPath to snake_case project_name/project_path

### DIFF
--- a/docs/guides/AGENT-STEROID-GUIDE.md
+++ b/docs/guides/AGENT-STEROID-GUIDE.md
@@ -44,8 +44,8 @@ entry names its owning backend via `backend_name`.
 **Response Fields (per window):**
 | Field | Description |
 |-------|-------------|
-| `projectName` | Project name (null if not a project window) |
-| `projectPath` | Project base path |
+| `project_name` | Project routing key — the same `project_name` as `steroid_list_projects` (null if not a project window) |
+| `project_path` | Project base path |
 | `windowId` | Unique window identifier for screenshot/input targeting |
 | `modalDialogShowing` | **True if any modal dialog is showing in IDE** |
 | `indexingInProgress` | **True if project is indexing (dumb mode)** |
@@ -61,7 +61,7 @@ entry names its owning backend via `backend_name`.
 | `text` | Current status text |
 | `fraction` | Progress 0.0-1.0 (null if indeterminate) |
 | `isIndeterminate` | True if no percentage available |
-| `projectName` | Associated project name |
+| `project_name` | Routing key of the associated project |
 | `backend_name` | The backend (IDE) this task runs in |
 
 Use the modality/indexing fields and `backgroundTasks` to poll for project readiness after `steroid_open_project`.

--- a/mcp-steroid-server/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/ListWindowsTool.kt
+++ b/mcp-steroid-server/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/ListWindowsTool.kt
@@ -50,9 +50,12 @@ data class ListedWindow(
      * tools (`steroid_execute_code`, `steroid_take_screenshot`, `steroid_input`, …). The SAME `project_name`
      * `steroid_list_projects` reports; look up the project's `name`/`path` there by this key. Null for
      * windows not tied to a project. Treat it as opaque.
+     *
+     * Serialized as snake_case `project_name`/`project_path` (#381) — one spelling of the routing key
+     * across `steroid_list_projects` and `steroid_list_windows`, matching the sibling `backend_name`.
      */
-    val projectName: String?,
-    val projectPath: String?,
+    @SerialName("project_name") val projectName: String?,
+    @SerialName("project_path") val projectPath: String?,
     val title: String?,
     val isActive: Boolean,
     val isVisible: Boolean,
@@ -105,9 +108,9 @@ data class ListedBackgroundTask(
     /**
      * The routing KEY of the project this task belongs to — the same opaque id `steroid_list_projects`
      * reports as `project_name` (look up the project's `name`/`path` there). Null if the task isn't tied
-     * to a known open project.
+     * to a known open project. Serialized as snake_case `project_name` (#381).
      */
-    val projectName: String?,
+    @SerialName("project_name") val projectName: String?,
     /** Owning backend's backend_name; null only when unknown. */
     @SerialName("backend_name") val backendName: String? = null,
 )

--- a/mcp-steroid-server/src/test/kotlin/com/jonnyzzz/mcpSteroid/server/ListWindowsToolSpecSchemaTest.kt
+++ b/mcp-steroid-server/src/test/kotlin/com/jonnyzzz/mcpSteroid/server/ListWindowsToolSpecSchemaTest.kt
@@ -1,6 +1,10 @@
 /* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
 package com.jonnyzzz.mcpSteroid.server
 
+import com.jonnyzzz.mcpSteroid.mcp.McpJson
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 
 class ListWindowsToolSpecSchemaTest {
@@ -10,5 +14,50 @@ class ListWindowsToolSpecSchemaTest {
         assertToolSpecHasValidJsonSchema(spec)
         assertToolIdentity(spec, "steroid_list_windows")
         assertRequiredExactly(spec.inputSchema)
+    }
+
+    @Test
+    fun `ListedWindow round-trips snake_case project keys`() {
+        // #381: the MCP surface uses snake_case `project_name`/`project_path` — the same routing key
+        // spelling as ListedProject and the sibling `backend_name` on this very entry.
+        val listed = ListedWindow(
+            projectName = "proj-9fk2a0xQ",
+            projectPath = "/p",
+            title = "proj – main",
+            isActive = true,
+            isVisible = true,
+            bounds = WindowBounds(0, 0, 100, 100),
+            windowId = "w1",
+            backendName = "iu-9fk2a0xQ",
+        )
+        val json = McpJson.encodeToString(ListedWindow.serializer(), listed)
+        assertTrue(json.contains("\"project_name\":\"proj-9fk2a0xQ\""), json)
+        assertTrue(json.contains("\"project_path\":\"/p\""), json)
+        assertTrue(json.contains("\"backend_name\":\"iu-9fk2a0xQ\""), json)
+        assertFalse(json.contains("projectName"), "MCP surface must not emit camelCase projectName: $json")
+        assertFalse(json.contains("projectPath"), "MCP surface must not emit camelCase projectPath: $json")
+        val decoded = McpJson.decodeFromString(ListedWindow.serializer(), json)
+        assertEquals(listed, decoded)
+    }
+
+    @Test
+    fun `ListedBackgroundTask round-trips snake_case project key`() {
+        // #381: background-task entries reference their project by `project_name`, like windows do.
+        val listed = ListedBackgroundTask(
+            title = "Indexing",
+            text = "scanning",
+            text2 = "",
+            fraction = null,
+            isIndeterminate = true,
+            isCancellable = false,
+            projectName = "proj-9fk2a0xQ",
+            backendName = "iu-9fk2a0xQ",
+        )
+        val json = McpJson.encodeToString(ListedBackgroundTask.serializer(), listed)
+        assertTrue(json.contains("\"project_name\":\"proj-9fk2a0xQ\""), json)
+        assertTrue(json.contains("\"backend_name\":\"iu-9fk2a0xQ\""), json)
+        assertFalse(json.contains("projectName"), "MCP surface must not emit camelCase projectName: $json")
+        val decoded = McpJson.decodeFromString(ListedBackgroundTask.serializer(), json)
+        assertEquals(listed, decoded)
     }
 }

--- a/test-integration/src/main/kotlin/com/jonnyzzz/mcpSteroid/integration/infra/mcp-steroid.kt
+++ b/test-integration/src/main/kotlin/com/jonnyzzz/mcpSteroid/integration/infra/mcp-steroid.kt
@@ -311,8 +311,9 @@ class McpSteroidDriver(
                 ?.map {
                     val window = it.jsonObject
                     McpWindowInfo(
-                        projectName = window["projectName"]?.jsonPrimitive?.contentOrNull,
-                        projectPath = window["projectPath"]?.jsonPrimitive?.contentOrNull,
+                        // snake_case keys since #381 — the shared ListedWindow contract (project_name/project_path).
+                        projectName = window["project_name"]?.jsonPrimitive?.contentOrNull,
+                        projectPath = window["project_path"]?.jsonPrimitive?.contentOrNull,
                         modalDialogShowing = window["modalDialogShowing"]?.jsonPrimitive?.booleanOrNull ?: false,
                         indexingInProgress = window["indexingInProgress"]?.jsonPrimitive?.booleanOrNull,
                         projectInitialized = window["projectInitialized"]?.jsonPrimitive?.booleanOrNull,

--- a/test-integration/src/test/kotlin/com/jonnyzzz/mcpSteroid/integration/tests/DevrigFakeIdeBridgeIntegrationTest.kt
+++ b/test-integration/src/test/kotlin/com/jonnyzzz/mcpSteroid/integration/tests/DevrigFakeIdeBridgeIntegrationTest.kt
@@ -157,10 +157,10 @@ class DevrigFakeIdeBridgeIntegrationTest {
         val windowsText = textContent(windowsResult)
         val window = McpJson.parseToJsonElement(windowsText).jsonObject["windows"]?.jsonArray?.single()?.jsonObject
             ?: error("list_windows result missing windows: $windowsText")
-        // devrig rewrites only the window's projectName to the routed (hash-suffixed) name; windowId is
+        // devrig rewrites only the window's project_name to the routed (hash-suffixed) name; windowId is
         // forwarded as-is (DevrigProjectRoutingService.rewriteWindow — "window_id is unique within the IDE
-        // resolved by project_name; forward it as-is").
-        assertEquals(projectName, window["projectName"]?.jsonPrimitive?.content)
+        // resolved by project_name; forward it as-is"). Snake_case key since #381.
+        assertEquals(projectName, window["project_name"]?.jsonPrimitive?.content)
         assertEquals("fake-window", window["windowId"]?.jsonPrimitive?.content, "windowId must be forwarded as-is: $window")
     }
 


### PR DESCRIPTION
Fixes #381

## What

`steroid_list_windows` entries mixed naming conventions: `projectName`/`projectPath` were camelCase while the sibling `backend_name` on the same entry is snake_case, and `steroid_list_projects` spells the very same routing key `project_name`. The tool description even promised `project_name` while the payload emitted `projectName`.

Renamed via `@SerialName` on the MCP-only response classes `ListedWindow` / `ListedBackgroundTask` (`mcp-steroid-server/.../ListWindowsTool.kt`) — shared by devrig and the in-IDE server, so one edit fixes both surfaces. Kotlin property names stay camelCase; only the JSON contract changes.

## Before / after

```jsonc
// before
{"windows":[{"projectName":"proj-9fk2a0xQ","projectPath":"/p", ..., "backend_name":"iu-1"}],
 "backgroundTasks":[{"title":"Indexing", ..., "projectName":"proj-9fk2a0xQ","backend_name":"iu-1"}]}

// after
{"windows":[{"project_name":"proj-9fk2a0xQ","project_path":"/p", ..., "backend_name":"iu-1"}],
 "backgroundTasks":[{"title":"Indexing", ..., "project_name":"proj-9fk2a0xQ","backend_name":"iu-1"}]}
```

## Breaking change

Any MCP consumer reading the camelCase keys from `steroid_list_windows` output (external scanners, `jq '.windows[].projectName'` scripts) must switch to `project_name` / `project_path`. All in-repo raw-key consumers are updated here.

**Not touched (on purpose):**
- The frozen devrig↔IDE **wire** DTOs (`WindowInfo` / `ProgressTaskInfo` inside `NpxBridgeWindowsResponse`) keep camelCase — the wire contract is additive-only and `ListedWindow`/`ListedBackgroundTask` never cross the wire (guarded by `WirePristinenessTest`), so this rename has zero cross-version devrig/plugin impact.
- The other camelCase fields on the same entries (`windowId`, `isActive`, `isVisible`, `bounds`, `modalDialogShowing`, `indexingInProgress`, `projectInitialized`, `isIndeterminate`, `isCancellable`, top-level `backgroundTasks`) — open question for the maintainer in #381.
- Nothing related to the `backends[]` lookup-table work (#155).

## Consumers updated

- `test-integration/src/main/kotlin/com/jonnyzzz/mcpSteroid/integration/infra/mcp-steroid.kt` — `mcpListWindows` raw-key parser (`project_name`/`project_path`)
- `test-integration/src/test/kotlin/com/jonnyzzz/mcpSteroid/integration/tests/DevrigFakeIdeBridgeIntegrationTest.kt` — devrig MCP output key assertion
- `docs/guides/AGENT-STEROID-GUIDE.md` — window + background-task response-field tables

Typed consumers (devrig handlers, ij-plugin handler, tests decoding via `ListWindowsResponse.serializer()`, test-integration's `McpWindowInfo` users) need no change — Kotlin property names are unchanged. Prompt articles already say `project_name`.

## Tests

Test-first: the two new round-trip tests failed on the old camelCase output, pass after the rename.

| Task | Result |
|---|---|
| `./gradlew :mcp-steroid-server:test` (incl. new `ListWindowsToolSpecSchemaTest` round-trips asserting `project_name`/`project_path` + absence of camelCase) | BUILD SUCCESSFUL |
| `./gradlew :npx-kt:test` (devrig list handlers, bridge client contract) | BUILD SUCCESSFUL |
| `./gradlew :ij-plugin:test --tests 'com.jonnyzzz.mcpSteroid.McpServerIntegrationTest'` (in-process MCP protocol incl. `steroid_list_windows` flow) | 33 tests, 0 failures |
| `./gradlew :test-integration:compileKotlin :test-integration:compileTestKotlin` (Docker suites not run per repo policy) | BUILD SUCCESSFUL |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
