### PR TITLE
Prompts: exec_code returns only printed output — last expression ignored

### DIFF
--- a/mcp-steroid-server/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/ExecuteCodeTool.kt
+++ b/mcp-steroid-server/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/ExecuteCodeTool.kt
@@ -14,6 +14,7 @@ import com.jonnyzzz.mcpSteroid.mcp.string
 import com.jonnyzzz.mcpSteroid.mcp.withDefaultValue
 import com.jonnyzzz.mcpSteroid.prompts.Generic
 import com.jonnyzzz.mcpSteroid.prompts.PromptsContext
+import com.jonnyzzz.mcpSteroid.prompts.generated.skill.CodingWithIntelliJContextApiPromptArticle
 import com.jonnyzzz.mcpSteroid.prompts.generated.skill.ExecuteCodeToolDescriptionPromptArticle
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -83,10 +84,15 @@ class ExecuteCodeToolSpec(val handler: () -> ExecuteCodeToolHandler) : McpToolBa
 
     val code = InputSchemaElement.param("code")
         .description(
-            "Kotlin suspend method body. The response carries an execution_id header plus ONLY " +
-                "what the script explicitly prints (println/printJson/printCsv/printToon) — the " +
-                "last expression's value is ignored by the runtime (function body, not a REPL), " +
-                "so print everything you need to see before the script ends."
+            "Kotlin code that becomes the body of a `suspend McpScriptContext.() -> Unit` " +
+                "function. The return value is ignored (not a REPL: the last expression's value " +
+                "is discarded, `return <value>` does not compile) — the response carries an " +
+                "execution_id header plus ONLY what the script explicitly prints " +
+                "(println/printJson/printCsv/printToon), so print everything you need to see " +
+                "before the script ends. Read about the McpScriptContext receiver (built-in " +
+                "helpers, print methods, file access, read/write actions) in " +
+                "${CodingWithIntelliJContextApiPromptArticle().uri} — fetch it with " +
+                "steroid_fetch_resource."
         )
         .string()
         .required()

--- a/mcp-steroid-server/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/ExecuteCodeTool.kt
+++ b/mcp-steroid-server/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/ExecuteCodeTool.kt
@@ -87,7 +87,8 @@ class ExecuteCodeToolSpec(val handler: () -> ExecuteCodeToolHandler) : McpToolBa
             "Kotlin code. The response carries an execution_id header plus ONLY what the script " +
                 "explicitly prints (failed runs add error details) — print everything you need " +
                 "to see (println/printJson/printCsv/printToon); e.g. end with " +
-                "`printJson(results)`, never a bare `results`. Not a REPL: the code becomes the " +
+                "`printJson(results)`, never a bare `results` (a print-less run still succeeds, " +
+                "returning only a HINT line). Not a REPL: the code becomes the " +
                 "body of a " +
                 "`suspend McpScriptContext.() -> Unit` function, the last expression's value is " +
                 "ignored, and `return <value>` does not compile. Read about the McpScriptContext " +

--- a/mcp-steroid-server/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/ExecuteCodeTool.kt
+++ b/mcp-steroid-server/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/ExecuteCodeTool.kt
@@ -85,13 +85,15 @@ class ExecuteCodeToolSpec(val handler: () -> ExecuteCodeToolHandler) : McpToolBa
     val code = InputSchemaElement.param("code")
         .description(
             "Kotlin code. The response carries an execution_id header plus ONLY what the script " +
-                "explicitly prints — print everything you need to see " +
-                "(println/printJson/printCsv/printToon) before the script ends. Not a REPL: the " +
-                "code becomes the body of a `suspend McpScriptContext.() -> Unit` function, the " +
-                "last expression's value is discarded, and `return <value>` does not compile. " +
-                "Read about the McpScriptContext receiver (built-in helpers, print methods, file " +
-                "access, read/write actions) in ${CodingWithIntelliJContextApiPromptArticle().uri} " +
-                "— fetch it with steroid_fetch_resource."
+                "explicitly prints (failed runs add error details) — print everything you need " +
+                "to see (println/printJson/printCsv/printToon); e.g. end with " +
+                "`printJson(results)`, never a bare `results`. Not a REPL: the code becomes the " +
+                "body of a " +
+                "`suspend McpScriptContext.() -> Unit` function, the last expression's value is " +
+                "ignored, and `return <value>` does not compile. Read about the McpScriptContext " +
+                "receiver (built-in helpers, print methods, file access, read/write actions) in " +
+                "${CodingWithIntelliJContextApiPromptArticle().uri} — fetch it with " +
+                "steroid_fetch_resource."
         )
         .string()
         .required()

--- a/mcp-steroid-server/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/ExecuteCodeTool.kt
+++ b/mcp-steroid-server/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/ExecuteCodeTool.kt
@@ -82,7 +82,12 @@ class ExecuteCodeToolSpec(val handler: () -> ExecuteCodeToolHandler) : McpToolBa
     val projectName = CommonToolParams.projectName().registerToSchema()
 
     val code = InputSchemaElement.param("code")
