### PR TITLE
mcp-core: production process runner (file-redirected output, timeouts, tree kill) + route all launches through it

### DIFF
--- a/ai-agents/build.gradle.kts
+++ b/ai-agents/build.gradle.kts
@@ -7,6 +7,7 @@ repositories {
 }
 
 dependencies {
+    implementation(project(":mcp-core"))
 }
 
 kotlin {

--- a/ai-agents/src/main/kotlin/com/jonnyzzz/mcpSteroid/aiAgents/AiAgentCli.kt
+++ b/ai-agents/src/main/kotlin/com/jonnyzzz/mcpSteroid/aiAgents/AiAgentCli.kt
@@ -1,6 +1,11 @@
 /* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
 package com.jonnyzzz.mcpSteroid.aiAgents
 
+import com.jonnyzzz.mcpSteroid.util.process.ProcessRunSpec
+import com.jonnyzzz.mcpSteroid.util.process.runProcess
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
+
 enum class AiAgentCli(
     val binary: String,
     val displayName: String,
@@ -36,6 +41,8 @@ enum class AiAgentCli(
 data class AiAgentCliInvocation(
     val binary: String,
     val args: List<String>,
+    /** Wall-clock budget for the CLI call; enforced by [ProcessAiAgentCliRunner]. */
+    val timeout: Duration = 120.seconds,
 )
 
 data class AiAgentCliResult(
@@ -43,18 +50,38 @@ data class AiAgentCliResult(
     val output: String,
 )
 
+/**
+ * Runs one agent-CLI invocation to completion.
+ *
+ * Implementations may throw
+ * [com.jonnyzzz.mcpSteroid.util.process.ProcessRunException] — a timeout
+ * ([com.jonnyzzz.mcpSteroid.util.process.ProcessTimeoutException]) or a
+ * start failure such as a missing binary
+ * ([com.jonnyzzz.mcpSteroid.util.process.ProcessStartException]). Callers
+ * with best-effort semantics must catch the family at their boundary.
+ */
 fun interface AiAgentCliRunner {
     fun run(invocation: AiAgentCliInvocation): AiAgentCliResult
 }
 
+/**
+ * The production runner: stdin closed, stderr merged into stdout (the same
+ * interleaving `redirectErrorStream(true)` always produced here), output
+ * captured via the process log files under `~/.mcp-steroid/logs`, and the
+ * invocation's timeout enforced — a hung agent CLI can no longer hang
+ * devrig (the process tree is killed and
+ * [com.jonnyzzz.mcpSteroid.util.process.ProcessTimeoutException] thrown).
+ */
 class ProcessAiAgentCliRunner : AiAgentCliRunner {
     override fun run(invocation: AiAgentCliInvocation): AiAgentCliResult {
-        val process = ProcessBuilder(listOf(invocation.binary) + invocation.args)
-            .redirectErrorStream(true)
-            .start()
-        val output = process.inputStream.bufferedReader().use { it.readText() }
-        val exitCode = process.waitFor()
-        return AiAgentCliResult(exitCode, output)
+        val result = runProcess(
+            ProcessRunSpec(
+                command = listOf(invocation.binary) + invocation.args,
+                timeout = invocation.timeout,
+                name = invocation.binary,
+            ),
+        )
+        return AiAgentCliResult(result.exitCode, result.logs.readStdout())
     }
 }
 
@@ -66,6 +93,7 @@ fun mcpAddStdioInvocation(
     AiAgentCliInvocation(
         binary = agent.binary,
         args = agent.mcpAddStdioArgs(command, serverName),
+        timeout = 120.seconds,
     )
 
 fun mcpRemoveInvocation(
@@ -75,6 +103,8 @@ fun mcpRemoveInvocation(
     AiAgentCliInvocation(
         binary = agent.binary,
         args = agent.mcpRemoveArgs(serverName),
+        // Removals are quick config edits; a hung CLI must not stall the install flow for long.
+        timeout = 30.seconds,
     )
 
 fun mcpListInvocation(
@@ -83,4 +113,6 @@ fun mcpListInvocation(
     AiAgentCliInvocation(
         binary = agent.binary,
         args = agent.mcpListArgs(),
+        // Listing is best-effort at every call site; fail fast instead of stalling.
+        timeout = 30.seconds,
     )

--- a/docs/design/process-runner-api.md
+++ b/docs/design/process-runner-api.md
@@ -1,0 +1,295 @@
+# Design: production process runner in `mcp-core` (v6 — file-redirect model)
+
+Status: v6 — IMPLEMENTATION CONTRACT. History: v1–v4 specified a
+pipe-and-pump model, ratified by a 3-round agent quorum; the product owner
+then simplified mid-implementation (2026-07-30): output goes to **log
+files** under `~/.mcp-steroid/logs`, read after exit — no pipes, no pumps,
+no live callbacks. v5 (the file model) went through one more 3× quorum
+round (claude, codex, gemini — all CHANGES-REQUIRED, findings convergent);
+v6 folds in every v5 finding (table at the end). The final 3× CODE review
+before the PR re-verifies contract-vs-implementation.
+
+## Problem (unchanged)
+
+Production code starts OS processes with raw `ProcessBuilder`, each call
+site re-inventing (or forgetting) stream handling, timeouts, and kill logic:
+
+- `ai-agents/.../AiAgentCli.kt` (`ProcessAiAgentCliRunner.run`) — reads
+  merged output with `readText()` and calls `waitFor()` with **no timeout**:
+  a hung agent CLI hangs devrig forever.
+- `npx-kt/.../BinLauncher.kt` (`ensureWindowsPathEntry`) — PowerShell PATH
+  registration, `waitFor()` with **no timeout**.
+- `npx-kt/.../ManagedBackend.kt` (`spawnDetachedOnWindows`) — WMI spawn
+  helper, stderr and the resulting PID routed through **temp files**.
+
+In `devrig mcp` mode stdout is the MCP JSON-RPC channel — the helper must
+never write to `System.out` (the test-only `test-helper` ProcessRunner
+prints to stdout and is unusable in production).
+
+## Requirements (from the product owner, immutable)
+
+1. Processes always run to completion (we wait for finish).
+2. **stdin closed** (null device).
+3. stdout/stderr **redirected to files** under `~/.mcp-steroid/logs`; read
+   the files after exit when needed.
+4. A **command file** records the invocation; the runner references the
+   files via slf4j.
+5. Naming: `process-<name>-<timestamp>-…-{command,stdout,stderr}.log`.
+6. **Merge to one file** when Java supports it — VALIDATED (probe,
+   2026-07-30): `Redirect.appendTo` appends, `Redirect.to` truncates,
+   `redirectErrorStream(true)` + one `Redirect.to` file = single cleanly
+   interleaved file. Merged is the default; split mode (2 files) for
+   callers that must distinguish stderr.
+7. **Cleanup**: at most 10 000 process files, at most 30 days, touching
+   ONLY this runner's own files (other logs live in the same folder),
+   non-recursive.
+8. **API to delete** a run's files when the caller knows they're not needed.
+9. **Timeout** (kill the child tree) + **exit code** result;
+   Windows/Linux/macOS; `mcp-core` (3-OS TC matrix).
+
+## API
+
+`kotlin.time.Duration`; finite positive durations validated at construction.
+
+```kotlin
+/* package com.jonnyzzz.mcpSteroid.util.process */
+
+class ProcessRunSpec(
+    val command: List<String>,          // argv, non-empty
+    val timeout: Duration,              // finite, positive; spawn → exit
+    val name: String? = null,           // filename tag; sanitized to [A-Za-z0-9._-],
+                                        // max 40 chars, empty→"process" fallback;
+                                        // default: executable file name
+    val workingDir: Path? = null,
+    val environment: Map<String, String> = emptyMap(),  // ADDED on top of inherited
+    val mergeStderrIntoStdout: Boolean = true,
+    val logsDir: Path = defaultProcessLogsDir(),        // override for tests/embedding
+)
+
+fun defaultProcessLogsDir(): Path      // ~/.mcp-steroid/logs (== devrig HomePaths.logsDir)
+
+class ProcessRunLogs(
+    val commandLog: Path,
+    val stdoutLog: Path,               // BOTH streams when merged
+    val stderrLog: Path?,              // null when merged
+) {
+    /** Bounded UTF-8 read of stdoutLog (both streams when merged). Streams
+     *  at most maxChars BYTES from the file head (UTF-8 decodes N bytes to
+     *  ≤ N chars, so the char bound holds); a longer file gets the marker
+     *  " …[truncated by ProcessRunner]" APPENDED ON TOP of the cap (the
+     *  marker never ends in a digit — PID-parsing callers rely on that)
+     *  plus a WARN. maxChars must be positive. Returns "" (one DEBUG line)
+     *  when the file is missing (delete()/cleanup); other I/O errors
+     *  propagate as IOException. */
+    fun readStdout(maxChars: Int = DEFAULT_PROCESS_READ_LIMIT): String
+    /** Same contract; "" when merged (no stderr file) or missing. */
+    fun readStderr(maxChars: Int = DEFAULT_PROCESS_READ_LIMIT): String
+    /** Requirement 8. Best-effort, idempotent; already-deleted files are
+     *  success (never WARN). */
+    fun delete()
+}
+
+class ProcessRunResult(val exitCode: Int, val duration: Duration, val logs: ProcessRunLogs)
+
+/** Family supertype — best-effort call sites catch ONE clause and get
+ *  timeout AND start-failure (interruption intentionally stays outside:
+ *  InterruptedException propagates). The child tree (if it existed) has
+ *  been killed. [outputTail]: last lines read back from the files, bounded
+ *  100 lines / 8 KiB, tagged STDOUT-only in merged mode (attribution is
+ *  unrecoverable post-merge); NEVER in the message (secrets). Tail-read
+ *  failures WARN and yield an empty tail — they never mask this exception. */
+sealed class ProcessRunException(
+    message: String,                    // name + pid + limit; no output text
+    val processName: String,
+    val pid: Long,                      // -1 when the child never started
+    val outputTail: List<ProcessLine>,
+    val logs: ProcessRunLogs,
+) : RuntimeException(message)
+
+class ProcessTimeoutException(..., val timeout: Duration, ...) : ProcessRunException
+/** ProcessBuilder.start() failed (missing binary, bad workdir). cause = the
+ *  IOException. command.log kept with a START-FAILED record. */
+class ProcessStartException(..., cause: java.io.IOException) : ProcessRunException
+
+enum class ProcessStream { STDOUT, STDERR }
+data class ProcessLine(val stream: ProcessStream, val text: String)
+
+/** Blocking. @throws ProcessTimeoutException, ProcessStartException,
+ *  InterruptedException (child killed, flag restored), IOException only
+ *  for pre-start infrastructure failure (logsDir/command.log not
+ *  creatable — nothing was written). */
+fun runProcess(spec: ProcessRunSpec): ProcessRunResult
+
+/** Public, parameterized for direct testing; runProcess triggers it at
+ *  most once per JVM (AtomicBoolean CAS) and throttled by marker file. */
+fun cleanupProcessLogs(logsDir: Path, maxFiles: Int = 10_000, trimTo: Int = 8_000,
+                       maxAge: Duration = 30.days, nowMillis: Long): Int
+
+fun nullDevice(): File                  // NUL | /dev/null; reused by detached IDE spawn
+```
+
+No collect function, no line callback: the files are the capture;
+`result.logs.readStdout()` is the read path.
+
+## Mechanics
+
+**File naming & allocation.** Base prefix:
+`process-<name>-<yyyyMMdd-HHmmss-SSS>-<pid>-<seq>` where `<pid>` is the
+CURRENT JVM's pid (cross-process uniqueness — two devrig JVMs in the same
+millisecond must never collide; same convention as devrig's `Log.kt`
+per-pid sessions) and `<seq>` a JVM-global AtomicInteger (same-JVM
+concurrency). Belt-and-braces: `command.log` is created with `CREATE_NEW`;
+on `FileAlreadyExistsException` bump seq and retry (bounded retries).
+Suffixes: `-command.log`, `-stdout.log`, `-stderr.log` (split only).
+POSIX: files created with owner-only permissions (best-effort — command.log
+holds full argv).
+
+**command.log** (structured fields JSON-encoded via kotlinx.serialization —
+repo mandate; env keys SORTED, values NEVER written):
+
+```
+started:  2026-07-30T14:03:22.117+02:00
+command:  ["claude","mcp","add","…"]
+workdir:  "/path" | inherited
+env-keys: ["KEY1","KEY2"]
+merged:   true
+```
+
+appended on completion (every path):
+`pid: <n>` (omitted if never started) then one of
+`exit: <code>` | `exit: TIMEOUT after <t>` | `exit: INTERRUPTED` |
+`exit: START-FAILED: <msg>` and `duration: <d>`.
+On start failure the already-created stdout/stderr redirect files are KEPT
+(empty; cleanup reaps them) and the WARN log references commandLog (the
+thrown exception also carries `logs`). One DEBUG line at start and at
+completion references commandLog; kills/timeouts/deletions WARN.
+
+**Run.** `ProcessBuilder(command)`; stdin `Redirect.from(nullDevice())`;
+merged: `redirectErrorStream(true)` + `redirectOutput(Redirect.to(stdout))`;
+split: `Redirect.to` each. Then `process.waitFor(timeout)`:
+- in time → append completion, return.
+- expiry → v4 kill state machine verbatim (capture descendants while root
+  alive → destroy() root → re-capture union → destroyForcibly all → 1 s
+  wait; re-capture if root alive, force root → 1 s wait, WARN + proceed if
+  unkillable → final sweep from captured live handles, WARN survivors) →
+  append TIMEOUT → throw with tail from the files' last 8 KiB. Files KEPT.
+- `InterruptedException` from waitFor → kill tree (before restoring the
+  flag, so the bounded waits inside the kill work) → append INTERRUPTED →
+  restore flag → rethrow.
+- `start()` IOException → append START-FAILED → throw ProcessStartException
+  (cause attached).
+UTF-8 applies at read time (malformed → U+FFFD; legacy-code-page children
+degrade — accepted; migrated PowerShell scripts get the
+`$OutputEncoding = [Console]::OutputEncoding = UTF8` prologue).
+
+**Cleanup.** Triggered by runProcess BEFORE file allocation, at most once
+per JVM (AtomicBoolean CAS) AND skipped if the `.process-cleanup-stamp`
+marker file in logsDir is younger than 4 hours (touch/update it after a
+scan; the marker never matches the runner grammar). The scan:
+non-recursive, `Files.isRegularFile`, names matching the STRICT runner
+grammar `^process-.+-\d{8}-\d{6}-\d{3}-\d+-\d+-(command|stdout|stderr)\.log$`
+(an unrelated `process-foo.log` NEVER matches). Two passes:
+1. AGE: delete files older than 30 days.
+2. COUNT: if still over `maxFiles` (10 000), delete oldest-first down to
+   `trimTo` (8 000) — hysteresis so the trim runs once per ~2 000 runs, not
+   on every start. Ordering key: the FILENAME timestamp+pid+seq (NOT mtime —
+   the completion append bumps command.log's mtime and would split a run's
+   triple across the boundary); files sharing a run prefix are grouped so
+   triples live or die together. Age floor: the count pass never deletes a
+   run younger than 1 hour (protects live concurrent runs; the age pass is
+   inherently safe).
+Already-deleted files (concurrent cleanup from a parallel devrig JVM,
+`deleteIfExists == false`, NoSuchFileException) are SUCCESS, not WARN. One
+WARN summary line when anything was deleted; per-file WARN only on real
+failures. Cleanup failure never fails the run. There is deliberately no
+cross-process lock: with the age floor, filename-ordered deletion, and
+hysteresis, deleting a live run requires it to stay active while 2 000+
+newer runs accumulate — accepted as best-effort (proportionate; these are
+short CLI commands).
+
+## Carried over from v1–v4 (unchanged)
+
+Typed exceptions, no `(value, errorFlag)`; required finite timeout; null-
+device stdin; the ratified kill state machine; name-not-argv in messages;
+WARN/DEBUG discipline; never System.out; distinct names from test-helper
+types (`ProcessResultValue` etc.); no `internal`; `require` at
+construction; kotlin.time. Dropped with the pipe model: pumps, event
+protocol, budgets, drainTimeout, watchdog, onLine, ProcessLineDecoder,
+ProcessOutputBudgetException, collect function.
+
+## Migration plan (same PR)
+
+| Call site | Change |
+|---|---|
+| `ai-agents/AiAgentCli.kt` | `AiAgentCliInvocation` gains `val timeout: Duration = 120.seconds` (the interface change is pinned HERE: `AiAgentCliRunner.run(invocation)` keeps its shape; the budget travels in the invocation; fakes unaffected). `ProcessAiAgentCliRunner` = `runProcess` (merged) + `logs.readStdout()` → `AiAgentCliResult(exitCode, output)`. `ai-agents` gains `project(":mcp-core")` (verified acyclic). Runner KDoc documents the `ProcessRunException` family throw. Logs kept. |
+| `npx-kt/InstallCommand.kt` — all four `runner.run` sites | Catch `ProcessRunException` (now = timeout AND start-failure; a missing agent binary takes these graceful boundaries instead of today's Main.kt stack trace + exit 64 — deliberate improvement, flagged in the PR): install list (30 s) → fall back to known names + stderr diagnostic; each removal (30 s) → log, continue; add (120 s) → "Registration FAILED … did not complete: <message>" + pinned exit **1**; `--check` list (30 s) → unreadable → drift exit code. `--check`'s "writes NOTHING" wording is refined: read-only means NO agent-config/launcher mutation; diagnostic process logs under `~/.mcp-steroid/logs` are still written (KDoc + user text updated). Fake-runner tests pin all four sites for both failure types. |
+| `npx-kt/BinLauncher.kt` `ensureWindowsPathEntry` | `runProcess`, split, 60 s, UTF-8 prologue; after completion dump non-blank `readStderr()` to `System.err` (was live INHERIT — equivalent for a ≤60 s command); stdout never read (was DISCARD). `logs.delete()` on exit 0; kept + WARN path otherwise. Wrapped by the existing broad `catch (e: Exception)` — still non-fatal. |
+| `npx-kt/ManagedBackend.kt` `spawnDetachedOnWindows` | `runProcess`, split, 10 s, UTF-8 prologue; PowerShell prints the PID to stdout (both temp files + cleanup deleted). STRICT parse: exactly one non-blank stdout line, `trim().toLongOrNull()` — anything else is an error that KEEPS the files (chatter must not become a fake PID). `logs.delete()` only on exit 0 AND successful parse. Failures reference the log paths in `error(...)` — better than today. Timeout → existing "WMI spawn helper timed out" wording. Script text factored + platform-neutrally unit-tested. WMI-created-IDE indeterminacy documented as before. |
+| `npx-kt/ManagedBackend.kt` `spawnIdeProcess` (POSIX) | Stays raw `ProcessBuilder` (detached-by-design, never awaited, own log files); comment points here; uses public `nullDevice()`. |
+
+Out of scope: `IdeUnpacker.kt` (buildSrc-shared build tooling).
+
+## Testing plan (`mcp-core/src/test`, JUnit 5, all 3 OS unchanged)
+
+Child-JVM fixture (`${java.home}/bin/java` + @argfile classpath;
+deterministic bytes; no shell). Modes: exit-with-code + fixed interleaved
+lines, exact-UTF-8 bytes (multi-byte + malformed), stdin-EOF report,
+sleep-forever, spawn-grandchild-report-pid, env/cwd echo, flood-N-lines.
+All tests use a temp `logsDir`; `cleanupProcessLogs` is tested directly
+with small limits and an injected `nowMillis`.
+
+1. Exit 0/7 propagate; duration > 0; naming grammar (incl. pid token);
+   command.log: argv JSON, SORTED env keys (values absent), pid line,
+   exit + duration completion.
+2. Merged: one file, child's write order, stderrLog null, readStderr "".
+3. Split: streams separated.
+4. UTF-8 exact + U+FFFD for malformed; multi-byte char cut at the
+   readStdout byte boundary decodes without corruption beyond the cut.
+5. stdin closed → immediate EOF report.
+6. Timeout → ProcessTimeoutException; child AND grandchild dead
+   (deadline-polled); TIMEOUT completion line; files kept; tail non-empty;
+   message contains no output text.
+7. Interrupt mid-run → InterruptedException, flag restored, child+
+   grandchild dead, INTERRUPTED completion line.
+8. Missing executable → ProcessStartException (cause IOException);
+   command.log has START-FAILED; logs on the exception.
+9. workingDir + environment reach the child.
+10. readStdout bounded: cap honored, marker appended, marker not ending in
+    a digit; full read unaffected; maxChars ≤ 0 rejected.
+11. delete(): exactly this run's files; idempotent; read-after-delete "".
+12. Cleanup: age pass; count pass with hysteresis (maxFiles/trimTo);
+    filename-timestamp ordering keeps a run's triple together; age floor
+    spares young files; non-matching neighbors (`devrig.log`,
+    `process-foo.log`, `process-x.txt`, nested dirs) untouched; marker file
+    respected/refreshed.
+13. Same-JVM concurrency: N parallel runProcess → 3N distinct files, no
+    cross-talk.
+14. Invalid specs at construction; all-emoji name falls back to a usable
+    tag; sanitization strips separators.
+15. nullDevice() reads as EOF.
+
+Plus plan B in npx-kt: fake-runner tests for the four InstallCommand
+boundaries × {timeout, start-failure}; factored WMI script text test
+(prologue, PID-to-stdout, strict parse).
+
+## v5 quorum findings → v6 resolution
+
+| Finding | Resolution |
+|---|---|
+| Cross-JVM filename collision (all three, blocking) | pid token in the name + CREATE_NEW/retry allocation |
+| Cleanup O(N log N) every start (gemini#2) | 4 h marker-file throttle + once-per-JVM CAS + 10 000→8 000 hysteresis |
+| Start IOException outside the family (gemini#3, claude-NB2, codex#4-part) | ProcessStartException in the family; InstallCommand boundaries now cover missing binaries (deliberate, flagged); interruption stays outside |
+| Cap accounting: run's own files push over limit (codex#2) | Hysteresis (trimTo 8 000) absorbs it |
+| Over-broad `^process-.*\.log$` (codex#2) | Strict full grammar + isRegularFile |
+| Cross-process cleanup races (codex#3, claude-NB3) | Idempotent deletes (NoSuchFile = success), 1 h age floor on count pass, filename ordering + triple grouping; NO locks — documented best-effort with rationale |
+| Once-per-JVM guard untestable in-suite (codex#3) | Guard trivial (CAS); cleanup logic tested via the public parameterized function; guard verified by review |
+| Timeout budgets not expressible (codex#4, claude-NB1) | `AiAgentCliInvocation.timeout` field; interface shape unchanged |
+| `--check` "writes NOTHING" contradiction (codex#5) | Read-only redefined = no config mutation; docs updated |
+| Read-contract ambiguities (codex#6, claude-NB4) | KDoc split per method; byte-bounded streaming read; marker on top of cap; positive maxChars; missing → "" + DEBUG; tail-read never masks |
+| command.log grammar gaps (claude-NB5) | INTERRUPTED variant; pid omitted on start failure; empty redirect files kept; pre-start infra failure = plain IOException |
+| WMI parse too lenient / delete ambiguity (codex-NB1, claude-NB6) | Strict single-line parse; delete only on exit 0 + parse OK; marker ends in a letter |
+| Hand-rolled JSON in command.log (gemini, codex-NB2) | kotlinx.serialization for all structured fields; sorted keys |
+| World-readable argv (codex-NB3) | Owner-only permissions, best-effort POSIX |
+| START-FAILED discoverability (codex-NB3) | WARN references commandLog; exception carries logs |
+| `registerOnUserPathWindows` name wrong (claude-NB7) | `ensureWindowsPathEntry` |
+| Test gaps (claude-NB8, codex#6) | Tests 4 (boundary cut), 11 (read-after-delete), 12 (marker), 13 (concurrency), 14 (emoji name) added |

--- a/mcp-core/src/main/kotlin/com/jonnyzzz/mcpSteroid/util/process/ProcessRun.kt
+++ b/mcp-core/src/main/kotlin/com/jonnyzzz/mcpSteroid/util/process/ProcessRun.kt
@@ -12,7 +12,7 @@ import java.nio.file.attribute.PosixFilePermissions
 import java.time.Instant
 import java.time.LocalDateTime
 import java.time.OffsetDateTime
-import java.time.ZoneId
+import java.time.ZoneOffset
 import java.time.format.DateTimeFormatter
 import java.util.Locale
 import java.util.concurrent.TimeUnit
@@ -31,10 +31,13 @@ private val log = LoggerFactory.getLogger("com.jonnyzzz.mcpSteroid.util.process.
 private val runSequence = AtomicInteger()
 private val cleanupTriggered = AtomicBoolean()
 
-private val FILE_TIMESTAMP_FORMAT = DateTimeFormatter.ofPattern("yyyyMMdd-HHmmss-SSS", Locale.ROOT)
+/** UTC on purpose: local-zone names are ambiguous during DST fall-back, which could make a
+ *  just-created run parse up to 1 h old — exactly the size of the count-pass age floor. */
+private val FILE_TIMESTAMP_FORMAT =
+    DateTimeFormatter.ofPattern("yyyyMMdd-HHmmss-SSS", Locale.ROOT).withZone(ZoneOffset.UTC)
 
 /** The complete filename grammar of this runner's files — cleanup deletes NOTHING else. */
-private val RUNNER_FILE_GRAMMAR = Regex("^process-.+-(\\d{8}-\\d{6}-\\d{3})-\\d+-\\d+-(command|stdout|stderr)\\.log$")
+private val RUNNER_FILE_GRAMMAR = Regex("^process-.+-(\\d{8}-\\d{6}-\\d{3})-(\\d+)-(\\d+)-(command|stdout|stderr)\\.log$")
 
 private const val CLEANUP_MARKER_FILE = ".process-cleanup-stamp"
 private val CLEANUP_THROTTLE = 4.hours
@@ -83,11 +86,14 @@ fun runProcess(spec: ProcessRunSpec): ProcessRunResult {
         builder.redirectError(ProcessBuilder.Redirect.to(checkNotNull(logs.stderrLog).toFile()))
     }
 
+    val attemptNanos = System.nanoTime()
     val process = try {
         builder.start()
     } catch (e: IOException) {
-        appendCommandLog(logs, "exit:     START-FAILED: ${e.message}")
+        appendCommandLog(logs, "exit:     START-FAILED: ${e.message}\nduration: ${(System.nanoTime() - attemptNanos).nanoseconds}")
         log.warn("process {} failed to start ({}); command log kept: {}", name, e.toString(), logs.commandLog)
+        // e.message carries the program name + OS error (e.g. "Cannot run program "claude": error=2");
+        // it never contains argv values, and callers (devrig install) surface it as the failure reason.
         throw ProcessStartException("process '$name' failed to start: ${e.message}", name, logs, e)
     }
     val pid = process.pid()
@@ -153,7 +159,7 @@ fun cleanupProcessLogs(
 ): Int {
     require(trimTo in 0..maxFiles) { "trimTo ($trimTo) must be within 0..maxFiles ($maxFiles)" }
 
-    class RunnerFile(val path: Path, val timestampMillis: Long, val runKey: String)
+    class RunnerFile(val path: Path, val timestampMillis: Long, val pid: Long, val seq: Long, val runKey: String)
 
     val files = try {
         Files.list(logsDir).use { stream ->
@@ -166,18 +172,24 @@ fun cleanupProcessLogs(
         val fileName = path.fileName.toString()
         val match = RUNNER_FILE_GRAMMAR.matchEntire(fileName) ?: return@mapNotNull null
         val timestamp = parseFileTimestamp(match.groupValues[1]) ?: return@mapNotNull null
-        RunnerFile(path, timestamp, fileName.removeSuffix("-${match.groupValues[2]}.log"))
+        val pid = match.groupValues[2].toLongOrNull() ?: return@mapNotNull null
+        val seq = match.groupValues[3].toLongOrNull() ?: return@mapNotNull null
+        RunnerFile(path, timestamp, pid, seq, fileName.removeSuffix("-${match.groupValues[4]}.log"))
     }
 
     var deleted = 0
-    fun deleteCounted(path: Path) {
-        try {
-            if (Files.deleteIfExists(path)) deleted++
-        } catch (e: NoSuchFileException) {
-            // a concurrent cleanup got there first — success
-        } catch (e: Exception) {
-            log.warn("process-log cleanup could not delete {}: {}", path, e.toString())
-        }
+    // Returns true when the file is GONE (deleted by us, or already removed by a concurrent cleanup —
+    // both count as progress toward the trim target).
+    fun deleteCounted(path: Path): Boolean = try {
+        val removed = Files.deleteIfExists(path)
+        if (removed) deleted++ else log.debug("process-log cleanup: {} already gone (concurrent cleanup)", path)
+        true
+    } catch (e: NoSuchFileException) {
+        log.debug("process-log cleanup: {} already gone (concurrent cleanup)", path)
+        true
+    } catch (e: Exception) {
+        log.warn("process-log cleanup could not delete {}: {}", path, e.toString())
+        false
     }
 
     val ageCutoff = nowMillis - maxAge.inWholeMilliseconds
@@ -186,13 +198,15 @@ fun cleanupProcessLogs(
 
     if (remaining.size > maxFiles) {
         val ageFloorCutoff = nowMillis - COUNT_PASS_AGE_FLOOR.inWholeMilliseconds
-        val groupsOldestFirst = remaining.groupBy { it.runKey }.values.sortedBy { group -> group.minOf { it.timestampMillis } }
+        // Deterministic oldest-first order even for equal-millisecond runs: timestamp, then pid, then seq.
+        val groupsOldestFirst = remaining.groupBy { it.runKey }.values.sortedWith(
+            compareBy({ group -> group.minOf { it.timestampMillis } }, { it.first().pid }, { it.first().seq }),
+        )
         var count = remaining.size
         for (group in groupsOldestFirst) {
             if (count <= trimTo) break
             if (group.any { it.timestampMillis > ageFloorCutoff }) continue
-            group.forEach { deleteCounted(it.path) }
-            count -= group.size
+            count -= group.count { deleteCounted(it.path) }
         }
     }
 
@@ -201,26 +215,42 @@ fun cleanupProcessLogs(
 }
 
 private fun parseFileTimestamp(text: String): Long? = try {
-    LocalDateTime.parse(text, FILE_TIMESTAMP_FORMAT).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli()
+    LocalDateTime.parse(text, FILE_TIMESTAMP_FORMAT).toInstant(ZoneOffset.UTC).toEpochMilli()
 } catch (e: Exception) {
     log.warn("process-log cleanup could not parse timestamp '{}': {}", text, e.toString())
     null
 }
 
+/**
+ * The marker-file throttle for [cleanupProcessLogs]: a scan is due when `.process-cleanup-stamp` in
+ * [logsDir] is missing or older than 4 hours. Public (with [touchProcessLogCleanupMarker]) so the
+ * throttle is unit-testable; [runProcess] additionally gates on a once-per-JVM CAS.
+ */
+fun shouldRunProcessLogCleanup(logsDir: Path, nowMillis: Long = System.currentTimeMillis()): Boolean {
+    val markerAgeMillis = try {
+        nowMillis - Files.getLastModifiedTime(logsDir.resolve(CLEANUP_MARKER_FILE)).toMillis()
+    } catch (e: IOException) {
+        log.debug("process-log cleanup marker missing/unreadable in {} — a scan is due ({})", logsDir, e.toString())
+        return true
+    }
+    return markerAgeMillis >= CLEANUP_THROTTLE.inWholeMilliseconds
+}
+
+/** Records that a cleanup scan ran now — refreshes the `.process-cleanup-stamp` marker. */
+fun touchProcessLogCleanupMarker(logsDir: Path, nowMillis: Long = System.currentTimeMillis()) {
+    Files.createDirectories(logsDir)
+    Files.writeString(logsDir.resolve(CLEANUP_MARKER_FILE), nowMillis.toString())
+}
+
 private fun maybeCleanupOncePerJvm(logsDir: Path) {
     if (!cleanupTriggered.compareAndSet(false, true)) return
     try {
-        val marker = logsDir.resolve(CLEANUP_MARKER_FILE)
-        val now = System.currentTimeMillis()
-        val markerAgeMillis = try {
-            now - Files.getLastModifiedTime(marker).toMillis()
-        } catch (e: IOException) {
-            Long.MAX_VALUE // no marker yet (or unreadable) — run the scan
-        }
-        if (markerAgeMillis < CLEANUP_THROTTLE.inWholeMilliseconds) return
-        cleanupProcessLogs(logsDir, nowMillis = now)
+        // Create the dir first so a fresh home does not WARN about an unlistable folder.
         Files.createDirectories(logsDir)
-        Files.writeString(marker, now.toString())
+        val now = System.currentTimeMillis()
+        if (!shouldRunProcessLogCleanup(logsDir, now)) return
+        cleanupProcessLogs(logsDir, nowMillis = now)
+        touchProcessLogCleanupMarker(logsDir, now)
     } catch (e: Exception) {
         log.warn("process-log cleanup skipped: {}", e.toString())
     }
@@ -231,8 +261,8 @@ private fun sanitizeProcessName(raw: String): String {
     val cleaned = raw.map { if (it.isLetterOrDigit() && it.code < 128 || it in "._-") it else '-' }
         .joinToString("")
         .replace(Regex("-{2,}"), "-")
-        .trim('-', '.')
         .take(40)
+        .trim('-', '.')
     return cleaned.ifBlank { "process" }
 }
 
@@ -240,22 +270,44 @@ private fun allocateLogFiles(spec: ProcessRunSpec, name: String): ProcessRunLogs
     Files.createDirectories(spec.logsDir)
     val jvmPid = ProcessHandle.current().pid()
     repeat(100) {
-        val timestamp = FILE_TIMESTAMP_FORMAT.withZone(ZoneId.systemDefault()).format(Instant.ofEpochMilli(System.currentTimeMillis()))
+        val timestamp = FILE_TIMESTAMP_FORMAT.format(Instant.ofEpochMilli(System.currentTimeMillis()))
         val base = "process-$name-$timestamp-$jvmPid-${runSequence.incrementAndGet()}"
         val commandLog = spec.logsDir.resolve("$base-command.log")
         try {
             createOwnerOnlyFile(commandLog) // CREATE_NEW: the atomic uniqueness reservation
         } catch (e: FileAlreadyExistsException) {
+            log.debug("process log name collision on {}; retrying with the next sequence", commandLog)
             return@repeat // collision (another JVM, same millisecond) — bump seq and retry
         }
-        Files.writeString(commandLog, commandLogHeader(spec), StandardOpenOption.WRITE)
         val stdoutLog = spec.logsDir.resolve("$base-stdout.log")
         val stderrLog = if (spec.mergeStderrIntoStdout) null else spec.logsDir.resolve("$base-stderr.log")
-        precreateOwnerOnly(stdoutLog)
-        stderrLog?.let { precreateOwnerOnly(it) }
+        try {
+            Files.writeString(commandLog, commandLogHeader(spec), StandardOpenOption.WRITE)
+            // A pre-existing sibling means OUR reservation raced a stale/foreign file whose permissions
+            // we do not control — treat it as a collision: roll back and retry with a fresh base name.
+            createOwnerOnlyFile(stdoutLog)
+            stderrLog?.let { createOwnerOnlyFile(it) }
+        } catch (e: FileAlreadyExistsException) {
+            log.debug("stale sibling for {} ({}); rolling back and retrying", base, e.toString())
+            rollbackAllocation(commandLog, stdoutLog, stderrLog)
+            return@repeat
+        } catch (e: Exception) {
+            rollbackAllocation(commandLog, stdoutLog, stderrLog)
+            throw e
+        }
         return ProcessRunLogs(commandLog, stdoutLog, stderrLog)
     }
     throw IOException("could not allocate unique process log file names in ${spec.logsDir}")
+}
+
+private fun rollbackAllocation(vararg files: Path?) {
+    for (file in files.filterNotNull()) {
+        try {
+            Files.deleteIfExists(file)
+        } catch (e: Exception) {
+            log.warn("could not roll back partially allocated process log {}: {}", file, e.toString())
+        }
+    }
 }
 
 private fun commandLogHeader(spec: ProcessRunSpec): String = buildString {
@@ -284,30 +336,29 @@ private fun createOwnerOnlyFile(path: Path) {
     }
 }
 
-private fun precreateOwnerOnly(path: Path) {
-    try {
-        createOwnerOnlyFile(path)
-    } catch (e: FileAlreadyExistsException) {
-        // stale leftover with the same reserved base name; Redirect.to truncates it anyway
-    }
-}
-
-/** Last lines of the run's output for [ProcessRunException.outputTail]: bounded 8 KiB per file, 100 lines total. */
+/** Last lines of the run's output for [ProcessRunException.outputTail]: bounded 8 KiB TOTAL, 100 lines. */
 private fun readOutputTail(logs: ProcessRunLogs): List<ProcessLine> = try {
+    val fileBudget = if (logs.stderrLog == null) 8192 else 4096 // one total budget, split across the files
+
     fun tailOf(file: Path, stream: ProcessStream): List<ProcessLine> {
         val size = try {
             Files.size(file)
         } catch (e: NoSuchFileException) {
+            log.debug("no output tail — {} is gone", file)
             return emptyList()
         }
-        val skip = maxOf(0L, size - 8192)
+        // Read one extra byte BEFORE the window: if it is a line terminator, the window's first line is
+        // complete and must be kept; only a genuinely partial first line is dropped.
+        val windowStart = maxOf(0L, size - fileBudget)
+        val probeStart = maxOf(0L, windowStart - 1)
         val bytes = Files.newInputStream(file).use { input ->
-            input.skipNBytes(skip)
-            input.readNBytes(8192)
+            input.skipNBytes(probeStart)
+            input.readNBytes(fileBudget + (windowStart - probeStart).toInt())
         }
-        val lines = String(bytes, Charsets.UTF_8).lines()
-        // The first line is likely a partial one when we started mid-file.
-        return (if (skip > 0 && lines.size > 1) lines.drop(1) else lines)
+        val precededByTerminator = windowStart == probeStart || bytes.firstOrNull()?.toInt()?.toChar() in listOf('\n', '\r')
+        val windowText = String(bytes, (windowStart - probeStart).toInt(), bytes.size - (windowStart - probeStart).toInt(), Charsets.UTF_8)
+        val lines = windowText.lines()
+        return (if (!precededByTerminator && lines.size > 1) lines.drop(1) else lines)
             .filter { it.isNotEmpty() }
             .map { ProcessLine(stream, it) }
     }
@@ -371,6 +422,7 @@ private fun killProcessTree(process: Process, name: String) {
         try {
             Thread.sleep(20)
         } catch (e: InterruptedException) {
+            log.debug("kill sweep for {} interrupted; proceeding with what is dead so far", name)
             Thread.currentThread().interrupt()
             break
         }
@@ -384,6 +436,7 @@ private fun killProcessTree(process: Process, name: String) {
 private fun quietWaitFor(process: Process, millis: Long): Boolean = try {
     process.waitFor(millis, TimeUnit.MILLISECONDS)
 } catch (e: InterruptedException) {
+    log.debug("kill-escalation wait for pid {} interrupted; continuing without the grace", process.pid())
     Thread.currentThread().interrupt()
     !process.isAlive
 }

--- a/mcp-core/src/main/kotlin/com/jonnyzzz/mcpSteroid/util/process/ProcessRun.kt
+++ b/mcp-core/src/main/kotlin/com/jonnyzzz/mcpSteroid/util/process/ProcessRun.kt
@@ -1,0 +1,389 @@
+/* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
+package com.jonnyzzz.mcpSteroid.util.process
+
+import java.io.IOException
+import java.nio.file.FileAlreadyExistsException
+import java.nio.file.FileSystems
+import java.nio.file.Files
+import java.nio.file.NoSuchFileException
+import java.nio.file.Path
+import java.nio.file.StandardOpenOption
+import java.nio.file.attribute.PosixFilePermissions
+import java.time.Instant
+import java.time.LocalDateTime
+import java.time.OffsetDateTime
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+import java.util.Locale
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.days
+import kotlin.time.Duration.Companion.hours
+import kotlin.time.Duration.Companion.nanoseconds
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import org.slf4j.LoggerFactory
+
+private val log = LoggerFactory.getLogger("com.jonnyzzz.mcpSteroid.util.process.ProcessRun")
+
+private val runSequence = AtomicInteger()
+private val cleanupTriggered = AtomicBoolean()
+
+private val FILE_TIMESTAMP_FORMAT = DateTimeFormatter.ofPattern("yyyyMMdd-HHmmss-SSS", Locale.ROOT)
+
+/** The complete filename grammar of this runner's files — cleanup deletes NOTHING else. */
+private val RUNNER_FILE_GRAMMAR = Regex("^process-.+-(\\d{8}-\\d{6}-\\d{3})-\\d+-\\d+-(command|stdout|stderr)\\.log$")
+
+private const val CLEANUP_MARKER_FILE = ".process-cleanup-stamp"
+private val CLEANUP_THROTTLE = 4.hours
+
+/** The count pass never deletes runs younger than this — protects live concurrent runs. */
+private val COUNT_PASS_AGE_FLOOR = 1.hours
+
+/**
+ * Runs the process to completion. Blocking; safe to call from any thread.
+ * See docs/design/process-runner-api.md (v6) for the contract:
+ * - stdin from [nullDevice] (the child sees immediate EOF);
+ * - stdout/stderr redirected to log files in [ProcessRunSpec.logsDir]
+ *   (merged into one file by default);
+ * - the command log records the invocation before start and the outcome
+ *   after; the runner references it via slf4j (DEBUG lifecycle, WARN for
+ *   kills/losses); System.out is never touched;
+ * - `waitFor(timeout)` IS the timeout enforcement — on expiry the child
+ *   tree is killed (bounded, best-effort) and [ProcessTimeoutException]
+ *   is thrown with the files kept;
+ * - on caller interruption the child tree is killed, the interrupt flag is
+ *   restored, and the [InterruptedException] propagates;
+ * - log-folder cleanup runs at most once per JVM, throttled by a marker
+ *   file — see [cleanupProcessLogs].
+ *
+ * @throws ProcessTimeoutException on timeout (child tree killed, files kept)
+ * @throws ProcessStartException when the process cannot be started
+ * @throws InterruptedException when the calling thread is interrupted
+ * @throws java.io.IOException only for pre-start infrastructure failure
+ *   (logsDir / command log not creatable — nothing was written)
+ */
+fun runProcess(spec: ProcessRunSpec): ProcessRunResult {
+    maybeCleanupOncePerJvm(spec.logsDir)
+
+    val name = sanitizeProcessName(spec.name ?: Path.of(spec.command.first()).fileName?.toString().orEmpty())
+    val logs = allocateLogFiles(spec, name)
+    log.debug("starting process {}; command log: {}", name, logs.commandLog)
+
+    val builder = ProcessBuilder(spec.command)
+    spec.workingDir?.let { builder.directory(it.toFile()) }
+    builder.environment().putAll(spec.environment)
+    builder.redirectInput(ProcessBuilder.Redirect.from(nullDevice()))
+    builder.redirectOutput(ProcessBuilder.Redirect.to(logs.stdoutLog.toFile()))
+    if (spec.mergeStderrIntoStdout) {
+        builder.redirectErrorStream(true)
+    } else {
+        builder.redirectError(ProcessBuilder.Redirect.to(checkNotNull(logs.stderrLog).toFile()))
+    }
+
+    val process = try {
+        builder.start()
+    } catch (e: IOException) {
+        appendCommandLog(logs, "exit:     START-FAILED: ${e.message}")
+        log.warn("process {} failed to start ({}); command log kept: {}", name, e.toString(), logs.commandLog)
+        throw ProcessStartException("process '$name' failed to start: ${e.message}", name, logs, e)
+    }
+    val pid = process.pid()
+    val startNanos = System.nanoTime()
+
+    try {
+        val finished = process.waitFor(spec.timeout.inWholeNanoseconds, TimeUnit.NANOSECONDS)
+        val duration = (System.nanoTime() - startNanos).nanoseconds
+        if (!finished) {
+            log.warn("process {} (pid {}) exceeded its {} timeout; killing the process tree; logs: {}", name, pid, spec.timeout, logs.commandLog)
+            killProcessTree(process, name)
+            appendCommandLog(logs, "pid:      $pid\nexit:     TIMEOUT after ${spec.timeout}\nduration: $duration")
+            throw ProcessTimeoutException(
+                "process '$name' (pid $pid) timed out after ${spec.timeout}; logs kept at ${logs.commandLog}",
+                name, pid, spec.timeout, readOutputTail(logs), logs,
+            )
+        }
+        val exitCode = process.exitValue()
+        appendCommandLog(logs, "pid:      $pid\nexit:     $exitCode\nduration: $duration")
+        log.debug("process {} (pid {}) exited with {} in {}; command log: {}", name, pid, exitCode, duration, logs.commandLog)
+        return ProcessRunResult(exitCode, duration, logs)
+    } catch (e: InterruptedException) {
+        // The interrupt flag is cleared right now, so the bounded waits inside the
+        // kill sequence still work; the flag is restored before rethrowing.
+        killProcessTree(process, name)
+        appendCommandLog(logs, "pid:      $pid\nexit:     INTERRUPTED\nduration: ${(System.nanoTime() - startNanos).nanoseconds}")
+        log.warn("process {} (pid {}) interrupted by the caller; process tree killed; logs: {}", name, pid, logs.commandLog)
+        Thread.currentThread().interrupt()
+        throw e
+    }
+}
+
+/**
+ * Deletes this runner's old log files in [logsDir] — and ONLY files
+ * matching the runner's full filename grammar (other logs live in the same
+ * folder and are never touched); non-recursive, regular files only.
+ *
+ * Two passes, both keyed on the FILENAME timestamp (not mtime — the
+ * completion append bumps the command log's mtime and would split a run's
+ * file group):
+ * 1. age: delete runs older than [maxAge];
+ * 2. count: if more than [maxFiles] files remain, delete oldest runs (kept
+ *    together as whole groups) down to [trimTo] — hysteresis, so the trim
+ *    runs once per ~([maxFiles]-[trimTo]) runs, not on every start. Runs
+ *    younger than one hour are never count-deleted (protects live
+ *    concurrent runs).
+ *
+ * Concurrent cleanups from parallel devrig JVMs are fine: already-deleted
+ * files count as success. Failures are WARN-logged and never thrown.
+ *
+ * Public and parameterized for direct testing; [runProcess] invokes it at
+ * most once per JVM and only when the `.process-cleanup-stamp` marker file
+ * is older than 4 hours.
+ *
+ * @return number of files deleted
+ */
+fun cleanupProcessLogs(
+    logsDir: Path,
+    maxFiles: Int = 10_000,
+    trimTo: Int = 8_000,
+    maxAge: Duration = 30.days,
+    nowMillis: Long = System.currentTimeMillis(),
+): Int {
+    require(trimTo in 0..maxFiles) { "trimTo ($trimTo) must be within 0..maxFiles ($maxFiles)" }
+
+    class RunnerFile(val path: Path, val timestampMillis: Long, val runKey: String)
+
+    val files = try {
+        Files.list(logsDir).use { stream ->
+            stream.filter { Files.isRegularFile(it) }.toList()
+        }
+    } catch (e: Exception) {
+        log.warn("process-log cleanup could not list {}: {}", logsDir, e.toString())
+        return 0
+    }.mapNotNull { path ->
+        val fileName = path.fileName.toString()
+        val match = RUNNER_FILE_GRAMMAR.matchEntire(fileName) ?: return@mapNotNull null
+        val timestamp = parseFileTimestamp(match.groupValues[1]) ?: return@mapNotNull null
+        RunnerFile(path, timestamp, fileName.removeSuffix("-${match.groupValues[2]}.log"))
+    }
+
+    var deleted = 0
+    fun deleteCounted(path: Path) {
+        try {
+            if (Files.deleteIfExists(path)) deleted++
+        } catch (e: NoSuchFileException) {
+            // a concurrent cleanup got there first — success
+        } catch (e: Exception) {
+            log.warn("process-log cleanup could not delete {}: {}", path, e.toString())
+        }
+    }
+
+    val ageCutoff = nowMillis - maxAge.inWholeMilliseconds
+    val (expired, remaining) = files.partition { it.timestampMillis < ageCutoff }
+    expired.forEach { deleteCounted(it.path) }
+
+    if (remaining.size > maxFiles) {
+        val ageFloorCutoff = nowMillis - COUNT_PASS_AGE_FLOOR.inWholeMilliseconds
+        val groupsOldestFirst = remaining.groupBy { it.runKey }.values.sortedBy { group -> group.minOf { it.timestampMillis } }
+        var count = remaining.size
+        for (group in groupsOldestFirst) {
+            if (count <= trimTo) break
+            if (group.any { it.timestampMillis > ageFloorCutoff }) continue
+            group.forEach { deleteCounted(it.path) }
+            count -= group.size
+        }
+    }
+
+    if (deleted > 0) log.warn("process-log cleanup removed {} file(s) from {}", deleted, logsDir)
+    return deleted
+}
+
+private fun parseFileTimestamp(text: String): Long? = try {
+    LocalDateTime.parse(text, FILE_TIMESTAMP_FORMAT).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli()
+} catch (e: Exception) {
+    log.warn("process-log cleanup could not parse timestamp '{}': {}", text, e.toString())
+    null
+}
+
+private fun maybeCleanupOncePerJvm(logsDir: Path) {
+    if (!cleanupTriggered.compareAndSet(false, true)) return
+    try {
+        val marker = logsDir.resolve(CLEANUP_MARKER_FILE)
+        val now = System.currentTimeMillis()
+        val markerAgeMillis = try {
+            now - Files.getLastModifiedTime(marker).toMillis()
+        } catch (e: IOException) {
+            Long.MAX_VALUE // no marker yet (or unreadable) — run the scan
+        }
+        if (markerAgeMillis < CLEANUP_THROTTLE.inWholeMilliseconds) return
+        cleanupProcessLogs(logsDir, nowMillis = now)
+        Files.createDirectories(logsDir)
+        Files.writeString(marker, now.toString())
+    } catch (e: Exception) {
+        log.warn("process-log cleanup skipped: {}", e.toString())
+    }
+}
+
+/** Sanitizes a run name for use inside a file name: [A-Za-z0-9._-], max 40 chars, "process" fallback. */
+private fun sanitizeProcessName(raw: String): String {
+    val cleaned = raw.map { if (it.isLetterOrDigit() && it.code < 128 || it in "._-") it else '-' }
+        .joinToString("")
+        .replace(Regex("-{2,}"), "-")
+        .trim('-', '.')
+        .take(40)
+    return cleaned.ifBlank { "process" }
+}
+
+private fun allocateLogFiles(spec: ProcessRunSpec, name: String): ProcessRunLogs {
+    Files.createDirectories(spec.logsDir)
+    val jvmPid = ProcessHandle.current().pid()
+    repeat(100) {
+        val timestamp = FILE_TIMESTAMP_FORMAT.withZone(ZoneId.systemDefault()).format(Instant.ofEpochMilli(System.currentTimeMillis()))
+        val base = "process-$name-$timestamp-$jvmPid-${runSequence.incrementAndGet()}"
+        val commandLog = spec.logsDir.resolve("$base-command.log")
+        try {
+            createOwnerOnlyFile(commandLog) // CREATE_NEW: the atomic uniqueness reservation
+        } catch (e: FileAlreadyExistsException) {
+            return@repeat // collision (another JVM, same millisecond) — bump seq and retry
+        }
+        Files.writeString(commandLog, commandLogHeader(spec), StandardOpenOption.WRITE)
+        val stdoutLog = spec.logsDir.resolve("$base-stdout.log")
+        val stderrLog = if (spec.mergeStderrIntoStdout) null else spec.logsDir.resolve("$base-stderr.log")
+        precreateOwnerOnly(stdoutLog)
+        stderrLog?.let { precreateOwnerOnly(it) }
+        return ProcessRunLogs(commandLog, stdoutLog, stderrLog)
+    }
+    throw IOException("could not allocate unique process log file names in ${spec.logsDir}")
+}
+
+private fun commandLogHeader(spec: ProcessRunSpec): String = buildString {
+    append("started:  ").append(OffsetDateTime.now()).append('\n')
+    append("command:  ").append(Json.encodeToString(spec.command)).append('\n')
+    append("workdir:  ").append(spec.workingDir?.let { Json.encodeToString(it.toString()) } ?: "inherited").append('\n')
+    // KEYS only — environment values may carry secrets and must never reach the log.
+    append("env-keys: ").append(Json.encodeToString(spec.environment.keys.sorted())).append('\n')
+    append("merged:   ").append(spec.mergeStderrIntoStdout).append('\n')
+}
+
+private fun appendCommandLog(logs: ProcessRunLogs, text: String) {
+    try {
+        Files.writeString(logs.commandLog, text + "\n", StandardOpenOption.CREATE, StandardOpenOption.APPEND)
+    } catch (e: Exception) {
+        log.warn("could not append to command log {}: {}", logs.commandLog, e.toString())
+    }
+}
+
+/** command.log carries the full argv — keep it owner-only where the platform can express that. */
+private fun createOwnerOnlyFile(path: Path) {
+    if (FileSystems.getDefault().supportedFileAttributeViews().contains("posix")) {
+        Files.createFile(path, PosixFilePermissions.asFileAttribute(PosixFilePermissions.fromString("rw-------")))
+    } else {
+        Files.createFile(path)
+    }
+}
+
+private fun precreateOwnerOnly(path: Path) {
+    try {
+        createOwnerOnlyFile(path)
+    } catch (e: FileAlreadyExistsException) {
+        // stale leftover with the same reserved base name; Redirect.to truncates it anyway
+    }
+}
+
+/** Last lines of the run's output for [ProcessRunException.outputTail]: bounded 8 KiB per file, 100 lines total. */
+private fun readOutputTail(logs: ProcessRunLogs): List<ProcessLine> = try {
+    fun tailOf(file: Path, stream: ProcessStream): List<ProcessLine> {
+        val size = try {
+            Files.size(file)
+        } catch (e: NoSuchFileException) {
+            return emptyList()
+        }
+        val skip = maxOf(0L, size - 8192)
+        val bytes = Files.newInputStream(file).use { input ->
+            input.skipNBytes(skip)
+            input.readNBytes(8192)
+        }
+        val lines = String(bytes, Charsets.UTF_8).lines()
+        // The first line is likely a partial one when we started mid-file.
+        return (if (skip > 0 && lines.size > 1) lines.drop(1) else lines)
+            .filter { it.isNotEmpty() }
+            .map { ProcessLine(stream, it) }
+    }
+
+    val tail = tailOf(logs.stdoutLog, ProcessStream.STDOUT) +
+        (logs.stderrLog?.let { tailOf(it, ProcessStream.STDERR) } ?: emptyList())
+    tail.takeLast(100)
+} catch (e: Exception) {
+    // The tail is diagnostics for an exception that is already being thrown — never mask it.
+    log.warn("could not read the output tail: {}", e.toString())
+    emptyList()
+}
+
+/**
+ * Bounded, best-effort kill of the whole child process tree (the v4/v6
+ * design-doc state machine): capture descendants while the root is alive,
+ * destroy() the root, re-capture (a TERM handler may have spawned more),
+ * force-kill everything captured, escalate on the root, then a final sweep
+ * over the captured live handles' own descendants. Survivors are
+ * WARN-logged. Handles that reparent/detach (e.g. WMI-created processes)
+ * are out of reach by design.
+ */
+private fun killProcessTree(process: Process, name: String) {
+    val captured = LinkedHashMap<Long, ProcessHandle>()
+    fun capture() {
+        try {
+            process.toHandle().descendants().forEach { captured.putIfAbsent(it.pid(), it) }
+        } catch (e: Exception) {
+            log.warn("process {}: could not enumerate descendants: {}", name, e.toString())
+        }
+    }
+
+    capture()
+    process.destroy()
+    capture() // union right after destroy: a TERM handler can spawn a child even as the root exits
+    captured.values.forEach { it.destroyForcibly() }
+
+    if (!quietWaitFor(process, 1_000)) {
+        capture() // root still alive — a fresh snapshot is still meaningful
+        process.destroyForcibly()
+        captured.values.forEach { it.destroyForcibly() }
+        if (!quietWaitFor(process, 1_000)) {
+            log.warn("process {}: root pid {} would not die; proceeding", name, process.pid())
+        }
+    }
+
+    captured.values.filter { it.isAlive }.forEach { handle ->
+        try {
+            handle.descendants().forEach { d ->
+                captured.putIfAbsent(d.pid(), d)
+                d.destroyForcibly()
+            }
+        } catch (e: Exception) {
+            log.warn("process {}: final descendant sweep failed for pid {}: {}", name, handle.pid(), e.toString())
+        }
+        handle.destroyForcibly()
+    }
+
+    val deadlineNanos = System.nanoTime() + 1_000_000_000L
+    while (captured.values.any { it.isAlive } && System.nanoTime() < deadlineNanos) {
+        try {
+            Thread.sleep(20)
+        } catch (e: InterruptedException) {
+            Thread.currentThread().interrupt()
+            break
+        }
+    }
+    val survivors = captured.values.filter { it.isAlive }.map { it.pid() }
+    if (survivors.isNotEmpty()) {
+        log.warn("process {}: descendant pid(s) still alive after the kill sweep: {}", name, survivors)
+    }
+}
+
+private fun quietWaitFor(process: Process, millis: Long): Boolean = try {
+    process.waitFor(millis, TimeUnit.MILLISECONDS)
+} catch (e: InterruptedException) {
+    Thread.currentThread().interrupt()
+    !process.isAlive
+}

--- a/mcp-core/src/main/kotlin/com/jonnyzzz/mcpSteroid/util/process/ProcessRunTypes.kt
+++ b/mcp-core/src/main/kotlin/com/jonnyzzz/mcpSteroid/util/process/ProcessRunTypes.kt
@@ -1,0 +1,198 @@
+/* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
+package com.jonnyzzz.mcpSteroid.util.process
+
+import java.io.File
+import java.io.IOException
+import java.nio.file.Files
+import java.nio.file.NoSuchFileException
+import java.nio.file.Path
+import kotlin.time.Duration
+import org.slf4j.LoggerFactory
+
+private val logger = LoggerFactory.getLogger("com.jonnyzzz.mcpSteroid.util.process.ProcessRunLogs")
+
+/** Suffix appended by the bounded reads when the file exceeded the limit. Never ends in a digit. */
+const val PROCESS_READ_TRUNCATION_MARKER: String = " …[truncated by ProcessRunner]"
+
+/**
+ * Production process runner for mcp-core — the file-redirect model. See
+ * docs/design/process-runner-api.md (v6, the quorum-reviewed implementation
+ * contract) for full semantics.
+ *
+ * ALL production process launches go through [runProcess]; the single
+ * documented exception is npx-kt's detached IDE spawn
+ * (`ManagedBackend.spawnIdeProcess`), which never reads its streams.
+ * The runner NEVER writes to System.out — in `devrig mcp` mode stdout is
+ * the MCP JSON-RPC channel.
+ */
+
+/** Which stream of the child process a line was attributed to. */
+enum class ProcessStream { STDOUT, STDERR }
+
+/** One line of child output (no trailing terminator). In merged mode every line is tagged [ProcessStream.STDOUT]. */
+data class ProcessLine(val stream: ProcessStream, val text: String)
+
+/** Default bound for [ProcessRunLogs.readStdout]/[ProcessRunLogs.readStderr]: 32 MiB. */
+const val DEFAULT_PROCESS_READ_LIMIT: Int = 32 * 1024 * 1024
+
+/**
+ * Everything needed to run one child process to completion. Validation
+ * happens at construction — an invalid spec fails before anything starts.
+ *
+ * @param command argv list (executable first); must be non-empty.
+ * @param timeout wall-clock budget from spawn to exit; finite and positive.
+ *   On expiry the whole child process tree is killed (bounded, best-effort)
+ *   and [ProcessTimeoutException] is thrown.
+ * @param name filename-safe tag for the log files (sanitized to
+ *   `[A-Za-z0-9._-]`, max 40 chars, falls back to "process" when nothing
+ *   survives sanitization); defaults to the executable's file name. The
+ *   full argv is recorded in the command log file, never in messages.
+ * @param workingDir child working directory (inherited if null).
+ * @param environment entries ADDED on top of the inherited environment.
+ *   Only the KEYS are recorded in the command log — values may be secrets.
+ * @param mergeStderrIntoStdout true (default): `redirectErrorStream(true)`,
+ *   ONE output file with exact interleaving. false: separate stdout/stderr
+ *   files, for callers that must distinguish stderr.
+ * @param logsDir where the log files go; default `~/.mcp-steroid/logs`
+ *   (devrig's `HomePaths.logsDir`). Overridable for tests and embeddings.
+ */
+class ProcessRunSpec(
+    val command: List<String>,
+    val timeout: Duration,
+    val name: String? = null,
+    val workingDir: Path? = null,
+    val environment: Map<String, String> = emptyMap(),
+    val mergeStderrIntoStdout: Boolean = true,
+    val logsDir: Path = defaultProcessLogsDir(),
+) {
+    init {
+        require(command.isNotEmpty()) { "command must not be empty" }
+        require(timeout.isFinite() && timeout.isPositive()) { "timeout must be finite and positive: $timeout" }
+    }
+}
+
+/** `~/.mcp-steroid/logs` — the same location as devrig's `HomePaths.logsDir`. */
+fun defaultProcessLogsDir(): Path =
+    Path.of(System.getProperty("user.home"), ".mcp-steroid", "logs").toAbsolutePath().normalize()
+
+/**
+ * Handle on the files one run produced:
+ * `process-<name>-<yyyyMMdd-HHmmss-SSS>-<pid>-<seq>-{command,stdout,stderr}.log`
+ * in the spec's logsDir. [commandLog] records the invocation (argv JSON,
+ * workdir, sorted env KEYS, merge flag) and the completion (pid, exit code /
+ * TIMEOUT / INTERRUPTED / START-FAILED, duration).
+ */
+class ProcessRunLogs(
+    val commandLog: Path,
+    /** Child stdout — BOTH streams when merged. */
+    val stdoutLog: Path,
+    /** Child stderr; null in merged mode. */
+    val stderrLog: Path?,
+) {
+    /**
+     * Bounded UTF-8 read of [stdoutLog] (both streams when merged). Streams
+     * at most [maxChars] BYTES from the file head (UTF-8 decodes N bytes to
+     * <= N chars, so the char bound holds); a longer file gets
+     * " …[truncated by ProcessRunner]" APPENDED on top of the cap (the
+     * marker never ends in a digit — PID-parsing callers rely on that) and
+     * a WARN. Returns "" when the file is missing (after [delete] or
+     * cleanup); other I/O errors propagate.
+     */
+    fun readStdout(maxChars: Int = DEFAULT_PROCESS_READ_LIMIT): String = readBounded(stdoutLog, maxChars)
+
+    /** Same contract as [readStdout]; "" when merged (no stderr file) or missing. */
+    fun readStderr(maxChars: Int = DEFAULT_PROCESS_READ_LIMIT): String =
+        stderrLog?.let { readBounded(it, maxChars) } ?: ""
+
+    /**
+     * Deletes this run's files — for callers that know the run is fine and
+     * the files are noise. Best-effort and idempotent: already-missing
+     * files are success; real failures are WARN-logged, never thrown.
+     */
+    fun delete() {
+        for (file in listOfNotNull(commandLog, stdoutLog, stderrLog)) {
+            try {
+                Files.deleteIfExists(file)
+            } catch (e: Exception) {
+                logger.warn("could not delete process log {}: {}", file, e.toString())
+            }
+        }
+    }
+
+    private fun readBounded(file: Path, maxChars: Int): String {
+        require(maxChars > 0) { "maxChars must be positive: $maxChars" }
+        val bytes = try {
+            Files.newInputStream(file).use { it.readNBytes(maxChars) }
+        } catch (e: NoSuchFileException) {
+            logger.debug("process log {} is gone (deleted or cleaned up); returning empty", file)
+            return ""
+        }
+        // String(bytes, UTF_8) replaces malformed sequences with U+FFFD, never throws.
+        val text = String(bytes, Charsets.UTF_8)
+        val truncated = bytes.size >= maxChars && Files.size(file) > maxChars
+        if (!truncated) return text
+        logger.warn("process log {} exceeds the {}-char read limit; returning a truncated head", file, maxChars)
+        return text + PROCESS_READ_TRUNCATION_MARKER
+    }
+}
+
+/** Successful completion (the child exited on its own within the timeout). */
+class ProcessRunResult(
+    val exitCode: Int,
+    /** Spawn-to-exit wall time (nanoTime based; excludes kill/cleanup phases). */
+    val duration: Duration,
+    val logs: ProcessRunLogs,
+)
+
+/**
+ * Family supertype of the runner's typed failures — best-effort call sites
+ * catch ONE clause (`catch (e: ProcessRunException)`) and cover timeout AND
+ * start failure. (Caller interruption intentionally stays outside:
+ * `InterruptedException` propagates.) The child tree, if it ever existed,
+ * has been killed (bounded, best-effort).
+ *
+ * [outputTail] holds the last lines read back from the log files (bounded
+ * 100 lines / 8 KiB; tagged STDOUT-only in merged mode — attribution is
+ * unrecoverable post-merge). The tail is NEVER interpolated into the
+ * message — messages get logged and output may contain secrets; callers
+ * opt in by reading [outputTail]. [pid] is -1 when the child never started.
+ * [logs] points at the kept files for diagnosis.
+ */
+sealed class ProcessRunException(
+    message: String,
+    val processName: String,
+    val pid: Long,
+    val outputTail: List<ProcessLine>,
+    val logs: ProcessRunLogs,
+    cause: Throwable? = null,
+) : RuntimeException(message, cause)
+
+/** [ProcessRunSpec.timeout] elapsed; the child tree has been killed; files kept. */
+class ProcessTimeoutException(
+    message: String,
+    processName: String,
+    pid: Long,
+    val timeout: Duration,
+    outputTail: List<ProcessLine>,
+    logs: ProcessRunLogs,
+) : ProcessRunException(message, processName, pid, outputTail, logs)
+
+/**
+ * `ProcessBuilder.start()` failed (missing binary, bad working directory).
+ * [cause] is the original [IOException]; the command log is kept with a
+ * START-FAILED record.
+ */
+class ProcessStartException(
+    message: String,
+    processName: String,
+    logs: ProcessRunLogs,
+    cause: IOException,
+) : ProcessRunException(message, processName, pid = -1, outputTail = emptyList(), logs = logs, cause = cause)
+
+/**
+ * The OS null device: `NUL` on Windows, `/dev/null` elsewhere. The runner
+ * redirects the child's stdin from it; also used by npx-kt's detached IDE
+ * spawn, which stays on raw ProcessBuilder by design.
+ */
+fun nullDevice(): File =
+    if (System.getProperty("os.name").startsWith("Windows")) File("NUL") else File("/dev/null")

--- a/mcp-core/src/main/kotlin/com/jonnyzzz/mcpSteroid/util/process/ProcessRunTypes.kt
+++ b/mcp-core/src/main/kotlin/com/jonnyzzz/mcpSteroid/util/process/ProcessRunTypes.kt
@@ -101,8 +101,10 @@ class ProcessRunLogs(
     fun readStdout(maxChars: Int = DEFAULT_PROCESS_READ_LIMIT): String = readBounded(stdoutLog, maxChars)
 
     /** Same contract as [readStdout]; "" when merged (no stderr file) or missing. */
-    fun readStderr(maxChars: Int = DEFAULT_PROCESS_READ_LIMIT): String =
-        stderrLog?.let { readBounded(it, maxChars) } ?: ""
+    fun readStderr(maxChars: Int = DEFAULT_PROCESS_READ_LIMIT): String {
+        require(maxChars > 0) { "maxChars must be positive: $maxChars" }
+        return stderrLog?.let { readBounded(it, maxChars) } ?: ""
+    }
 
     /**
      * Deletes this run's files — for callers that know the run is fine and
@@ -121,18 +123,20 @@ class ProcessRunLogs(
 
     private fun readBounded(file: Path, maxChars: Int): String {
         require(maxChars > 0) { "maxChars must be positive: $maxChars" }
+        // Read one byte beyond the cap from the SAME stream: truncation is detected without a second
+        // Files.size() stat, which could race with a concurrent delete()/cleanup and leak
+        // NoSuchFileException after a successful read.
+        val probeLength = if (maxChars < Int.MAX_VALUE) maxChars + 1 else maxChars
         val bytes = try {
-            Files.newInputStream(file).use { it.readNBytes(maxChars) }
+            Files.newInputStream(file).use { it.readNBytes(probeLength) }
         } catch (e: NoSuchFileException) {
             logger.debug("process log {} is gone (deleted or cleaned up); returning empty", file)
             return ""
         }
         // String(bytes, UTF_8) replaces malformed sequences with U+FFFD, never throws.
-        val text = String(bytes, Charsets.UTF_8)
-        val truncated = bytes.size >= maxChars && Files.size(file) > maxChars
-        if (!truncated) return text
+        if (bytes.size <= maxChars) return String(bytes, Charsets.UTF_8)
         logger.warn("process log {} exceeds the {}-char read limit; returning a truncated head", file, maxChars)
-        return text + PROCESS_READ_TRUNCATION_MARKER
+        return String(bytes, 0, maxChars, Charsets.UTF_8) + PROCESS_READ_TRUNCATION_MARKER
     }
 }
 

--- a/mcp-core/src/test/kotlin/com/jonnyzzz/mcpSteroid/util/process/CleanupProcessLogsTest.kt
+++ b/mcp-core/src/test/kotlin/com/jonnyzzz/mcpSteroid/util/process/CleanupProcessLogsTest.kt
@@ -5,7 +5,7 @@ import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.attribute.FileTime
 import java.time.Instant
-import java.time.ZoneId
+import java.time.ZoneOffset
 import java.time.format.DateTimeFormatter
 import java.util.Locale
 import kotlin.io.path.exists
@@ -21,7 +21,9 @@ class CleanupProcessLogsTest {
     lateinit var logsDir: Path
 
     private val nowMillis = System.currentTimeMillis()
-    private val nameFormat = DateTimeFormatter.ofPattern("yyyyMMdd-HHmmss-SSS", Locale.ROOT).withZone(ZoneId.systemDefault())
+
+    // UTC — matches the production filename-timestamp contract (local zones are DST-ambiguous).
+    private val nameFormat = DateTimeFormatter.ofPattern("yyyyMMdd-HHmmss-SSS", Locale.ROOT).withZone(ZoneOffset.UTC)
 
     /** Creates one run's files following the runner's filename grammar, aged [ageMillis] back from now. */
     private fun mkRun(tag: String, ageMillis: Long, seq: Int, vararg suffixes: String = arrayOf("command", "stdout")): List<Path> {
@@ -90,6 +92,33 @@ class CleanupProcessLogsTest {
 
         oldByName.forEach { assertFalse(it.exists(), "oldest BY NAME must be deleted despite fresh mtime") }
         newByName.forEach { assertTrue(it.exists(), "newest BY NAME must survive despite old mtime") }
+    }
+
+    @Test
+    fun `equal-timestamp runs trim deterministically by pid then seq`() {
+        // Same timestamp for all: ordering must fall back to pid, then seq — never Files.list order.
+        val ts = nameFormat.format(Instant.ofEpochMilli(nowMillis - hours(20)))
+        fun mkExact(pid: Long, seq: Int): Path =
+            Files.writeString(logsDir.resolve("process-tie-$ts-$pid-$seq-command.log"), "x")
+        val oldestPid = mkExact(pid = 100, seq = 9)
+        val midSeq = mkExact(pid = 200, seq = 1)
+        val newestSeq = mkExact(pid = 200, seq = 2)
+
+        cleanupProcessLogs(logsDir, maxFiles = 2, trimTo = 2, maxAge = 30.days, nowMillis = nowMillis)
+
+        assertFalse(oldestPid.exists(), "lowest pid trims first on a timestamp tie")
+        assertTrue(midSeq.exists())
+        assertTrue(newestSeq.exists())
+    }
+
+    @Test
+    fun `marker throttle - scan is due without a marker, not due right after touching it`() {
+        assertTrue(shouldRunProcessLogCleanup(logsDir, nowMillis), "no marker → a scan is due")
+        touchProcessLogCleanupMarker(logsDir, nowMillis)
+        assertFalse(shouldRunProcessLogCleanup(logsDir, nowMillis), "fresh marker → throttled")
+        // Backdate the marker beyond the 4h throttle window.
+        Files.setLastModifiedTime(logsDir.resolve(".process-cleanup-stamp"), FileTime.fromMillis(nowMillis - hours(5)))
+        assertTrue(shouldRunProcessLogCleanup(logsDir, nowMillis), "stale marker → a scan is due again")
     }
 
     @Test

--- a/mcp-core/src/test/kotlin/com/jonnyzzz/mcpSteroid/util/process/CleanupProcessLogsTest.kt
+++ b/mcp-core/src/test/kotlin/com/jonnyzzz/mcpSteroid/util/process/CleanupProcessLogsTest.kt
@@ -1,0 +1,116 @@
+/* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
+package com.jonnyzzz.mcpSteroid.util.process
+
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.attribute.FileTime
+import java.time.Instant
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+import java.util.Locale
+import kotlin.io.path.exists
+import kotlin.time.Duration.Companion.days
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+
+class CleanupProcessLogsTest {
+    @TempDir
+    lateinit var logsDir: Path
+
+    private val nowMillis = System.currentTimeMillis()
+    private val nameFormat = DateTimeFormatter.ofPattern("yyyyMMdd-HHmmss-SSS", Locale.ROOT).withZone(ZoneId.systemDefault())
+
+    /** Creates one run's files following the runner's filename grammar, aged [ageMillis] back from now. */
+    private fun mkRun(tag: String, ageMillis: Long, seq: Int, vararg suffixes: String = arrayOf("command", "stdout")): List<Path> {
+        val ts = nameFormat.format(Instant.ofEpochMilli(nowMillis - ageMillis))
+        return suffixes.map { suffix ->
+            val f = logsDir.resolve("process-$tag-$ts-11111-$seq-$suffix.log")
+            Files.writeString(f, "x")
+            f
+        }
+    }
+
+    private fun hours(h: Long) = h * 3_600_000L
+    private fun daysMs(d: Long) = d * 24 * 3_600_000L
+
+    @Test
+    fun `age pass deletes runs older than maxAge`() {
+        val ancient = mkRun("ancient", ageMillis = daysMs(45), seq = 1)
+        val fresh = mkRun("fresh", ageMillis = daysMs(1), seq = 2)
+
+        val deleted = cleanupProcessLogs(logsDir, maxFiles = 100, trimTo = 100, maxAge = 30.days, nowMillis = nowMillis)
+
+        assertEquals(2, deleted)
+        ancient.forEach { assertFalse(it.exists(), "45-day-old $it must be deleted") }
+        fresh.forEach { assertTrue(it.exists()) }
+    }
+
+    @Test
+    fun `count pass trims oldest runs to trimTo keeping triples together`() {
+        val oldest = mkRun("r1", ageMillis = hours(40), seq = 1)
+        val older = mkRun("r2", ageMillis = hours(30), seq = 2)
+        val newer = mkRun("r3", ageMillis = hours(20), seq = 3)
+        val newest = mkRun("r4", ageMillis = hours(10), seq = 4)
+        // 8 files total; maxFiles=6 triggers, trimTo=4 → the two oldest runs go, as whole pairs.
+
+        cleanupProcessLogs(logsDir, maxFiles = 6, trimTo = 4, maxAge = 30.days, nowMillis = nowMillis)
+
+        (oldest + older).forEach { assertFalse(it.exists(), "$it must be trimmed") }
+        (newer + newest).forEach { assertTrue(it.exists(), "$it must survive") }
+    }
+
+    @Test
+    fun `count pass is skipped below the maxFiles watermark`() {
+        val runs = (1..3).flatMap { mkRun("r$it", ageMillis = hours(10L * it), seq = it) }
+        cleanupProcessLogs(logsDir, maxFiles = 6, trimTo = 2, maxAge = 30.days, nowMillis = nowMillis)
+        runs.forEach { assertTrue(it.exists(), "under the watermark nothing is trimmed: $it") }
+    }
+
+    @Test
+    fun `count pass never deletes runs younger than the age floor`() {
+        val young = (1..4).flatMap { mkRun("young$it", ageMillis = 60_000L * it, seq = it) } // minutes old
+
+        cleanupProcessLogs(logsDir, maxFiles = 2, trimTo = 1, maxAge = 30.days, nowMillis = nowMillis)
+
+        young.forEach { assertTrue(it.exists(), "sub-age-floor file must never be count-deleted: $it") }
+    }
+
+    @Test
+    fun `ordering uses the filename timestamp not the file mtime`() {
+        val oldByName = mkRun("oldname", ageMillis = hours(40), seq = 1)
+        val newByName = mkRun("newname", ageMillis = hours(10), seq = 2)
+        // Invert mtimes: the newest-named file gets the oldest mtime.
+        newByName.forEach { Files.setLastModifiedTime(it, FileTime.fromMillis(nowMillis - daysMs(20))) }
+        oldByName.forEach { Files.setLastModifiedTime(it, FileTime.fromMillis(nowMillis)) }
+
+        cleanupProcessLogs(logsDir, maxFiles = 3, trimTo = 2, maxAge = 30.days, nowMillis = nowMillis)
+
+        oldByName.forEach { assertFalse(it.exists(), "oldest BY NAME must be deleted despite fresh mtime") }
+        newByName.forEach { assertTrue(it.exists(), "newest BY NAME must survive despite old mtime") }
+    }
+
+    @Test
+    fun `cleanup never touches files outside the runner grammar`() {
+        val foreign = listOf(
+            logsDir.resolve("devrig.log"),
+            logsDir.resolve("process-foo.log"),           // no timestamp grammar
+            logsDir.resolve("process-x.txt"),             // wrong extension
+            logsDir.resolve(".process-cleanup-stamp"),    // the throttle marker itself
+        ).map { Files.writeString(it, "x") }
+        foreign.forEach { Files.setLastModifiedTime(it, FileTime.fromMillis(nowMillis - daysMs(400))) }
+        val nestedDir = Files.createDirectory(logsDir.resolve("nested"))
+        val nested = Files.writeString(
+            nestedDir.resolve("process-deep-20200101-010101-000-1-1-command.log"), "x",
+        )
+        mkRun("real", ageMillis = daysMs(45), seq = 1)
+
+        val deleted = cleanupProcessLogs(logsDir, maxFiles = 1, trimTo = 1, maxAge = 30.days, nowMillis = nowMillis)
+
+        assertEquals(2, deleted, "only the one real ancient run (2 files) may be deleted")
+        foreign.forEach { assertTrue(it.exists(), "foreign file must never be touched: $it") }
+        assertTrue(nested.exists(), "cleanup must not recurse")
+    }
+}

--- a/mcp-core/src/test/kotlin/com/jonnyzzz/mcpSteroid/util/process/ProcessFixtureMain.kt
+++ b/mcp-core/src/test/kotlin/com/jonnyzzz/mcpSteroid/util/process/ProcessFixtureMain.kt
@@ -1,0 +1,112 @@
+/* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
+package com.jonnyzzz.mcpSteroid.util.process
+
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
+
+/**
+ * Child-JVM test fixture for the process runner. Launched as a real OS
+ * process by [processFixtureCommand]; emits deterministic bytes on every OS
+ * (shell commands like `echo` are code-page- and quoting-dependent — banned
+ * by the design doc's test plan).
+ */
+object ProcessFixtureMain {
+    @JvmStatic
+    fun main(args: Array<String>) {
+        when (args.firstOrNull()) {
+            "exit" -> {
+                // exit <code>: fixed lines to both streams, then exit.
+                System.out.println("out-first")
+                System.err.println("err-first")
+                System.out.println("out-second")
+                System.out.flush()
+                System.err.flush()
+                Runtime.getRuntime().exit(args[1].toInt())
+            }
+            "utf8" -> {
+                // Exact UTF-8 bytes incl. multi-byte, plus one malformed byte line.
+                System.out.write("héllo-你好-😀\n".toByteArray(Charsets.UTF_8))
+                System.out.write(byteArrayOf('b'.code.toByte(), 0xFF.toByte(), 'd'.code.toByte(), '\n'.code.toByte()))
+                System.out.flush()
+            }
+            "stdin" -> {
+                // Report how many bytes stdin delivered before EOF.
+                var count = 0L
+                val buf = ByteArray(8192)
+                while (true) {
+                    val n = System.`in`.read(buf)
+                    if (n < 0) break
+                    count += n
+                }
+                System.out.println("stdin-eof:$count")
+                System.out.flush()
+            }
+            "sleep" -> {
+                while (true) Thread.sleep(60_000)
+            }
+            "grandchild" -> {
+                // Spawn a sleeping grandchild JVM, report its pid, then sleep
+                // forever ourselves (used for tree-kill verification).
+                val pid = spawnSleeperGrandchild()
+                System.out.println("grandchild-pid:$pid")
+                System.out.flush()
+                while (true) Thread.sleep(60_000)
+            }
+            "env" -> {
+                System.out.println("env:${System.getenv(args[1]) ?: "<null>"}")
+                System.out.flush()
+            }
+            "cwd" -> {
+                System.out.println("cwd:${Paths.get("").toAbsolutePath()}")
+                System.out.flush()
+            }
+            "flood" -> {
+                // flood <lines>: deterministic volume for read-limit tests.
+                val n = args[1].toInt()
+                val out = System.out
+                for (i in 0 until n) out.println("flood-$i-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx")
+                out.flush()
+            }
+            else -> {
+                System.err.println("unknown fixture mode: ${args.toList()}")
+                Runtime.getRuntime().exit(64)
+            }
+        }
+    }
+
+    private fun spawnSleeperGrandchild(): Long {
+        val javaBin = currentJavaBinary()
+        val argFile = Files.createTempFile("fixture-grandchild-", ".args")
+        argFile.toFile().deleteOnExit()
+        Files.writeString(argFile, classpathArgFileContent())
+        val pb = ProcessBuilder(javaBin.toString(), "@$argFile", ProcessFixtureMain::class.java.name, "sleep")
+        pb.redirectInput(ProcessBuilder.Redirect.INHERIT)
+        pb.redirectOutput(ProcessBuilder.Redirect.INHERIT)
+        pb.redirectError(ProcessBuilder.Redirect.INHERIT)
+        return pb.start().pid()
+    }
+}
+
+fun currentJavaBinary(): Path {
+    val isWindows = System.getProperty("os.name").startsWith("Windows")
+    return Paths.get(System.getProperty("java.home"), "bin", if (isWindows) "java.exe" else "java")
+}
+
+/**
+ * `-cp "<classpath>"` in java @argfile syntax: forward slashes avoid
+ * backslash-escape rules inside quoted argfile tokens; quoting covers
+ * spaces. The @argfile keeps us under the Windows ~32k command-line limit.
+ */
+fun classpathArgFileContent(): String {
+    val cp = System.getProperty("java.class.path").replace('\\', '/')
+    return "-cp \"$cp\"\n"
+}
+
+/** Command line to launch the fixture as a child JVM. */
+fun processFixtureCommand(vararg mode: String): List<String> {
+    val argFile = Files.createTempFile("process-fixture-", ".args")
+    argFile.toFile().deleteOnExit()
+    Files.writeString(argFile, classpathArgFileContent())
+    return listOf(currentJavaBinary().toString(), "@$argFile", ProcessFixtureMain::class.java.name) + mode
+}

--- a/mcp-core/src/test/kotlin/com/jonnyzzz/mcpSteroid/util/process/ProcessRunTest.kt
+++ b/mcp-core/src/test/kotlin/com/jonnyzzz/mcpSteroid/util/process/ProcessRunTest.kt
@@ -1,0 +1,300 @@
+/* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
+package com.jonnyzzz.mcpSteroid.util.process
+
+import java.io.FileInputStream
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import kotlin.io.path.exists
+import kotlin.io.path.listDirectoryEntries
+import kotlin.io.path.name
+import kotlin.io.path.readText
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Duration.Companion.seconds
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Timeout
+import org.junit.jupiter.api.io.TempDir
+
+@Timeout(120, unit = TimeUnit.SECONDS)
+class ProcessRunTest {
+    @TempDir
+    lateinit var logsDir: Path
+
+    private fun spec(
+        vararg fixtureMode: String,
+        timeout: Duration = 1.minutes,
+        merge: Boolean = true,
+        name: String? = null,
+        workingDir: Path? = null,
+        environment: Map<String, String> = emptyMap(),
+    ) = ProcessRunSpec(
+        command = processFixtureCommand(*fixtureMode),
+        timeout = timeout,
+        name = name,
+        workingDir = workingDir,
+        environment = environment,
+        mergeStderrIntoStdout = merge,
+        logsDir = logsDir,
+    )
+
+    private fun awaitTrue(what: String, timeoutMs: Long = 30_000, condition: () -> Boolean) {
+        val deadline = System.nanoTime() + timeoutMs * 1_000_000
+        while (!condition()) {
+            check(System.nanoTime() < deadline) { "timed out waiting for: $what" }
+            Thread.sleep(20)
+        }
+    }
+
+    private fun awaitProcessDead(pid: Long) =
+        awaitTrue("process $pid to die") { ProcessHandle.of(pid).map { !it.isAlive }.orElse(true) }
+
+    @Test
+    fun `exit code zero propagates and files match the contract`() {
+        val result = runProcess(spec("exit", "0"))
+        assertEquals(0, result.exitCode)
+        assertTrue(result.duration.isPositive()) { "duration: ${result.duration}" }
+
+        val namePattern = Regex("process-java(\\.exe)?-\\d{8}-\\d{6}-\\d{3}-\\d+-\\d+-command\\.log")
+        assertTrue(result.logs.commandLog.name.matches(namePattern)) {
+            "unexpected command log name: ${result.logs.commandLog.name}"
+        }
+        assertTrue(result.logs.commandLog.exists())
+        assertTrue(result.logs.stdoutLog.exists())
+        assertNull(result.logs.stderrLog)
+
+        val commandLog = result.logs.commandLog.readText()
+        assertTrue(commandLog.contains("\"exit\"")) { "argv json expected in:\n$commandLog" }
+        assertTrue(commandLog.contains(Regex("exit:\\s+0"))) { commandLog }
+        assertTrue(commandLog.contains(Regex("pid:\\s+\\d+"))) { commandLog }
+        assertTrue(commandLog.contains("duration:")) { commandLog }
+    }
+
+    @Test
+    fun `nonzero exit code propagates without throwing`() {
+        assertEquals(7, runProcess(spec("exit", "7")).exitCode)
+    }
+
+    @Test
+    fun `environment keys are recorded sorted but values stay out of the command log`() {
+        val result = runProcess(
+            spec(
+                "env", "MCP_STEROID_FIXTURE_TEST_ENV",
+                environment = mapOf(
+                    "MCP_STEROID_FIXTURE_TEST_ENV" to "secret-token-42",
+                    "AAA_FIRST_KEY" to "another-secret",
+                ),
+            ),
+        )
+        assertTrue(result.logs.readStdout().contains("env:secret-token-42"))
+        val commandLog = result.logs.commandLog.readText()
+        val envKeysLine = commandLog.lines().single { it.startsWith("env-keys:") }
+        assertTrue(envKeysLine.contains("MCP_STEROID_FIXTURE_TEST_ENV")) { commandLog }
+        assertTrue(envKeysLine.indexOf("AAA_FIRST_KEY") < envKeysLine.indexOf("MCP_STEROID_FIXTURE_TEST_ENV")) {
+            "env keys must be sorted:\n$commandLog"
+        }
+        assertFalse(commandLog.contains("secret-token-42")) { "env VALUE leaked into command log:\n$commandLog" }
+        assertFalse(commandLog.contains("another-secret")) { "env VALUE leaked into command log:\n$commandLog" }
+    }
+
+    @Test
+    fun `merged mode interleaves both streams into one file in write order`() {
+        val result = runProcess(spec("exit", "0"))
+        val output = result.logs.readStdout()
+        val outFirst = output.indexOf("out-first")
+        val errFirst = output.indexOf("err-first")
+        val outSecond = output.indexOf("out-second")
+        assertTrue(outFirst in 0 until errFirst && errFirst < outSecond) { "order broken:\n$output" }
+        assertEquals("", result.logs.readStderr())
+    }
+
+    @Test
+    fun `split mode separates the streams`() {
+        val result = runProcess(spec("exit", "0", merge = false))
+        val stdout = result.logs.readStdout()
+        val stderr = result.logs.readStderr()
+        assertTrue(stdout.contains("out-first") && stdout.contains("out-second") && !stdout.contains("err-first")) { stdout }
+        assertTrue(stderr.contains("err-first") && !stderr.contains("out-first")) { stderr }
+        assertTrue(result.logs.stderrLog!!.exists())
+    }
+
+    @Test
+    fun `output is read back as utf8 with replacement for malformed bytes`() {
+        val output = runProcess(spec("utf8")).logs.readStdout()
+        assertTrue(output.contains("héllo-你好-😀")) { output }
+        assertTrue(output.contains("b�d")) { output }
+    }
+
+    @Test
+    fun `stdin is closed - child sees immediate eof`() {
+        val result = runProcess(spec("stdin", timeout = 30.seconds))
+        assertEquals(0, result.exitCode)
+        assertTrue(result.logs.readStdout().contains("stdin-eof:0")) { result.logs.readStdout() }
+    }
+
+    @Test
+    fun `timeout kills the child tree and throws with tail and kept files`() {
+        val ex = assertThrows(ProcessTimeoutException::class.java) {
+            runProcess(spec("grandchild", timeout = 10.seconds))
+        }
+        assertTrue(ex.pid > 0)
+        assertEquals(10.seconds, ex.timeout)
+        awaitProcessDead(ex.pid)
+
+        val stdout = ex.logs.readStdout()
+        val grandchildPid = Regex("grandchild-pid:(\\d+)").find(stdout)?.groupValues?.get(1)?.toLong()
+        checkNotNull(grandchildPid) { "fixture did not report a grandchild pid:\n$stdout" }
+        awaitProcessDead(grandchildPid)
+
+        assertTrue(ex.outputTail.any { it.text.contains("grandchild-pid:") }) { "tail: ${ex.outputTail}" }
+        assertTrue(ex.logs.commandLog.readText().contains("TIMEOUT")) { ex.logs.commandLog.readText() }
+        assertTrue(ex.logs.stdoutLog.exists(), "files must be kept on timeout")
+        assertFalse(ex.message!!.contains("grandchild-pid:"), "output text must not leak into the message")
+    }
+
+    @Test
+    fun `interrupting the caller kills the child tree and restores the flag`() {
+        var thrown: Throwable? = null
+        var interruptedFlag = false
+        val runner = Thread {
+            try {
+                runProcess(spec("grandchild", timeout = 2.minutes))
+            } catch (t: Throwable) {
+                thrown = t
+                interruptedFlag = Thread.currentThread().isInterrupted
+            }
+        }
+        runner.start()
+        // The stdout log file is written live; wait until the child reported its grandchild.
+        awaitTrue("fixture to start and report") {
+            logsDir.listDirectoryEntries("process-*-stdout.log").any { it.readText().contains("grandchild-pid:") }
+        }
+        val stdout = logsDir.listDirectoryEntries("process-*-stdout.log").single().readText()
+        val grandchildPid = Regex("grandchild-pid:(\\d+)").find(stdout)!!.groupValues[1].toLong()
+
+        runner.interrupt()
+        runner.join(30_000)
+        assertFalse(runner.isAlive, "runner thread must finish")
+        assertTrue(thrown is InterruptedException) { "expected InterruptedException, got $thrown" }
+        assertTrue(interruptedFlag, "interrupt status must be restored")
+        awaitProcessDead(grandchildPid)
+        val commandLog = logsDir.listDirectoryEntries("process-*-command.log").single().readText()
+        assertTrue(commandLog.contains("INTERRUPTED")) { commandLog }
+    }
+
+    @Test
+    fun `missing executable throws ProcessStartException carrying logs`() {
+        val ex = assertThrows(ProcessStartException::class.java) {
+            runProcess(
+                ProcessRunSpec(
+                    command = listOf("mcp-steroid-no-such-binary-a6f1"),
+                    timeout = 10.seconds,
+                    logsDir = logsDir,
+                ),
+            )
+        }
+        assertTrue(ex.cause is java.io.IOException) { "cause: ${ex.cause}" }
+        assertEquals(-1, ex.pid)
+        assertTrue(ex.logs.commandLog.readText().contains("START-FAILED")) { ex.logs.commandLog.readText() }
+    }
+
+    @Test
+    fun `working directory and environment reach the child`() {
+        val dir = Files.createDirectory(logsDir.resolve("work")).toRealPath()
+        val result = runProcess(spec("cwd", workingDir = dir))
+        assertTrue(result.logs.readStdout().contains("cwd:$dir")) { result.logs.readStdout() }
+    }
+
+    @Test
+    fun `readStdout is bounded and appends a marker that does not end in a digit`() {
+        val result = runProcess(spec("flood", "5000"))
+        val bounded = result.logs.readStdout(maxChars = 1_000)
+        assertTrue(bounded.length in 1_000..1_100) { "length ${bounded.length}" }
+        assertTrue(bounded.contains("[truncated by ProcessRunner]")) { bounded.takeLast(200) }
+        assertFalse(bounded.last().isDigit(), "marker must not end in a digit (PID-parsing callers)")
+        val full = result.logs.readStdout()
+        assertTrue(full.contains("flood-4999-")) { "full read must not truncate here" }
+        assertThrows(IllegalArgumentException::class.java) { result.logs.readStdout(maxChars = 0) }
+    }
+
+    @Test
+    fun `readStdout cut inside a multi byte character does not corrupt the rest`() {
+        val file = logsDir.resolve("multibyte-probe.txt")
+        // "😀" is 4 UTF-8 bytes; cut after 2 of them.
+        Files.write(file, "ab😀".toByteArray(Charsets.UTF_8))
+        val logs = ProcessRunLogs(commandLog = file, stdoutLog = file, stderrLog = null)
+        val cut = logs.readStdout(maxChars = 4)
+        assertTrue(cut.startsWith("ab")) { cut }
+        assertTrue(cut.contains('�')) { "expected replacement char at the cut: $cut" }
+    }
+
+    @Test
+    fun `delete removes exactly this runs files - idempotent - reads return empty`() {
+        val keep = runProcess(spec("exit", "0"))
+        val victim = runProcess(spec("exit", "0", merge = false))
+        victim.logs.delete()
+        assertFalse(victim.logs.commandLog.exists())
+        assertFalse(victim.logs.stdoutLog.exists())
+        assertFalse(victim.logs.stderrLog!!.exists())
+        victim.logs.delete() // idempotent
+        assertEquals("", victim.logs.readStdout())
+        assertEquals("", victim.logs.readStderr())
+        assertTrue(keep.logs.commandLog.exists())
+        assertTrue(keep.logs.stdoutLog.exists())
+    }
+
+    @Test
+    fun `name is sanitized and an all-symbol name falls back to a usable tag`() {
+        val weird = runProcess(spec("exit", "0", name = "we!rd/na me\\x"))
+        val fileName = weird.logs.commandLog.name
+        assertTrue(fileName.startsWith("process-")) { fileName }
+        assertFalse(fileName.contains('/') || fileName.contains('\\') || fileName.contains('!') || fileName.contains(' ')) { fileName }
+
+        val emoji = runProcess(spec("exit", "0", name = "😀🎉"))
+        assertTrue(emoji.logs.commandLog.name.matches(Regex("process-[A-Za-z0-9._-]+-\\d{8}.*"))) {
+            "all-symbol name must fall back: ${emoji.logs.commandLog.name}"
+        }
+    }
+
+    @Test
+    fun `concurrent runs in one jvm produce fully distinct files`() {
+        val pool = Executors.newFixedThreadPool(4)
+        try {
+            val results = (1..4).map { pool.submit<ProcessRunResult> { runProcess(spec("exit", "0", merge = false)) } }
+                .map { it.get(60, TimeUnit.SECONDS) }
+            val allFiles = results.flatMap { listOfNotNull(it.logs.commandLog, it.logs.stdoutLog, it.logs.stderrLog) }
+            assertEquals(12, allFiles.size)
+            assertEquals(12, allFiles.map { it.name }.toSet().size) { "file names must be unique: $allFiles" }
+            results.forEach { assertTrue(it.logs.readStdout().contains("out-first")) }
+        } finally {
+            pool.shutdownNow()
+        }
+    }
+
+    @Test
+    fun `invalid specs fail at construction`() {
+        assertThrows(IllegalArgumentException::class.java) {
+            ProcessRunSpec(command = emptyList(), timeout = 10.seconds, logsDir = logsDir)
+        }
+        assertThrows(IllegalArgumentException::class.java) {
+            ProcessRunSpec(command = listOf("x"), timeout = Duration.ZERO, logsDir = logsDir)
+        }
+        assertThrows(IllegalArgumentException::class.java) {
+            ProcessRunSpec(command = listOf("x"), timeout = (-5).seconds, logsDir = logsDir)
+        }
+        assertThrows(IllegalArgumentException::class.java) {
+            ProcessRunSpec(command = listOf("x"), timeout = Duration.INFINITE, logsDir = logsDir)
+        }
+    }
+
+    @Test
+    fun `null device reads as empty on this os`() {
+        FileInputStream(nullDevice()).use { assertEquals(-1, it.read()) }
+    }
+}

--- a/mcp-core/src/test/kotlin/com/jonnyzzz/mcpSteroid/util/process/ProcessRunTest.kt
+++ b/mcp-core/src/test/kotlin/com/jonnyzzz/mcpSteroid/util/process/ProcessRunTest.kt
@@ -171,14 +171,19 @@ class ProcessRunTest {
             }
         }
         runner.start()
-        // The stdout log file is written live; wait until the child reported its grandchild.
-        awaitTrue("fixture to start and report") {
-            logsDir.listDirectoryEntries("process-*-stdout.log").any { it.readText().contains("grandchild-pid:") }
+        val pidRecord = Regex("grandchild-pid:(\\d+)\r?\n") // newline-terminated ⇒ the record is complete
+        try {
+            // The stdout log file is written live; wait until the child reported its grandchild fully.
+            awaitTrue("fixture to start and report") {
+                logsDir.listDirectoryEntries("process-*-stdout.log").any { pidRecord.containsMatchIn(it.readText()) }
+            }
+        } finally {
+            // Whatever happened above, never leave the runner thread (and its child JVM) behind.
+            runner.interrupt()
         }
         val stdout = logsDir.listDirectoryEntries("process-*-stdout.log").single().readText()
-        val grandchildPid = Regex("grandchild-pid:(\\d+)").find(stdout)!!.groupValues[1].toLong()
+        val grandchildPid = pidRecord.find(stdout)!!.groupValues[1].toLong()
 
-        runner.interrupt()
         runner.join(30_000)
         assertFalse(runner.isAlive, "runner thread must finish")
         assertTrue(thrown is InterruptedException) { "expected InterruptedException, got $thrown" }

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/BinLauncher.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/BinLauncher.kt
@@ -1,6 +1,8 @@
 /* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
 package com.jonnyzzz.mcpSteroid.devrig
 
+import com.jonnyzzz.mcpSteroid.util.process.ProcessRunSpec
+import com.jonnyzzz.mcpSteroid.util.process.runProcess
 import java.io.File
 import java.nio.file.AtomicMoveNotSupportedException
 import java.nio.file.Files
@@ -9,6 +11,7 @@ import java.nio.file.StandardCopyOption
 import java.nio.file.attribute.PosixFilePermission
 import kotlin.io.path.exists
 import kotlin.io.path.readText
+import kotlin.time.Duration.Companion.seconds
 
 internal fun isWindows(): Boolean =
     System.getProperty("os.name").lowercase().contains("windows")
@@ -298,31 +301,44 @@ internal fun ensureWindowsPathEntry(binDir: Path) {
     val marker = binDirNorm.resolve(".user-path-registered")
     if (Files.exists(marker)) return
     val bin = binDirNorm.toString()
-    // De-dup: drop blanks and any existing == bin entry, then append exactly one bin entry.
+    // De-dup: drop blanks and any existing == bin entry, then append exactly one bin entry. The UTF-8
+    // prologue keeps localized PowerShell diagnostics readable through the runner's UTF-8 file decoding.
     val script =
-        "\$d = '${bin.replace("'", "''")}'; " +
+        "\$OutputEncoding = [Console]::OutputEncoding = [System.Text.Encoding]::UTF8; " +
+            "\$d = '${bin.replace("'", "''")}'; " +
             "\$p = [Environment]::GetEnvironmentVariable('Path','User'); if (\$null -eq \$p) { \$p = '' }; " +
             "\$parts = @(\$p -split ';' | Where-Object { \$_ -ne '' -and \$_ -ne \$d }); " +
             "\$new = (\$parts + \$d) -join ';'; " +
             "[Environment]::SetEnvironmentVariable('Path', \$new, 'User'); " +
             "[Console]::Error.WriteLine('[mcp-steroid] registered ' + \$d + ' on the user PATH (1 entry; open a new terminal to use it)')"
     try {
-        val exit = ProcessBuilder("powershell", "-NoProfile", "-NonInteractive", "-Command", script)
-            .redirectErrorStream(false)
-            .redirectOutput(ProcessBuilder.Redirect.DISCARD) // keep the MCP JSON-RPC channel clean
-            .redirectError(ProcessBuilder.Redirect.INHERIT)
-            .start()
-            .waitFor()
-        if (exit == 0) {
+        // Output goes to the runner's log files (never to stdout — the MCP JSON-RPC channel stays clean);
+        // stderr is replayed to our stderr after completion, preserving the old INHERIT narration.
+        val result = runProcess(
+            ProcessRunSpec(
+                command = listOf("powershell", "-NoProfile", "-NonInteractive", "-Command", script),
+                timeout = 60.seconds,
+                name = "powershell-user-path",
+                mergeStderrIntoStdout = false,
+            ),
+        )
+        val stderrText = result.logs.readStderr()
+        if (stderrText.isNotBlank()) System.err.print(stderrText.let { if (it.endsWith("\n")) it else it + "\n" })
+        if (result.exitCode == 0) {
+            result.logs.delete() // routine success — the log files are noise
             try {
                 Files.writeString(marker, bin)
             } catch (e: Exception) {
                 System.err.println("[mcp-steroid] could not write the user-PATH marker $marker: $e")
             }
         } else {
-            System.err.println("[mcp-steroid] PowerShell PATH registration exited $exit; will retry next start")
+            System.err.println(
+                "[mcp-steroid] PowerShell PATH registration exited ${result.exitCode}; will retry next start " +
+                    "(details: ${result.logs.commandLog})",
+            )
         }
     } catch (e: Exception) {
+        // Includes ProcessRunException (timeout / powershell missing) — registration stays best-effort.
         System.err.println(
             "[mcp-steroid] could not register $bin on the user PATH ($e); add it manually via " +
                 "System Properties -> Environment Variables (User PATH), or run devrig by full path",

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/InstallCommand.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/InstallCommand.kt
@@ -313,7 +313,7 @@ fun runInstallCheckCommand(
 
     out.println(
         "Checking the '$DEVRIG_MCP_SERVER_NAME' MCP registration for ${agent.displayName} " +
-            "(read-only — nothing is changed).",
+            "(read-only — no agent configuration is changed).",
     )
     out.println()
 

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/InstallCommand.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/InstallCommand.kt
@@ -1,9 +1,11 @@
 /* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
 package com.jonnyzzz.mcpSteroid.devrig
 
+import com.jonnyzzz.mcpSteroid.aiAgents.AiAgentCliInvocation
 import com.jonnyzzz.mcpSteroid.aiAgents.AiAgentCliResult
 import com.jonnyzzz.mcpSteroid.aiAgents.AiAgentCliRunner
 import com.jonnyzzz.mcpSteroid.aiAgents.ProcessAiAgentCliRunner
+import com.jonnyzzz.mcpSteroid.util.process.ProcessRunException
 import com.jonnyzzz.mcpSteroid.aiAgents.StdioMcpCommand
 import com.jonnyzzz.mcpSteroid.aiAgents.mcpAddStdioInvocation
 import com.jonnyzzz.mcpSteroid.aiAgents.mcpListInvocation
@@ -143,14 +145,15 @@ fun runInstallCommand(
     out.println()
 
     // Step 1 — review the agent's registered MCP servers so we can act on every devrig-owned entry,
-    // not just the canonical name. Listing is best-effort: if it fails or we can't parse it, we fall
-    // back to reconciling the known devrig names.
+    // not just the canonical name. Listing is best-effort: if it fails, times out, or the agent CLI
+    // cannot even start, we fall back to reconciling the known devrig names.
     out.println("Step 1/3: reviewing ${agent.displayName}'s registered MCP servers…")
-    val listResult = runner.run(mcpListInvocation(agent))
-    val listed = if (listResult.exitCode == 0) parseMcpServerList(agent, listResult.output) else emptyList()
+    val listResult = runAgentCliOrNull(runner, mcpListInvocation(agent), err)
+    val listReadable = listResult != null && listResult.exitCode == 0
+    val listed = if (listResult != null && listResult.exitCode == 0) parseMcpServerList(agent, listResult.output) else emptyList()
     val detected = listed.filter { it.isDevrigOwned() }
     when {
-        listResult.exitCode != 0 ->
+        !listReadable ->
             out.println("  could not read the server list; reconciling the known devrig names.")
         detected.isEmpty() ->
             out.println("  no existing devrig / '$DEVRIG_MCP_SERVER_NAME' registration found.")
@@ -162,14 +165,15 @@ fun runInstallCommand(
 
     // The shared install plan — `--check` prints exactly this same set (see installRemovalNames), so the
     // dry-run can never drift from what install actually removes.
-    val namesToRemove = installRemovalNames(detected, listReadable = listResult.exitCode == 0)
+    val namesToRemove = installRemovalNames(detected, listReadable = listReadable)
 
-    // Step 2 — clear them all. Each removal is best-effort: a non-zero exit means "not present", which is
-    // expected and not fatal. Underlying agent messages go to stderr; stdout reports confirmed removals.
+    // Step 2 — clear them all. Each removal is best-effort: a non-zero exit means "not present", and a
+    // timeout / unstartable CLI is diagnosed and skipped — neither is fatal. Underlying agent messages go
+    // to stderr; stdout reports confirmed removals.
     out.println("Step 2/3: consolidating into a single '$DEVRIG_MCP_SERVER_NAME' entry…")
     val removed = mutableListOf<String>()
     for (name in namesToRemove) {
-        val removeResult = runner.run(mcpRemoveInvocation(agent, name))
+        val removeResult = runAgentCliOrNull(runner, mcpRemoveInvocation(agent, name), err) ?: continue
         if (removeResult.exitCode == 0) removed += name
         emitAgentOutput(removeResult, err)
     }
@@ -179,10 +183,22 @@ fun runInstallCommand(
         removed.forEach { out.println("  - removed '$it'") }
     }
 
-    // Step 3 — add the single canonical registration.
+    // Step 3 — add the single canonical registration. This step is fatal on failure — unlike list and
+    // remove, a registration that did not happen must be reported loudly, but still with the friendly
+    // epilogue rather than Main.kt's unexpected-error stack trace.
     out.println("Step 3/3: registering '$DEVRIG_MCP_SERVER_NAME' with ${agent.displayName}…")
     val addInvocation = mcpAddStdioInvocation(agent, mcpCommand, DEVRIG_MCP_SERVER_NAME)
-    val addResult = runner.run(addInvocation)
+    val addResult = try {
+        runner.run(addInvocation)
+    } catch (e: ProcessRunException) {
+        err.println()
+        err.println(
+            "Registration FAILED: '${agent.binary} ${addInvocation.args.joinToString(" ")}' " +
+                "did not complete: ${e.message}",
+        )
+        err.println("Fix the error reported above, then re-run 'devrig install ${agent.binary}'.")
+        return 1
+    }
     emitAgentOutput(addResult, err)
     if (addResult.exitCode != 0) {
         err.println()
@@ -199,6 +215,23 @@ fun runInstallCommand(
     out.println("  Command ${agent.displayName} will run: $renderedCommand")
     out.println("  Verify with: ${agent.binary} mcp list")
     return 0
+}
+
+/**
+ * Runs a BEST-EFFORT agent CLI invocation: the [ProcessRunException] family (a timeout or an agent CLI
+ * that cannot start, e.g. not on PATH) becomes a stderr diagnostic and `null`, so the caller takes its
+ * existing graceful-degradation branch instead of aborting the whole flow. Fatal steps (the canonical
+ * add) do NOT use this — they catch the family themselves and fail loudly.
+ */
+private fun runAgentCliOrNull(
+    runner: AiAgentCliRunner,
+    invocation: AiAgentCliInvocation,
+    err: PrintStream,
+): AiAgentCliResult? = try {
+    runner.run(invocation)
+} catch (e: ProcessRunException) {
+    err.println("  '${invocation.binary} ${invocation.args.joinToString(" ")}' did not complete: ${e.message}")
+    null
 }
 
 private fun emitAgentOutput(result: AiAgentCliResult, err: PrintStream) {
@@ -261,7 +294,9 @@ fun DevrigServices.collectIdeReachability(): IdeReachabilityReport {
  * list cannot be read, since the state cannot be verified then.
  *
  * Stateless by design (Tenet 3): the only agent CLI invocation is the read-only `mcp list`, the IDE probe
- * reads markers/ports on demand, and the check writes nothing — two concurrent `--check` runs are safe.
+ * reads markers/ports on demand, and the check changes no agent configuration or launcher state — two
+ * concurrent `--check` runs are safe. (Like every devrig process launch, the `mcp list` call leaves
+ * diagnostic process logs under `~/.mcp-steroid/logs`; the runner's cleanup bounds them.)
  */
 fun runInstallCheckCommand(
     command: DevrigCommand.DevrigCommandInstall,
@@ -290,11 +325,12 @@ fun runInstallCheckCommand(
         out.println()
     }
 
-    // The SAME review step install performs — and the only agent CLI call --check makes.
+    // The SAME review step install performs — and the only agent CLI call --check makes. A timeout or an
+    // unstartable agent CLI degrades to the same unreadable-list drift path as a non-zero exit.
     val listInvocation = mcpListInvocation(agent)
-    val listResult = runner.run(listInvocation)
-    val listReadable = listResult.exitCode == 0
-    val listed = if (listReadable) parseMcpServerList(agent, listResult.output) else emptyList()
+    val listResult = runAgentCliOrNull(runner, listInvocation, err)
+    val listReadable = listResult != null && listResult.exitCode == 0
+    val listed = if (listResult != null && listResult.exitCode == 0) parseMcpServerList(agent, listResult.output) else emptyList()
     val detected = listed.filter { it.isDevrigOwned() }
 
     out.println("Current registration state:")
@@ -303,7 +339,7 @@ fun runInstallCheckCommand(
             out.println(
                 "  could not read ${agent.displayName}'s MCP server list " +
                     "('${listInvocation.binary} ${listInvocation.args.joinToString(" ")}' " +
-                    "exited with code ${listResult.exitCode}).",
+                    (if (listResult != null) "exited with code ${listResult.exitCode})." else "did not complete)."),
             )
         detected.isEmpty() ->
             out.println("  no existing devrig / '$DEVRIG_MCP_SERVER_NAME' registration found.")

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/ManagedBackend.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/ManagedBackend.kt
@@ -13,6 +13,10 @@ import com.jonnyzzz.mcpSteroid.ideDownloader.resolveHostOs
 import com.jonnyzzz.mcpSteroid.ideDownloader.unpackIdeArchive
 import com.jonnyzzz.mcpSteroid.ideDownloader.writeIdeStartupConfigFiles
 import com.jonnyzzz.mcpSteroid.ideDownloader.writeIdeUserStartupConfigFiles
+import com.jonnyzzz.mcpSteroid.util.process.ProcessRunSpec
+import com.jonnyzzz.mcpSteroid.util.process.ProcessTimeoutException
+import com.jonnyzzz.mcpSteroid.util.process.nullDevice
+import com.jonnyzzz.mcpSteroid.util.process.runProcess
 import java.io.File
 import java.nio.channels.FileChannel
 import java.nio.channels.OverlappingFileLockException
@@ -27,6 +31,7 @@ import kotlin.io.path.exists
 import kotlin.io.path.isDirectory
 import kotlin.jvm.optionals.getOrNull
 import kotlin.streams.asSequence
+import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.Serializable
@@ -860,10 +865,6 @@ private fun deleteRecursively(path: Path) {
     }
 }
 
-private fun nullDevice(): File {
-    return if (System.getProperty("os.name").startsWith("Windows", ignoreCase = true)) File("NUL") else File("/dev/null")
-}
-
 /**
  * Spawn the IDE launcher detached from the current process's lifetime, so it
  * survives devrig termination (and, on Windows, the surrounding shell's).
@@ -872,6 +873,11 @@ private fun nullDevice(): File {
  * and outlives the parent without special flags.
  *
  * Windows — see [spawnDetachedOnWindows].
+ *
+ * This is the ONE documented exception to "all process launches go through
+ * `runProcess`" (docs/design/process-runner-api.md): the IDE is detached by
+ * design, its output is appended to the backend's own log files, and it is
+ * never awaited — the runner's run-to-completion contract does not apply.
  */
 private fun spawnIdeProcess(
     launcher: Path,
@@ -910,65 +916,70 @@ private fun spawnDetachedOnWindows(
     // Start-Process (still inherits the caller's Job Object on Windows) is
     // sufficient — the IDE dies the moment a non-interactive shell session
     // (e.g. SSH-spawned cmd.exe) closes. WMI is the only stdlib-only escape.
-    val pidFile = Files.createTempFile("devrig-spawn-", ".pid")
-    val errFile = Files.createTempFile("devrig-spawn-", ".err")
-    try {
-        val launcherExt = launcher.fileName.toString().substringAfterLast('.', "").lowercase()
-        val isBatchScript = launcherExt == "bat" || launcherExt == "cmd"
-        val script = buildString {
-            // Win32_Process.Create (which wraps CreateProcess) cannot execute .bat/.cmd scripts
-            // directly — they require the cmd.exe interpreter. Wrap with cmd.exe /c so the batch
-            // file path is still visible in the process's command-line arguments, which lets
-            // processCommandIsUnderBackendsDir() recognise the process for stop/list tracking.
-            if (isBatchScript) {
-                append("\$cmd = 'cmd.exe /c \"' + '").append(psQuote(launcher.toString())).append("' + '\"'; ")
-            } else {
-                append("\$cmd = '\"' + '").append(psQuote(launcher.toString())).append("' + '\"'; ")
-            }
-            if (environment.isEmpty()) {
-                append("\$startup = \$null; ")
-            } else {
-                append("\$startup = ([wmiclass]'\\\\.\\root\\cimv2:Win32_ProcessStartup').CreateInstance(); ")
-                append("\$startup.EnvironmentVariables = @(")
-                append(environment.entries.joinToString(", ") { "'${psQuote("${it.key}=${it.value}")}'" })
-                append("); ")
-            }
-            append("\$r = ([wmiclass]'\\\\.\\root\\cimv2:Win32_Process').Create(\$cmd, '")
-            append(psQuote(workDir.toString())).append("', \$startup); ")
-            append("if (\$r.ReturnValue -ne 0) { Write-Error (\"Win32_Process.Create returned \" + \$r.ReturnValue); exit \$r.ReturnValue }; ")
-            append("\$r.ProcessId | Out-File -FilePath '").append(psQuote(pidFile.toAbsolutePath().toString())).append("' -Encoding ASCII")
-        }
-
-        val helper = ProcessBuilder("powershell.exe", "-NoProfile", "-NonInteractive", "-Command", script)
-            .redirectInput(ProcessBuilder.Redirect.from(nullDevice()))
-            .redirectOutput(ProcessBuilder.Redirect.DISCARD)
-            .redirectError(errFile.toFile())
-            .start()
-
-        val finished = helper.waitFor(10, TimeUnit.SECONDS)
-        if (!finished) {
-            helper.destroyForcibly()
-            error("WMI spawn helper timed out launching $launcher")
-        }
-        if (helper.exitValue() != 0) {
-            val errOutput = Files.readString(errFile).trim()
-            error("WMI spawn helper exited ${helper.exitValue()} launching $launcher; stderr: $errOutput")
-        }
-        val pidText = Files.readString(pidFile).trim()
-        return pidText.toLongOrNull()
-            ?: error("Could not parse pid from WMI spawn helper output: '$pidText'")
-    } finally {
-        deleteTempQuietly(pidFile)
-        deleteTempQuietly(errFile)
+    //
+    // Note: if the helper dies AFTER Win32_Process.Create succeeded, the IDE may
+    // be running although we report failure — the WMI-created process is not our
+    // descendant and cannot be tracked from here (same indeterminacy as always).
+    val result = try {
+        runProcess(
+            ProcessRunSpec(
+                command = listOf("powershell.exe", "-NoProfile", "-NonInteractive", "-Command", buildWmiSpawnScript(launcher, workDir, environment)),
+                timeout = 10.seconds,
+                name = "powershell-wmi-spawn",
+                mergeStderrIntoStdout = false,
+            ),
+        )
+    } catch (e: ProcessTimeoutException) {
+        error("WMI spawn helper timed out launching $launcher; logs: ${e.logs.commandLog}")
     }
+    if (result.exitCode != 0) {
+        error(
+            "WMI spawn helper exited ${result.exitCode} launching $launcher; " +
+                "stderr: ${result.logs.readStderr().trim()}; logs: ${result.logs.commandLog}",
+        )
+    }
+    // STRICT pid contract: the script prints exactly one line — the pid. Anything else (PowerShell
+    // chatter, profiles, encoding banners) must NOT be turned into a fake pid; keep the logs and fail.
+    val stdoutLines = result.logs.readStdout().lines().filter { it.isNotBlank() }
+    val pid = stdoutLines.singleOrNull()?.trim()?.toLongOrNull()
+        ?: error(
+            "Could not parse pid from WMI spawn helper output (${stdoutLines.size} non-blank line(s)); " +
+                "logs kept: ${result.logs.commandLog}",
+        )
+    result.logs.delete() // clean success — the log files are noise (matches the old temp-file lifecycle)
+    return pid
 }
 
-private fun deleteTempQuietly(path: Path) {
-    try {
-        Files.deleteIfExists(path)
-    } catch (e: Exception) {
-        System.err.println("Failed to delete temp file $path: $e")
+/**
+ * The PowerShell `-Command` script for [spawnDetachedOnWindows]. Factored and public (top-level) so the
+ * script text is unit-testable platform-neutrally: UTF-8 prologue, Win32_Process.Create, and the pid
+ * printed as the script's ONLY stdout line (the runner captures stdout to a log file; no temp files).
+ */
+fun buildWmiSpawnScript(launcher: Path, workDir: Path, environment: Map<String, String>): String = buildString {
+    append("\$OutputEncoding = [Console]::OutputEncoding = [System.Text.Encoding]::UTF8; ")
+    val launcherExt = launcher.fileName.toString().substringAfterLast('.', "").lowercase()
+    val isBatchScript = launcherExt == "bat" || launcherExt == "cmd"
+    // Win32_Process.Create (which wraps CreateProcess) cannot execute .bat/.cmd scripts
+    // directly — they require the cmd.exe interpreter. Wrap with cmd.exe /c so the batch
+    // file path is still visible in the process's command-line arguments, which lets
+    // processCommandIsUnderBackendsDir() recognise the process for stop/list tracking.
+    if (isBatchScript) {
+        append("\$cmd = 'cmd.exe /c \"' + '").append(psQuote(launcher.toString())).append("' + '\"'; ")
+    } else {
+        append("\$cmd = '\"' + '").append(psQuote(launcher.toString())).append("' + '\"'; ")
     }
+    if (environment.isEmpty()) {
+        append("\$startup = \$null; ")
+    } else {
+        append("\$startup = ([wmiclass]'\\\\.\\root\\cimv2:Win32_ProcessStartup').CreateInstance(); ")
+        append("\$startup.EnvironmentVariables = @(")
+        append(environment.entries.joinToString(", ") { "'${psQuote("${it.key}=${it.value}")}'" })
+        append("); ")
+    }
+    append("\$r = ([wmiclass]'\\\\.\\root\\cimv2:Win32_Process').Create(\$cmd, '")
+    append(psQuote(workDir.toString())).append("', \$startup); ")
+    append("if (\$r.ReturnValue -ne 0) { Write-Error (\"Win32_Process.Create returned \" + \$r.ReturnValue); exit \$r.ReturnValue }; ")
+    append("\$r.ProcessId")
 }
 
 /** Doubles single quotes for embedding inside a PowerShell single-quoted string literal. */

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/ManagedBackend.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/ManagedBackend.kt
@@ -26,7 +26,6 @@ import java.nio.file.StandardCopyOption
 import java.nio.file.StandardOpenOption
 import java.security.MessageDigest
 import java.time.Instant
-import java.util.concurrent.TimeUnit
 import kotlin.io.path.exists
 import kotlin.io.path.isDirectory
 import kotlin.jvm.optionals.getOrNull
@@ -938,17 +937,22 @@ private fun spawnDetachedOnWindows(
                 "stderr: ${result.logs.readStderr().trim()}; logs: ${result.logs.commandLog}",
         )
     }
-    // STRICT pid contract: the script prints exactly one line — the pid. Anything else (PowerShell
-    // chatter, profiles, encoding banners) must NOT be turned into a fake pid; keep the logs and fail.
-    val stdoutLines = result.logs.readStdout().lines().filter { it.isNotBlank() }
-    val pid = stdoutLines.singleOrNull()?.trim()?.toLongOrNull()
+    val pid = parseWmiSpawnPid(result.logs.readStdout())
         ?: error(
-            "Could not parse pid from WMI spawn helper output (${stdoutLines.size} non-blank line(s)); " +
-                "logs kept: ${result.logs.commandLog}",
+            "Could not parse pid from WMI spawn helper output; logs kept: ${result.logs.commandLog}",
         )
     result.logs.delete() // clean success — the log files are noise (matches the old temp-file lifecycle)
     return pid
 }
+
+/**
+ * STRICT pid contract for [spawnDetachedOnWindows]: the script prints exactly ONE non-blank stdout
+ * line — the pid. Anything else (PowerShell chatter, profiles, encoding banners, a truncation marker)
+ * must NOT be turned into a fake pid — null keeps the log files and fails the spawn. Factored and
+ * public (top-level) for platform-neutral unit tests.
+ */
+fun parseWmiSpawnPid(stdout: String): Long? =
+    stdout.lines().filter { it.isNotBlank() }.singleOrNull()?.trim()?.toLongOrNull()
 
 /**
  * The PowerShell `-Command` script for [spawnDetachedOnWindows]. Factored and public (top-level) so the

--- a/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/InstallCommandTest.kt
+++ b/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/InstallCommandTest.kt
@@ -425,6 +425,30 @@ class InstallCommandTest {
     }
 
     @Test
+    fun `install list start failure falls back to the known devrig names and still succeeds`() {
+        val recording = RecordingRunner()
+        val (exitCode, stdout, _) = runInstallWith(
+            AiAgentCli.CLAUDE,
+            FailingRunner(recording, failOnArg = "list", failure = startFailure("claude")),
+        )
+        assertEquals(0, exitCode)
+        assertContains(stdout, "could not read the server list; reconciling the known devrig names.")
+        assertTrue(recording.invocations.any { it.args.contains("add") }, "the add step must still run")
+    }
+
+    @Test
+    fun `install removal start failure is diagnosed and the remaining steps still run`() {
+        val recording = RecordingRunner()
+        val (exitCode, _, stderr) = runInstallWith(
+            AiAgentCli.CLAUDE,
+            FailingRunner(recording, failOnArg = "remove", failure = startFailure("claude")),
+        )
+        assertEquals(0, exitCode, "removals are best-effort:\n$stderr")
+        assertContains(stderr, "did not complete")
+        assertTrue(recording.invocations.any { it.args.contains("add") }, "the add step must still run")
+    }
+
+    @Test
     fun `install removal timeout is diagnosed and the remaining steps still run`() {
         val recording = RecordingRunner()
         val (exitCode, _, stderr) = runInstallWith(

--- a/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/InstallCommandTest.kt
+++ b/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/InstallCommandTest.kt
@@ -5,13 +5,18 @@ import com.jonnyzzz.mcpSteroid.aiAgents.AiAgentCli
 import com.jonnyzzz.mcpSteroid.aiAgents.AiAgentCliInvocation
 import com.jonnyzzz.mcpSteroid.aiAgents.AiAgentCliResult
 import com.jonnyzzz.mcpSteroid.aiAgents.AiAgentCliRunner
+import com.jonnyzzz.mcpSteroid.util.process.ProcessRunLogs
+import com.jonnyzzz.mcpSteroid.util.process.ProcessStartException
+import com.jonnyzzz.mcpSteroid.util.process.ProcessTimeoutException
 import java.io.ByteArrayOutputStream
+import java.io.IOException
 import java.io.PrintStream
 import java.nio.file.Path
 import kotlin.test.assertContains
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.seconds
 import org.junit.jupiter.api.Test
 
 class InstallCommandTest {
@@ -345,6 +350,148 @@ class InstallCommandTest {
             reachability = IdeReachabilityReport(reachable = 0, discovered = 0),
         )
         assertContains(r.stdout, "none discovered")
+    }
+
+    // --- ProcessRunException semantic boundaries (design doc v6, migration table) ------------------
+    // A hung agent CLI (ProcessTimeoutException) or one that cannot start, e.g. not on PATH
+    // (ProcessStartException), must degrade exactly like a non-zero exit at the best-effort steps
+    // (list, remove, --check list) and fail loudly-but-friendly at the fatal step (add) — never via
+    // Main.kt's unexpected-error stack trace.
+
+    private fun timeoutFailure(binary: String) = ProcessTimeoutException(
+        "process '$binary' (pid 123) timed out after 30s",
+        processName = binary,
+        pid = 123,
+        timeout = 30.seconds,
+        outputTail = emptyList(),
+        logs = dummyLogs(),
+    )
+
+    private fun startFailure(binary: String) = ProcessStartException(
+        "process '$binary' failed to start: No such file or directory",
+        processName = binary,
+        logs = dummyLogs(),
+        cause = IOException("No such file or directory"),
+    )
+
+    private fun dummyLogs() = ProcessRunLogs(
+        commandLog = Path.of("build/test-dummy-command.log"),
+        stdoutLog = Path.of("build/test-dummy-stdout.log"),
+        stderrLog = null,
+    )
+
+    /** Wraps a [RecordingRunner]; throws [failure] for invocations whose args contain [failOnArg]. */
+    private class FailingRunner(
+        private val delegate: RecordingRunner,
+        private val failOnArg: String,
+        private val failure: Throwable,
+    ) : AiAgentCliRunner {
+        override fun run(invocation: AiAgentCliInvocation): AiAgentCliResult {
+            if (invocation.args.contains(failOnArg)) throw failure
+            return delegate.run(invocation)
+        }
+    }
+
+    private fun runInstallWith(agent: AiAgentCli, runner: AiAgentCliRunner): Triple<Int, String, String> {
+        val stdout = ByteArrayOutputStream()
+        val stderr = ByteArrayOutputStream()
+        val exitCode = runInstallCommand(
+            command = DevrigCommand.DevrigCommandInstall(agent),
+            mcpCommand = mcpCommand,
+            out = PrintStream(stdout, true, Charsets.UTF_8),
+            err = PrintStream(stderr, true, Charsets.UTF_8),
+            runner = runner,
+        )
+        return Triple(exitCode, stdout.toString(Charsets.UTF_8), stderr.toString(Charsets.UTF_8))
+    }
+
+    @Test
+    fun `install list timeout falls back to the known devrig names and still succeeds`() {
+        val recording = RecordingRunner()
+        val (exitCode, stdout, stderr) = runInstallWith(
+            AiAgentCli.CLAUDE,
+            FailingRunner(recording, failOnArg = "list", failure = timeoutFailure("claude")),
+        )
+        assertEquals(0, exitCode, "install must still register:\n$stderr")
+        assertContains(stdout, "could not read the server list; reconciling the known devrig names.")
+        assertContains(stderr, "did not complete")
+        assertTrue(recording.invocations.any { it.args.contains("add") }, "the add step must still run")
+        // Unreadable list ⇒ the legacy name is cleared defensively too.
+        assertTrue(
+            recording.invocations.filter { it.args.contains("remove") }.map { it.args.last() }
+                .containsAll(listOf("mcp-steroid", "devrig")),
+            recording.invocations.toString(),
+        )
+    }
+
+    @Test
+    fun `install removal timeout is diagnosed and the remaining steps still run`() {
+        val recording = RecordingRunner()
+        val (exitCode, _, stderr) = runInstallWith(
+            AiAgentCli.CLAUDE,
+            FailingRunner(recording, failOnArg = "remove", failure = timeoutFailure("claude")),
+        )
+        assertEquals(0, exitCode, "removals are best-effort:\n$stderr")
+        assertContains(stderr, "did not complete")
+        assertTrue(recording.invocations.any { it.args.contains("add") }, "the add step must still run")
+    }
+
+    @Test
+    fun `install add timeout reports Registration FAILED with pinned exit 1`() {
+        val (exitCode, _, stderr) = runInstallWith(
+            AiAgentCli.CLAUDE,
+            FailingRunner(RecordingRunner(), failOnArg = "add", failure = timeoutFailure("claude")),
+        )
+        assertEquals(1, exitCode)
+        assertContains(stderr, "Registration FAILED")
+        assertContains(stderr, "did not complete")
+        assertContains(stderr, "re-run 'devrig install claude'")
+        assertFalse(stderr.contains("Unexpected error"), "must never take the Main.kt catch-all:\n$stderr")
+    }
+
+    @Test
+    fun `install add start failure (agent CLI not on PATH) reports Registration FAILED with exit 1`() {
+        val (exitCode, _, stderr) = runInstallWith(
+            AiAgentCli.CODEX,
+            FailingRunner(RecordingRunner(), failOnArg = "add", failure = startFailure("codex")),
+        )
+        assertEquals(1, exitCode)
+        assertContains(stderr, "Registration FAILED")
+        assertContains(stderr, "failed to start")
+    }
+
+    @Test
+    fun `check list timeout reports drift without crashing`() {
+        val stdout = ByteArrayOutputStream()
+        val stderr = ByteArrayOutputStream()
+        val exitCode = runInstallCheckCommand(
+            command = DevrigCommand.DevrigCommandInstall(AiAgentCli.CLAUDE, check = true),
+            mcpCommand = mcpCommand,
+            out = PrintStream(stdout, true, Charsets.UTF_8),
+            err = PrintStream(stderr, true, Charsets.UTF_8),
+            runner = FailingRunner(RecordingRunner(), failOnArg = "list", failure = timeoutFailure("claude")),
+            ideReachability = { IdeReachabilityReport(reachable = 0, discovered = 0) },
+        )
+        assertEquals(INSTALL_CHECK_DRIFT_EXIT_CODE, exitCode)
+        val out = stdout.toString(Charsets.UTF_8)
+        assertContains(out, "did not complete")
+        assertContains(out, "Drift detected")
+    }
+
+    @Test
+    fun `check list start failure reports drift without crashing`() {
+        val stdout = ByteArrayOutputStream()
+        val stderr = ByteArrayOutputStream()
+        val exitCode = runInstallCheckCommand(
+            command = DevrigCommand.DevrigCommandInstall(AiAgentCli.GEMINI, check = true),
+            mcpCommand = mcpCommand,
+            out = PrintStream(stdout, true, Charsets.UTF_8),
+            err = PrintStream(stderr, true, Charsets.UTF_8),
+            runner = FailingRunner(RecordingRunner(), failOnArg = "list", failure = startFailure("gemini")),
+            ideReachability = { IdeReachabilityReport(reachable = 0, discovered = 0) },
+        )
+        assertEquals(INSTALL_CHECK_DRIFT_EXIT_CODE, exitCode)
+        assertContains(stdout.toString(Charsets.UTF_8), "Drift detected")
     }
 
     private fun runCheck(

--- a/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/WmiSpawnScriptTest.kt
+++ b/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/WmiSpawnScriptTest.kt
@@ -3,7 +3,9 @@ package com.jonnyzzz.mcpSteroid.devrig
 
 import java.nio.file.Path
 import kotlin.test.assertContains
+import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import org.junit.jupiter.api.Test
 
@@ -60,5 +62,20 @@ class WmiSpawnScriptTest {
     fun `single quotes in paths are doubled for powershell literals`() {
         val script = buildWmiSpawnScript(Path.of("C:\\it's here\\idea64.exe"), workDir, emptyMap())
         assertContains(script, "it''s here")
+    }
+
+    @Test
+    fun `pid parse accepts exactly one non-blank numeric line`() {
+        assertEquals(4242L, parseWmiSpawnPid("4242"))
+        assertEquals(4242L, parseWmiSpawnPid("\n  4242  \r\n\n"))
+    }
+
+    @Test
+    fun `pid parse rejects chatter, multiple lines, and non-numeric output`() {
+        assertNull(parseWmiSpawnPid(""), "empty output")
+        assertNull(parseWmiSpawnPid("Loading personal profile...\n4242"), "chatter before the pid")
+        assertNull(parseWmiSpawnPid("4242\n4243"), "two numeric lines are ambiguous")
+        assertNull(parseWmiSpawnPid("PID: 4242"), "prefixed line is not a bare pid")
+        assertNull(parseWmiSpawnPid("4242 …[truncated by ProcessRunner]"), "a truncated line must not parse")
     }
 }

--- a/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/WmiSpawnScriptTest.kt
+++ b/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/WmiSpawnScriptTest.kt
@@ -1,0 +1,64 @@
+/* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
+package com.jonnyzzz.mcpSteroid.devrig
+
+import java.nio.file.Path
+import kotlin.test.assertContains
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * Platform-neutral checks of the WMI spawn PowerShell script TEXT (design doc v6, migration table).
+ * The Windows runtime path keeps its integration coverage; here we pin the script's contract:
+ * UTF-8 prologue, pid printed as the only stdout expression (captured by the process runner's log
+ * file — no temp files), batch wrapping, and quoting.
+ */
+class WmiSpawnScriptTest {
+    private val workDir = Path.of("C:\\work dir")
+
+    @Test
+    fun `script sets utf8 output encoding before anything else`() {
+        val script = buildWmiSpawnScript(Path.of("C:\\ide\\bin\\idea64.exe"), workDir, emptyMap())
+        assertTrue(
+            script.startsWith("\$OutputEncoding = [Console]::OutputEncoding = [System.Text.Encoding]::UTF8; "),
+            script,
+        )
+    }
+
+    @Test
+    fun `script emits the pid as its final stdout expression and uses no files`() {
+        val script = buildWmiSpawnScript(Path.of("C:\\ide\\bin\\idea64.exe"), workDir, emptyMap())
+        assertTrue(script.trimEnd().endsWith("\$r.ProcessId"), script)
+        assertFalse(script.contains("Out-File"), "pid must go to stdout, not a temp file: $script")
+    }
+
+    @Test
+    fun `batch launchers are wrapped with cmd exe so the script path stays visible`() {
+        val script = buildWmiSpawnScript(Path.of("C:\\ide\\bin\\idea.bat"), workDir, emptyMap())
+        assertContains(script, "cmd.exe /c")
+        assertContains(script, "idea.bat")
+    }
+
+    @Test
+    fun `binary launchers are not wrapped`() {
+        val script = buildWmiSpawnScript(Path.of("C:\\ide\\bin\\idea64.exe"), workDir, emptyMap())
+        assertFalse(script.contains("cmd.exe /c"), script)
+    }
+
+    @Test
+    fun `environment variables are embedded via Win32_ProcessStartup`() {
+        val script = buildWmiSpawnScript(
+            Path.of("C:\\ide\\bin\\idea64.exe"),
+            workDir,
+            mapOf("DEVRIG_TEST" to "value"),
+        )
+        assertContains(script, "Win32_ProcessStartup")
+        assertContains(script, "DEVRIG_TEST=value")
+    }
+
+    @Test
+    fun `single quotes in paths are doubled for powershell literals`() {
+        val script = buildWmiSpawnScript(Path.of("C:\\it's here\\idea64.exe"), workDir, emptyMap())
+        assertContains(script, "it''s here")
+    }
+}


### PR DESCRIPTION
## Summary

Introduces a production process runner in `mcp-core` (`com.jonnyzzz.mcpSteroid.util.process`) and routes every production `ProcessBuilder` call site through it. Design contract: `docs/design/process-runner-api.md` (v6) — refined through **five 3× agent-quorum review rounds** (claude / codex / gemini via run-agent), plus a final 3× code review of this diff.

### The runner (`runProcess`)

- **stdin closed** — redirected from the OS null device (`NUL` / `/dev/null`).
- **stdout/stderr redirected to log files** under `~/.mcp-steroid/logs` (merged into one file by default via `redirectErrorStream(true)`; split mode where stderr matters). Read after completion via bounded UTF-8 reads (`ProcessRunLogs.readStdout/readStderr`, 32 MiB cap, explicit truncation marker).
- **Command file audit record** — `process-<name>-<timestamp>-<pid>-<seq>-command.log` with argv (JSON), workdir, **sorted env KEYS only** (values may be secrets), merge flag; completed with pid, exit code / `TIMEOUT` / `INTERRUPTED` / `START-FAILED`, and duration. Owner-only permissions on POSIX. Cross-JVM-unique naming (pid token + `CREATE_NEW` retry).
- **Timeout** — required parameter; `waitFor(timeout)` + a bounded, best-effort **kill of the whole child tree** (descendants captured while the root is alive, root-first destroy, forced escalation, final sweep, WARN'd survivors). `ProcessTimeoutException` carries a bounded output tail (never in the message) and the log-file handles.
- **Typed failure family** — `ProcessRunException` = `ProcessTimeoutException` | `ProcessStartException` (missing binary), so best-effort call sites catch one clause. Interruption kills the child and propagates with the flag restored.
- **`logs.delete()`** — callers that know a run was routine can remove its files.
- **Cleanup** — at most once per JVM + 4 h marker throttle; strictly grammar-matched `process-*.log` files only (never other logs in the folder), non-recursive; 30-day age pass + 10 000-file watermark trimmed to 8 000 (filename-timestamp ordering keeps a run's files together; 1 h age floor protects live concurrent runs).
- **Never writes to stdout** — in `devrig mcp` mode stdout is the MCP JSON-RPC channel; the runner logs via slf4j only (WARN for kills/losses, DEBUG lifecycle).

### Migrations

| Call site | Before | After |
|---|---|---|
| `ai-agents` `ProcessAiAgentCliRunner` | `waitFor()` with **no timeout** | runner, merged streams, per-invocation budgets (30 s list/remove, 120 s add) |
| `npx-kt` `InstallCommand` (all four `runner.run` sites incl. `--check`) | a hung/missing agent CLI crashed via Main.kt's catch-all (exit 64 + stack trace) | `ProcessRunException` handled at each semantic boundary: list → fallback to known names, removals → log + continue, add → "Registration FAILED" + exit 1, `--check` → drift exit code |
| `npx-kt` `BinLauncher.ensureWindowsPathEntry` | `waitFor()` no timeout, stderr INHERIT | 60 s budget, UTF-8 PowerShell prologue, stderr replayed post-completion, logs deleted on success |
| `npx-kt` `ManagedBackend.spawnDetachedOnWindows` (WMI) | 2 temp files (pid + err) | runner captures both; script (factored + unit-tested) prints the pid to stdout; strict single-line pid parse; failure messages reference the kept log files |
| `npx-kt` `ManagedBackend.spawnIdeProcess` (POSIX) | raw `ProcessBuilder` | **stays raw** — the one documented exception (detached-by-design, never awaited); now reuses the public `nullDevice()` |

Deliberate behavior change (flagged for review): a missing agent binary during `devrig install` now takes the graceful boundaries instead of an "Unexpected error" stack trace.

## Tests

- `mcp-core`: cross-platform **child-JVM fixture** suite (no shell commands — deterministic bytes on Windows/Linux/macOS; `:mcp-core:test` runs on the 3-OS TC matrix): exit codes, merged/split streams, UTF-8 + malformed bytes, stdin EOF, **timeout kills child AND grandchild** (deadline-polled), interruption, START-FAILED, workdir/env, bounded reads, `delete()`, name sanitization, same-JVM concurrency, spec validation, null device; `CleanupProcessLogsTest` pins both cleanup passes, hysteresis, the age floor, filename-timestamp ordering, and the never-touch-foreign-files guarantee.
- `npx-kt`: `InstallCommandTest` boundary suite (timeout + start-failure at every step, incl. `--check`), `WmiSpawnScriptTest` (UTF-8 prologue, pid-to-stdout, batch wrapping, quoting).

`./gradlew :mcp-core:test :ai-agents:test :npx-kt:test` — green locally (macOS); Windows/Linux via the TC matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
