### PR TITLE
Bound every production process wait: agent-CLI + PowerShell timeouts, WMI tree kill

### DIFF
--- a/ai-agents/build.gradle.kts
+++ b/ai-agents/build.gradle.kts
@@ -7,8 +7,15 @@ repositories {
 }
 
 dependencies {
+    testImplementation(platform("org.junit:junit-bom:5.11.4"))
+    testImplementation("org.junit.jupiter:junit-jupiter")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 }
 
 kotlin {
     jvmToolchain(25)
+}
+
+tasks.test {
+    useJUnitPlatform()
 }

--- a/ai-agents/src/main/kotlin/com/jonnyzzz/mcpSteroid/aiAgents/AiAgentCli.kt
+++ b/ai-agents/src/main/kotlin/com/jonnyzzz/mcpSteroid/aiAgents/AiAgentCli.kt
@@ -1,6 +1,11 @@
 /* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
 package com.jonnyzzz.mcpSteroid.aiAgents
 
+import java.nio.file.Files
+import java.util.concurrent.TimeUnit
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
+
 enum class AiAgentCli(
     val binary: String,
     val displayName: String,
@@ -47,14 +52,50 @@ fun interface AiAgentCliRunner {
     fun run(invocation: AiAgentCliInvocation): AiAgentCliResult
 }
 
-class ProcessAiAgentCliRunner : AiAgentCliRunner {
+/**
+ * Runs an agent CLI to completion with a hard [timeout].
+ *
+ * Output goes to a TEMP FILE, not a pipe: with a pipe, draining via
+ * `readText()` blocks until EOF and no timeout can ever fire — a hung agent
+ * CLI then hangs devrig forever, uninterruptibly (pipe reads ignore thread
+ * interrupts). With a file redirect, `waitFor(timeout)` is real timeout
+ * enforcement. stderr stays merged into stdout (same interleaving as the
+ * previous `redirectErrorStream(true)` behavior); stdin is closed right
+ * after start so a CLI that reads stdin sees EOF instead of blocking on a
+ * pipe nobody writes to.
+ *
+ * On timeout the child process tree is killed (descendants captured before
+ * the root dies — they reparent afterwards) and [IllegalStateException] is
+ * thrown: a loud, bounded failure instead of today's unbounded hang.
+ */
+class ProcessAiAgentCliRunner(
+    private val timeout: Duration = 120.seconds,
+) : AiAgentCliRunner {
     override fun run(invocation: AiAgentCliInvocation): AiAgentCliResult {
-        val process = ProcessBuilder(listOf(invocation.binary) + invocation.args)
-            .redirectErrorStream(true)
-            .start()
-        val output = process.inputStream.bufferedReader().use { it.readText() }
-        val exitCode = process.waitFor()
-        return AiAgentCliResult(exitCode, output)
+        val outputFile = Files.createTempFile("devrig-agent-cli-", ".out")
+        try {
+            val process = ProcessBuilder(listOf(invocation.binary) + invocation.args)
+                .redirectErrorStream(true)
+                .redirectOutput(outputFile.toFile())
+                .start()
+            process.outputStream.close() // stdin: immediate EOF
+            if (!process.waitFor(timeout.inWholeMilliseconds, TimeUnit.MILLISECONDS)) {
+                val descendants = process.descendants().toList()
+                process.destroyForcibly()
+                descendants.forEach { it.destroyForcibly() }
+                throw IllegalStateException(
+                    "'${invocation.binary} ${invocation.args.joinToString(" ")}' " +
+                        "timed out after $timeout and was killed",
+                )
+            }
+            return AiAgentCliResult(process.exitValue(), Files.readString(outputFile, Charsets.UTF_8))
+        } finally {
+            try {
+                Files.deleteIfExists(outputFile)
+            } catch (e: Exception) {
+                System.err.println("[mcp-steroid] could not delete agent CLI output file $outputFile: $e")
+            }
+        }
     }
 }
 