-        .description("Kotlin suspend method body")
+        .description(
+            "Kotlin suspend method body. The response carries an execution_id header plus ONLY " +
+                "what the script explicitly prints (println/printJson/printCsv/printToon) — the " +
+                "last expression's value is ignored by the runtime (function body, not a REPL), " +
+                "so print everything you need to see before the script ends."
+        )
         .string()
         .required()
         .registerToSchema()

--- a/mcp-steroid-server/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/ExecuteCodeTool.kt
+++ b/mcp-steroid-server/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/ExecuteCodeTool.kt
@@ -84,15 +84,14 @@ class ExecuteCodeToolSpec(val handler: () -> ExecuteCodeToolHandler) : McpToolBa
 
     val code = InputSchemaElement.param("code")
         .description(
-            "Kotlin code that becomes the body of a `suspend McpScriptContext.() -> Unit` " +
-                "function. The return value is ignored (not a REPL: the last expression's value " +
-                "is discarded, `return <value>` does not compile) — the response carries an " +
-                "execution_id header plus ONLY what the script explicitly prints " +
-                "(println/printJson/printCsv/printToon), so print everything you need to see " +
-                "before the script ends. Read about the McpScriptContext receiver (built-in " +
-                "helpers, print methods, file access, read/write actions) in " +
-                "${CodingWithIntelliJContextApiPromptArticle().uri} — fetch it with " +
-                "steroid_fetch_resource."
+            "Kotlin code. The response carries an execution_id header plus ONLY what the script " +
+                "explicitly prints — print everything you need to see " +
+                "(println/printJson/printCsv/printToon) before the script ends. Not a REPL: the " +
+                "code becomes the body of a `suspend McpScriptContext.() -> Unit` function, the " +
+                "last expression's value is discarded, and `return <value>` does not compile. " +
+                "Read about the McpScriptContext receiver (built-in helpers, print methods, file " +
+                "access, read/write actions) in ${CodingWithIntelliJContextApiPromptArticle().uri} " +
+                "— fetch it with steroid_fetch_resource."
         )
         .string()
         .required()

--- a/prompts/src/main/prompts/mcp-steroid-info.md
+++ b/prompts/src/main/prompts/mcp-steroid-info.md
@@ -16,7 +16,10 @@ This is a **STATEFUL** API — every call changes the IDE state. The IntelliJ ID
 **Getting started:**
 1. Call `steroid_list_projects` to see what's open — route every project-scoped call by the `project_name` it returns (the unique, opaque key), never by the human-readable `name`; to map a file/dir path to a project, pick the one whose `path` is the longest prefix of your target path
 2. Use `steroid_fetch_resource` to read the `mcp-steroid://` skill guide for your task
-3. Use `steroid_execute_code` for any IDE automation task (including every file edit)
+3. Use `steroid_execute_code` for any IDE automation task (including every file edit). The call
+   returns an `execution_id` header plus ONLY what the script explicitly prints (`println` /
+   `printJson`) — the last expression's value is ignored by the runtime, so print everything
+   you need to see
 
 **Modality — the `modal` option on `steroid_execute_code`.** By default (`modal=smart_non_modal`) the call
 closes stray modal dialogs, requires a non-modal IDE, commits/saves documents + refreshes the VFS, and waits

--- a/prompts/src/main/prompts/prompt/skill.md
+++ b/prompts/src/main/prompts/prompt/skill.md
@@ -140,7 +140,7 @@ Give your AI agent a senior developer's toolkit: semantic code understanding, au
 
 **Returns:** `execution_id` plus ONLY what the script explicitly prints (`println` / `printJson` /
 `printCsv` / `printToon`). The last expression's value is ignored by the runtime — a script that
-computes but never prints returns no output at all.
+computes but never prints returns no data, just a `HINT:` about the missing print.
 
 **Complete guide:** `mcp-steroid://skill/coding-with-intellij` (API reference, patterns, examples, best practices)
 

--- a/prompts/src/main/prompts/prompt/skill.md
+++ b/prompts/src/main/prompts/prompt/skill.md
@@ -138,7 +138,9 @@ Give your AI agent a senior developer's toolkit: semantic code understanding, au
 
 **Parameters:** `project_name`, `code` (Kotlin suspend function body), `task_id`, `reason`, `timeout` (optional)
 
-**Returns:** Execution output with `execution_id` for feedback
+**Returns:** `execution_id` plus ONLY what the script explicitly prints (`println` / `printJson` /
+`printCsv` / `printToon`). The last expression's value is ignored by the runtime — a script that
+computes but never prints returns no output at all.
 
 **Complete guide:** `mcp-steroid://skill/coding-with-intellij` (API reference, patterns, examples, best practices)
 
@@ -241,6 +243,9 @@ Built-in helpers available in every script (no imports needed):
 | **Scopes** | `projectScope()`, `allScope()` |
 | **File access** | `findFile()`, `findPsiFile()`, `findProjectFile()`, `findProjectFiles("src/main/**/*.kt")`, `findProjectPsiFile()` |
 | **Analysis** | `runInspectionsDirectly()` |
