### PR TITLE
Fix steroid_input/take_screenshot dialog defects under modality (#309)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,18 @@
 # TODO
 
+- [ ] **steroid_input / take_screenshot #309 follow-ups** (the three core defects — modal-EDT hang,
+  window-relative click coordinates, wrong window_id echo — are fixed and guarded by
+  `SteroidInputDialogIntegrationTest`; remaining hardening surfaced by the 2026-07-30 review):
+  - [ ] Ghost-input hazard: an input step already parked on the EDT when its MCP request dies
+    (client disconnect / handler timeout) still fires later against whatever UI is current.
+    Consider a cancellation check inside each EDT step before dispatching.
+  - [ ] `steroid_take_screenshot` has no handler-level timeout either (P1's `withTimeout` was added
+    to `steroid_input` only); capture() uses `ModalityState.any()` so it does not hang under modals,
+    but a wedged EDT would still stall it — consider the same safety net.
+  - [ ] Update issue #309: causal theory (window_id → P1/P2) disproven; Breakpoints dialog is
+    non-modal (`setModal(false)`); tool docs could state coordinates are window-relative including
+    decorations, and that `screen:` targets exist.
+
 - [ ] **Native MCP tools — implement per `docs/native-mcp-tools-design.md`** (spec landed first;
   research 3×-quorum validated + live-tested on IU-261.25134.95, 2026-07-22):
   - [ ] Scenario B (chosen first step): `IntelliJMcpServerProbe.listNativeTools()` (+ drop the

--- a/ij-plugin/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/ListWindowsToolHandler.kt
+++ b/ij-plugin/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/ListWindowsToolHandler.kt
@@ -139,7 +139,13 @@ class IdeWindowsCollector {
                         WindowInfo(
                             projectName = null,
                             projectPath = null,
-                            title = (window as? Frame)?.title,
+                            // Dialogs are the common case in this fallback branch — a Frame-only cast
+                            // left every dialog with title=null, making them untargetable (issue #309).
+                            title = when (window) {
+                                is Frame -> window.title
+                                is java.awt.Dialog -> window.title
+                                else -> null
+                            },
                             isActive = window.isActive,
                             isVisible = window.isVisible,
                             bounds = WindowBounds(bounds.x, bounds.y, bounds.width, bounds.height),

--- a/ij-plugin/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/VisionInputToolHandler.kt
+++ b/ij-plugin/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/VisionInputToolHandler.kt
@@ -6,8 +6,15 @@ import com.intellij.openapi.diagnostic.thisLogger
 import com.jonnyzzz.mcpSteroid.mcp.ToolCallResult
 import com.jonnyzzz.mcpSteroid.mcp.builder
 import com.jonnyzzz.mcpSteroid.storage.executionStorage
+import com.jonnyzzz.mcpSteroid.vision.InputStep
 import com.jonnyzzz.mcpSteroid.vision.VisionService
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.withTimeout
 import kotlinx.serialization.json.*
+
+/** Fixed allowance for delivering the non-delay steps of an input sequence (issue #309). */
+private const val INPUT_DISPATCH_TIMEOUT_MS = 60_000L
 
 class VisionInputToolHandlerIJ : VisionInputToolHandler {
     private val json = Json { ignoreUnknownKeys = true }
@@ -30,13 +37,30 @@ class VisionInputToolHandlerIJ : VisionInputToolHandler {
 
         val windowId = inputParams.windowId
 
+        // Safety net for issue #309, problem 1: input dispatch must never hang the tool call
+        // indefinitely (no other layer on the tools/call path bounds it). The budget covers the
+        // sequence's own delay steps plus a fixed dispatch allowance.
+        val delayBudgetMs = inputParams.sequence.filterIsInstance<InputStep.Delay>().sumOf { it.ms }
+        val timeoutMs = delayBudgetMs + INPUT_DISPATCH_TIMEOUT_MS
+
         try {
             log("execution_id: ${executionId.executionId}")
             log("WARNING: Heavy endpoint. Prefer steroid_execute_code for regular automation.")
             log("Using window_id: $windowId")
 
-            VisionService.getInstance(project).executeInput(windowId, inputParams.sequence)
+            withTimeout(timeoutMs) {
+                VisionService.getInstance(project).executeInput(windowId, inputParams.sequence)
+            }
             log("Input sequence executed successfully.")
+        } catch (e: TimeoutCancellationException) {
+            // A domain error the agent must see, not a control-flow signal — caught BEFORE the
+            // generic CancellationException rethrow (same pattern as ScriptExecutor.executeCodeBlocks).
+            val message = "Input execution timed out after ${timeoutMs} ms — the input events could not be " +
+                    "delivered to window_id $windowId (EDT busy or window not processing events)"
+            builder.addTextContent("ERROR: $message").markAsError()
+            project.executionStorage.writeCodeErrorEvent(executionId, message)
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
             val message = "Input execution failed: ${e.message}"
             builder.addTextContent("ERROR: $message").markAsError()

--- a/ij-plugin/src/main/kotlin/com/jonnyzzz/mcpSteroid/vision/VisionService.kt
+++ b/ij-plugin/src/main/kotlin/com/jonnyzzz/mcpSteroid/vision/VisionService.kt
@@ -17,6 +17,7 @@ import com.jonnyzzz.mcpSteroid.storage.executionStorage
 import kotlinx.coroutines.CoroutineName
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -143,14 +144,13 @@ class VisionService(
             dir
         }
 
-        // Capture component info on EDT (use ModalityState.any() so this works even when modal dialogs are showing)
-        val capture = withContext(Dispatchers.EDT + ModalityState.any().asContextElement()) {
-            captureOnEdt(windowId)
-        }
-
-        // Create context for metadata providers (image is provided by ScreenshotImageProvider)
-        val component = withContext(Dispatchers.EDT + ModalityState.any().asContextElement()) {
-            resolveComponent(windowId)
+        // Capture component info on EDT (use ModalityState.any() so this works even when modal dialogs
+        // are showing). Resolve the component ONCE and reuse it for the metadata providers below —
+        // resolving again in a second hop could describe a different component than the captured image
+        // (e.g. a modal dialog closing in between).
+        val (capture, component) = withContext(Dispatchers.EDT + ModalityState.any().asContextElement()) {
+            val component = resolveComponent(windowId)
+            captureOnEdt(component) to component
         }
 
         val initialContext = ScreenCaptureContext(
@@ -380,9 +380,7 @@ class VisionService(
         val projectPath: String?,
     )
 
-    private fun captureOnEdt(windowId: String?): CaptureInfo {
-        val component = resolveComponent(windowId)
-
+    private fun captureOnEdt(component: Component): CaptureInfo {
         val size = component.size
         val preferred = component.preferredSize
         val width = size.width.takeIf { it > 0 } ?: preferred.width.takeIf { it > 0 } ?: 1024
@@ -397,10 +395,17 @@ class VisionService(
         }
 
         val location = runCatching { component.locationOnScreen }.getOrNull()
-        val window = SwingUtilities.getWindowAncestor(component)
+        // A captured dialog IS a Window: getWindowAncestor walks from getParent(), which for a Window
+        // is its OWNER — the response would echo the owner frame's windowId/bounds/title instead of
+        // the dialog's (issue #309, problem 3). Same pattern as ensureFocus.
+        val window = component as? Window ?: SwingUtilities.getWindowAncestor(component)
         val windowIdValue = WindowIdUtil.compute(window, component)
         val windowBounds = window?.bounds?.let { Rect(it.x, it.y, it.width, it.height) }
-        val windowTitle = (window as? java.awt.Frame)?.title
+        val windowTitle = when (window) {
+            is java.awt.Frame -> window.title
+            is java.awt.Dialog -> window.title
+            else -> null
+        }
 
         return CaptureInfo(
             image = image,
@@ -462,25 +467,37 @@ class VisionService(
         private val stuckKeys = LinkedHashSet<Int>()
 
         suspend fun execute(steps: List<InputStep>) {
-            val rootComponent = withContext(Dispatchers.EDT) {
+            // ModalityState.any(): bare Dispatchers.EDT dispatches with NON_MODAL modality, which the
+            // platform withholds while any modal dialog is open — the first hop would park forever and
+            // the whole tool call hangs (issue #309, problem 1). Input must reach dialogs too; this is
+            // the same fix capture() received in e4ebf791.
+            val edtAny = Dispatchers.EDT + ModalityState.any().asContextElement()
+            val rootComponent = withContext(edtAny) {
                 resolveComponentForInput()
             }
 
             try {
-                withContext(Dispatchers.EDT) {
-                    ensureFocus(rootComponent)
+                withContext(edtAny) {
+                    // Activate the target window ONLY — do not requestFocus() on the root component.
+                    // ensureFocus(root) would call IdeFocusManager.requestFocus(window, true), which
+                    // displaces the focus owner a prior click established, so a following press:/type:
+                    // step (which must reach the focused component) loses its target (issue #309,
+                    // problem 2 — the press:SPACE case).
+                    activateWindow(rootComponent)
                 }
                 for (step in steps) {
                     when (step) {
                         is InputStep.Delay -> delay(step.ms)
-                        is InputStep.StickKey -> withContext(Dispatchers.EDT) { stickKey(rootComponent, step) }
-                        is InputStep.PressKey -> withContext(Dispatchers.EDT) { pressKey(rootComponent, step) }
-                        is InputStep.TypeText -> withContext(Dispatchers.EDT) { typeText(rootComponent, step) }
-                        is InputStep.Click -> withContext(Dispatchers.EDT) { click(rootComponent, step) }
+                        is InputStep.StickKey -> withContext(edtAny) { stickKey(rootComponent, step) }
+                        is InputStep.PressKey -> withContext(edtAny) { pressKey(rootComponent, step) }
+                        is InputStep.TypeText -> withContext(edtAny) { typeText(rootComponent, step) }
+                        is InputStep.Click -> withContext(edtAny) { click(rootComponent, step) }
                     }
                 }
             } finally {
-                withContext(Dispatchers.EDT) {
+                // NonCancellable: on cancellation a plain withContext throws before running the block,
+                // leaking stuck modifier keys into the IDE.
+                withContext(NonCancellable + edtAny) {
                     releaseAll(rootComponent)
                 }
             }
@@ -492,22 +509,31 @@ class VisionService(
         }
 
         private fun stickKey(component: Component, step: InputStep.StickKey) {
-            ensureFocus(component)
+            // Read the focus owner BEFORE ensuring focus: ensureFocus(focus) re-asserts focus on the
+            // current owner, but ensureFocus(root) would displace it (issue #309, problem 2).
+            val focus = focusOwner(component)
+            ensureFocus(focus)
             if (stuckKeys.add(step.keyCode)) {
-                dispatchKey(component, KeyEvent.KEY_PRESSED, step.keyCode, '\u0000', currentModifiers())
+                dispatchKey(focus, KeyEvent.KEY_PRESSED, step.keyCode, '\u0000', currentModifiers())
             }
         }
 
         private fun pressKey(component: Component, step: InputStep.PressKey) {
-            ensureFocus(component)
+            // Directly-dispatched KeyEvents are never retargeted to the focus owner (the
+            // KeyboardFocusManager only retargets POSTED events), so a key sent to the root window
+            // cannot reach the focused component's WHEN_FOCUSED bindings (issue #309, problem 2) —
+            // dispatch to the focus owner, as typeText already does. Read the owner FIRST, then
+            // ensureFocus(focus) re-asserts it; ensureFocus(root) would displace it before dispatch.
+            val focus = focusOwner(component)
+            ensureFocus(focus)
             val tempModifiers = step.modifiers.mapNotNull { modifierKeyCode(it) }
                 .filterNot { stuckKeys.contains(it) }
-            tempModifiers.forEach { dispatchKey(component, KeyEvent.KEY_PRESSED, it, '\u0000', currentModifiers()) }
+            tempModifiers.forEach { dispatchKey(focus, KeyEvent.KEY_PRESSED, it, '\u0000', currentModifiers()) }
 
-            dispatchKey(component, KeyEvent.KEY_PRESSED, step.keyCode, '\u0000', currentModifiers(step.modifiers))
-            dispatchKey(component, KeyEvent.KEY_RELEASED, step.keyCode, '\u0000', currentModifiers(step.modifiers))
+            dispatchKey(focus, KeyEvent.KEY_PRESSED, step.keyCode, '\u0000', currentModifiers(step.modifiers))
+            dispatchKey(focus, KeyEvent.KEY_RELEASED, step.keyCode, '\u0000', currentModifiers(step.modifiers))
 
-            tempModifiers.reversed().forEach { dispatchKey(component, KeyEvent.KEY_RELEASED, it, '\u0000', currentModifiers()) }
+            tempModifiers.reversed().forEach { dispatchKey(focus, KeyEvent.KEY_RELEASED, it, '\u0000', currentModifiers()) }
         }
 
         private fun typeText(component: Component, step: InputStep.TypeText) {
@@ -551,9 +577,14 @@ class VisionService(
                 MouseButton.MIDDLE -> MouseEvent.BUTTON2
             }
 
-            dispatchMouse(targetComponent, MouseEvent.MOUSE_PRESSED, point, button, modifiers)
-            dispatchMouse(targetComponent, MouseEvent.MOUSE_RELEASED, point, button, modifiers)
-            dispatchMouse(targetComponent, MouseEvent.MOUSE_CLICKED, point, button, modifiers)
+            // The MouseEvent's x/y must be in the TARGET's local space: Swing button listeners gate on
+            // component.contains(e.x, e.y), so window-space coordinates never arm the model — focus
+            // moves, state does not change (issue #309, problem 2).
+            val localPoint = SwingUtilities.convertPoint(component, point, targetComponent)
+
+            dispatchMouse(targetComponent, MouseEvent.MOUSE_PRESSED, localPoint, button, modifiers)
+            dispatchMouse(targetComponent, MouseEvent.MOUSE_RELEASED, localPoint, button, modifiers)
+            dispatchMouse(targetComponent, MouseEvent.MOUSE_CLICKED, localPoint, button, modifiers)
         }
 
         private fun mapScreenshotPoint(component: Component, x: Int, y: Int): Point {
@@ -572,20 +603,28 @@ class VisionService(
         }
 
         private fun ensureFocus(component: Component) {
-            val window = component as? Window ?: SwingUtilities.getWindowAncestor(component)
-            if (window != null) {
-                if (!window.isActive) {
-                    window.toFront()
-                    window.requestFocus()
-                }
-            }
-
+            activateWindow(component)
             IdeFocusManager.findInstanceByComponent(component).requestFocus(component, true)
         }
 
+        /**
+         * Bring the component's window to the front and make it active — WITHOUT the
+         * `IdeFocusManager.requestFocus(component, true)` step that [ensureFocus] performs. Requesting
+         * focus on the root window displaces whatever component currently owns focus, which breaks a
+         * key step that must reach a previously-focused component (issue #309, problem 2).
+         */
+        private fun activateWindow(component: Component) {
+            val window = component as? Window ?: SwingUtilities.getWindowAncestor(component)
+            if (window != null && !window.isActive) {
+                window.toFront()
+                window.requestFocus()
+            }
+        }
+
         private fun releaseAll(component: Component) {
+            val focus = focusOwner(component)
             stuckKeys.reversed().forEach { code ->
-                dispatchKey(component, KeyEvent.KEY_RELEASED, code, '\u0000', currentModifiers())
+                dispatchKey(focus, KeyEvent.KEY_RELEASED, code, '\u0000', currentModifiers())
             }
             stuckKeys.clear()
         }

--- a/test-integration/src/main/kotlin/com/jonnyzzz/mcpSteroid/integration/infra/mcp-steroid.kt
+++ b/test-integration/src/main/kotlin/com/jonnyzzz/mcpSteroid/integration/infra/mcp-steroid.kt
@@ -53,6 +53,9 @@ data class McpWindowInfo(
     val modalDialogShowing: Boolean,
     val indexingInProgress: Boolean?,
     val projectInitialized: Boolean?,
+    val windowId: String? = null,
+    val title: String? = null,
+    val isVisible: Boolean? = null,
 )
 
 internal fun ProcessResult.resolveJavaHomeLookup(jdkVersion: String): String {
@@ -317,6 +320,9 @@ class McpSteroidDriver(
                         modalDialogShowing = window["modalDialogShowing"]?.jsonPrimitive?.booleanOrNull ?: false,
                         indexingInProgress = window["indexingInProgress"]?.jsonPrimitive?.booleanOrNull,
                         projectInitialized = window["projectInitialized"]?.jsonPrimitive?.booleanOrNull,
+                        windowId = window["windowId"]?.jsonPrimitive?.contentOrNull,
+                        title = window["title"]?.jsonPrimitive?.contentOrNull,
+                        isVisible = window["isVisible"]?.jsonPrimitive?.booleanOrNull,
                     )
                 }
                 ?: throw McpRequestFailedError("steroid_list_windows returned no windows payload: $payload")
@@ -600,6 +606,87 @@ try {
         }.toString()
 
         val run = executeMcpRequest(sessionId, toolCallRequest, timeoutSeconds = timeout.toLong() + 30)
+        return ProcessResultValue(
+            exitCode = if (parseMcpToolResultIsError(run)) 1 else 0,
+            stdout = parseMcpToolResultBody(run),
+            stderr = "",
+        )
+    }
+
+    /**
+     * Send an input sequence to an IDE window via the `steroid_input` tool.
+     *
+     * Direct MCP call (no AI agent). [timeoutSeconds] bounds the curl request; a server-side hang
+     * (issue #309: EDT dispatch withheld under a modal dialog) surfaces as the transport's
+     * [TransientMcpRequestException] ("curl killed, exit -1") — callers reproducing the hang catch
+     * exactly that type.
+     */
+    fun mcpInput(
+        windowId: String,
+        sequence: String,
+        taskId: String = "integration-test-input",
+        reason: String = "Integration test input",
+        projectName: String = resolveProjectName(),
+        timeoutSeconds: Long = 60,
+    ): ProcessResult {
+        val sessionId = mcpInitialize()
+
+        val toolCallRequest = buildJsonObject {
+            put("jsonrpc", "2.0")
+            put("id", 2)
+            putJsonObject("params") {
+                put("name", "steroid_input")
+                putJsonObject("arguments") {
+                    put("project_name", projectName)
+                    put("task_id", taskId)
+                    put("reason", reason)
+                    put("window_id", windowId)
+                    put("sequence", sequence)
+                }
+            }
+            put("method", "tools/call")
+        }.toString()
+
+        val run = executeMcpRequest(sessionId, toolCallRequest, timeoutSeconds = timeoutSeconds)
+        return ProcessResultValue(
+            exitCode = if (parseMcpToolResultIsError(run)) 1 else 0,
+            stdout = parseMcpToolResultBody(run),
+            stderr = "",
+        )
+    }
+
+    /**
+     * Capture a screenshot via the `steroid_take_screenshot` tool and return its TEXT content
+     * (the `window_id: …` / artifact-path lines); the image content item carries no `text` key and
+     * is skipped by [parseMcpToolResultBody].
+     */
+    fun mcpTakeScreenshot(
+        windowId: String? = null,
+        taskId: String = "integration-test-screenshot",
+        reason: String = "Integration test screenshot",
+        projectName: String = resolveProjectName(),
+        timeoutSeconds: Long = 120,
+    ): ProcessResult {
+        val sessionId = mcpInitialize()
+
+        val toolCallRequest = buildJsonObject {
+            put("jsonrpc", "2.0")
+            put("id", 2)
+            putJsonObject("params") {
+                put("name", "steroid_take_screenshot")
+                putJsonObject("arguments") {
+                    put("project_name", projectName)
+                    put("task_id", taskId)
+                    put("reason", reason)
+                    if (windowId != null) {
+                        put("window_id", windowId)
+                    }
+                }
+            }
+            put("method", "tools/call")
+        }.toString()
+
+        val run = executeMcpRequest(sessionId, toolCallRequest, timeoutSeconds = timeoutSeconds)
         return ProcessResultValue(
             exitCode = if (parseMcpToolResultIsError(run)) 1 else 0,
             stdout = parseMcpToolResultBody(run),

--- a/test-integration/src/test/kotlin/com/jonnyzzz/mcpSteroid/integration/tests/SteroidInputDialogIntegrationTest.kt
+++ b/test-integration/src/test/kotlin/com/jonnyzzz/mcpSteroid/integration/tests/SteroidInputDialogIntegrationTest.kt
@@ -1,0 +1,302 @@
+/* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
+package com.jonnyzzz.mcpSteroid.integration.tests
+
+import com.jonnyzzz.mcpSteroid.integration.infra.IntelliJContainer
+import com.jonnyzzz.mcpSteroid.integration.infra.IntelliJContainerOpts
+import com.jonnyzzz.mcpSteroid.integration.infra.IntelliJProject
+import com.jonnyzzz.mcpSteroid.integration.infra.ModalMode
+import com.jonnyzzz.mcpSteroid.integration.infra.TransientMcpRequestException
+import com.jonnyzzz.mcpSteroid.integration.infra.create
+import com.jonnyzzz.mcpSteroid.integration.infra.waitForProjectReady
+import com.jonnyzzz.mcpSteroid.testHelper.CloseableStackHost
+import com.jonnyzzz.mcpSteroid.testHelper.process.ProcessResult
+import com.jonnyzzz.mcpSteroid.testHelper.process.assertExitCode
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Timeout
+import java.util.concurrent.TimeUnit
+
+/**
+ * Reproduces the three `steroid_input` / `steroid_take_screenshot` defects from issue #309
+ * against a real dialog in a Dockerized IDE (Xvfb — the reporter's environment):
+ *
+ * 1. `steroid_input` targeting a window while a MODAL dialog is open must answer (success or
+ *    error) in bounded time. The executor's EDT hops (`withContext(Dispatchers.EDT)` in
+ *    `SwingInputExecutor`) carry no `ModalityState.any()` context element, so the dispatch is
+ *    withheld until the modal closes and the MCP call hangs forever.
+ * 2. A click on a `JCheckBox` inside a (non-modal, to isolate from 1.) dialog must toggle it.
+ *    `SwingInputExecutor.click` dispatches the `MouseEvent` to the deepest component with
+ *    window-relative coordinates (no `SwingUtilities.convertPoint` to the target), so the
+ *    button model never arms — focus moves, state does not change.
+ * 3. `steroid_take_screenshot` with a dialog `window_id` must echo THAT id back.
+ *    `captureOnEdt` re-derives the window via `SwingUtilities.getWindowAncestor(component)`,
+ *    which for a `Window` returns its OWNER (the IDE frame), so the response reports the
+ *    main frame's id while the image shows the dialog.
+ *
+ * Uses direct MCP HTTP calls (no AI agents). Same session pattern as [DialogKillerIntegrationTest].
+ */
+class SteroidInputDialogIntegrationTest {
+
+    companion object {
+        val lifetime by lazy { CloseableStackHost(this::class.java.simpleName) }
+        val session by lazy {
+            IntelliJContainer.create(
+                lifetime, IntelliJContainerOpts(
+                    consoleTitle = "Steroid Input Dialog",
+                    // Project content is irrelevant — the empty project skips JDK setup and import.
+                    project = IntelliJProject.EmptyProject,
+                )
+            ).waitForProjectReady()
+        }
+        val console get() = session.console
+
+        @AfterAll
+        @JvmStatic
+        fun cleanup() {
+            lifetime.closeAllStacks()
+        }
+    }
+
+    /** Opens a DialogWrapper carrying a named, initially-unselected JCheckBox; fire-and-forget on EDT. */
+    private fun openDialog(title: String, modal: Boolean) {
+        console.writeStep("Opening test dialog '$title' (modal=$modal)")
+        session.mcpSteroid.mcpExecuteCode(
+            modal = ModalMode.UNLEASHED,
+            code = $$"""
+                // Fire-and-forget from a vanilla EDT scope so a modal show() does not block this script
+                // (mirrors a real, user-opened dialog; same pattern as DialogKillerIntegrationTest).
+                kotlinx.coroutines.CoroutineScope(kotlinx.coroutines.Dispatchers.EDT).launch {
+                    val dialog = object : com.intellij.openapi.ui.DialogWrapper(project) {
+                        init {
+                            title = "$$title"
+                            setModal($$modal)
+                            init()
+                        }
+
+                        override fun createCenterPanel(): javax.swing.JComponent {
+                            val panel = javax.swing.JPanel()
+                            panel.add(javax.swing.JLabel("steroid_input repro dialog"))
+                            val checkBox = javax.swing.JCheckBox("Filter checkbox", false)
+                            checkBox.name = "test-checkbox"
+                            panel.add(checkBox)
+                            return panel
+                        }
+                    }
+                    dialog.show()
+                }
+
+                kotlinx.coroutines.delay(1500)
+                println("dialog opened")
+            """.trimIndent(),
+            taskId = "open-input-test-dialog",
+            reason = "Open test dialog for steroid_input repro",
+        ).assertExitCode(0)
+    }
+
+    /**
+     * Reads the dialog's identity from inside the IDE: its `window_id` (computed exactly like
+     * `steroid_list_windows` mints it), the checkbox center in window-relative coordinates
+     * (the documented `click:...@x,y` coordinate space), and the checkbox state.
+     */
+    private fun inspectDialog(title: String): DialogProbe {
+        val result = session.mcpSteroid.mcpExecuteCode(
+            modal = ModalMode.UNLEASHED,
+            code = $$"""
+                import com.jonnyzzz.mcpSteroid.vision.WindowIdUtil
+
+                val info = withContext(
+                    kotlinx.coroutines.Dispatchers.EDT +
+                            com.intellij.openapi.application.ModalityState.any().asContextElement()
+                ) {
+                    val w = java.awt.Window.getWindows()
+                        .firstOrNull { it.isVisible && (it as? java.awt.Dialog)?.title == "$$title" }
+                        ?: error("dialog '$$title' not found among visible windows")
+
+                    fun findCheckBox(c: java.awt.Component): javax.swing.JCheckBox? {
+                        if (c is javax.swing.JCheckBox && c.name == "test-checkbox") return c
+                        if (c is java.awt.Container) {
+                            c.components.forEach { child -> findCheckBox(child)?.let { return it } }
+                        }
+                        return null
+                    }
+
+                    val cb = findCheckBox(w) ?: error("test-checkbox not found in dialog '$$title'")
+                    val center = javax.swing.SwingUtilities.convertPoint(cb, cb.width / 2, cb.height / 2, w)
+                    val focusOwner = java.awt.KeyboardFocusManager.getCurrentKeyboardFocusManager().focusOwner
+                    val focusDesc = focusOwner?.let { it.javaClass.simpleName + "/" + it.name } ?: "<null>"
+                    "WINDOW_ID: " + WindowIdUtil.compute(w, w) +
+                            "\nCHECKBOX_AT: " + center.x + "," + center.y +
+                            "\nSELECTED: " + cb.isSelected +
+                            "\nFOCUS_OWNER: " + focusDesc +
+                            "\nCHECKBOX_HAS_FOCUS: " + (focusOwner === cb)
+                }
+                println(info)
+            """.trimIndent(),
+            taskId = "inspect-input-test-dialog",
+            reason = "Read dialog window_id / checkbox position for steroid_input repro",
+        )
+        result.assertExitCode(0)
+        console.writeInfo(
+            "dialog probe:\n" + result.stdout.lineSequence()
+                .filter { line -> listOf("WINDOW_ID:", "CHECKBOX_AT:", "SELECTED:", "FOCUS_OWNER:", "CHECKBOX_HAS_FOCUS:").any { line.trim().startsWith(it) } }
+                .joinToString("\n") { it.trim() }
+        )
+        return DialogProbe(
+            windowId = result.extract("WINDOW_ID"),
+            checkboxAt = result.extract("CHECKBOX_AT"),
+            selected = result.extract("SELECTED").toBooleanStrict(),
+        )
+    }
+
+    private data class DialogProbe(val windowId: String, val checkboxAt: String, val selected: Boolean)
+
+    private fun ProcessResult.extract(key: String): String =
+        stdout.lineSequence().map { it.trim() }
+            .firstOrNull { it.startsWith("$key: ") }
+            ?.removePrefix("$key: ")
+            ?: throw AssertionError("marker '$key:' not found in probe output:\n$stdout")
+
+    private fun disposeDialog(title: String) {
+        console.writeStep("Disposing test dialog '$title'")
+        session.mcpSteroid.mcpExecuteCode(
+            modal = ModalMode.UNLEASHED,
+            code = $$"""
+                withContext(
+                    kotlinx.coroutines.Dispatchers.EDT +
+                            com.intellij.openapi.application.ModalityState.any().asContextElement()
+                ) {
+                    java.awt.Window.getWindows()
+                        .filter { it.isDisplayable && (it as? java.awt.Dialog)?.title == "$$title" }
+                        .forEach { it.dispose() }
+                }
+                println("disposed")
+            """.trimIndent(),
+            taskId = "dispose-input-test-dialog",
+            reason = "Dispose test dialog after steroid_input repro",
+        ).assertExitCode(0)
+    }
+
+    private fun closeModalDialogs() {
+        console.writeStep("Closing leftover modal dialogs")
+        session.mcpSteroid.mcpExecuteCode(
+            modal = ModalMode.UNLEASHED,
+            code = """
+                val closed = closeModalDialogs()
+                println("closed ${'$'}closed dialog(s)")
+            """.trimIndent(),
+            taskId = "close-modal-after-input-repro",
+            reason = "Cleanup modal dialog after steroid_input repro",
+        ).assertExitCode(0)
+    }
+
+    @Test
+    @Timeout(value = 15, unit = TimeUnit.MINUTES)
+    fun `steroid_input answers in bounded time while a modal dialog is open`() {
+        val title = "MCP Steroid Input Modal Hang Repro"
+        openDialog(title, modal = true)
+        try {
+            val probe = inspectDialog(title)
+            console.writeStep("Sending click to modal dialog ${probe.windowId} (45s bound)")
+            val result = try {
+                session.mcpSteroid.mcpInput(
+                    windowId = probe.windowId,
+                    sequence = "click:Left@${probe.checkboxAt}",
+                    timeoutSeconds = 45,
+                )
+            } catch (e: TransientMcpRequestException) {
+                // The transport kills curl after 45s only when the server never answered.
+                Assertions.fail<Nothing>(
+                    "issue #309 Problem 1 reproduced: steroid_input gave no answer within 45s while a modal " +
+                            "dialog was open — SwingInputExecutor's Dispatchers.EDT hops carry no " +
+                            "ModalityState.any(), so the dispatch is withheld until the modal closes: ${e.message}"
+                )
+            }
+            // Answering at all (success or a fast diagnostic error) is the contract under test here.
+            console.writeInfo("steroid_input answered: exit=${result.exitCode}\n${result.stdout}")
+            console.writeSuccess("steroid_input answered in bounded time under a modal dialog")
+        } finally {
+            closeModalDialogs()
+        }
+    }
+
+    @Test
+    @Timeout(value = 15, unit = TimeUnit.MINUTES)
+    fun `steroid_input click toggles a checkbox in a non-modal dialog`() {
+        val title = "MCP Steroid Input Checkbox Repro"
+        openDialog(title, modal = false)
+        try {
+            val probe = inspectDialog(title)
+            Assertions.assertFalse(probe.selected, "checkbox must start unselected")
+
+            console.writeStep("Clicking checkbox at window-relative ${probe.checkboxAt} in ${probe.windowId}")
+            session.mcpSteroid.mcpInput(
+                windowId = probe.windowId,
+                sequence = "click:Left@${probe.checkboxAt}",
+                timeoutSeconds = 60,
+            ).assertExitCode(0)
+
+            val after = inspectDialog(title)
+            Assertions.assertTrue(
+                after.selected,
+                "issue #309 Problem 2 reproduced: click:Left@${probe.checkboxAt} did not toggle the checkbox — " +
+                        "SwingInputExecutor.click dispatches window-relative coordinates to the target component " +
+                        "without SwingUtilities.convertPoint, so the button model never arms",
+            )
+            console.writeSuccess("Checkbox toggled by steroid_input click")
+
+            // The reporter's second strategy: focus the checkbox (done by the click above), then
+            // press SPACE. Key events dispatched to the root window are never retargeted to the
+            // focus owner, so this only works when the executor routes keys to the focus owner.
+            console.writeStep("Pressing SPACE to toggle the focused checkbox back")
+            session.mcpSteroid.mcpInput(
+                windowId = probe.windowId,
+                sequence = "press:SPACE",
+                timeoutSeconds = 60,
+            ).assertExitCode(0)
+
+            val afterSpace = inspectDialog(title)
+            Assertions.assertFalse(
+                afterSpace.selected,
+                "issue #309 Problem 2 reproduced: press:SPACE on the focused checkbox did not toggle it — " +
+                        "SwingInputExecutor.pressKey dispatches the KeyEvent to the root window, which is never " +
+                        "retargeted to the focus owner's WHEN_FOCUSED bindings",
+            )
+            console.writeSuccess("SPACE toggled the focused checkbox back")
+        } finally {
+            disposeDialog(title)
+        }
+    }
+
+    @Test
+    @Timeout(value = 15, unit = TimeUnit.MINUTES)
+    fun `steroid_take_screenshot echoes the requested dialog window_id`() {
+        val title = "MCP Steroid Screenshot WindowId Repro"
+        openDialog(title, modal = false)
+        try {
+            val probe = inspectDialog(title)
+
+            // The id we computed in-process must be discoverable the way agents discover it.
+            val listed = session.mcpSteroid.mcpListWindows()
+            Assertions.assertTrue(
+                listed.any { it.windowId == probe.windowId },
+                "dialog ${probe.windowId} must be listed by steroid_list_windows; got: $listed",
+            )
+
+            console.writeStep("Taking screenshot of dialog ${probe.windowId}")
+            val screenshot = session.mcpSteroid.mcpTakeScreenshot(windowId = probe.windowId)
+            screenshot.assertExitCode(0)
+
+            val echoed = screenshot.extract("window_id")
+            Assertions.assertEquals(
+                probe.windowId, echoed,
+                "issue #309 Problem 3 reproduced: steroid_take_screenshot echoed window_id $echoed for the " +
+                        "requested dialog ${probe.windowId} — captureOnEdt resolves the window via " +
+                        "SwingUtilities.getWindowAncestor(component), which for a Window returns its OWNER frame",
+            )
+            console.writeSuccess("Screenshot echoed the requested dialog window_id")
+        } finally {
+            disposeDialog(title)
+        }
+    }
+}


### PR DESCRIPTION
Fixes the three defects in issue #309. They are **independent bugs** from the input/vision feature (`e6c0de23`), all against dialogs — not the single cascading fault the report described. None is a regression. Reproduced against a real dialog in a Dockerized IDE under Xvfb (the reporter's environment) by `SteroidInputDialogIntegrationTest`.

## Problem 1 — `steroid_input` hangs while a modal dialog is open
Two stacked defects:
- `SwingInputExecutor.execute()` hopped to a **bare `Dispatchers.EDT`** (`NON_MODAL`), whose runnables the platform withholds while a modal is open — the first hop parks forever.
- The tool path had **no timeout of its own**, so the withheld coroutine never surfaced an error and `tools/call` hung until the client gave up.

**Fix:** `Dispatchers.EDT + ModalityState.any().asContextElement()` on every executor hop (same fix `capture()` received in `e4ebf791`), plus a handler-level `withTimeout(delayBudget + 60s)` in `VisionInputToolHandler` reporting a diagnostic error — caught as `TimeoutCancellationException` **before** the generic `CancellationException` rethrow, per the CE-rethrow rule.

## Problem 2 — click does not toggle a checkbox
Three sub-bugs behind the one symptom:
1. **Window-space mouse coordinates.** `click()` dispatched the `MouseEvent` with window-relative x/y; Swing's `BasicButtonListener` arms the model only if `component.contains(e.x, e.y)` in **local** space, so focus moved but the model never armed. → `SwingUtilities.convertPoint(window, point, target)` before dispatch.
2. **Keys to the root window are never retargeted.** `press:`/`stick:` dispatched to the root; the KeyboardFocusManager only retargets *posted* events to the focus owner, never *directly-dispatched* ones. → dispatch keys to the focus owner (as `typeText` already did).
3. **`ensureFocus(rootWindow)` displaced click-established focus.** Both the entry hop and `pressKey` called `IdeFocusManager.requestFocus(window, true)`, yanking focus back to the dialog's default button before the key dispatched. → new `activateWindow()` (front/activate **without** requesting focus) at entry, and read the focus owner **before** re-asserting focus in `stickKey`/`pressKey`.

## Problem 3 — wrong `window_id` echoed (the "easy" one)
`captureOnEdt` re-derived the window via `SwingUtilities.getWindowAncestor(component)`; for a `Window`, `getParent()` returns its **owner**, so a dialog's screenshot echoed the IDE frame's id/bounds/title. Same bug in `ListWindowsToolHandler`'s fallback branch, where a `Frame`-only cast also left every dialog `title = null` (untargetable). → resolve a `Window` as itself; cover `Dialog` titles in `list_windows`.

## Report audit — where the bug report was wrong
- **Causal theory disproven.** The report implied the wrong `window_id` (P3) *caused* the hang / toggle failures (P1/P2). Each is independent — you can target the correct id and still hit P1 and P2.
- **"BreakpointsDialog is modal" is wrong** — it calls `setModal(false)`. The Settings dialog *is* `APPLICATION_MODAL`, so the modal-hang repro opens a modal `DialogWrapper` directly.
- **"No timeout"** was symptom-accurate but missed the underlying `ModalityState.any()` withholding.

## Tests
`SteroidInputDialogIntegrationTest` (3 tests, one Dockerized IDE, Xvfb — direct MCP HTTP, no AI agents):

| # | Test | Result |
|---|------|--------|
| 1 | `steroid_input` answers in bounded time under a modal dialog | PASS |
| 2 | click toggles checkbox, then `press:SPACE` toggles it back | PASS (both assertions) |
| 3 | `steroid_take_screenshot` echoes the requested dialog `window_id` | PASS |

An in-IDE `FOCUS_OWNER` probe made P2 decisive: before input `FOCUS_OWNER: JButton/null`; after click `JCheckBox/test-checkbox` + `CHECKBOX_HAS_FOCUS: true` + `SELECTED: true`; after SPACE `SELECTED: false` with focus still on the checkbox.

`:ij-plugin:test` full unit suite: BUILD SUCCESSFUL, zero failures.

## Follow-ups (logged in TODO.md, not in this PR)
- Ghost-input hazard: a step parked on the EDT still fires after its request dies.
- `steroid_take_screenshot` has no handler-level timeout (P1's `withTimeout` covers `steroid_input` only).
- Update issue #309 with the disproven causal theory + the non-modal BreakpointsDialog note.