### PR TITLE
Launcher replacement is rename-based to survive Windows file locks

### DIFF
--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/BinLauncher.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/BinLauncher.kt
@@ -2,7 +2,6 @@
 package com.jonnyzzz.mcpSteroid.devrig
 
 import java.io.File
-import java.nio.file.AtomicMoveNotSupportedException
 import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.StandardCopyOption
@@ -338,28 +337,65 @@ internal fun ensureWindowsPathEntry(binDir: Path) {
 
 private fun writeAtomically(dir: Path, target: Path, content: String, executable: Boolean) {
     Files.createDirectories(dir)
-    val tmp = dir.resolve(".tmp.${ProcessHandle.current().pid()}.${target.fileName}")
-    try {
-        Files.writeString(tmp, content)
-        // Set the executable bit on the staging file BEFORE the move, so the final launcher is never
-        // momentarily non-executable (mirrors install.sh: chmod +x then mv).
-        if (executable) setExecutable(tmp)
+    replaceLauncherFile(target, content, executable)
+}
+
+/**
+ * Replace [target] with [content] via a sibling `.new<pid>` staging file: move it onto the target
+ * (atomic, then plain); if blocked (Windows holds the launcher open), rename the original to `.old<pid>`
+ * — NTFS allows renaming an open file — and move again; delete the `.old<pid>`. Any failure retries the
+ * whole sequence after 10 ms, up to 5 attempts; then the last failure propagates to the caller's
+ * best-effort catch. Crash leftovers (`.new<pid>`/`.old<pid>`) are accepted and never swept.
+ */
+fun replaceLauncherFile(
+    target: Path,
+    content: String,
+    executable: Boolean,
+    move: (from: Path, to: Path, atomic: Boolean) -> Unit = ::moveFile,
+) {
+    val pid = ProcessHandle.current().pid()
+    val fresh = target.resolveSibling("${target.fileName}.new$pid")
+    val old = target.resolveSibling("${target.fileName}.old$pid")
+    var lastFailure: Exception? = null
+    for (attempt in 1..5) {
+        if (attempt > 1) Thread.sleep(10)
         try {
-            Files.move(tmp, target, StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING)
-        } catch (e: AtomicMoveNotSupportedException) {
-            System.err.println("[mcp-steroid] atomic move unsupported (${e.message}); using a plain move")
-            Files.move(tmp, target, StandardCopyOption.REPLACE_EXISTING)
-        }
-    } finally {
-        // On success the move consumed tmp (this is a no-op); on any failure above, sweep the orphan
-        // staging file instead of leaking a `.tmp.<pid>.devrig` into the bin dir.
-        if (Files.exists(tmp)) {
+            Files.writeString(fresh, content)
+            if (executable) setExecutable(fresh) // +x BEFORE any move: the launcher is never non-executable
             try {
-                Files.deleteIfExists(tmp)
-            } catch (e: Exception) {
-                System.err.println("[mcp-steroid] could not remove staging file $tmp: $e")
+                moveOnto(fresh, target, move)
+            } catch (blocked: Exception) {
+                System.err.println("[mcp-steroid] $target is held open ($blocked); renaming it aside")
+                move(target, old, true) // park the held-open original; its open handles follow the rename
+                moveOnto(fresh, target, move)
             }
+            Files.deleteIfExists(old)
+            return
+        } catch (e: Exception) {
+            lastFailure = e
+            System.err.println("[mcp-steroid] replace of $target, attempt $attempt/5 failed: $e")
         }
+    }
+    throw lastFailure ?: IllegalStateException("no replace attempt was made for $target")
+}
+
+/** The two move attempts of the sequence: atomic first, plain second; the plain failure propagates. */
+private fun moveOnto(from: Path, to: Path, move: (from: Path, to: Path, atomic: Boolean) -> Unit) {
+    try {
+        move(from, to, true)
+        return
+    } catch (e: Exception) {
+        System.err.println("[mcp-steroid] atomic move $from -> $to failed ($e); trying a plain move")
+    }
+    move(from, to, false)
+}
+
+/** Default production move; the [replaceLauncherFile] seam lets tests inject failures. */
+private fun moveFile(from: Path, to: Path, atomic: Boolean) {
+    if (atomic) {
+        Files.move(from, to, StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING)
+    } else {
+        Files.move(from, to, StandardCopyOption.REPLACE_EXISTING)
     }
 }
 

--- a/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/BinLauncherTest.kt
+++ b/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/BinLauncherTest.kt
@@ -5,11 +5,13 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.condition.DisabledOnOs
 import org.junit.jupiter.api.condition.OS
 import org.junit.jupiter.api.io.TempDir
+import java.io.IOException
 import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.attribute.PosixFilePermission
 import kotlin.io.path.readText
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
@@ -155,6 +157,76 @@ class BinLauncherTest {
 
         run()
         assertTrue(Files.isExecutable(launcher), "self-heal must restore +x even when bytes are unchanged")
+    }
+
+    // ── rename-based replace (Windows lock scenario exercised on POSIX via the move seam) ───────
+
+    @DisabledOnOs(OS.WINDOWS)
+    @Test
+    fun `a blocked direct move parks the original as old-pid, renames the new file into place, deletes the old`(@TempDir dir: Path) {
+        val target = dir.resolve("devrig")
+        Files.writeString(target, "old launcher\n")
+        val old = dir.resolve("devrig.old${ProcessHandle.current().pid()}")
+
+        // Model the Windows lock semantics: moving ONTO an existing (held-open) file fails; renames of
+        // that file and moves to a free name succeed.
+        var calls = 0
+        replaceLauncherFile(target, "new launcher\n", executable = true) { from, to, _ ->
+            calls++
+            if (Files.exists(to)) throw IOException("simulated sharing violation: target is held open")
+            if (to == target) {
+                // The into-place move AFTER parking: the original must sit at old-pid with its bytes.
+                assertEquals("old launcher\n", old.readText(), "the original must be parked before this move")
+            }
+            Files.move(from, to)
+        }
+
+        assertEquals(4, calls, "expected atomic + plain direct moves (fail) + park + into-place rename, got $calls")
+        assertEquals("new launcher\n", target.readText())
+        assertTrue(Files.isExecutable(target), "the executable bit set on the staged file must survive the rename")
+        assertFalse(Files.exists(old), "the old-pid file must be deleted as the last step of the sequence")
+        assertFalse(Files.exists(dir.resolve("devrig.new${ProcessHandle.current().pid()}")), "the staged file must be consumed")
+    }
+
+    @DisabledOnOs(OS.WINDOWS)
+    @Test
+    fun `a missing original converges on the first attempt - one atomic move, nothing to park or delete`(@TempDir dir: Path) {
+        val target = dir.resolve("devrig")
+
+        var calls = 0
+        replaceLauncherFile(target, "new launcher\n", executable = true) { from, to, _ ->
+            calls++
+            Files.move(from, to)
+        }
+
+        assertEquals(1, calls, "the first atomic move must already succeed when the original is missing")
+        assertEquals("new launcher\n", target.readText())
+        assertTrue(Files.isExecutable(target))
+        val leftovers = Files.list(dir).use { s -> s.filter { it != target }.toList() }
+        assertTrue(leftovers.isEmpty(), "no staging or old-pid file may remain: $leftovers")
+    }
+
+    @Test
+    fun `when every move keeps failing the 5 attempts give up loudly and the original stays untouched`(@TempDir dir: Path) {
+        val target = dir.resolve("devrig")
+        Files.writeString(target, "old launcher\n")
+
+        var calls = 0
+        val startNanos = System.nanoTime()
+        val boom = assertFailsWith<IOException> {
+            replaceLauncherFile(target, "new launcher\n", executable = false) { _, _, _ ->
+                calls++
+                throw IOException("simulated persistent lock")
+            }
+        }
+        val elapsedMs = (System.nanoTime() - startNanos) / 1_000_000
+
+        assertEquals("simulated persistent lock", boom.message, "the LAST failure must propagate unwrapped")
+        assertEquals(15, calls, "each of the 5 attempts = atomic + plain direct moves + park, all failing")
+        assertTrue(elapsedMs >= 40, "4 inter-attempt delays of 10 ms expected, took only ${elapsedMs} ms")
+        assertEquals("old launcher\n", target.readText(), "a total failure must leave the original launcher in place")
+        assertFalse(Files.exists(dir.resolve("devrig.old${ProcessHandle.current().pid()}")),
+            "no old-pid file can exist when even the park move failed")
     }
 
     // ── PATH symlink (POSIX) ────────────────────────────────────────────────────────────────────

--- a/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/BinLauncherWindowsTest.kt
+++ b/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/BinLauncherWindowsTest.kt
@@ -1,0 +1,184 @@
+/* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
+package com.jonnyzzz.mcpSteroid.devrig
+
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Timeout
+import org.junit.jupiter.api.condition.EnabledOnOs
+import org.junit.jupiter.api.condition.OS
+import org.junit.jupiter.api.io.TempDir
+import java.io.ByteArrayOutputStream
+import java.io.IOException
+import java.io.PrintStream
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.concurrent.TimeUnit
+import kotlin.io.path.readText
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Real-Windows validation of the [replaceLauncherFile] sequence against genuine NTFS file contention —
+ * no seam injection, real `Files.move` semantics. The Windows-only holders:
+ *
+ *  - `cmd.exe /d /c <batch>` actually EXECUTING the target (the production contention case);
+ *  - a PowerShell process holding a memory-mapped section of the target — the running/mapped-file
+ *    semantics (delete and overwrite blocked, rename allowed), deterministic;
+ *  - a PowerShell process holding the target open with `FileShare.Read` only (no delete sharing) —
+ *    the strict-scanner case where NOTHING works, not even the rename-aside.
+ */
+@EnabledOnOs(OS.WINDOWS)
+@Timeout(value = 180, unit = TimeUnit.SECONDS)
+class BinLauncherWindowsTest {
+
+    private val old = "@echo off\r\nrem OLD launcher\r\nping -n 2 127.0.0.1 >nul\r\n"
+    private val new = "@echo off\r\nrem NEW launcher\r\n"
+
+    @Test
+    fun `no contention - creates a missing launcher and replaces an existing one on real NTFS`(@TempDir dir: Path) {
+        val target = dir.resolve("devrig.cmd")
+
+        replaceLauncherFile(target, old, executable = false)
+        assertEquals(old, target.readText(), "the first write must create the launcher")
+
+        replaceLauncherFile(target, new, executable = false)
+        assertEquals(new, target.readText(), "the second write must replace it")
+        val leftovers = Files.list(dir).use { s -> s.filter { it != target }.toList() }
+        assertTrue(leftovers.isEmpty(), "no staging or old-pid file may remain: $leftovers")
+    }
+
+    @Test
+    fun `replaces the launcher while cmd exe is executing it`(@TempDir dir: Path) {
+        val target = dir.resolve("devrig.cmd")
+        // The production contention: an agent launched devrig via this very .cmd and the rewrite happens
+        // while cmd.exe still executes it. The batch loops so cmd keeps coming back to read more lines.
+        Files.writeString(target, "@echo off\r\n:loop\r\nping -n 2 127.0.0.1 >nul\r\ngoto loop\r\n")
+        val runner = ProcessBuilder("cmd.exe", "/d", "/c", target.toString())
+            .redirectOutput(ProcessBuilder.Redirect.DISCARD)
+            .redirectError(ProcessBuilder.Redirect.DISCARD)
+            .start()
+        try {
+            Thread.sleep(700) // let cmd read the batch and enter the loop
+            assertTrue(runner.isAlive, "precondition: cmd.exe must still be executing the batch")
+
+            val (failure, stderr) = runCaptured { replaceLauncherFile(target, new, executable = false) }
+            println("[x220] cmd-runner scenario stderr:\n$stderr")
+            println("[x220] cmd-runner scenario leftovers: ${Files.list(dir).use { s -> s.filter { it != target }.toList() }}")
+
+            // Finding on real Windows (eugene-x220): cmd.exe holds the executing batch with FULL sharing
+            // (read+write+delete), so even the direct MoveFileEx replace succeeds — the sequence converges
+            // on its very first move without needing the rename-aside.
+            assertNull(failure, "the sequence must converge while cmd.exe executes the launcher: $failure\n$stderr")
+            assertEquals(new, target.readText(), "the launcher must carry the NEW content")
+        } finally {
+            killTree(runner)
+        }
+    }
+
+    @Test
+    fun `mapped-section holder (running-file semantics) - rename-aside replaces content, locked old-pid leftover is tolerated`(@TempDir dir: Path) {
+        val target = dir.resolve("devrig.cmd")
+        Files.writeString(target, old)
+        // A memory-mapped section blocks DELETE and overwrite of the data but NOT rename — exactly the
+        // semantics of a running executable/mapped file. The file handle itself shares read/write/delete,
+        // so the section is the only blocker (isolates the NTFS rule under test).
+        val path = target.toString().replace("'", "''")
+        val holder = startHolder(
+            "\$fs=[System.IO.File]::Open('$path',[System.IO.FileMode]::Open,[System.IO.FileAccess]::Read,[System.IO.FileShare]'ReadWrite, Delete'); " +
+                "\$mmf=[System.IO.MemoryMappedFiles.MemoryMappedFile]::CreateFromFile(\$fs,\$null,0,[System.IO.MemoryMappedFiles.MemoryMappedFileAccess]::Read,\$null,[System.IO.HandleInheritability]::None,\$true); " +
+                "[Console]::Out.WriteLine('LOCKED'); Start-Sleep -Seconds 150",
+        )
+        val aside = dir.resolve("devrig.cmd.old${ProcessHandle.current().pid()}")
+        try {
+            val (failure, stderr) = runCaptured { replaceLauncherFile(target, new, executable = false) }
+            println("[x220] mapped-holder scenario stderr:\n$stderr")
+
+            // The direct replace is blocked, the rename-aside succeeds, the new content lands — but the
+            // final delete of .old<pid> keeps failing while the mapping lives, so after 5 rounds the
+            // sequence gives up loudly with the CORRECT content in place and the leftover staying behind.
+            assertEquals(new, target.readText(), "the rename-aside must have delivered the NEW content\n$stderr")
+            assertTrue(Files.exists(aside), "the parked original must still exist (locked by the mapping)\n$stderr")
+            assertEquals(old, aside.readText(), "the parked original must keep its bytes")
+            assertNotNull(failure, "the undeletable .old<pid> must surface as the give-up failure")
+        } finally {
+            killTree(holder)
+        }
+        // Once the holder is gone the leftover is deletable — proof the mapping was the only blocker.
+        Files.deleteIfExists(aside)
+        assertFalse(Files.exists(aside))
+    }
+
+    @Test
+    fun `share-read-only holder (strict scanner) - everything is blocked, original untouched, recovers once released`(@TempDir dir: Path) {
+        val target = dir.resolve("devrig.cmd")
+        Files.writeString(target, old)
+        // FileShare.Read denies write AND delete sharing: the direct replace fails and so does the
+        // rename-aside (a rename needs delete access on the file). No rename dance can beat this holder.
+        val path = target.toString().replace("'", "''")
+        val holder = startHolder(
+            "\$fs=[System.IO.File]::Open('$path',[System.IO.FileMode]::Open,[System.IO.FileAccess]::Read,[System.IO.FileShare]::Read); " +
+                "[Console]::Out.WriteLine('LOCKED'); Start-Sleep -Seconds 150",
+        )
+        try {
+            val (failure, stderr) = runCaptured { replaceLauncherFile(target, new, executable = false) }
+            println("[x220] read-only-holder scenario stderr:\n$stderr")
+
+            assertNotNull(failure, "all 5 attempts must fail against a no-delete-sharing holder")
+            assertTrue(failure is IOException, "a real filesystem failure is expected, got $failure")
+            assertEquals(old, target.readText(), "the original launcher must be left untouched and usable")
+            assertFalse(Files.exists(dir.resolve("devrig.cmd.old${ProcessHandle.current().pid()}")),
+                "the rename-aside cannot have parked anything")
+        } finally {
+            killTree(holder)
+        }
+        // The transient-lock story: once the holder is gone, the next (self-heal) write succeeds.
+        replaceLauncherFile(target, new, executable = false)
+        assertEquals(new, target.readText(), "the write must succeed once the lock is released")
+    }
+
+    /** What a captured run observed: the failure thrown by the sequence (null if none) and its stderr log. */
+    private data class Captured(val failure: Exception?, val stderr: String)
+
+    /** Runs [block] with System.err captured; the observations are asserted by each scenario. */
+    private fun runCaptured(block: () -> Unit): Captured {
+        val buffer = ByteArrayOutputStream()
+        val original = System.err
+        System.setErr(PrintStream(buffer, true))
+        val failure = try {
+            block()
+            null
+        } catch (e: Exception) {
+            e // returned to the caller, which asserts on it — never swallowed
+        } finally {
+            System.setErr(original)
+        }
+        return Captured(failure, buffer.toString())
+    }
+
+    /** Spawns a PowerShell holder and blocks until it confirms the lock is in place. */
+    private fun startHolder(script: String): Process {
+        val process = ProcessBuilder("powershell", "-NoProfile", "-NonInteractive", "-Command", script)
+            .redirectErrorStream(true)
+            .start()
+        val reader = process.inputStream.bufferedReader()
+        val line = reader.readLine() // bounded by the class-level @Timeout
+        if (line != "LOCKED") {
+            val rest = try {
+                reader.readText()
+            } catch (e: Exception) {
+                "(output unreadable: $e)"
+            }
+            killTree(process)
+            throw IllegalStateException("the PowerShell holder failed to acquire the lock: $line\n$rest")
+        }
+        return process
+    }
+
+    private fun killTree(process: Process) {
+        process.toHandle().descendants().forEach { it.destroyForcibly() }
+        process.destroyForcibly()
+        process.waitFor(10, TimeUnit.SECONDS)
+    }
+}

--- a/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/BinLauncherWindowsTest.kt
+++ b/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/BinLauncherWindowsTest.kt
@@ -85,9 +85,11 @@ class BinLauncherWindowsTest {
         // semantics of a running executable/mapped file. The file handle itself shares read/write/delete,
         // so the section is the only blocker (isolates the NTFS rule under test).
         val path = target.toString().replace("'", "''")
+        // NB [NullString]::Value: PowerShell coerces $null to "" for String parameters, and
+        // CreateFromFile rejects an empty map name.
         val holder = startHolder(
             "\$fs=[System.IO.File]::Open('$path',[System.IO.FileMode]::Open,[System.IO.FileAccess]::Read,[System.IO.FileShare]'ReadWrite, Delete'); " +
-                "\$mmf=[System.IO.MemoryMappedFiles.MemoryMappedFile]::CreateFromFile(\$fs,\$null,0,[System.IO.MemoryMappedFiles.MemoryMappedFileAccess]::Read,\$null,[System.IO.HandleInheritability]::None,\$true); " +
+                "\$mmf=[System.IO.MemoryMappedFiles.MemoryMappedFile]::CreateFromFile(\$fs,[NullString]::Value,0,[System.IO.MemoryMappedFiles.MemoryMappedFileAccess]::Read,\$null,[System.IO.HandleInheritability]::None,\$true); " +
                 "[Console]::Out.WriteLine('LOCKED'); Start-Sleep -Seconds 150",
         )
         val aside = dir.resolve("devrig.cmd.old${ProcessHandle.current().pid()}")
@@ -165,12 +167,12 @@ class BinLauncherWindowsTest {
         val reader = process.inputStream.bufferedReader()
         val line = reader.readLine() // bounded by the class-level @Timeout
         if (line != "LOCKED") {
+            killTree(process) // kill FIRST: draining a still-sleeping holder would block until its exit
             val rest = try {
                 reader.readText()
             } catch (e: Exception) {
                 "(output unreadable: $e)"
             }
-            killTree(process)
             throw IllegalStateException("the PowerShell holder failed to acquire the lock: $line\n$rest")
         }
         return process


### PR DESCRIPTION
## Problem

`ensureBinLauncher` self-heals `~/.mcp-steroid/bin/devrig` (POSIX sh) / `devrig.cmd` (Windows batch) on every devrig start and from `devrig install devrig`, via a temp file + `Files.move(tmp, target, ATOMIC_MOVE, REPLACE_EXISTING)`. On Windows this fails whenever another process holds the launcher open — most notably **cmd.exe executing `devrig.cmd` right now** (the wrapper that launched the very devrig doing the rewrite), or an antivirus/indexer scanning it. The self-heal then silently no-ops (best-effort catch), leaving a stale launcher in place.

## Research: why replace fails and rename works

**What Java does on Windows.** OpenJDK's [`WindowsFileCopy.move`](https://github.com/openjdk/jdk/blob/master/src/java.base/windows/classes/sun/nio/fs/WindowsFileCopy.java) implements `ATOMIC_MOVE` as `MoveFileEx(src, dst, MOVEFILE_REPLACE_EXISTING)`; the non-atomic `REPLACE_EXISTING` path is `DeleteFile(target)` followed by `MoveFileEx(..., 0)`. Both need delete-class access to the **target**. Per Microsoft's [Moving and Replacing Files](https://learn.microsoft.com/en-us/windows/win32/fileio/moving-and-replacing-files) and the [MoveFileEx docs](https://learn.microsoft.com/en-us/windows/desktop/api/WinBase/nf-winbase-movefileexa), that fails when the destination is open without compatible sharing — surfacing as `ERROR_SHARING_VIOLATION` (→ `FileSystemException`) or `ERROR_ACCESS_DENIED` (→ `AccessDeniedException`).

**Why a rename-aside succeeds.** A rename rewires only the directory entry, never the file data. Renaming a file another process has open succeeds when the open handles share delete access (`FILE_SHARE_DELETE`), and — the key asymmetry — a running or memory-mapped file blocks *delete and write* but **not rename**: [Len Holgate, "Allowing renaming but not deleting for files on Windows"](https://lenholgate.com/blog/2022/09/allowing-renaming-but-not-deleting-for-files-on-windows.html); the Go toolchain relies on the same behavior ([golang/go#21997](https://github.com/golang/go/issues/21997): the executable of a running process can be renamed without error — rename only, not delete or write). Handles follow the renamed file, so whoever holds the old launcher keeps reading exactly the bytes it opened.

**The cmd.exe batch hazard.** cmd.exe reads batch files incrementally, remembering a byte offset between lines ([SS64](https://ss64.com/nt/syntax-redirection.html), [The Old New Thing on batch parsing quirks](https://devblogs.microsoft.com/oldnewthing/20210726-00/?p=105483)) — the classic reason editing a running batch file misbehaves: the interpreter resumes at the old offset inside *new* bytes. An in-place overwrite of `devrig.cmd` while cmd executes it risks exactly that; a rename leaves the old bytes intact under cmd's position, and the new file only takes over the *name*.

**Prior art.** This is the standard self-replacement dance on Windows: [rustup's self-update](https://github.com/rust-lang/rustup/blob/main/src/cli/self_update.rs) parks the live binary as `.old` and moves the new one in ([overview](https://deepwiki.com/rust-lang/rustup/4-self-update-system)); [`self-replace`](https://docs.rs/self-replace) and [go-update](https://github.com/inconshreveable/go-update/issues/14) do the same.

**ATOMIC_MOVE applicability.** All renames here are same-directory, same-volume, so `MoveFileEx` handles them as true renames; `AtomicMoveNotSupportedException` only occurs on `ERROR_NOT_SAME_DEVICE`, which cannot happen here — the sequence's non-atomic second attempt covers exotic filesystems anyway.

## Mechanism: one fixed sequence

`replaceLauncherFile(target, content, executable)` in `BinLauncher.kt` — identical on every platform, identical whether or not the original file exists, no existence checks:

1. write the new launcher content to `<name>.new<pid>` (executable bit set before any move) — the original is never edited in place;
2. attempt to move it onto the original **atomically**;
3. attempt to move it **non-atomically**;
4. rename the original to `<name>.old<pid>` — the rename succeeds where the replace was blocked (see research);
5. repeat the two move attempts;
6. delete `<name>.old<pid>`.

If anything fails at any step, wait 10 ms and repeat the whole sequence — up to **5 attempts total** — then log to stderr and give up (the next devrig start rewrites the launcher anyway). A no-op — nothing to park, nothing to delete — is success, not failure, so a missing original converges on the first move.

**Accepted trade-offs (by design):** the brief no-launcher gap between step 4 and step 5; a tiny `.new<pid>`/`.old<pid>` leftover after a crash or after 5 failed rounds (each process touches only its own pid-named files — there is no cross-process sweeping or directory scanning).

## Tests (`BinLauncherTest`, all green via `./gradlew :npx-kt:test`)

The Windows lock scenario is exercised on POSIX through the `move` seam, which every rename in the sequence goes through:

- a seam that fails moves onto an *existing* target (modeling the sharing violation) but allows renames → the original is parked as `devrig.old<pid>` (verified with its original bytes mid-sequence), the target gets the new content with the executable bit intact, and the `.old<pid>` is deleted as the last step (4 seam calls total)
- a missing original converges within the first attempt: one atomic move, nothing parked, no leftovers
- when every move keeps failing: 5 rounds (15 seam calls) with 10 ms delays in between (asserted ≥ 40 ms elapsed), then the last failure propagates loudly and the original launcher is left untouched

## Validated on real Windows (eugene-x220)

Windows 10 22H2 (19045) / NTFS / PowerShell 5.1 / Corretto JDK. A dedicated **`BinLauncherWindowsTest`** (`@EnabledOnOs(WINDOWS)`) exercises the REAL sequence — no seam injection — against genuine holder processes. Results on the box: **`BinLauncherWindowsTest` 4/4 passed**, and the full **`:npx-kt:test` suite: 1315 tests, 0 failures, 0 errors, 25 skipped** (first time this module ever ran on real Windows).

| Scenario | Holder | Observed on NTFS |
|---|---|---|
| No contention | — | create + replace both work, no leftovers (0.01 s) |
| **cmd.exe EXECUTING the launcher** | `cmd /d /c` running a looping batch | **the direct atomic replace succeeded on the very first move** — cmd.exe opens executing batches with full sharing (read+write+delete), so the production case (rewriting `devrig.cmd` from the devrig it launched) does not even need the fallback; stderr empty, zero leftovers |
| **Memory-mapped section** (running-file semantics) | PowerShell `MemoryMappedFile.CreateFromFile` over a delete-sharing handle | atomic and plain replace onto the mapped file → `AccessDeniedException`; **the rename-aside succeeded** (`devrig.cmd` parked as `devrig.cmd.old<pid>`), the new content landed; the aside delete failed on all 5 rounds while the mapping lived (`AccessDeniedException: ...devrig.cmd.old8704`) → loud give-up with the CORRECT content in place; the aside was deletable the moment the holder died |
| **`FileShare.Read`-only** (strict scanner) | PowerShell `File.Open` | everything blocked *including* the rename-aside ("The process cannot access the file because it is being used by another process") — confirming a rename needs delete sharing; 5 rounds, original launcher untouched and usable; the first write after the holder exited succeeded |

The three outcomes match the researched semantics exactly: full-sharing holders (cmd.exe) never block; mapped/running files block replace but not rename — the case this PR fixes; no-delete-sharing holders block everything and degrade to the designed give-up + next-start self-heal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