+
+The output methods are the only way to get data back to the agent — the script's
+last-expression value is ignored by the runtime, so print everything you need.
 
 **Tabular output cheat sheet** — for find-references, call-hierarchy, project-search, document-symbols, or any flat array-of-records result. Signatures are different on purpose; `printCsv` takes parallel lists (positional), `printToon` takes a list of maps (keyed). Mixing them up is the #1 first-try compile error.
 
@@ -360,7 +365,7 @@ or `prompts/list` — the tool is the canonical discovery surface.
 
 ### Common Issues
 - **"Project not found"** - Run `steroid_list_projects` first to get exact project names
-- **No output from execute** - Make sure to call `println()` or `printJson()` to see results
+- **No output from execute** - Only printed values come back; the last expression's value is ignored by the runtime. End the script with `println()` / `printJson()` of everything you need
 - **Timeout** - Increase `timeout` parameter (default 60 seconds)
 - **Script errors** - Check Kotlin syntax; imports are optional
 

--- a/prompts/src/main/prompts/skill/coding-with-intellij-context-api.md
+++ b/prompts/src/main/prompts/skill/coding-with-intellij-context-api.md
@@ -44,6 +44,10 @@ println("Project: ${project.name}, disposed: $isDisposed")
 
 ### Output Methods
 
+These methods are the ONLY channel back to the caller — apart from the `execution_id:` header,
+the tool response contains what the script prints, nothing else. The last expression's value is
+ignored by the runtime (function body, not a REPL), so always compute, then explicitly print.
+
 ```kotlin
 // Output methods:
 println("Hello", "World")               // Print space-separated values

--- a/prompts/src/main/prompts/skill/coding-with-intellij-intro.md
+++ b/prompts/src/main/prompts/skill/coding-with-intellij-intro.md
@@ -57,6 +57,26 @@ execute {
 
 > **Early exit.** Use plain `return` to stop the script. There is no `@execute` (or `@script`) label to return to — the body runs as the wrapping suspend function, so any unlabeled `return` exits cleanly. `return@execute` does NOT compile.
 
+### Output: Only What You Print Comes Back
+
+Apart from the `execution_id:` header, the tool response contains ONLY what your script
+explicitly prints — `println(...)`, `printJson(...)`, `printCsv(...)`, or `printToon(...)`.
+The last expression's value is **ignored by the runtime**: the body compiles as a suspend
+function body, not a REPL, so there is no implicit return value. `return` cannot carry one
+either — a bare `return` only exits early, and `return <value>` does not even compile (the
+generated function returns `Unit`). A script that computes a result but never prints it
+responds with just `execution_id: …` — indistinguishable from a script that produced nothing.
+
+```kotlin
+val paths = findProjectFiles("**/*.kt").map { it.path }
+
+// ✗ WRONG — ending the script with the bare expression `paths`:
+// its value is silently discarded and the response shows no output at all.
+
+// ✓ CORRECT — explicitly print everything the caller needs:
+println(paths.joinToString("\n"))
+```
+
 ### Script is a Coroutine
 
 The script body runs as a **suspend function**. This means:
@@ -160,7 +180,7 @@ println(if (problems.isEmpty()) "OK" else problems.toString())
 4. **Execution** - Your script body runs with timeout
    - Progress messages throttled to 1/second
    - Context disposed when complete
-5. **Response** - Output returned to MCP client
+5. **Response** - Everything the script printed (and nothing else) returned to MCP client
 
 ### Fast Failure
 

--- a/prompts/src/main/prompts/skill/coding-with-intellij-intro.md
+++ b/prompts/src/main/prompts/skill/coding-with-intellij-intro.md
@@ -64,8 +64,9 @@ explicitly prints — `println(...)`, `printJson(...)`, `printCsv(...)`, or `pri
 The last expression's value is **ignored by the runtime**: the body compiles as a suspend
 function body, not a REPL, so there is no implicit return value. `return` cannot carry one
 either — a bare `return` only exits early, and `return <value>` does not even compile (the
-generated function returns `Unit`). A script that computes a result but never prints it
-responds with just `execution_id: …` — indistinguishable from a script that produced nothing.
+generated function returns `Unit`). A script that computes a result but never prints it still
+succeeds — the response carries just the `execution_id:` header plus a `HINT:` about the
+missing print, and your data is gone.
 
 ```kotlin
 val paths = findProjectFiles("**/*.kt").map { it.path }

--- a/prompts/src/main/prompts/skill/execute-code-tool-description.md
+++ b/prompts/src/main/prompts/skill/execute-code-tool-description.md
@@ -65,7 +65,7 @@ If your next instinct is a native `Read` / `Edit` / `Grep` / `Glob` / `Bash` cal
 - Any IDE task → `mcp-steroid://prompt/skill`
 
 **Quick Start:**