--- a/ai-agents/src/main/kotlin/com/jonnyzzz/mcpSteroid/aiAgents/AiAgentCli.kt
+++ b/ai-agents/src/main/kotlin/com/jonnyzzz/mcpSteroid/aiAgents/AiAgentCli.kt
@@ -64,9 +64,8 @@ fun interface AiAgentCliRunner {
  * after start so a CLI that reads stdin sees EOF instead of blocking on a
  * pipe nobody writes to.
  *
- * On timeout the child process tree is killed (descendants captured before
- * the root dies — they reparent afterwards) and [IllegalStateException] is
- * thrown: a loud, bounded failure instead of today's unbounded hang.
+ * On timeout the child is killed and [IllegalStateException] is thrown:
+ * a loud, bounded failure instead of an unbounded hang.
  */
 class ProcessAiAgentCliRunner(
     private val timeout: Duration = 120.seconds,
@@ -78,11 +77,9 @@ class ProcessAiAgentCliRunner(
                 .redirectErrorStream(true)
                 .redirectOutput(outputFile.toFile())
                 .start()
-            process.outputStream.close() // stdin: immediate EOF
+            runCatching { process.outputStream.close() } // stdin: immediate EOF
             if (!process.waitFor(timeout.inWholeMilliseconds, TimeUnit.MILLISECONDS)) {
-                val descendants = process.descendants().toList()
                 process.destroyForcibly()
-                descendants.forEach { it.destroyForcibly() }
                 throw IllegalStateException(
                     "'${invocation.binary} ${invocation.args.joinToString(" ")}' " +
                         "timed out after $timeout and was killed",

--- a/ai-agents/src/test/kotlin/com/jonnyzzz/mcpSteroid/aiAgents/AgentCliFixtureMain.kt
+++ b/ai-agents/src/test/kotlin/com/jonnyzzz/mcpSteroid/aiAgents/AgentCliFixtureMain.kt
@@ -1,0 +1,66 @@
+/* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
+package com.jonnyzzz.mcpSteroid.aiAgents
+
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
+
+/**
+ * Child-JVM stand-in for an agent CLI (`claude`/`codex`/`gemini`) in
+ * [ProcessAiAgentCliRunner] tests. A real JVM process gives deterministic,
+ * OS-independent behavior — shell commands differ per OS and are banned for
+ * behavioral tests by the process-runner design doc.
+ */
+object AgentCliFixtureMain {
+    @JvmStatic
+    fun main(args: Array<String>) {
+        when (args.firstOrNull()) {
+            // echo <exitCode>: one line to each stream, then exit.
+            "echo" -> {
+                System.out.println("fixture-stdout-line")
+                System.err.println("fixture-stderr-line")
+                System.out.flush()
+                System.err.flush()
+                Runtime.getRuntime().exit(args[1].toInt())
+            }
+            // stdin: report how many bytes stdin delivered before EOF, exit 0.
+            "stdin" -> {
+                var count = 0L
+                val buf = ByteArray(8192)
+                while (true) {
+                    val n = System.`in`.read(buf)
+                    if (n < 0) break
+                    count += n
+                }
+                System.out.println("stdin-eof:$count")
+                System.out.flush()
+            }
+            // sleep <pidFile>: report our pid to the file, then hang forever.
+            "sleep" -> {
+                Files.writeString(Paths.get(args[1]), ProcessHandle.current().pid().toString())
+                while (true) Thread.sleep(60_000)
+            }
+            else -> {
+                System.err.println("unknown fixture mode: ${args.toList()}")
+                Runtime.getRuntime().exit(64)
+            }
+        }
+    }
+}
+
+/**
+ * Builds an [AiAgentCliInvocation] that launches the fixture as a child JVM.
+ * The classpath travels via a java @argfile (forward slashes inside a quoted
+ * token) so the command stays under the Windows ~32k command-line limit.
+ */
+fun agentCliFixtureInvocation(vararg mode: String): AiAgentCliInvocation {
+    val isWindows = System.getProperty("os.name").startsWith("Windows")
+    val javaBin = Paths.get(System.getProperty("java.home"), "bin", if (isWindows) "java.exe" else "java")
+    val argFile: Path = Files.createTempFile("agent-cli-fixture-", ".args")
+    argFile.toFile().deleteOnExit()
+    Files.writeString(argFile, "-cp \"${System.getProperty("java.class.path").replace('\\', '/')}\"\n")
+    return AiAgentCliInvocation(
+        binary = javaBin.toString(),
+        args = listOf("@$argFile", AgentCliFixtureMain::class.java.name) + mode,
+    )
+}

--- a/ai-agents/src/test/kotlin/com/jonnyzzz/mcpSteroid/aiAgents/ProcessAiAgentCliRunnerTest.kt
+++ b/ai-agents/src/test/kotlin/com/jonnyzzz/mcpSteroid/aiAgents/ProcessAiAgentCliRunnerTest.kt
@@ -1,0 +1,84 @@
+/* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
+package com.jonnyzzz.mcpSteroid.aiAgents
+
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.concurrent.TimeUnit
+import kotlin.io.path.exists
+import kotlin.io.path.readText
+import kotlin.time.Duration.Companion.seconds
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Timeout
+import org.junit.jupiter.api.io.TempDir
+
+@Timeout(120, unit = TimeUnit.SECONDS)
+class ProcessAiAgentCliRunnerTest {
+    @TempDir
+    lateinit var tempDir: Path
+
+    private fun awaitTrue(what: String, timeoutMs: Long = 30_000, condition: () -> Boolean) {
+        val deadline = System.nanoTime() + timeoutMs * 1_000_000
+        while (!condition()) {
+            check(System.nanoTime() < deadline) { "timed out waiting for: $what" }
+            Thread.sleep(20)
+        }
+    }
+
+    @Test
+    fun `exit code and merged output pass through`() {
+        val result = ProcessAiAgentCliRunner().run(agentCliFixtureInvocation("echo", "3"))
+        assertEquals(3, result.exitCode)
+        assertTrue(result.output.contains("fixture-stdout-line")) { result.output }
+        assertTrue(result.output.contains("fixture-stderr-line"), "stderr must stay merged into the output")
+    }
+
+    @Test
+    fun `zero exit code passes through`() {
+        assertEquals(0, ProcessAiAgentCliRunner().run(agentCliFixtureInvocation("echo", "0")).exitCode)
+    }
+
+    @Test
+    fun `stdin is closed - a stdin-reading agent CLI sees immediate eof instead of hanging`() {
+        val result = ProcessAiAgentCliRunner(timeout = 30.seconds).run(agentCliFixtureInvocation("stdin"))
+        assertEquals(0, result.exitCode)
+        assertTrue(result.output.contains("stdin-eof:0")) { result.output }
+    }
+
+    @Test
+    fun `a hung agent CLI is killed at the timeout and reported loudly`() {
+        val pidFile = tempDir.resolve("fixture.pid")
+        val ex = assertThrows(IllegalStateException::class.java) {
+            ProcessAiAgentCliRunner(timeout = 3.seconds).run(agentCliFixtureInvocation("sleep", pidFile.toString()))
+        }
+        assertTrue(ex.message!!.contains("timed out")) { ex.message }
+
+        assertTrue(pidFile.exists(), "the fixture must have started and reported its pid")
+        val pid = pidFile.readText().trim().toLong()
+        awaitTrue("hung agent CLI process $pid to be killed") {
+            ProcessHandle.of(pid).map { !it.isAlive }.orElse(true)
+        }
+    }
+
+    @Test
+    fun `no temp output files are left behind`() {
+        val before = tempOutputFiles()
+        ProcessAiAgentCliRunner().run(agentCliFixtureInvocation("echo", "0"))
+        assertThrows(IllegalStateException::class.java) {
+            ProcessAiAgentCliRunner(timeout = 2.seconds).run(agentCliFixtureInvocation("sleep", tempDir.resolve("p.pid").toString()))
+        }
+        val after = tempOutputFiles()
+        assertEquals(before, after, "runner must clean up its temp output files on success AND on timeout")
+        assertFalse(after.any { it.contains("devrig-agent-cli") && !before.contains(it) })
+    }
+
+    private fun tempOutputFiles(): Set<String> {
+        val tmp = Path.of(System.getProperty("java.io.tmpdir"))
+        return Files.list(tmp).use { stream ->
+            stream.map { it.fileName.toString() }.filter { it.startsWith("devrig-agent-cli-") }.toList().toSet()
+        }
+    }
+}

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/BinLauncher.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/BinLauncher.kt
@@ -7,6 +7,7 @@ import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.StandardCopyOption
 import java.nio.file.attribute.PosixFilePermission
+import java.util.concurrent.TimeUnit
 import kotlin.io.path.exists
 import kotlin.io.path.readText
 
@@ -307,20 +308,27 @@ internal fun ensureWindowsPathEntry(binDir: Path) {
             "[Environment]::SetEnvironmentVariable('Path', \$new, 'User'); " +
             "[Console]::Error.WriteLine('[mcp-steroid] registered ' + \$d + ' on the user PATH (1 entry; open a new terminal to use it)')"
     try {
-        val exit = ProcessBuilder("powershell", "-NoProfile", "-NonInteractive", "-Command", script)
+        val process = ProcessBuilder("powershell", "-NoProfile", "-NonInteractive", "-Command", script)
             .redirectErrorStream(false)
             .redirectOutput(ProcessBuilder.Redirect.DISCARD) // keep the MCP JSON-RPC channel clean
             .redirectError(ProcessBuilder.Redirect.INHERIT)
             .start()
-            .waitFor()
-        if (exit == 0) {
+        process.outputStream.close() // stdin: immediate EOF — never an open pipe the child could block on
+        // This runs on the devrig start-up path: an unbounded waitFor() would let a stuck
+        // powershell block every `devrig mcp` start forever. Bounded + killed instead.
+        if (!process.waitFor(60, TimeUnit.SECONDS)) {
+            val descendants = process.descendants().toList() // capture BEFORE the root dies — they reparent after
+            process.destroyForcibly()
+            descendants.forEach { it.destroyForcibly() }
+            System.err.println("[mcp-steroid] PowerShell PATH registration timed out after 60s and was killed; will retry next start")
+        } else if (process.exitValue() == 0) {
             try {
                 Files.writeString(marker, bin)
             } catch (e: Exception) {
                 System.err.println("[mcp-steroid] could not write the user-PATH marker $marker: $e")
             }
         } else {
-            System.err.println("[mcp-steroid] PowerShell PATH registration exited $exit; will retry next start")
+            System.err.println("[mcp-steroid] PowerShell PATH registration exited ${process.exitValue()}; will retry next start")
         }
     } catch (e: Exception) {
         System.err.println(

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/BinLauncher.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/BinLauncher.kt
@@ -313,13 +313,11 @@ internal fun ensureWindowsPathEntry(binDir: Path) {
             .redirectOutput(ProcessBuilder.Redirect.DISCARD) // keep the MCP JSON-RPC channel clean
             .redirectError(ProcessBuilder.Redirect.INHERIT)
             .start()
-        process.outputStream.close() // stdin: immediate EOF — never an open pipe the child could block on
+        runCatching { process.outputStream.close() } // stdin: immediate EOF — never an open pipe the child could block on
         // This runs on the devrig start-up path: an unbounded waitFor() would let a stuck
         // powershell block every `devrig mcp` start forever. Bounded + killed instead.
         if (!process.waitFor(60, TimeUnit.SECONDS)) {
-            val descendants = process.descendants().toList() // capture BEFORE the root dies — they reparent after
             process.destroyForcibly()
-            descendants.forEach { it.destroyForcibly() }
             System.err.println("[mcp-steroid] PowerShell PATH registration timed out after 60s and was killed; will retry next start")
         } else if (process.exitValue() == 0) {
             try {

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/ManagedBackend.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/ManagedBackend.kt
@@ -947,7 +947,11 @@ private fun spawnDetachedOnWindows(
 
         val finished = helper.waitFor(10, TimeUnit.SECONDS)
         if (!finished) {
+            // Kill the whole helper tree, not just powershell.exe: capture descendants BEFORE the
+            // root dies — orphans reparent afterwards and would escape the sweep.
+            val descendants = helper.descendants().toList()
             helper.destroyForcibly()
+            descendants.forEach { it.destroyForcibly() }
             error("WMI spawn helper timed out launching $launcher")
         }
         if (helper.exitValue() != 0) {

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/ManagedBackend.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/ManagedBackend.kt
@@ -947,11 +947,7 @@ private fun spawnDetachedOnWindows(
 
         val finished = helper.waitFor(10, TimeUnit.SECONDS)
         if (!finished) {
-            // Kill the whole helper tree, not just powershell.exe: capture descendants BEFORE the
-            // root dies — orphans reparent afterwards and would escape the sweep.
-            val descendants = helper.descendants().toList()
             helper.destroyForcibly()
-            descendants.forEach { it.destroyForcibly() }
             error("WMI spawn helper timed out launching $launcher")
         }
         if (helper.exitValue() != 0) {


### PR DESCRIPTION
## Summary

Minimal hotfix for the production findings of the ProcessBuilder / stream audit: every production process wait is now bounded, and no child is left with an open stdin pipe. The systematic replacement is PR #386, which supersedes these call sites via the shared `mcp-core` runner and will rebase on top of this.

**Fixes #150** — the exact hang from that issue's thread dump (`ensureWindowsPathEntry` → `ProcessImpl.waitFor`, open stdin + unbounded wait): stdin is now closed right after start (`runCatching { outputStream.close() }`) and the wait is bounded at 60 s with a kill + non-fatal retry-next-start message. (#150's secondary ask — capturing PowerShell output for diagnostics — lands with #386's per-process log files.)

Related: #342 (raw stacktrace when the agent CLI is missing) — not fixed here; #386 introduces the typed `ProcessRunException` family and graceful handling at the install/--check boundaries.

| Call site | Before (main) | After |
|---|---|---|
| `ai-agents` `ProcessAiAgentCliRunner` (every `devrig install`) | no timeout; `readText()` on the merged pipe blocks until EOF — a hung agent CLI hangs devrig **forever and uninterruptibly** (pipe reads ignore thread interrupts; reproduced: a test worker sat 37 min in `FileInputStream.readBytes` with JUnit `@Timeout` unable to stop it). stdin left as an open pipe that never delivers EOF. | output → temp file, so `waitFor(120 s default)` is real timeout enforcement; stdin closed right after start; on timeout the child is killed and a clear `IllegalStateException` replaces the hang. Temp file always deleted. |
| `BinLauncher.ensureWindowsPathEntry` (devrig start-up path) | open stdin + unbounded `waitFor()` — a stuck `powershell` blocks every `devrig mcp` start (#150) | stdin closed, bounded at 60 s, killed, logged non-fatally (registration retries next start). stdout stays DISCARDed — the MCP JSON-RPC channel is untouched. |

Kept deliberately minimal per review: direct-child kill only (no descendants sweep — tree-kill semantics arrive with #386's runner), and the WMI spawn helper is untouched (reverted to main).

## Tests

First test suite for `:ai-agents` (JUnit 5 wired up): a cross-platform child-JVM fixture (no shell commands — deterministic on the 3-OS TC matrix) pins exit-code/merged-output passthrough, stdin-EOF, the timeout kill (fixture reports its pid; the test polls it to death), and temp-file cleanup on both success and timeout. `./gradlew :ai-agents:test :npx-kt:test` green locally; `:ai-agents:test` is already in the per-OS `ciBuildPluginTests` matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)