### PR TITLE
backends[] lookup with IntelliJ identity on the list tools (#155)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,7 +18,7 @@ build/
 !.idea/dictionaries
 
 out/
-.intellijPlatform/
+.intellijPlatform
 
 .vscode
 

--- a/docs/PHILOSOPHY.md
+++ b/docs/PHILOSOPHY.md
@@ -201,6 +201,12 @@ shape changed from one `backends[]` to three explicit arrays
 (`mcpSteroidBackends[]`, `otherIdes[]`, `startableBackends[]`). This
 waiver is a one-time exception, not a precedent — the principle stays in
 force for all future changes. See `docs/startable-backends-design.md`.
+(#155 later re-introduced a deliberately slimmer, **identity-only**
+`backends[]` on the two list responses — `{backend_name, intellij{name,
+version, build}}` via `BackendRef`/`IntelliJInfo`, not the deleted
+`BackendInfo`. That output is devrig-computed MCP surface — inside the
+"devrig-owned, free to reshape" carve-out below, additive-only in
+practice, and never wire-crossing: `WirePristinenessTest` guards it.)
 
 **The devrig-computed MCP/CLI output is devrig-owned and outside this
 contract — free to reshape.** `steroid_list_projects` results

--- a/docs/guides/AGENT-STEROID-GUIDE.md
+++ b/docs/guides/AGENT-STEROID-GUIDE.md
@@ -169,8 +169,14 @@ anyway it is logged and ignored.
 
 Every `projects[]`, `windows[]`, and `backgroundTasks[]` entry in the
 response carries a `backend_name` that identifies which IDE owns it.
-There is no separate top-level `backends[]` array. Backend *discovery*
-lives in `steroid_open_project`.
+Each response also carries a `backends[]` lookup table (#155) resolving
+every referenced `backend_name` to the owning IDE's identity —
+`{ "backend_name": …, "intellij": { "name", "version", "build" } }`
+(`intellij` = the IntelliJ-Platform IDE; a GoLand backend still nests
+under `intellij`). The table is identity-only and referenced-only — a
+direct in-IDE connection always lists exactly one element (itself, even
+with zero open projects). Backend *inventory and discovery* still live
+in `steroid_open_project` and `devrig backend --json`.
 
 To pick a `backend_name` for `open_project`:
 

--- a/docs/startable-backends-design.md
+++ b/docs/startable-backends-design.md
@@ -135,12 +135,19 @@ that back-references its source; `ensureBackendRunning` dispatches on whichever 
 - **Drop `backends[]`** from both `ListProjectsResponse` and `ListWindowsResponse`.
 - Each `ListedProject` / window / background-task item keeps its `backend_name`.
 - This removes `ListedBackendInfo` and the rich `BackendInfo` from these tools.
+- **Superseded by #155 (2026-07):** a deliberately slimmer, identity-only `backends[]` was
+  re-introduced on both response types — `{backend_name, intellij{name, version, build}}`
+  (`BackendRef`/`IntelliJInfo`), NOT the deleted `BackendInfo`. Membership is referenced-only on
+  devrig (derived from the routing snapshot); inventory stays in `devrig backend --json` (#151).
 
 ### 5. in-IDE (HTTP-MCP) plugin surface
 
 - `list_projects` / `list_windows`: items carry the **self** `backend_name`; no `backends[]`.
 - `open_project`: **ignores** `backend_name` (single-IDE surface; there is only this IDE). Matches
   the existing `OpenProjectToolSpec(includeBackendName = false)` registration.
+- **Superseded by #155 (2026-07):** the direct surface now always emits a single-element
+  identity-only `backends[]` self entry (present even with zero open projects — the identity probe);
+  `open_project` still ignores `backend_name`.
 
 ### 6. CLI `devrig backend`
 
@@ -197,7 +204,8 @@ install/launch work behind `ensureBackendRunning` and the CLI `backend download/
 - **ij-plugin integration**:
   - `PidMarker.ideHome` is populated (`PathManager.getHomePath()`).
   - `/projects` bridge unaffected.
-  - list tools no longer emit `backends[]`; in-IDE `open_project` ignores `backend_name`.
+  - list tools no longer emit `backends[]` (later superseded by #155's identity-only re-introduction
+    — see §§4–5); in-IDE `open_project` ignores `backend_name`.
 
 ## Blast radius / docs to reconcile
 

--- a/ij-plugin/CLAUDE.md
+++ b/ij-plugin/CLAUDE.md
@@ -452,7 +452,8 @@ which never crosses the wire. `ProjectsStreamService` only ever builds `ProjectI
 reversion changed zero emitted bytes.) A **wire-pristineness guard test** (`WirePristinenessTest`,
 `mcp-steroid-server`) asserts `NpxStreamEnvelope` (`/projects/stream`) and `NpxBridgeWindowsResponse`
 (`/windows`) never serialize the devrig-only `backend_name` / `project_name` / `ListedProject`
-keys (`BackendInfo` and `ListedBackendInfo` were deleted in the startable-backends release).
+keys, nor the #155 MCP-only `backends` / `intellij` identity keys (`BackendInfo` and
+`ListedBackendInfo` were deleted in the startable-backends release).
 
 **MCP-surface-only, never wire-crossing:**
 - `OpenProjectParams.backendName: String? = null` is **MCP-surface only** and is **NOT forwarded** to the
@@ -462,9 +463,14 @@ keys (`BackendInfo` and `ListedBackendInfo` were deleted in the startable-backen
 - `ListProjectsResponse` / `ListWindowsResponse` / `ListedProject` are devrig-computed MCP/CLI output types
   (built from devrig's routing snapshot, never fetched from the IDE) — devrig-owned and outside the wire
   contract. Note: `BackendInfo` and `ListedBackendInfo` were **deleted** in the startable-backends release;
-  `backends[]` was **removed** from both response types (they now carry only `projects` / `windows` +
-  `backgroundTasks`). The one-release additive-only waiver that permitted this is recorded in
-  `docs/PHILOSOPHY.md` Tenet 5 and `docs/startable-backends-design.md`.
+  `backends[]` was **removed** from both response types. The one-release additive-only waiver that
+  permitted this is recorded in `docs/PHILOSOPHY.md` Tenet 5 and `docs/startable-backends-design.md`.
+  **#155 re-introduced a deliberately slimmer, identity-only `backends[]`** on both response types:
+  `BackendRef{backend_name, intellij{name, version, build}}` (`IntelliJInfo` is a dedicated presentation
+  type — a projection of the marker `IdeInfo`, drift-gated by `BackendRefSerializationTest`, never
+  wire-crossing). Membership: referenced-only on devrig (derived from the routing snapshot); the direct
+  in-IDE surface always emits its single self entry, even with zero open projects. `projects[]` is sorted
+  by `project_name`, `backends[]` by `backend_name`; windows/tasks keep their produced order.
 
 **`PidMarker` fields added in the startable-backends release (additive, nullable):**
 - `PidMarker.ideHome: String? = null` — the IDE install home (`PathManager.getHomePath()`), written by

--- a/ij-plugin/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/ListProjectsToolHandler.kt
+++ b/ij-plugin/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/ListProjectsToolHandler.kt
@@ -50,7 +50,7 @@ class SelfBackendDescription(
  */
 fun SelfBackendDescription.toListProjectsResponse(): ListProjectsResponse = ListProjectsResponse(
     projects = projects.sortedBy { it.projectName },
-    backends = listOf(selfBackendRef()),
+    backends = backendsTable(listOf(selfBackendRef())),
 )
 
 suspend fun describeSelfBackend(): SelfBackendDescription {

--- a/ij-plugin/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/ListProjectsToolHandler.kt
+++ b/ij-plugin/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/ListProjectsToolHandler.kt
@@ -20,15 +20,12 @@ fun projectNameFor(project: Project): String =
 /**
  * Direct in-IDE `steroid_list_projects`. No top-level `ide`/`plugin`/`pid` header (the responding
  * server's identity lives in the MCP server info). Each [ListedProject] carries a stable base36
- * hash as `project_name` (derived from the real name) and `backend_name` pointing at this IDE's self-id.
+ * hash as `project_name` (derived from the real name) and `backend_name` pointing at this IDE's
+ * self-id, resolvable to the IDE's identity via the single-element `backends[]` table (#155).
  */
 class ListProjectsToolHandlerIJ : ListProjectsToolHandler {
-    override suspend fun collectListProjectsResponse(): ListProjectsResponse {
-        val self = describeSelfBackend()
-        return ListProjectsResponse(
-            projects = self.projects,
-        )
-    }
+    override suspend fun collectListProjectsResponse(): ListProjectsResponse =
+        describeSelfBackend().toListProjectsResponse()
 }
 
 class SelfBackendDescription(
@@ -36,6 +33,24 @@ class SelfBackendDescription(
     val backendName: String,
     /** Open projects, each with a hashed `project_name` ([projectNameFor]) and `backend_name == `[backendName]. */
     val projects: List<ListedProject>,
+    /** This IDE's presentation identity ([IdeInfo.ofApplication] projected) for the `backends[]` self entry. */
+    val intellij: IntelliJInfo,
+) {
+    /**
+     * The `backends[]` self entry. On the direct in-IDE surface it is UNCONDITIONAL — a server always
+     * describes itself, so a fresh IDE with zero open projects/windows stays identifiable (#155).
+     */
+    fun selfBackendRef(): BackendRef = BackendRef(backendName = backendName, intellij = intellij)
+}
+
+/**
+ * Maps the self-description to the MCP `steroid_list_projects` response: `projects[]` sorted by
+ * `project_name` (determinism — `ProjectManager` open-order is meaningless to consumers) and the
+ * unconditional single-element `backends[]` self entry.
+ */
+fun SelfBackendDescription.toListProjectsResponse(): ListProjectsResponse = ListProjectsResponse(
+    projects = projects.sortedBy { it.projectName },
+    backends = listOf(selfBackendRef()),
 )
 
 suspend fun describeSelfBackend(): SelfBackendDescription {
@@ -59,5 +74,6 @@ suspend fun describeSelfBackend(): SelfBackendDescription {
     return SelfBackendDescription(
         backendName = selfBackendName,
         projects = listedProjects,
+        intellij = ide.toIntelliJInfo(),
     )
 }

--- a/ij-plugin/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/ListWindowsToolHandler.kt
+++ b/ij-plugin/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/ListWindowsToolHandler.kt
@@ -25,8 +25,11 @@ class ListWindowsToolHandlerIJ : ListWindowsToolHandler {
         val snapshot = service<IdeWindowsCollector>().collect()
         val self = describeSelfBackend()
         return ListWindowsResponse(
+            // windows[]/backgroundTasks[] keep their produced order (#155 sorts list_projects only).
             windows = snapshot.windows.map { it.listed(it.projectName, self.backendName) },
             backgroundTasks = snapshot.backgroundTasks.map { it.listed(it.projectName, self.backendName) },
+            // Unconditional self entry — the identity probe works even with zero open windows (#155).
+            backends = listOf(self.selfBackendRef()),
         )
     }
 }

--- a/ij-plugin/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/ListWindowsToolHandler.kt
+++ b/ij-plugin/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/ListWindowsToolHandler.kt
@@ -29,7 +29,7 @@ class ListWindowsToolHandlerIJ : ListWindowsToolHandler {
             windows = snapshot.windows.map { it.listed(it.projectName, self.backendName) },
             backgroundTasks = snapshot.backgroundTasks.map { it.listed(it.projectName, self.backendName) },
             // Unconditional self entry — the identity probe works even with zero open windows (#155).
-            backends = listOf(self.selfBackendRef()),
+            backends = backendsTable(listOf(self.selfBackendRef())),
         )
     }
 }

--- a/ij-plugin/src/test/kotlin/com/jonnyzzz/mcpSteroid/McpServerIntegrationTest.kt
+++ b/ij-plugin/src/test/kotlin/com/jonnyzzz/mcpSteroid/McpServerIntegrationTest.kt
@@ -1,12 +1,14 @@
 /* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
 package com.jonnyzzz.mcpSteroid
 
+import com.intellij.openapi.application.ApplicationInfo
 import com.intellij.testFramework.common.timeoutRunBlocking
 import com.intellij.testFramework.fixtures.BasePlatformTestCase
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
 import com.jonnyzzz.mcpSteroid.mcp.*
+import com.jonnyzzz.mcpSteroid.server.IntelliJInfo
 import com.jonnyzzz.mcpSteroid.server.ListProjectsResponse
 import com.jonnyzzz.mcpSteroid.server.ListWindowsResponse
 import com.jonnyzzz.mcpSteroid.server.NpxBridgeService
@@ -206,6 +208,34 @@ class McpServerIntegrationTest : BasePlatformTestCase() {
                 windows.windows.any { it.windowId.isNotBlank() }
             )
         }
+
+        // #155: exactly one backends[] element on the direct surface — this IDE — resolving every
+        // entry's backend_name, with the identity taken straight from ApplicationInfo.
+        val selfBackend = windows.backends.single()
+        val appInfo = ApplicationInfo.getInstance()
+        assertEquals(
+            "backends[].intellij must be the running IDE's ApplicationInfo identity",
+            IntelliJInfo(
+                name = appInfo.fullApplicationName,
+                version = appInfo.fullVersion,
+                build = appInfo.build.asString(),
+            ),
+            selfBackend.intellij,
+        )
+        windows.windows.forEach { window ->
+            assertEquals(
+                "every window's backend_name must resolve to the single backends[] self entry",
+                selfBackend.backendName,
+                window.backendName,
+            )
+        }
+        windows.backgroundTasks.forEach { task ->
+            assertEquals(
+                "every background task's backend_name must resolve to the single backends[] self entry",
+                selfBackend.backendName,
+                task.backendName,
+            )
+        }
     }
 
     // The /products and /server-metadata bridge endpoints were removed (unused by devrig). Auth-rejection
@@ -347,6 +377,34 @@ class McpServerIntegrationTest : BasePlatformTestCase() {
             assertTrue(
                 "Direct-IDE project must carry a non-blank backend_name",
                 project.backendName?.isNotBlank() == true
+            )
+        }
+
+        // #155: projects[] is sorted by project_name (single-project fixtures pass trivially; the
+        // multi-project ordering is pinned unit-level in SelfBackendResponseMappingTest).
+        assertEquals(
+            "list_projects entries must be sorted by project_name",
+            response.projects.map { it.projectName }.sorted(),
+            response.projects.map { it.projectName },
+        )
+
+        // #155: exactly one backends[] element — this IDE — and every project resolves to it.
+        val selfBackend = response.backends.single()
+        val appInfo = ApplicationInfo.getInstance()
+        assertEquals(
+            "backends[].intellij must be the running IDE's ApplicationInfo identity",
+            IntelliJInfo(
+                name = appInfo.fullApplicationName,
+                version = appInfo.fullVersion,
+                build = appInfo.build.asString(),
+            ),
+            selfBackend.intellij,
+        )
+        response.projects.forEach { project ->
+            assertEquals(
+                "every project's backend_name must resolve to the single backends[] self entry",
+                selfBackend.backendName,
+                project.backendName,
             )
         }
     }

--- a/ij-plugin/src/test/kotlin/com/jonnyzzz/mcpSteroid/server/SelfBackendResponseMappingTest.kt
+++ b/ij-plugin/src/test/kotlin/com/jonnyzzz/mcpSteroid/server/SelfBackendResponseMappingTest.kt
@@ -1,0 +1,44 @@
+/* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
+package com.jonnyzzz.mcpSteroid.server
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Pure-mapping guards for the direct in-IDE #155 surface
+ * ([SelfBackendDescription.toListProjectsResponse]): the `backends[]` self entry is UNCONDITIONAL —
+ * a fresh IDE with zero open projects must still be identifiable — and `projects[]` is sorted by
+ * `project_name` regardless of `ProjectManager` open-order. (The platform-backed integration
+ * fixture opens exactly one project, so these two rows are pinned here at the unit level.)
+ */
+class SelfBackendResponseMappingTest {
+    private val intellij = IntelliJInfo(name = "IntelliJ IDEA 2026.1.3", version = "2026.1.3", build = "IU-261.25134.95")
+
+    @Test
+    fun `zero open projects still yield the unconditional backends self entry`() {
+        val response = SelfBackendDescription(
+            backendName = "iu-47qi79c1",
+            projects = emptyList(),
+            intellij = intellij,
+        ).toListProjectsResponse()
+
+        assertTrue(response.projects.isEmpty())
+        assertEquals(listOf(BackendRef(backendName = "iu-47qi79c1", intellij = intellij)), response.backends)
+    }
+
+    @Test
+    fun `projects are sorted by project_name regardless of open order`() {
+        val zulu = ListedProject(projectName = "zulu-9fk2a0xq", name = "zulu", path = "/z", backendName = "iu-47qi79c1")
+        val alpha = ListedProject(projectName = "alpha-8x1k2mq0", name = "alpha", path = "/a", backendName = "iu-47qi79c1")
+
+        val response = SelfBackendDescription(
+            backendName = "iu-47qi79c1",
+            projects = listOf(zulu, alpha),
+            intellij = intellij,
+        ).toListProjectsResponse()
+
+        assertEquals(listOf(alpha, zulu), response.projects)
+        assertEquals(listOf(BackendRef(backendName = "iu-47qi79c1", intellij = intellij)), response.backends)
+    }
+}

--- a/mcp-steroid-server/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/BackendRef.kt
+++ b/mcp-steroid-server/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/BackendRef.kt
@@ -1,0 +1,47 @@
+/* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
+package com.jonnyzzz.mcpSteroid.server
+
+import com.jonnyzzz.mcpSteroid.IdeInfo
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Presentation-only identity of an IntelliJ-Platform IDE, as exposed on the MCP tool responses
+ * (`backends[]`, #155). Dedicated to this surface by design: it is NOT the marker/wire [IdeInfo] —
+ * the marker type can evolve (per #151) without leaking new fields here, and this type never
+ * crosses the devrig<->IDE wire. Exactly the three fields the historic consumers read; adding a
+ * field requires a concrete consumer need and a `BackendRefSerializationTest` drift-gate update —
+ * inventory extras (pid, port, endpoints, plugins) belong to `devrig backend --json` (#151),
+ * never here. Naming note: the JSON field is `intellij` = "the IntelliJ-*Platform* IDE" — a GoLand
+ * or PyCharm backend still nests under `intellij`; the product is identified by [name]/[build].
+ */
+@Serializable
+data class IntelliJInfo(
+    /** e.g. "IntelliJ IDEA 2026.1.3" (`ApplicationInfo.fullApplicationName`). */
+    val name: String,
+    /** e.g. "2026.1.3" (`ApplicationInfo.fullVersion`). */
+    val version: String,
+    /** e.g. "IU-261.25134.95" (`ApplicationInfo.build.asString()`). */
+    val build: String,
+)
+
+/** The single shared projection both surfaces use — keeps the mapping identical by construction. */
+fun IdeInfo.toIntelliJInfo(): IntelliJInfo = IntelliJInfo(name = name, version = version, build = build)
+
+/**
+ * MCP-only lookup element: resolves a `backend_name` seen on `projects[]`/`windows[]`/
+ * `backgroundTasks[]` entries to the owning IDE's identity. Never crosses the devrig<->IDE wire.
+ */
+@Serializable
+data class BackendRef(
+    @SerialName("backend_name") val backendName: String,
+    val intellij: IntelliJInfo,
+)
+
+/**
+ * Builds a response's `backends[]` resolution table: de-duplicated by `backend_name` (keep-first)
+ * and sorted by it — deterministic regardless of snapshot/scan order. Shared by the direct in-IDE
+ * handlers and devrig's aggregating handlers so the table rule cannot diverge.
+ */
+fun backendsTable(refs: Iterable<BackendRef>): List<BackendRef> =
+    refs.distinctBy { it.backendName }.sortedBy { it.backendName }

--- a/mcp-steroid-server/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/ListProjectsTool.kt
+++ b/mcp-steroid-server/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/ListProjectsTool.kt
@@ -13,7 +13,7 @@ import kotlinx.serialization.Serializable
  */
 class ListProjectsToolSpec(val handler: () -> ListProjectsToolHandler) : McpToolBase() {
     override val name = "steroid_list_projects"
-    override val description = "List all open projects in the IDE. Each entry has `project_name` (a unique routing key — pass it to steroid_execute_code and the other project-scoped tools) and `name` (the raw folder name, informational only); they are not equal."
+    override val description = "List all open projects in the IDE. Each entry has `project_name` (a unique routing key — pass it to steroid_execute_code and the other project-scoped tools) and `name` (the raw folder name, informational only); they are not equal. Resolve an entry's `backend_name` to the owning IDE's identity (`intellij` = `{name, version, build}`) via the `backends` lookup in the same response."
 
     override suspend fun call(context: ToolCallContext): ToolCallResult {
         val response = handler().collectListProjectsResponse()
@@ -31,18 +31,28 @@ interface ListProjectsToolHandler {
 
 /**
  * MCP-only output of `steroid_list_projects` — never crosses the devrig<->IDE wire. There is no
- * top-level `ide`/`plugin`/`pid` header: the responding server's identity lives in the MCP server
- * info, and per-entry attribution happens via `backend_name` on each project entry.
+ * top-level `ide`/`plugin`/`pid` header (#89): the responding server's identity lives in the MCP
+ * server info, and per-entry attribution happens via `backend_name` on each project entry,
+ * resolvable to the owning IDE's identity through the `backends[]` table of the same response (#155).
  */
 @Serializable
 data class ListProjectsResponse(
     /**
-     * Projects reachable through this connection. Each entry's `project_name` is the within-IDE-unique
-     * routing KEY an agent passes back to the project-scoped tools — opaque (do not parse or rely on its
-     * format); never equal to the raw `name`; `name` is the raw folder name and is informational only. On
-     * a direct in-IDE connection `backend_name` is this IDE's self-id; on devrig the owning discovered IDE.
+     * Projects reachable through this connection, sorted by `project_name`. Each entry's `project_name`
+     * is the within-IDE-unique routing KEY an agent passes back to the project-scoped tools — opaque
+     * (do not parse or rely on its format); never equal to the raw `name`; `name` is the raw folder name
+     * and is informational only. On a direct in-IDE connection `backend_name` is this IDE's self-id; on
+     * devrig the owning discovered IDE.
      */
     val projects: List<ListedProject>,
+    /**
+     * Resolution table for this response (#155): exactly the distinct `backend_name` values referenced
+     * by `projects[]` — no more, no less — sorted by `backend_name`, with one deliberate exception: on
+     * a direct in-IDE connection the single self entry is ALWAYS present, even with zero open projects
+     * (a server always describes itself — the identity probe). Identity-only by design: growth belongs
+     * to `devrig backend --json` (#151), never here.
+     */
+    val backends: List<BackendRef> = emptyList(),
 )
 
 /**

--- a/mcp-steroid-server/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/ListWindowsTool.kt
+++ b/mcp-steroid-server/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/ListWindowsTool.kt
@@ -13,7 +13,7 @@ import kotlinx.serialization.Serializable
  */
 class ListWindowsToolSpec(val handler: () -> ListWindowsToolHandler) : McpToolBase() {
     override val name = "steroid_list_windows"
-    override val description = "List open IDE windows and their background tasks, with per-window readiness (modal/indexing/initialized) and a `window_id` for screenshot/input targeting in multi-window setups. Each window and background-task entry references its project by `project_name` — the single routing key for the project-scoped tools; look up that project's human-readable `name` and `path` via steroid_list_projects by the key (they are not duplicated here). `project_name` is null for windows not tied to a project."
+    override val description = "List open IDE windows and their background tasks, with per-window readiness (modal/indexing/initialized) and a `window_id` for screenshot/input targeting in multi-window setups. Each window and background-task entry references its project by `project_name` — the single routing key for the project-scoped tools; look up that project's human-readable `name` and `path` via steroid_list_projects by the key (they are not duplicated here). `project_name` is null for windows not tied to a project. Resolve an entry's `backend_name` to the owning IDE's identity (`intellij` = `{name, version, build}`) via the `backends` lookup in the same response."
 
     override suspend fun call(context: ToolCallContext): ToolCallResult {
         val response = handler().collectListWindowsResponse()
@@ -30,13 +30,22 @@ interface ListWindowsToolHandler {
 
 /**
  * MCP-only output of `steroid_list_windows` — never crosses the devrig<->IDE wire. There is no
- * top-level `ide`/`plugin`/`pid` header: the responding server's identity lives in the MCP server
- * info, and per-entry attribution happens via `backend_name` on each window/task entry.
+ * top-level `ide`/`plugin`/`pid` header (#89): the responding server's identity lives in the MCP
+ * server info, and per-entry attribution happens via `backend_name` on each window/task entry,
+ * resolvable to the owning IDE's identity through the `backends[]` table of the same response (#155).
  */
 @Serializable
 data class ListWindowsResponse(
     val windows: List<ListedWindow>,
     val backgroundTasks: List<ListedBackgroundTask>,
+    /**
+     * Resolution table for this response (#155): exactly the distinct `backend_name` values referenced
+     * by `windows[]` / `backgroundTasks[]` — no more, no less — sorted by `backend_name`, with one
+     * deliberate exception: on a direct in-IDE connection the single self entry is ALWAYS present, even
+     * with zero open windows (a server always describes itself — the identity probe). Identity-only by
+     * design: growth belongs to `devrig backend --json` (#151), never here.
+     */
+    val backends: List<BackendRef> = emptyList(),
 )
 
 /**

--- a/mcp-steroid-server/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/ListWindowsTool.kt
+++ b/mcp-steroid-server/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/ListWindowsTool.kt
@@ -39,10 +39,12 @@ data class ListWindowsResponse(
     val windows: List<ListedWindow>,
     val backgroundTasks: List<ListedBackgroundTask>,
     /**
-     * Resolution table for this response (#155): exactly the distinct `backend_name` values referenced
-     * by `windows[]` / `backgroundTasks[]` — no more, no less — sorted by `backend_name`, with one
-     * deliberate exception: on a direct in-IDE connection the single self entry is ALWAYS present, even
-     * with zero open windows (a server always describes itself — the identity probe). Identity-only by
+     * Resolution table for this response (#155), sorted by `backend_name`: every `backend_name`
+     * referenced by `windows[]` / `backgroundTasks[]` resolves to exactly one element. On a direct
+     * in-IDE connection it is the single self entry, ALWAYS present even with zero open windows (a
+     * server always describes itself — the identity probe). Via devrig it is derived from the same
+     * routing snapshot the entries come from — a route-owning backend can appear with zero entries in
+     * transient states (e.g. a project registered while its frame is still opening). Identity-only by
      * design: growth belongs to `devrig backend --json` (#151), never here.
      */
     val backends: List<BackendRef> = emptyList(),

--- a/mcp-steroid-server/src/test/kotlin/com/jonnyzzz/mcpSteroid/server/BackendRefSerializationTest.kt
+++ b/mcp-steroid-server/src/test/kotlin/com/jonnyzzz/mcpSteroid/server/BackendRefSerializationTest.kt
@@ -1,0 +1,60 @@
+/* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
+package com.jonnyzzz.mcpSteroid.server
+
+import com.jonnyzzz.mcpSteroid.IdeInfo
+import com.jonnyzzz.mcpSteroid.mcp.McpJson
+import kotlinx.serialization.json.jsonObject
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+/**
+ * Drift gate for the #155 `backends[]` identity surface. [IntelliJInfo] is *identity-minimal* by
+ * design — exactly `{name, version, build}`; any extra serialized key on a `backends[]` element or
+ * its nested `intellij` object fails here. Growth pressure on the MCP identity is answered with
+ * "add it to #151's `devrig backend --json`", never with a new [IntelliJInfo] field, unless a
+ * concrete consumer message grounds it.
+ */
+class BackendRefSerializationTest {
+    private val ide = IdeInfo(name = "IntelliJ IDEA 2026.1.3", version = "2026.1.3", build = "IU-261.25134.95")
+
+    @Test
+    fun `BackendRef element serializes to exactly backend_name + intellij`() {
+        val json = McpJson.encodeToString(BackendRef.serializer(), BackendRef("iu-47qi79c1", ide.toIntelliJInfo()))
+        val root = McpJson.parseToJsonElement(json).jsonObject
+        assertEquals(setOf("backend_name", "intellij"), root.keys, json)
+        assertEquals(setOf("name", "version", "build"), root["intellij"]!!.jsonObject.keys, json)
+    }
+
+    @Test
+    fun `BackendRef round-trips through JSON unchanged`() {
+        val ref = BackendRef("iu-47qi79c1", ide.toIntelliJInfo())
+        val json = McpJson.encodeToString(BackendRef.serializer(), ref)
+        assertEquals(ref, McpJson.decodeFromString(BackendRef.serializer(), json))
+    }
+
+    @Test
+    fun `toIntelliJInfo projects the three identity fields 1-to-1`() {
+        val projected = ide.toIntelliJInfo()
+        assertEquals(ide.name, projected.name)
+        assertEquals(ide.version, projected.version)
+        assertEquals(ide.build, projected.build)
+    }
+
+    @Test
+    fun `backendsTable de-dups by backend_name and sorts deterministically`() {
+        val goland = IdeInfo(name = "GoLand 2026.1.2", version = "2026.1.2", build = "GO-261.24374.154")
+        val unsorted = listOf(
+            BackendRef("iu-47qi79c1", ide.toIntelliJInfo()),
+            BackendRef("go-3f9dk21a", goland.toIntelliJInfo()),
+            // Duplicate key (two projects on the same IDE): keep-first, appears once.
+            BackendRef("iu-47qi79c1", ide.toIntelliJInfo()),
+        )
+        assertEquals(
+            listOf(
+                BackendRef("go-3f9dk21a", goland.toIntelliJInfo()),
+                BackendRef("iu-47qi79c1", ide.toIntelliJInfo()),
+            ),
+            backendsTable(unsorted),
+        )
+    }
+}

--- a/mcp-steroid-server/src/test/kotlin/com/jonnyzzz/mcpSteroid/server/ListProjectsToolSpecSchemaTest.kt
+++ b/mcp-steroid-server/src/test/kotlin/com/jonnyzzz/mcpSteroid/server/ListProjectsToolSpecSchemaTest.kt
@@ -2,6 +2,8 @@
 package com.jonnyzzz.mcpSteroid.server
 
 import com.jonnyzzz.mcpSteroid.mcp.McpJson
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -20,6 +22,7 @@ class ListProjectsToolSpecSchemaTest {
     fun `response decodes ListedProject with snake_case keys`() {
         // No top-level ide/plugin/pid header (#89) — projects[] only.
         // ListedProject uses snake_case `project_name`/`backend_name` (@SerialName).
+        // A pre-#155 payload without `backends` still decodes (tolerant default).
         val json = """{"projects":[{"project_name":"n","name":"n","path":"/p"}]}"""
         val decoded = McpJson.decodeFromString(ListProjectsResponse.serializer(), json)
         val project = decoded.projects.single()
@@ -27,18 +30,35 @@ class ListProjectsToolSpecSchemaTest {
         assertEquals("n", project.name)
         assertEquals("/p", project.path)
         assertNull(project.backendName)
+        assertTrue(decoded.backends.isEmpty())
     }
 
     @Test
     fun `response serializes no top-level ide-plugin-pid header`() {
-        // #89: devrig's own identity lives in the MCP server info; attribution is per-entry via backend_name.
+        // #89: devrig's own identity lives in the MCP server info; attribution is per-entry via
+        // backend_name. #155 re-added a populated backends[] lookup — the fixture carries a realistic
+        // element to prove the guard holds against the richer JSON: the nested key is `intellij`
+        // (no quoted "ide" substring), never a resurrected top-level singular header.
         val response = ListProjectsResponse(
             projects = listOf(ListedProject(projectName = "n", name = "n", path = "/p", backendName = "iu-1")),
+            backends = listOf(
+                BackendRef(
+                    backendName = "iu-1",
+                    intellij = IntelliJInfo(name = "IntelliJ IDEA 2026.1.3", version = "2026.1.3", build = "IU-261.25134.95"),
+                ),
+            ),
         )
         val json = McpJson.encodeToString(ListProjectsResponse.serializer(), response)
         assertTrue(!json.contains("\"ide\""), json)
         assertTrue(!json.contains("\"plugin\""), json)
         assertTrue(!json.contains("\"pid\""), json)
+
+        // Semantic pin (not just lexical): exactly {projects, backends} at the top level,
+        // and the identity nests under exactly `intellij` inside each backends[] element.
+        val root = McpJson.parseToJsonElement(json).jsonObject
+        assertEquals(setOf("projects", "backends"), root.keys, json)
+        val backend = root["backends"]!!.jsonArray.single().jsonObject
+        assertEquals(setOf("backend_name", "intellij"), backend.keys, json)
     }
 
     @Test

--- a/mcp-steroid-server/src/test/kotlin/com/jonnyzzz/mcpSteroid/server/ListWindowsToolSpecSchemaTest.kt
+++ b/mcp-steroid-server/src/test/kotlin/com/jonnyzzz/mcpSteroid/server/ListWindowsToolSpecSchemaTest.kt
@@ -2,6 +2,8 @@
 package com.jonnyzzz.mcpSteroid.server
 
 import com.jonnyzzz.mcpSteroid.mcp.McpJson
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -59,5 +61,53 @@ class ListWindowsToolSpecSchemaTest {
         assertFalse(json.contains("projectName"), "MCP surface must not emit camelCase projectName: $json")
         val decoded = McpJson.decodeFromString(ListedBackgroundTask.serializer(), json)
         assertEquals(listed, decoded)
+    }
+
+    @Test
+    fun `response serializes no top-level ide-plugin-pid header`() {
+        // #89: no top-level singular identity header; #155 re-added the backends[] lookup — the
+        // fixture carries a realistic element to prove the guard holds against the richer JSON
+        // (the nested key is `intellij`; no quoted "ide"/"plugin"/"pid" substring appears).
+        val response = ListWindowsResponse(
+            windows = listOf(
+                WindowInfo(
+                    projectName = "n-9fk2a0xq",
+                    projectPath = "/p",
+                    title = "n – readme.md",
+                    isActive = true,
+                    isVisible = true,
+                    bounds = WindowBounds(0, 0, 100, 100),
+                    windowId = "w-1",
+                ).listed(projectName = "n-9fk2a0xq", backendName = "iu-1"),
+            ),
+            backgroundTasks = emptyList(),
+            backends = listOf(
+                BackendRef(
+                    backendName = "iu-1",
+                    intellij = IntelliJInfo(name = "IntelliJ IDEA 2026.1.3", version = "2026.1.3", build = "IU-261.25134.95"),
+                ),
+            ),
+        )
+        val json = McpJson.encodeToString(ListWindowsResponse.serializer(), response)
+        assertTrue(!json.contains("\"ide\""), json)
+        assertTrue(!json.contains("\"plugin\""), json)
+        assertTrue(!json.contains("\"pid\""), json)
+
+        // Semantic pin: exactly {windows, backgroundTasks, backends} at the top level, and the
+        // identity nests under exactly `intellij` inside each backends[] element.
+        val root = McpJson.parseToJsonElement(json).jsonObject
+        assertEquals(setOf("windows", "backgroundTasks", "backends"), root.keys, json)
+        val backend = root["backends"]!!.jsonArray.single().jsonObject
+        assertEquals(setOf("backend_name", "intellij"), backend.keys, json)
+    }
+
+    @Test
+    fun `response without backends still decodes`() {
+        // Pre-#155 payload shape (tolerant default) — protects test fixtures and round-tripping consumers.
+        val decoded = McpJson.decodeFromString(
+            ListWindowsResponse.serializer(),
+            """{"windows":[],"backgroundTasks":[]}""",
+        )
+        assertTrue(decoded.backends.isEmpty())
     }
 }

--- a/mcp-steroid-server/src/test/kotlin/com/jonnyzzz/mcpSteroid/server/WirePristinenessTest.kt
+++ b/mcp-steroid-server/src/test/kotlin/com/jonnyzzz/mcpSteroid/server/WirePristinenessTest.kt
@@ -9,9 +9,10 @@ import org.junit.jupiter.api.Test
 
 /**
  * R3.5 — mechanical guard that the devrig<->IDE WIRE stays pristine. The MCP/CLI-surface types
- * [ListedProject] (and their `backend_name` / `project_name` keys) must NEVER serialize
- * into a wire-crossing payload. The only wire DTOs are [NpxStreamEnvelope] (`/projects/stream`, carrying
- * the pristine `{name, path}` [ProjectInfo]) and [NpxBridgeWindowsResponse] (`/windows`).
+ * [ListedProject] and the #155 [BackendRef]/[IntelliJInfo] identity table (their `backend_name` /
+ * `project_name` / `backends` / `intellij` keys) must NEVER serialize into a wire-crossing payload.
+ * The only wire DTOs are [NpxStreamEnvelope] (`/projects/stream`, carrying the pristine
+ * `{name, path}` [ProjectInfo]) and [NpxBridgeWindowsResponse] (`/windows`).
  */
 class WirePristinenessTest {
     @Test
@@ -31,6 +32,9 @@ class WirePristinenessTest {
         assertFalse(json.contains("project_name"), "wire must not carry project_name: $json")
         assertFalse(json.contains("backendName"), "wire must not carry backendName: $json")
         assertFalse(json.contains("projectName"), "wire must not carry projectName: $json")
+        // ...and the #155 MCP-only backends[] identity table never leaks onto the wire either.
+        assertFalse(json.contains("backends"), "wire must not carry backends: $json")
+        assertFalse(json.contains("intellij"), "wire must not carry intellij: $json")
 
         // And it round-trips to the pristine shape.
         val decodedProject = NpxStreamJson.decodeEnvelope(json).projects!!.single()
@@ -75,6 +79,9 @@ class WirePristinenessTest {
         // The backend-id keys (the R3 additions) must never leak onto the wire.
         assertFalse(json.contains("backend_name"), "wire must not carry backend_name: $json")
         assertFalse(json.contains("backendName"), "wire must not carry backendName: $json")
+        // ...and neither may the #155 MCP-only backends[] identity table or its nested intellij key.
+        assertFalse(json.contains("backends"), "wire must not carry backends: $json")
+        assertFalse(json.contains("intellij"), "wire must not carry intellij: $json")
         // Note: `projectName` IS a legitimate WindowInfo wire field — now the IDE's stable project id
         // (base36 hash of the project's base dir + name), the same id `/projects` emits, so devrig can
         // match a window to its project. It is NOT the MCP-only ListedProject.project_name key, so it

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/BackendCommand.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/BackendCommand.kt
@@ -337,9 +337,10 @@ fun renderBackendOutput3(
     s3: List<InstalledBackend>,
     out: PrintStream,
 ) {
-    // Split S1 by compatibility: ideHome present = compatible (new plugin), absent = incompatible (old plugin)
-    val s1Compatible = s1.filter { it.ideHome != null }
-    val s1Incompatible = s1.filter { it.ideHome == null }
+    // Split S1 by compatibility: ideHome present = compatible (new plugin), absent = incompatible (old plugin).
+    // Same ordering as the MCP backends[] lookup (#155): marker-backed rows sort by backend_name.
+    val s1Compatible = s1.filter { it.ideHome != null }.sortedBy { it.backendName }
+    val s1Incompatible = s1.filter { it.ideHome == null }.sortedBy { it.backendName }
 
     if (s1Compatible.isEmpty() && s1Incompatible.isEmpty() && s2.isEmpty() && s3.isEmpty()) {
         out.println(NO_BACKENDS_DETECTED_MESSAGE)
@@ -363,7 +364,7 @@ fun renderBackendOutput3(
         out.println("  (none)")
     } else {
         for ((index, ide) in s1Compatible.withIndex()) {
-            out.println("  [${index + 1}] ${markerBackendDisplayName(ide)} (${markerBackendLocatorLabel(ide)})")
+            out.println("  [${index + 1}] ${markerBackendDisplayName(ide)} (${ide.backendName}; ${markerBackendLocatorLabel(ide)})")
             val plugin = ide.plugin
             out.println("        ${plugin.name.ifBlank { "MCP Steroid" }}: ${plugin.version.ifBlank { "unknown" }}")
             if (index < s1Compatible.lastIndex) out.println()
@@ -380,14 +381,14 @@ fun renderBackendOutput3(
         out.println("  (none)")
     } else {
         for ((index, ide) in s1Incompatible.withIndex()) {
-            out.println("  [${index + 1}] ${markerBackendDisplayName(ide)} (${markerBackendLocatorLabel(ide)}) (incompatible plugin, old version)")
+            out.println("  [${index + 1}] ${markerBackendDisplayName(ide)} (${ide.backendName}; ${markerBackendLocatorLabel(ide)}) (incompatible plugin, old version)")
             val plugin = ide.plugin
             out.println("        ${plugin.name.ifBlank { "MCP Steroid" }}: ${plugin.version.ifBlank { "unknown" }} (incompatible)")
             if (index < group2Count - 1) out.println()
         }
         for ((index, ide) in s2Sorted.withIndex()) {
             val entryIndex = s1Incompatible.size + index + 1
-            out.println("  [$entryIndex] ${portBackendDisplayName(ide)} (${portBackendLocatorLabel(ide)}) (run: ${provisionCommand(provisionTargetId(ide.port))})")
+            out.println("  [$entryIndex] ${portBackendDisplayName(ide)} (${backendNameForPort(ide.port, ide.buildNumber)}; ${portBackendLocatorLabel(ide)}) (run: ${provisionCommand(provisionTargetId(ide.port))})")
             out.println("        MCP Steroid: not installed")
             if (s1Incompatible.size + index < group2Count - 1) out.println()
         }
@@ -402,7 +403,7 @@ fun renderBackendOutput3(
         out.println("  (none)")
     } else {
         for ((index, installed) in s3.withIndex()) {
-            out.println("  [${index + 1}] ${installed.ide.name} ${installed.ide.version} (managed: ${installed.id})")
+            out.println("  [${index + 1}] ${installed.ide.name} ${installed.ide.version} (${startableBackendName(installed)}; managed: ${installed.id})")
             out.println("        ideHome: ${installed.ideHome}")
             if (index < s3.lastIndex) out.println()
         }
@@ -439,8 +440,9 @@ fun renderBackendJson3(
     s3: List<InstalledBackend>,
     out: PrintStream,
 ) {
-    val s1Compatible = s1.filter { it.ideHome != null }
-    val s1Incompatible = s1.filter { it.ideHome == null }
+    // Same ordering as the MCP backends[] lookup (#155): marker-backed rows sort by backend_name.
+    val s1Compatible = s1.filter { it.ideHome != null }.sortedBy { it.backendName }
+    val s1Incompatible = s1.filter { it.ideHome == null }.sortedBy { it.backendName }
     val allMarkerBuilds = s1.mapNotNull { normaliseBuildForDedup(it.ide.build) }.toSet()
     val s2Deduped = s2.filter { portIde ->
         val norm = normaliseBuildForDedup(portIde.buildNumber)

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/ProjectCommand.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/ProjectCommand.kt
@@ -36,7 +36,7 @@ fun DevrigServices.runProjectCommand(command: DevrigCommand.DevrigCommandProject
  * Listing N open project(s) across M backend(s):
  *
  *   [1] <project-name>  →  <project-path>
- *         <IDE name> <version> (pid <pid>)
+ *         <IDE name> <version> (<backend_name>; build <build>, pid <pid>)
  *         MCP Steroid: <version>
  *
  * Skipped K backend(s) with MCP Steroid not installed:
@@ -70,14 +70,17 @@ fun renderProjectOutput3(
     out.println("Listing ${routes.size} open project(s) across $backendCount backend(s):")
     out.println()
 
-    val padWidth = routes.maxOf { it.exposedProjectName.codePointWidth() }.coerceAtMost(40)
-    for ((index, route) in routes.withIndex()) {
+    // Same ordering and identity key as the MCP steroid_list_projects response (#155):
+    // projects sort by project_name, and every entry names its backend_name.
+    val sortedRoutes = routes.sortedBy { it.exposedProjectName }
+    val padWidth = sortedRoutes.maxOf { it.exposedProjectName.codePointWidth() }.coerceAtMost(40)
+    for ((index, route) in sortedRoutes.withIndex()) {
         val paddedName = route.exposedProjectName.padEndCodePoints(padWidth)
         out.println("  [${index + 1}] $paddedName  →  ${route.projectPath}")
-        out.println("        ${markerBackendDisplayName(route.route)} (${markerBackendLocatorLabel(route.route)})")
+        out.println("        ${markerBackendDisplayName(route.route)} (${route.exposedBackendName}; ${markerBackendLocatorLabel(route.route)})")
         val plugin = route.route.plugin
         out.println("        ${plugin.name.ifBlank { "MCP Steroid" }}: ${plugin.version.ifBlank { "unknown" }}")
-        if (index < routes.lastIndex) out.println()
+        if (index < sortedRoutes.lastIndex) out.println()
     }
 
     renderPortSkippedFooter(portIdes, out)
@@ -117,7 +120,8 @@ fun renderProjectJson3(routes: List<ProjectRoute>, out: PrintStream) {
             put("version", DevrigVersionMetadata.getDevrigVersion())
         })
         putJsonArray("projects") {
-            for (route in routes) {
+            // Same ordering as the MCP steroid_list_projects response (#155): sort by project_name.
+            for (route in routes.sortedBy { it.exposedProjectName }) {
                 add(buildJsonObject {
                     put("project_name", route.exposedProjectName)
                     put("name", route.originalProjectName)

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/server/DevrigListProjectsToolHandler.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/server/DevrigListProjectsToolHandler.kt
@@ -1,8 +1,11 @@
 package com.jonnyzzz.mcpSteroid.devrig.server
 
+import com.jonnyzzz.mcpSteroid.server.BackendRef
 import com.jonnyzzz.mcpSteroid.server.ListProjectsResponse
 import com.jonnyzzz.mcpSteroid.server.ListProjectsToolHandler
 import com.jonnyzzz.mcpSteroid.server.ListedProject
+import com.jonnyzzz.mcpSteroid.server.backendsTable
+import com.jonnyzzz.mcpSteroid.server.toIntelliJInfo
 
 class DevrigListProjectsToolHandler(
     private val routing: DevrigProjectRoutingService,
@@ -22,7 +25,12 @@ class DevrigListProjectsToolHandler(
         }
 
         return ListProjectsResponse(
-            projects = listedProjects,
+            projects = listedProjects.sortedBy { it.projectName },
+            // Referenced-only membership (#155): derived from the same routing snapshot the entries
+            // come from, so every entry's backend_name resolves and no unreferenced backend appears.
+            // Zero-project running, startable, and port-only backends own no route — their inventory
+            // lives in `devrig backend --json` (#151) and the open_project candidate listing.
+            backends = backendsTable(routes.map { BackendRef(it.route.backendName, it.route.ide.toIntelliJInfo()) }),
         )
     }
 }

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/server/DevrigListWindowsToolHandler.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/server/DevrigListWindowsToolHandler.kt
@@ -1,10 +1,13 @@
 package com.jonnyzzz.mcpSteroid.devrig.server
 
 import com.jonnyzzz.mcpSteroid.devrig.monitor.DiscoveredIde
+import com.jonnyzzz.mcpSteroid.server.BackendRef
 import com.jonnyzzz.mcpSteroid.server.ListWindowsResponse
 import com.jonnyzzz.mcpSteroid.server.ListWindowsToolHandler
 import com.jonnyzzz.mcpSteroid.server.NpxBridgeWindowsResponse
+import com.jonnyzzz.mcpSteroid.server.backendsTable
 import com.jonnyzzz.mcpSteroid.server.listed
+import com.jonnyzzz.mcpSteroid.server.toIntelliJInfo
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
@@ -16,9 +19,11 @@ class DevrigListWindowsToolHandler(
     override suspend fun collectListWindowsResponse(): ListWindowsResponse = coroutineScope {
         val routes = routing.routes()
 
-        val responses = routes
+        val routedBackends = routes
             .map { it.route }
             .distinctBy { it.backendName }
+
+        val responses = routedBackends
             .map { state ->
                 async { state to bridge.fetchWindows(state) }
             }.awaitAll()
@@ -28,6 +33,7 @@ class DevrigListWindowsToolHandler(
         }?.exposedProjectName
 
         ListWindowsResponse(
+            // windows[]/backgroundTasks[] keep their produced order (#155 sorts list_projects only).
             windows = responses.flatMap { (state, response) ->
                 response.windows.map { window ->
                     window.listed(
@@ -44,6 +50,10 @@ class DevrigListWindowsToolHandler(
                     )
                 }
             },
+            // Referenced-only membership (#155): the same routed-backend set the entries above come
+            // from, so every entry's backend_name resolves. Zero-project running, startable, and
+            // port-only backends own no route — their inventory is `devrig backend --json` (#151).
+            backends = backendsTable(routedBackends.map { BackendRef(it.backendName, it.ide.toIntelliJInfo()) }),
         )
     }
 }

--- a/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/BackendCommandJsonRenderTest.kt
+++ b/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/BackendCommandJsonRenderTest.kt
@@ -142,6 +142,16 @@ class BackendCommandJsonRenderTest {
     }
 
     @Test
+    fun `mcpSteroidBackends are sorted by backend_name`() {
+        // Same ordering as the MCP backends[] lookup (#155), whatever the discovery order.
+        val a = markerIde(pid = 1111L)
+        val b = markerIde(pid = 2222L)
+        val expected = listOf(a, b).map { it.backendName }.sorted()
+        val backends = render(s1 = listOf(b, a))["mcpSteroidBackends"]!!.jsonArray
+        assertEquals(expected, backends.map { it.jsonObject["backend_name"]?.jsonPrimitive?.contentOrNull })
+    }
+
+    @Test
     fun `multiple S1 entries are ordered as provided`() {
         val ide1 = markerIde(pid = 1L, build = "IU-261.1")
         val ide2 = markerIde(name = "PyCharm", pid = 2L, build = "PC-253.9")

--- a/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/BackendCommandRenderTest.kt
+++ b/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/BackendCommandRenderTest.kt
@@ -41,6 +41,7 @@ class BackendCommandRenderTest {
         build: String = "IU-253.21581.142",
         mcpUrl: String = "http://127.0.0.1:65000/mcp",
         ideHome: String? = "/mock/ide/home",
+        backendName: String = "mock-backend-name",
     ): DiscoveredIde {
         val ideInfo = IdeInfo(name = name, version = version, build = build)
         val pluginInfo = PluginInfo(id = "com.jonnyzzz.mcp-steroid", name = "MCP Steroid", version = "0.0.0-test")
@@ -50,7 +51,7 @@ class BackendCommandRenderTest {
             bridgeHeaders = emptyMap(),
             ide = ideInfo,
             plugin = pluginInfo,
-            backendName = "mock-backend-name",
+            backendName = backendName,
             ideHome = ideHome,
         )
     }
@@ -126,8 +127,8 @@ class BackendCommandRenderTest {
         val text = render(s1 = listOf(markerIde("IntelliJ IDEA", "2025.3.3", pid = 1234L)))
         assertTrue(text.contains("MCP Steroid backends (1):"),
             "expected section header with count; got:\n$text")
-        assertTrue(text.contains("[1] IntelliJ IDEA 2025.3.3 (build IU-253.21581.142, pid 1234)"),
-            "expected numbered entry with version+build+locator; got:\n$text")
+        assertTrue(text.contains("[1] IntelliJ IDEA 2025.3.3 (mock-backend-name; build IU-253.21581.142, pid 1234)"),
+            "expected numbered entry with backend_name+version+build+locator (#155); got:\n$text")
         assertTrue(text.contains("MCP Steroid: 0.0.0-test"),
             "expected MCP Steroid plugin status; got:\n$text")
     }
@@ -162,8 +163,8 @@ class BackendCommandRenderTest {
         val text = render(s2 = setOf(portIde(port = 63342)))
         assertTrue(text.contains("Other IDEs (incompatible or no MCP Steroid) (1):"),
             "expected S2 section header; got:\n$text")
-        assertTrue(text.contains("[1] IntelliJ IDEA Ultimate (build IU-253.21581.142, port 63342) (run: devrig backend provision port-63342)"),
-            "expected S2 entry with provision hint; got:\n$text")
+        assertTrue(text.contains("[1] IntelliJ IDEA Ultimate (${backendNameForPort(63342, "IU-253.21581.142")}; build IU-253.21581.142, port 63342) (run: devrig backend provision port-63342)"),
+            "expected S2 entry with backend_name + provision hint; got:\n$text")
         assertTrue(text.contains("MCP Steroid: not installed"),
             "expected not-installed status; got:\n$text")
     }
@@ -193,8 +194,8 @@ class BackendCommandRenderTest {
     @Test
     fun `S2 port-discovered IDE drops build segment when buildNumber is null`() {
         val text = render(s2 = setOf(portIde(buildNumber = null)))
-        assertTrue(text.contains("(port 63342) (run: devrig backend provision port-63342)"),
-            "no buildNumber → locator should be `port N` only; got:\n$text")
+        assertTrue(text.contains("; port 63342) (run: devrig backend provision port-63342)"),
+            "no buildNumber → locator should be `port N` only after the backend_name; got:\n$text")
         assertFalse(text.contains("build ,"), "must not produce 'build , port …' when buildNumber is null; got:\n$text")
     }
 
@@ -209,11 +210,12 @@ class BackendCommandRenderTest {
 
     @Test
     fun `S3 installed backend shows section header and IDE identity`() {
-        val text = render(s3 = listOf(installedBackend()))
+        val installed = installedBackend()
+        val text = render(s3 = listOf(installed))
         assertTrue(text.contains("Installed, not running (startable) (1):"),
             "expected S3 section header; got:\n$text")
-        assertTrue(text.contains("[1] GoLand 2026.1 (managed: goland-2026.1)"),
-            "expected S3 entry; got:\n$text")
+        assertTrue(text.contains("[1] GoLand 2026.1 (${startableBackendName(installed)}; managed: goland-2026.1)"),
+            "expected S3 entry with backend_name; got:\n$text")
         assertTrue(text.contains("ideHome: /home/user/.mcp-steroid/backends/goland-2026.1/bundle-goland-2026.1"),
             "expected ideHome line; got:\n$text")
     }
@@ -258,8 +260,19 @@ class BackendCommandRenderTest {
         val text = render(s1 = listOf(
             markerIde("IntelliJ IDEA 2026.1.4", "2026.1.4", pid = 1234L, build = "IU-261.1")
         ))
-        assertTrue(text.contains("[1] IntelliJ IDEA 2026.1.4 (build IU-261.1, pid 1234)"), text)
+        assertTrue(text.contains("[1] IntelliJ IDEA 2026.1.4 (mock-backend-name; build IU-261.1, pid 1234)"), text)
         assertFalse(text.contains("2026.1.4 2026.1.4"), text)
+    }
+
+    @Test
+    fun `S1 backends are sorted by backend_name`() {
+        // Same ordering as the MCP backends[] lookup (#155), whatever the discovery order.
+        val late = markerIde("IntelliJ IDEA", "2025.3.3", pid = 1L, backendName = "zz-late")
+        val early = markerIde("GoLand", "2025.3.3", pid = 2L, backendName = "aa-early")
+        val text = render(s1 = listOf(late, early))
+        val i1 = text.indexOf("[1] GoLand 2025.3.3 (aa-early;")
+        val i2 = text.indexOf("[2] IntelliJ IDEA 2025.3.3 (zz-late;")
+        assertTrue(i1 in 0 until i2, "S1 must sort by backend_name; got:\n$text")
     }
     // -------------------- Finding C: compatibility by ideHome ----------------
 

--- a/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/ProjectCommandJsonRenderTest.kt
+++ b/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/ProjectCommandJsonRenderTest.kt
@@ -130,10 +130,11 @@ class ProjectCommandJsonRenderTest {
     }
 
     @Test
-    fun `multiple projects are rendered in input order`() {
+    fun `multiple projects are sorted by project_name`() {
+        // Same ordering as the MCP steroid_list_projects response (#155), whatever the input order.
         val r1 = route("alpha-aaa", originalName = "alpha", path = "/p/alpha", backendName = "iu-aaa")
         val r2 = route("bravo-bbb", originalName = "bravo", path = "/p/bravo", backendName = "iu-bbb")
-        val projects = render(listOf(r1, r2))["projects"]!!.jsonArray
+        val projects = render(listOf(r2, r1))["projects"]!!.jsonArray
         assertEquals(2, projects.size)
         assertEquals("alpha-aaa", projects[0].jsonObject["project_name"]?.jsonPrimitive?.contentOrNull)
         assertEquals("bravo-bbb", projects[1].jsonObject["project_name"]?.jsonPrimitive?.contentOrNull)

--- a/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/ProjectCommandRenderTest.kt
+++ b/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/ProjectCommandRenderTest.kt
@@ -79,6 +79,15 @@ class ProjectCommandRenderTest {
             projectPath = path,
         )
 
+    @Test
+    fun `projects are sorted by project_name`() {
+        // Same ordering as the MCP steroid_list_projects response (#155), whatever the input order.
+        val text = render(routes = listOf(route("zulu", "/p/zulu"), route("alpha", "/p/alpha")))
+        val i1 = text.indexOf("[1] alpha-rendertst")
+        val i2 = text.indexOf("[2] zulu-rendertst")
+        assertTrue(i1 in 0 until i2, "projects must render sorted by project_name; got:\n$text")
+    }
+
     // ------------------------------ shape ---------------------------------
 
     @Test
@@ -115,8 +124,8 @@ class ProjectCommandRenderTest {
             "expected list header for one project; got:\n$text")
         assertTrue(text.contains("[1] my-app") && text.contains("→") && text.contains("/Users/x/Work/my-app"),
             "expected project to render as name → path; got:\n$text")
-        assertTrue(text.contains("        IntelliJ IDEA 2025.3.3 (build IU-253.21581.142, pid 1234)"),
-            "expected owning IDE line to reuse backend identity formatting; got:\n$text")
+        assertTrue(text.contains("        IntelliJ IDEA 2025.3.3 (mock-backend-name; build IU-253.21581.142, pid 1234)"),
+            "expected owning IDE line to carry backend_name + identity formatting (#155); got:\n$text")
         assertTrue(text.contains("        MCP Steroid: 0.0.0-test"),
             "expected plugin status line; got:\n$text")
     }

--- a/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/server/DevrigListToolHandlersTest.kt
+++ b/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/server/DevrigListToolHandlersTest.kt
@@ -12,6 +12,7 @@ import com.jonnyzzz.mcpSteroid.server.NpxBridgeWindowsResponse
 import com.jonnyzzz.mcpSteroid.server.ProgressTaskInfo
 import com.jonnyzzz.mcpSteroid.server.WindowInfo
 import com.jonnyzzz.mcpSteroid.server.backendNameForMarker
+import com.jonnyzzz.mcpSteroid.server.toIntelliJInfo
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.cio.CIO
 import io.ktor.client.plugins.HttpTimeout
@@ -67,6 +68,60 @@ class DevrigListToolHandlersTest {
         // projects[] only lists the IDE that actually has a project open, tagged with its own backend_name.
         assertEquals(listOf(name42), response.projects.map { it.backendName })
         assertEquals(listOf("alpha"), response.projects.map { it.name })
+    }
+
+    @Test
+    fun `list_projects backends is the referenced-only identity table sorted by backend_name`(
+        @TempDir tempDir: Path,
+    ) = runBlocking {
+        val homeZ = Files.createDirectories(tempDir.resolve("zulu"))
+        val homeA = Files.createDirectories(tempDir.resolve("alpha"))
+        val homeM = Files.createDirectories(tempDir.resolve("mike"))
+        // Deliberately unsorted snapshot: the "zulu" project first, backends in scan (not name) order.
+        // Note the fixture markers carry no ideHome (the incompatible/old-plugin marker shape) — such
+        // backends own routes, so they MUST still appear in the table (#155 membership rule).
+        val ideZ = IdeMonitorState(
+            ide = discoveredIde(pid = 99, build = "IU-261.1"),
+            projects = listOf(
+                IdeProjectState("zulu", homeZ.toString()),
+                IdeProjectState("alpha", homeA.toString()),
+            ),
+        )
+        val ideM = IdeMonitorState(
+            ide = discoveredIde(pid = 42, build = "GO-261.2"),
+            projects = listOf(IdeProjectState("mike", homeM.toString())),
+        )
+        // Running with zero open projects: owns no route => absent from backends[] (referenced-only).
+        // Startable and port-only IDEs never enter the routing snapshot at all, so they are absent
+        // structurally — their inventory is `devrig backend --json` (#151).
+        val idle = IdeMonitorState(ide = discoveredIde(pid = 7, build = "IU-253.9"))
+        val routing = DevrigProjectRoutingService { listOf(ideZ, ideM, idle) }
+
+        val response = DevrigListProjectsToolHandler(routing).collectListProjectsResponse()
+
+        // (d) projects[] sorted by project_name regardless of the routing-snapshot order.
+        assertEquals(response.projects.map { it.projectName }.sorted(), response.projects.map { it.projectName })
+        assertEquals(3, response.projects.size)
+
+        // (a) every entry's backend_name resolves to exactly one backends[] element.
+        for (project in response.projects) {
+            assertEquals(1, response.backends.count { it.backendName == project.backendName })
+        }
+
+        // (b) every backends[] element is referenced by >=1 entry; (e) the idle backend is absent.
+        val referenced = response.projects.map { it.backendName }.toSet()
+        assertEquals(referenced, response.backends.map { it.backendName }.toSet())
+        assertTrue(response.backends.none { it.backendName == idle.ide.backendName })
+
+        // (c) de-duped (ideZ owns two projects yet appears once) + sorted by backend_name.
+        assertEquals(response.backends.map { it.backendName }.distinct(), response.backends.map { it.backendName })
+        assertEquals(response.backends.map { it.backendName }.sorted(), response.backends.map { it.backendName })
+
+        // (f)+(g) each element's identity is the marker-decoded IdeInfo projected via toIntelliJInfo().
+        val routedByName = listOf(ideZ, ideM).associateBy { it.ide.backendName }
+        for (backend in response.backends) {
+            assertEquals(routedByName.getValue(backend.backendName).ide.ide.toIntelliJInfo(), backend.intellij)
+        }
     }
 
     @Test
@@ -159,6 +214,11 @@ class DevrigListToolHandlersTest {
             val route = routing.routes().single { it.route.pid == pid }
             assertEquals(route.exposedProjectName, window.projectName)
         }
+        // #155: backends[] resolves both referenced backend_names — referenced-only, sorted, with the
+        // marker-decoded identity projected via toIntelliJInfo().
+        assertEquals(listOf(name42, name43).sorted(), response.backends.map { it.backendName })
+        assertEquals(stateA.ide.ide.toIntelliJInfo(), response.backends.single { it.backendName == name42 }.intellij)
+        assertEquals(stateB.ide.ide.toIntelliJInfo(), response.backends.single { it.backendName == name43 }.intellij)
     }
 
     private fun windowsResponseJson(pid: Long): String = McpJson.encodeToString(

--- a/prompts/src/main/prompts/open-project/managing-backends.md
+++ b/prompts/src/main/prompts/open-project/managing-backends.md
@@ -53,6 +53,33 @@ routing KEY you pass to project-scoped tools), the human-readable folder
 `name` (informational only), `path`, and a `backend_name` naming its
 owning backend.
 
+## Resolving a `backend_name` to the IDE's identity
+
+Both list-tool responses carry a `backends` lookup table — the
+resolution step for every `backend_name` referenced by that response's
+entries. Each element is identity-only:
+
+```
+{ "backend_name": "iu-47qi79c1",
+  "intellij": { "name": "IntelliJ IDEA 2026.1.3",
+                "version": "2026.1.3",
+                "build": "IU-261.25134.95" } }
+```
+
+- `intellij` means "the IntelliJ-Platform IDE" — a GoLand or PyCharm
+  backend still nests under `intellij`; the product is identified by
+  `name`/`build` (e.g. `"GO-261.24374.154"`).
+- On a direct in-IDE connection, `backends` always contains exactly one
+  element (the IDE itself), even with zero open projects — so probing a
+  fresh IDE's identity is a single `steroid_list_projects` call.
+- Via devrig, `backends` lists exactly the backends referenced by this
+  response's entries — no more. Backend *inventory* (zero-project,
+  startable, and no-plugin IDEs) lives in `devrig backend --json`.
+- `windows[].projectName` is the opaque routing key, not a display
+  name — enrich the human-readable `name`/`path` via
+  `steroid_list_projects` (which carries the same `backends` table, so
+  one call resolves both the project and its IDE).
+
 If the chosen `backend_name` belongs to a startable managed backend
 (not yet running), `open_project` starts it and blocks until it is
 reachable, then opens the project.
@@ -63,7 +90,8 @@ startable).
 
 **A `backend_name` is not stable across IDE restarts** (it is derived
 from the pid or the install path). Re-read `steroid_list_projects`
-rather than caching a `backend_name`.
+rather than caching a `backend_name` — its `backends` table is the
+resolution step from a fresh key to the owning IDE's identity.
 
 ## The `devrig backend` CLI — for installing and managing IDEs
 

--- a/prompts/src/main/prompts/open-project/managing-backends.md
+++ b/prompts/src/main/prompts/open-project/managing-backends.md
@@ -72,9 +72,11 @@ entries. Each element is identity-only:
 - On a direct in-IDE connection, `backends` always contains exactly one
   element (the IDE itself), even with zero open projects — so probing a
   fresh IDE's identity is a single `steroid_list_projects` call.
-- Via devrig, `backends` lists exactly the backends referenced by this
-  response's entries — no more. Backend *inventory* (zero-project,
-  startable, and no-plugin IDEs) lives in `devrig backend --json`.
+- Via devrig, `backends` is derived from the same routing snapshot the
+  entries come from: every referenced `backend_name` resolves, and a
+  backend can appear with zero entries only in transient startup
+  states. Backend *inventory* (zero-project, startable, and no-plugin
+  IDEs) lives in `devrig backend --json`.
 - `windows[].projectName` is the opaque routing key, not a display
   name — enrich the human-readable `name`/`path` via
   `steroid_list_projects` (which carries the same `backends` table, so

--- a/prompts/src/main/prompts/open-project/open-trusted.md
+++ b/prompts/src/main/prompts/open-project/open-trusted.md
@@ -66,6 +66,11 @@ val expectedResponseExample = """
 println("Expected response format:\n$expectedResponseExample")
 ```
 
+The real response also carries a `backends` lookup (elided above for brevity): on a direct
+in-IDE connection it always holds exactly one element resolving `backend_name` to the IDE's
+identity (`intellij` = `{name, version, build}`) — see
+[Managing IDE backends](mcp-steroid://open-project/managing-backends).
+
 ### Step 4: Start Working
 
 Now you can use `steroid_execute_code` with the project:
@@ -94,7 +99,8 @@ println(executeCodeJson)
 → [wait 3 seconds]
 
 → steroid_list_projects()
-← {"projects":[{"project_name":"my-app-9fk2a0xq","name":"my-app","path":"/Users/me/projects/my-app","backend_name":"iu-9fk2a0xq"}]}
+← {"projects":[{"project_name":"my-app-9fk2a0xq","name":"my-app","path":"/Users/me/projects/my-app","backend_name":"iu-9fk2a0xq"}],
+   "backends":[{"backend_name":"iu-9fk2a0xq","intellij":{"name":"IntelliJ IDEA 2026.1.3","version":"2026.1.3","build":"IU-261.25134.95"}}]}
 
 → steroid_execute_code(project_name="my-app-9fk2a0xq", code="println(project.basePath)", ...)
 ← /Users/me/projects/my-app

--- a/prompts/src/main/prompts/open-project/open-with-dialogs.md
+++ b/prompts/src/main/prompts/open-project/open-with-dialogs.md
@@ -116,7 +116,8 @@ The Trust Project dialog has these buttons:
 ← Input delivered
 
 → steroid_list_projects()
-← {"projects":[{"project_name":"untrusted-project-1a2b3c4d","name":"untrusted-project","path":"/path/to/untrusted-project","backend_name":"iu-9fk2a0xq"}, ...]}
+← {"projects":[{"project_name":"untrusted-project-1a2b3c4d","name":"untrusted-project","path":"/path/to/untrusted-project","backend_name":"iu-9fk2a0xq"}, ...],
+   "backends":[{"backend_name":"iu-9fk2a0xq","intellij":{"name":"IntelliJ IDEA 2026.1.3","version":"2026.1.3","build":"IU-261.25134.95"}}]}
 ```
 
 The `project_name` passed to the screenshot/input tools is the unique, opaque routing key from

--- a/prompts/src/main/prompts/prompt/skill.md
+++ b/prompts/src/main/prompts/prompt/skill.md
@@ -52,7 +52,8 @@ target path (this disambiguates nested checkouts and git worktrees).
 **Example session:**
 ```
 → steroid_list_projects
-← {"projects":[{"project_name":"my-app-9fk2a0xq","name":"my-app","path":"/path/to/my-app","backend_name":"iu-9fk2a0xq"}]}
+← {"projects":[{"project_name":"my-app-9fk2a0xq","name":"my-app","path":"/path/to/my-app","backend_name":"iu-9fk2a0xq"}],
+   "backends":[{"backend_name":"iu-9fk2a0xq","intellij":{"name":"IntelliJ IDEA 2026.1.3","version":"2026.1.3","build":"IU-261.25134.95"}}]}
 
 → steroid_execute_code(project_name="my-app-9fk2a0xq", code="println(project.name)", ...)
 ← "my-app"


### PR DESCRIPTION
Fixes #155

## Problem

Since #89 (drop of the misleading top-level `ide`/`plugin`/`pid` header) and the startable-backends cleanup (deletion of `BackendInfo` and the `backends[]` arrays), a client connected to an mcp-steroid MCP server could no longer resolve the host IDE's `{name, version, build}`: `steroid_list_projects` / `steroid_list_windows` entries carried only an opaque `backend_name` with no lookup in the response. JetDesk's `ide-scanner.js` regressed to reading `~/.mcp-steroid/markers/` directly, and agents had to burn a ~5 s `steroid_execute_code` kotlinc round-trip just to learn which IDE they were driving.

## Design (proposal v3, maintainer-final)

- **Dedicated presentation types** (`mcp-steroid-server/BackendRef.kt`): `IntelliJInfo {name, version, build}` nested under the JSON field **`intellij`**, and `BackendRef {backend_name, intellij}`. `IntelliJInfo` is a projection (`IdeInfo.toIntelliJInfo()`) — the marker/wire `IdeInfo` is untouched and free to grow under #151; nothing new crosses the devrig<->IDE wire (`WirePristinenessTest` gains `backends`/`intellij` negatives). `intellij` means "the IntelliJ-Platform IDE" — a GoLand backend still nests under `intellij`; the product is identified by `name`/`build`.
- **Both response types** append `backends: List<BackendRef> = emptyList()` — additive-only; existing keys and entry field names unchanged.
- **Membership**: the table resolves every `backend_name` referenced by the response's entries.
  - Direct in-IDE surface: the single **self entry is emitted unconditionally** — a fresh IDE with zero open projects stays identifiable (the #155 probe).
  - devrig surface: **referenced-only**, derived from the same routing snapshot the entries come from (includes incompatible-plugin markers that own routes; excludes zero-project/startable/port-only backends — their inventory stays in `devrig backend --json`, #151).
- **Sorting**: `projects[]` by `project_name`, `backends[]` by `backend_name`, on both surfaces; `windows[]`/`backgroundTasks[]` keep their produced order. The shared `backendsTable()` (dedup + sort) is used by **both** surfaces so the table rule cannot diverge.
- **Not done, deliberately**: no top-level singular `ide` header (#89's root defect), no `serverInfo` change, no new tool, no `pid`/`port`/`mcpUrl` fields (the `mcpUrl` half of #155's sketch stays delegated to #151's `endpoints[]`), no wire change.

## Slack-sufficiency verdict

The D4NFU8KEG conversation (2026-06-24) was re-verified in full for the proposal: `{name, version, build}` are **exactly** the three fields Serge named (`ideName`/`ideVersion`/`ideBuild`) and the only fields his `ide-scanner.js` parser reads; the port ask was aimed at the CLI (#151), and the agent use case asks only for identity. **Verdict: the three fields are sufficient; no additional field is grounded in any message.** Consumer migration is one line — `data.backends?.[0]?.intellij` on a direct connection.

## Example payloads

Direct in-IDE `steroid_list_projects`:

```json
{
  "projects": [
    { "project_name": "support-toolkit-6356wdt0", "name": "support-toolkit", "path": "C:/work/attaches/support-repro/support-toolkit", "backend_name": "iu-47qi79c1" }
  ],
  "backends": [
    { "backend_name": "iu-47qi79c1", "intellij": { "name": "IntelliJ IDEA 2026.1.3", "version": "2026.1.3", "build": "IU-261.25134.95" } }
  ]
}
```

devrig, multi-backend (`projects[]` sorted by `project_name`, `backends[]` by `backend_name`):

```json
{
  "projects": [
    { "project_name": "marinator-service-8x1k2mq0", "name": "marinator-service", "path": "/Users/serge/work/marinator-service", "backend_name": "go-3f9dk21a" },
    { "project_name": "mcp-steroid-77fh0q2z", "name": "mcp-steroid", "path": "/Users/serge/work/mcp-steroid", "backend_name": "iu-47qi79c1" }
  ],
  "backends": [
    { "backend_name": "go-3f9dk21a", "intellij": { "name": "GoLand 2026.1.2", "version": "2026.1.2", "build": "GO-261.24374.154" } },
    { "backend_name": "iu-47qi79c1", "intellij": { "name": "IntelliJ IDEA 2026.1.3", "version": "2026.1.3", "build": "IU-261.25134.95" } }
  ]
}
```

Fresh IDE, zero projects (direct): `{ "projects": [], "backends": [ { ...self... } ] }` — the identity probe still works.

## Test evidence

All run on this branch after the review fixes; all green:

| Task | Result |
|---|---|
| `./gradlew :mcp-steroid-server:test` (BackendRefSerializationTest drift gate, extended #89 schema guards on both tools, WirePristinenessTest negatives) | BUILD SUCCESSFUL |
| `./gradlew :npx-kt:test` (DevrigListToolHandlersTest membership/sort/identity rows, DevrigDescriptorParityTest) | BUILD SUCCESSFUL |
| `./gradlew :ij-plugin:test` (McpServerIntegrationTest backends assertions, SelfBackendResponseMappingTest zero-project self entry + sort) | BUILD SUCCESSFUL |
| `./gradlew :prompts:test --tests '*MarkdownArticleContract*'` (prose-only prompt edits — no kotlin fence touched) | BUILD SUCCESSFUL |

## Quorum outcome

3 independent adversarial reviewers (spec-fidelity, correctness, consumers-tests): **approve / approve / approve**. Findings applied in the follow-up commit:

- **should-fix**: the `list_windows` `backends[]` KDoc and the managing-backends article over-claimed "no more, no less" — via devrig a route-owning backend can appear with zero window/task entries in transient startup states. Wording softened to the routing-snapshot derivation the proposal actually mandates (the `list_projects` claim is exact by construction and kept).
- **nit**: `backendsTable()`'s "shared by both surfaces" KDoc is now structurally true — the direct in-IDE handlers route through it.
- **nit**: the illustrative `steroid_list_projects` transcripts in three other prompt articles now show the always-present `backends` key (the one kotlin-fence example gets a prose elision note — kotlin fences untouched, no KtBlock matrix required).
- **nit (recorded, no change)**: test-plan row (e)'s startable/port-only absence is structural — those categories cannot be represented in the routing snapshot's types — and is documented in the test rather than asserted; both reviewers verified and accepted this as the honest maximum.

## Notes

- The `list_windows` `projectName`/`projectPath` camelCase-vs-snake_case rename ships **separately** (maintainer decision, proposal §3.7) — entry field names are untouched here.
- Action item before release: share the final shape (including the `intellij` field name) with Serge in D4NFU8KEG so the JetDesk marker-file fallback can be dropped.