-- Code is a suspend function body (never use runBlocking)
+- Your code becomes the body of a `suspend McpScriptContext.() -> Unit` function (never use runBlocking)
 - **Apart from the `execution_id:` header, the response contains ONLY what your script explicitly
   prints.** The last expression's value is IGNORED by the runtime — this is a function body, not a
   REPL, and there is no implicit return value. Print everything the caller needs (`println` /

--- a/prompts/src/main/prompts/skill/execute-code-tool-description.md
+++ b/prompts/src/main/prompts/skill/execute-code-tool-description.md
@@ -66,6 +66,10 @@ If your next instinct is a native `Read` / `Edit` / `Grep` / `Glob` / `Bash` cal
 
 **Quick Start:**
 - Code is a suspend function body (never use runBlocking)
+- **Apart from the `execution_id:` header, the response contains ONLY what your script explicitly
+  prints.** The last expression's value is IGNORED by the runtime — this is a function body, not a
+  REPL, and there is no implicit return value. Print everything the caller needs (`println` /
+  `printJson` / `printCsv` / `printToon`) before the script ends. Full rules in "Output rules" below.
 - With the default `modal=smart_non_modal`, leftover modal dialogs are closed, the IDE is required
   non-modal, documents are committed/saved + VFS refreshed, and `waitForSmartMode()` runs — all before
   your script; then a monitor watches the run and **closes any modal that appears mid-script and FAILS the
@@ -118,8 +122,15 @@ Kotlin, so inspect the captured diagnostics first.
 **Surface is fixed.** `McpScriptContext` won't grow new helpers — call IntelliJ APIs directly. See `mcp-steroid://skill/design-philosophy` Tenet 3.
 
 **Output rules — the #1 reason agents think a call "returned empty":**
-- The last expression's value is NOT auto-printed (this is a Kotlin script, not a REPL).
-- To surface anything to the caller, wrap it in `println(value)` for plain text or `printJson(value)` for structured data.
+- **Everything you need back must be explicitly printed.** The last expression's value is IGNORED
+  by the runtime — never auto-printed, never returned (the code compiles as a suspend function
+  body, not a REPL). `return` only exits early; `return <value>` does not even compile (the
+  generated function returns `Unit`), so nothing can be carried back to the caller.
+- To surface anything to the caller, use a print helper: `println(value)` for plain text,
+  `printJson(value)` for structured data, `printCsv(...)` / `printToon(...)` for tabular records.
+- `progress(...)` is NOT output — it goes to MCP progress notifications and the IDE log, never
+  into the result. The print-only rule describes successful runs; a failed run additionally
+  carries the error text and diagnostic file paths (screenshot / thread dump).
 - A script that ends with `myList` (or any bare expression) prints nothing — you will see only `execution_id: …` in the response, identical to a script that returned no value at all. Always end with an explicit `println(...)` or `printJson(...)` of what the agent needs to see.
 - **For inspection / report tasks, print compact machine-readable lines on the first run.** Stable shapes like `KEY: value` per line or `printJson` parse cheaply on your end and let you build the user-facing summary without a second exec_code pass to reshape verbose IDE output. Recipes in `mcp-steroid://ide/find-duplicates`, `…/inspect-and-fix`, `…/inspection-summary` already follow this convention.
 - **For `runInspectionsDirectly`, do not `printJson(result)` directly.** It is Map-compatible and contains live `ProblemDescriptor` PSI/VFS references. Snapshot descriptor fields inside `readAction { }`, print a DTO, and always include `result.failedTools`; a non-empty `failedTools` means the check is not clean even when the findings map is empty.

--- a/prompts/src/main/prompts/skill/execute-code-tool-description.md
+++ b/prompts/src/main/prompts/skill/execute-code-tool-description.md
@@ -66,10 +66,11 @@ If your next instinct is a native `Read` / `Edit` / `Grep` / `Glob` / `Bash` cal
 
 **Quick Start:**
 - **Apart from the `execution_id:` header, the response contains ONLY what your script explicitly
-  prints.** Your code becomes the body of a `suspend McpScriptContext.() -> Unit` function (never
-  use runBlocking) — not a REPL: the last expression's value is IGNORED, and there is no implicit
-  return value. Print everything the caller needs (`println` / `printJson` / `printCsv` /
-  `printToon`) before the script ends. Full rules in "Output rules" below.
+  prints.** Your code becomes the body of a `suspend McpScriptContext.() -> Unit` function — not a
+  REPL: the last expression's value is IGNORED, and there is no implicit return value. Print
+  everything the caller needs (`println` / `printJson` / `printCsv` / `printToon`) before the
+  script ends. Full rules in "Output rules" below.
+- The body is already suspend — call suspend APIs directly; never use `runBlocking`.
 - With the default `modal=smart_non_modal`, leftover modal dialogs are closed, the IDE is required
   non-modal, documents are committed/saved + VFS refreshed, and `waitForSmartMode()` runs — all before
   your script; then a monitor watches the run and **closes any modal that appears mid-script and FAILS the
@@ -124,17 +125,20 @@ Kotlin, so inspect the captured diagnostics first.
 **Output rules — the #1 reason agents think a call "returned empty":**
 
 ```
-results            // ✗ as the last line: value discarded — response shows only execution_id: …
-printJson(results) // ✓ as the last line: this is what the caller receives
+results            // ✗ value ignored — no data in the response, only a no-output HINT
+return results     // ✗ does not compile — the script body returns Unit
+printJson(results) // ✓ response: execution_id + the printed JSON
 ```
 
 - **Everything you need back must be explicitly printed** — `println(value)` for plain text,
   `printJson(value)` for structured data, `printCsv(...)` / `printToon(...)` for tabular records.
-  Always end with an explicit print of what you need to see.
+  Prints anywhere in the script are captured, in order — just don't finish without printing what
+  you need.
 - The last expression's value is IGNORED by the runtime — never auto-printed, never returned (the
   code compiles as a suspend function body, not a REPL). `return` only exits early; `return <value>`
-  does not even compile (the generated function returns `Unit`), so nothing can be carried back to
-  the caller.
+  does not even compile (the generated function returns `Unit`). A print-less script still
+  SUCCEEDS — the response just carries a `HINT:` line about the missing print instead of your
+  data; it does not mean the call failed.
 - `progress(...)` is NOT output — it goes to MCP progress notifications and the IDE log, never
   into the result. The print-only rule describes successful runs; a failed run additionally
   carries the error text and diagnostic file paths (screenshot / thread dump).

--- a/prompts/src/main/prompts/skill/execute-code-tool-description.md
+++ b/prompts/src/main/prompts/skill/execute-code-tool-description.md
@@ -3,7 +3,7 @@ Execute Code Tool
 MCP tool description for the steroid_execute_code tool.
 
 ###_NO_AUTO_TOC_###
-Execute Kotlin code directly in IntelliJ's runtime with full API access — builds, tests, refactoring, inspections, debugging, navigation.
+Execute Kotlin code directly in IntelliJ's runtime with full API access — builds, tests, refactoring, inspections, debugging, navigation. The response contains only what your script explicitly prints.
 
 ## Multi-site edits: one script, one write action
 
@@ -57,7 +57,7 @@ literal anchors keep failing): the IDE's tolerance-matching patch engine — fet
 | **Tabular output (array of records — find-references, call-hierarchy, project-search, document-symbols)** | `printCsv(headers: List<String>, rows: Iterable<List<Any?>>, dictColumns: Set<String> = emptySet())` — CSV with optional path-dictionary preamble. **OR** `printToon(value: Any?)` — TOON array-of-records (Token-Oriented Object Notation). **Signatures differ**: `printCsv` wants parallel `List<List<Any?>>` rows; `printToon` wants `List<Map<String, Any?>>` and infers column order from the first map. Do not pass `List<Map>` to `printCsv` (common compile error). |
 | **Git / Docker CLI / shell** | native `Bash` — genuinely outside the IDE |
 
-If your next instinct is a native `Read` / `Edit` / `Grep` / `Glob` / `Bash` call, check this table first. The IDE path keeps VFS + PSI consistent, reuses the warm JVM, and one call reliably replaces 3-5 chained native-tool calls.
+If your next instinct is a native `Read` / `Edit` / `Grep` / `Glob` / `Bash` call, check this table first. The IDE path keeps VFS + PSI consistent, reuses the warm JVM, and one call reliably replaces 3-5 chained native-tool calls. The rows show the core call only — in a real script, always print the result, or the response carries no data.
 
 **Before your first call, read the guide for your task** with `steroid_fetch_resource`:
 - Building/testing → `mcp-steroid://prompt/test-skill`
@@ -65,11 +65,10 @@ If your next instinct is a native `Read` / `Edit` / `Grep` / `Glob` / `Bash` cal
 - Any IDE task → `mcp-steroid://prompt/skill`
 
 **Quick Start:**
-- **Apart from the `execution_id:` header, the response contains ONLY what your script explicitly
-  prints.** Your code becomes the body of a `suspend McpScriptContext.() -> Unit` function — not a
-  REPL: the last expression's value is IGNORED, and there is no implicit return value. Print
-  everything the caller needs (`println` / `printJson` / `printCsv` / `printToon`) before the
-  script ends. Full rules in "Output rules" below.
+- **The response is the `execution_id:` header plus ONLY what your script explicitly prints**
+  (a `HINT:` line is added if you print nothing; failures add error text). Your code becomes the
+  body of a `suspend McpScriptContext.() -> Unit` function — not a REPL. Full rules in
+  "Output rules" below.
 - The body is already suspend — call suspend APIs directly; never use `runBlocking`.
 - With the default `modal=smart_non_modal`, leftover modal dialogs are closed, the IDE is required
   non-modal, documents are committed/saved + VFS refreshed, and `waitForSmartMode()` runs — all before
@@ -79,6 +78,29 @@ If your next instinct is a native `Read` / `Edit` / `Grep` / `Glob` / `Bash` cal
 - **Use `project` directly** — not `context.project` (no `context.` prefix exists).
 - **Do not invent helpers.** `buildProject()`, `compileProject()`, `createProjectFile()`, `projectDir`, `findProjectDir()`, top-level `readText(vf)` do not exist. For build use `ProjectTaskManager.getInstance(project).buildAllModules().await()` (needs `import com.intellij.task.ProjectTaskManager` + `import org.jetbrains.concurrency.await`); for new files create+write inside one `writeAction` using `VfsUtil.createDirectoryIfMissing` + `dir.createChildData` + `VfsUtil.saveText`; for the project root use `project.basePath` or `project.guessProjectDir()`; for file content use `String(vf.contentsToByteArray(), vf.charset)`. Full table: `mcp-steroid://skill/coding-with-intellij-context-api` → "Real helpers vs invented names".
 - **Do not call daemon-highlighting internals** (`DaemonCodeAnalyzerImpl`, `DaemonProgressIndicator`, `HighlightingSession`) — they require state that does not exist in a script context. For inspection diagnostics use `runInspectionsDirectly(file)` or `mcp-steroid://ide/inspect-and-fix`.
+
+**Output rules — the #1 reason agents think a call "returned empty":**
+
+```
+results            // ✗ value ignored — run SUCCEEDS, but the response has only a no-output HINT
+return results     // ✗ does not compile — the script body returns Unit
+printJson(results) // ✓ response: execution_id + the printed JSON
+```
+
+- **Everything you need back must be explicitly printed** — `println(value)` for plain text,
+  `printJson(value)` for structured data, `printCsv(...)` / `printToon(...)` for tabular records.
+  Prints anywhere in the script are captured, in order — just don't finish without printing what
+  you need.
+- The last expression's value is IGNORED by the runtime — never auto-printed, never returned (the
+  code compiles as a suspend function body, not a REPL). `return` only exits early; `return <value>`
+  does not even compile (the generated function returns `Unit`). A print-less script still
+  SUCCEEDS — the response just carries a `HINT:` line about the missing print instead of your
+  data; it does not mean the call failed.
+- `progress(...)` is NOT output — it goes to MCP progress notifications and the IDE log, never
+  into the result. The print-only rule describes successful runs; a failed run additionally
+  carries the error text and diagnostic file paths (screenshot / thread dump).
+- **For inspection / report tasks, print compact machine-readable lines on the first run.** Stable shapes like `KEY: value` per line or `printJson` parse cheaply on your end and let you build the user-facing summary without a second exec_code pass to reshape verbose IDE output. Recipes in `mcp-steroid://ide/find-duplicates`, `…/inspect-and-fix`, `…/inspection-summary` already follow this convention.
+- **For `runInspectionsDirectly`, do not `printJson(result)` directly.** It is Map-compatible and contains live `ProblemDescriptor` PSI/VFS references. Snapshot descriptor fields inside `readAction { }`, print a DTO, and always include `result.failedTools`; a non-empty `failedTools` means the check is not clean even when the findings map is empty.
 
 ## Modality (the `modal` option)
 
@@ -121,29 +143,6 @@ smart-mode pre-flight hitting its deadlock-safety timeout) — that's documented
 Kotlin, so inspect the captured diagnostics first.
 
 **Surface is fixed.** `McpScriptContext` won't grow new helpers — call IntelliJ APIs directly. See `mcp-steroid://skill/design-philosophy` Tenet 3.
-
-**Output rules — the #1 reason agents think a call "returned empty":**
-
-```
-results            // ✗ value ignored — no data in the response, only a no-output HINT
-return results     // ✗ does not compile — the script body returns Unit
-printJson(results) // ✓ response: execution_id + the printed JSON
-```
-
-- **Everything you need back must be explicitly printed** — `println(value)` for plain text,
-  `printJson(value)` for structured data, `printCsv(...)` / `printToon(...)` for tabular records.
-  Prints anywhere in the script are captured, in order — just don't finish without printing what
-  you need.
-- The last expression's value is IGNORED by the runtime — never auto-printed, never returned (the
-  code compiles as a suspend function body, not a REPL). `return` only exits early; `return <value>`
-  does not even compile (the generated function returns `Unit`). A print-less script still
-  SUCCEEDS — the response just carries a `HINT:` line about the missing print instead of your
-  data; it does not mean the call failed.
-- `progress(...)` is NOT output — it goes to MCP progress notifications and the IDE log, never
-  into the result. The print-only rule describes successful runs; a failed run additionally
-  carries the error text and diagnostic file paths (screenshot / thread dump).
-- **For inspection / report tasks, print compact machine-readable lines on the first run.** Stable shapes like `KEY: value` per line or `printJson` parse cheaply on your end and let you build the user-facing summary without a second exec_code pass to reshape verbose IDE output. Recipes in `mcp-steroid://ide/find-duplicates`, `…/inspect-and-fix`, `…/inspection-summary` already follow this convention.
-- **For `runInspectionsDirectly`, do not `printJson(result)` directly.** It is Map-compatible and contains live `ProblemDescriptor` PSI/VFS references. Snapshot descriptor fields inside `readAction { }`, print a DTO, and always include `result.failedTools`; a non-empty `failedTools` means the check is not clean even when the findings map is empty.
 
 **Threading rules — apply preventively, not after an error:**
 

--- a/prompts/src/main/prompts/skill/execute-code-tool-description.md
+++ b/prompts/src/main/prompts/skill/execute-code-tool-description.md
@@ -43,7 +43,7 @@ literal anchors keep failing): the IDE's tolerance-matching patch engine — fet
 | Task shape | One-line IDE call |
 |---|---|
 | **Two or more literal-text edits, same or different files** | one `steroid_execute_code` script: read + `replace` each file, pre-check every match, then save all inside a single `writeAction { }` (see "Multi-site edits" above) |
-| **One literal-text edit, single file** | `val vf = findProjectFile(p) ?: error("not found: $p"); writeAction { VfsUtil.saveText(vf, String(vf.contentsToByteArray(), vf.charset).replace(OLD, NEW)) }` |
+| **One literal-text edit, single file** | `val vf = findProjectFile(p) ?: error("not found: $p"); writeAction { VfsUtil.saveText(vf, String(vf.contentsToByteArray(), vf.charset).replace(OLD, NEW)) }; println("saved: $p")` |
 | **Find files by extension** | `readAction { FilenameIndex.getAllFilesByExt(project, "java", projectScope()) }` — not `Bash find … -name "*.java"` |
 | **Find files by exact name** | `readAction { FilenameIndex.getVirtualFilesByName("UserService.java", projectScope()) }` |
 | **Find all references to a symbol** | `readAction { ReferencesSearch.search(psiElement, projectScope()).findAll() }` — type-aware; Grep over source text is a fallback |
@@ -65,11 +65,11 @@ If your next instinct is a native `Read` / `Edit` / `Grep` / `Glob` / `Bash` cal
 - Any IDE task → `mcp-steroid://prompt/skill`
 
 **Quick Start:**
-- Your code becomes the body of a `suspend McpScriptContext.() -> Unit` function (never use runBlocking)
 - **Apart from the `execution_id:` header, the response contains ONLY what your script explicitly
-  prints.** The last expression's value is IGNORED by the runtime — this is a function body, not a
-  REPL, and there is no implicit return value. Print everything the caller needs (`println` /
-  `printJson` / `printCsv` / `printToon`) before the script ends. Full rules in "Output rules" below.
+  prints.** Your code becomes the body of a `suspend McpScriptContext.() -> Unit` function (never
+  use runBlocking) — not a REPL: the last expression's value is IGNORED, and there is no implicit
+  return value. Print everything the caller needs (`println` / `printJson` / `printCsv` /
+  `printToon`) before the script ends. Full rules in "Output rules" below.
 - With the default `modal=smart_non_modal`, leftover modal dialogs are closed, the IDE is required
   non-modal, documents are committed/saved + VFS refreshed, and `waitForSmartMode()` runs — all before
   your script; then a monitor watches the run and **closes any modal that appears mid-script and FAILS the
@@ -122,16 +122,22 @@ Kotlin, so inspect the captured diagnostics first.
 **Surface is fixed.** `McpScriptContext` won't grow new helpers — call IntelliJ APIs directly. See `mcp-steroid://skill/design-philosophy` Tenet 3.
 
 **Output rules — the #1 reason agents think a call "returned empty":**
-- **Everything you need back must be explicitly printed.** The last expression's value is IGNORED
-  by the runtime — never auto-printed, never returned (the code compiles as a suspend function
-  body, not a REPL). `return` only exits early; `return <value>` does not even compile (the
-  generated function returns `Unit`), so nothing can be carried back to the caller.
-- To surface anything to the caller, use a print helper: `println(value)` for plain text,
+
+```
+results            // ✗ as the last line: value discarded — response shows only execution_id: …
+printJson(results) // ✓ as the last line: this is what the caller receives
+```
+
+- **Everything you need back must be explicitly printed** — `println(value)` for plain text,
   `printJson(value)` for structured data, `printCsv(...)` / `printToon(...)` for tabular records.
+  Always end with an explicit print of what you need to see.
+- The last expression's value is IGNORED by the runtime — never auto-printed, never returned (the
+  code compiles as a suspend function body, not a REPL). `return` only exits early; `return <value>`
+  does not even compile (the generated function returns `Unit`), so nothing can be carried back to
+  the caller.
 - `progress(...)` is NOT output — it goes to MCP progress notifications and the IDE log, never
   into the result. The print-only rule describes successful runs; a failed run additionally
   carries the error text and diagnostic file paths (screenshot / thread dump).
-- A script that ends with `myList` (or any bare expression) prints nothing — you will see only `execution_id: …` in the response, identical to a script that returned no value at all. Always end with an explicit `println(...)` or `printJson(...)` of what the agent needs to see.
 - **For inspection / report tasks, print compact machine-readable lines on the first run.** Stable shapes like `KEY: value` per line or `printJson` parse cheaply on your end and let you build the user-facing summary without a second exec_code pass to reshape verbose IDE output. Recipes in `mcp-steroid://ide/find-duplicates`, `…/inspect-and-fix`, `…/inspection-summary` already follow this convention.
 - **For `runInspectionsDirectly`, do not `printJson(result)` directly.** It is Map-compatible and contains live `ProblemDescriptor` PSI/VFS references. Snapshot descriptor fields inside `readAction { }`, print a DTO, and always include `result.failedTools`; a non-empty `failedTools` means the check is not clean even when the findings map is empty.
 
@@ -214,6 +220,7 @@ cfg.runnerParameters.workingDirPath = project.basePath!!
 cfg.runnerParameters.goals = listOf("test", "-Dtest=PetRestControllerTests", "-Dspotless.check.skip=true")
 val settings = RunManager.getInstance(project).createConfiguration(cfg, cfg.factory!!)
 ProgramRunnerUtil.executeConfiguration(settings, DefaultRunExecutor.getRunExecutorInstance())
+println("started: ${cfg.name}")   // always end with a print
 ```
 
 For deeper patterns (SMTRunner listeners that block until tests finish + emit structured JSON results) fetch `mcp-steroid://skill/coding-with-intellij-spring`. Bash `./mvnw test` is only OK as a last-resort when the IDE runner has genuinely failed for the scenario.
@@ -235,6 +242,7 @@ val content = String(vf.contentsToByteArray(), vf.charset)  // read
 val updated = content.replace("OLD_STRING", "NEW_STRING")
 check(updated != content) { "no match for OLD_STRING — verify with Grep first" }
 writeAction { VfsUtil.saveText(vf, updated) }               // write + VFS refresh
+println("saved: $path")                                     // always end with a print
 ```
 
 For exactly-one-occurrence replace: `.replace(OLD, NEW).also { check(… == 1 occurrence) }`. For regex: `Regex(pattern).replace(content, replacement)`. Do NOT pre-Read the file via the native tool before using this recipe — the `vf.contentsToByteArray()` read already covers that.


### PR DESCRIPTION
## Why

Agents regularly end `steroid_execute_code` scripts with a bare expression and conclude the call "returned empty". The runtime discards the script block's value — the body compiles into a `suspend McpScriptContext.() -> Unit` function (not a REPL), so only explicit `println` / `printJson` / `printCsv` / `printToon` output reaches the response. The rule existed only ~120 lines deep in the tool description; nothing stated it up front, and the `code` param description said just "Kotlin suspend method body".

## What

State the rule clearly on every surface an agent meets before its first call:

- **`ExecuteCodeTool.kt`**: the `code` param spec states the contract first (response = `execution_id` + explicit prints; print-less runs still succeed with a `HINT:` line), the exact receiver type `suspend McpScriptContext.() -> Unit`, that `return <value>` does not compile, a concrete micro-example (end with `printJson(results)`, never a bare `results`), and links the `McpScriptContext` article (`mcp-steroid://skill/coding-with-intellij-context-api`) via the generated article class so the URI cannot drift.
- **`skill/execute-code-tool-description.md`** (the served MCP tool description): the opening sentence carries the contract; the Output rules block sits directly after Quick Start (no longer buried behind the Modality reference) and opens with a scannable ✗/✗/✓ triple (`results` discarded / `return results` won't compile / `printJson(results)` returned); the decision-table intro warns rows are fragments that must be printed in a real script; every copy-paste recipe now ends with a print; `progress(...)`-is-not-output and failed-run carve-outs included.
- **`skill/coding-with-intellij-intro.md`**: new "Output: Only What You Print Comes Back" section with a compiled WRONG/CORRECT example.
- **`skill/coding-with-intellij-context-api.md`**, **`prompt/skill.md`**, **`mcp-steroid-info.md`**: one-line statements at the output-methods, tool-listing, and getting-started spots.

Verified against the runtime before writing: `ScriptExecutor` runs each block and discards its value; `CodeWrapperForCompilation.wrap` puts the body into a `Unit`-returning function; `ExecutionManager` prepends the `execution_id:` line (verified live); `ExecutionSuggestionService` appends a no-output `HINT:` when `userOutputCount == 0` — all four surfaces describe that behavior accurately.

## Validation — 8-model matrix × 3 iterations, each quorum-gated

Comprehension probe (unchanged across rounds): given only the tool description + param spec, (a) what does a bare-trailing-expression script return, (b) fix it, (c) does `return results` work? Plus scoped improvement-scouting.

**Models**: claude-opus-4-6, -4-7, -4-8, claude-sonnet-5, claude-opus-5, claude-fable-5 (Claude CLI) + gpt-5.4, gpt-5.5 (Codex CLI). Gemini unavailable locally (no Google credentials). **All 8 models answered all comprehension questions correctly in every iteration.**

- **Iteration 1** (`6acce07b`): consensus — lead with the output contract, show the anti-pattern as code, contract-first param spec, and (opus-5) recipes taught "end with a print" while modeling the opposite; all applied. Quorum fable-5 / opus-5 / gpt-5.5: 3× APPROVE.
- **Iteration 2** (`8189524e`): added the `return results` line to the example triple, presence-not-position capture wording, runBlocking unwedged. Quorum 3× APPROVE — and caught a stale claim: a print-less success is not a bare `execution_id:` response; the runtime appends a no-output `HINT:`. All surfaces corrected.
- **Iteration 3** (`2e69338d`): scores settled at the polish floor (uniform 4/5 with suggestion-scouting forced; one model proposed an already-applied change). Applied the last material items: Output rules block moved adjacent to Quick Start, opening-sentence contract, fragments-need-prints table note, HINT carve-outs. Quorum 3× APPROVE.

Tests after every round: `MarkdownArticleContractTest`, `PromptRoutingContractTest`, the changed articles' KtBlock compilations against the IDE matrix, `:mcp-steroid-server:test` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)