### PR TITLE
feat: devrig install plugin — install/update MCP Steroid into running IDEs over REST

### DIFF
--- a/docs/ide-plugin-deploy-and-update-spec.md
+++ b/docs/ide-plugin-deploy-and-update-spec.md
@@ -1,0 +1,490 @@
+# Deploying & updating the MCP Steroid plugin into *running* IDEs — research record + spec
+
+**Status:** research complete, design proposed, **not yet implemented**. Awaiting sign-off.
+**Date:** 2026-07-30. **Branch:** `worktree-ide-rest-plugin-deploy`.
+**Validation:** live-tested against 4 running IDEs (§2) **and peer-reviewed by codex over two rounds**
+(§9): round 1 refuted the first draft's "live dynamic self-swap" recommendation; round 2 refuted the
+v2 draft's claim that the update paths used only stable public APIs and tightened the version gate.
+This doc is the corrected v3. **Bottom line: there is no fully-public SDK API for programmatically
+staging a local plugin ZIP into a *running* IDE — every automated path here touches de-facto/internal
+platform surfaces, so the implementation must pin baselines + guard with tests, and the only
+fully-stable behavior is the *closed-IDE* file-drop / headless path.**
+**Scope owner:** `docs/` (long-form contract doc, sibling to
+[`devrig-deployment-spec.md`](devrig-deployment-spec.md) and
+[`native-mcp-tools-design.md`](native-mcp-tools-design.md)).
+
+Related: [`intellij-builtin-servers.md`](intellij-builtin-servers.md) (both IDE HTTP servers),
+[`updates-check/devrig-auto-update.md`](updates-check/devrig-auto-update.md) (devrig's *own*
+self-update — the pattern this doc mirrors for the *plugin*).
+
+---
+
+## 1. The problem
+
+devrig ships a **bundled** copy of the MCP Steroid plugin (`ij-plugin.zip`, resolved via
+`DevrigRoot.ijPluginZip()` / `ClasspathBundledPluginResolver.resolveBundledPluginZip()`).
+Today devrig only deploys that bundle into IDEs **it manages itself** (downloaded/started by
+`devrig backend`) via `ManagedBackend.deployMcpSteroidPlugin()` — a file copy into a managed
+plugins dir before the IDE is first started.
+
+For an IDE the **user already has open** (their daily-driver IntelliJ/WebStorm/GoLand/…), devrig
+today does nothing but *print instructions* (`BackendProvisionCommand` emits "(a) marketplace… (b)
+manual file install…" text). There is no path to:
+
+1. **install** the plugin into a running IDE the user opened themselves, and
+2. **update** an already-installed plugin when devrig bundles (or devrig.dev advertises) a newer one.
+
+The user's ask: detect IDEs locally on the standard IntelliJ ports, then deploy/update the plugin —
+**preferring devrig's bundled artifact + a version check** — with a **smooth, no-surprises UX**.
+
+### Non-goals
+
+- Replacing Marketplace distribution. The plugin stays published (id `com.jonnyzzz.mcp-steroid`,
+  Marketplace #30019); this is an *additional* local channel.
+- Managing IDEs devrig already owns (that is `ManagedBackend`'s job and already works).
+- Enterprise mass-deployment (IDE Services / Toolbox Enterprise already solve that).
+
+### TL;DR of the recommendation (after validation)
+
+| Situation | Recommended path | Restart? | Surprise? | API stability |
+|---|---|---|---|---|
+| Plugin **absent**, IDE **running** | REST `action=install` (native Marketplace dialog) | no (not guaranteed) | user approves in-IDE dialog (native) | de-facto endpoint (stable in practice) |
+| Plugin **absent/older**, IDE **closed** | file-drop of the bundle / headless `installPlugins` | applied next start | none | **fully stable** (filesystem / documented CLI) |
+| Plugin **present**, **older** than bundle, IDE running | stage the bundle for next launch (copy to a **disposable** staging file first) + "restart to apply" notice | **yes, user-timed** | none until user restarts | **internal** staging API — pin+guard |
+| Plugin **present**, want IDE to self-update (**release builds only**) | persist `devrig.dev/updatePlugins.xml` in `UpdateSettings.storedPluginHosts` → IDE's own update flow (best-effort live, else next start) | IDE-managed | native update notification | internal config API |
+| Live no-restart hot-swap from devrig | **ruled out** — the bridge runs *inside* the plugin; it cannot unload its own classloader (§2.1, §9) | — | — | — |
+
+> The two "IDE running" *update* rows require mutating in-IDE operations for which no public SDK API
+> exists (§2.5, §9-r2). Where fully-stable behavior matters more than immediacy, prefer closing the
+> IDE and using the file-drop / headless row (all-public, all-stable).
+
+---
+
+## 2. What was validated live (2026-07-30)
+
+Everything below was verified against **running IDEs on this machine** (and, for the API-mechanics
+claims, cross-checked in the IntelliJ 261 source at `origin/261` and by reflection in the live 261
+runtime — see §9). Live fleet at test time (from `~/.mcp-steroid/markers/*.mcp-steroid`):
+
+| IDE | Built-in port | Plugin version | Note |
+|---|---|---|---|
+| IntelliJ IDEA 2026.1 (`IU-261.22158.277`) | 64463 | `0.101.19999-SNAPSHOT-9f54111f` | dev SNAPSHOT — **port outside devrig's scan ranges** (§2.6) |
+| WebStorm 2026.1.4 (`WS-261.26222.58`) | 63342 | `0.101.19999-SNAPSHOT-f969ad18` | dev SNAPSHOT |
+| IntelliJ IDEA 2026.1.3 (`IU-261.25134.95`) | 63343 | `0.101.19999-SNAPSHOT-f969ad18` | dev SNAPSHOT |
+| **GoLand 2026.1.4 (`GO-261.26222.72`)** | 63344 | **`0.101-40690055`** | **published Marketplace build** |
+
+GoLand is the realistic "user already has the released plugin; is there a newer one?" case.
+
+### 2.1 The plugin descriptor is *dynamic-eligible* — but that does NOT make a live self-swap safe ⭐
+
+In-process, against the running GoLand:
+
+```
+version: 0.101-40690055     enabled: true
+descriptor class: com.intellij.ide.plugins.PluginMainDescriptor
+isRequireRestart: false
+checkCanUnloadWithoutRestart(descriptor)  ->  null      # descriptor-level: eligible to unload
+allowLoadUnloadWithoutRestart(descriptor) ->  true       # just re-runs the same check
+```
+
+This confirms *descriptor-level* eligibility only. It does **not** guarantee an actual live swap,
+and — critically — **devrig must not attempt one for the update case**, because:
+
+- The devrig↔IDE transport is the plugin's **own** Ktor bridge. Any update script devrig sends runs
+  **inside the mcp-steroid plugin's classloader**. Replacing the plugin means unloading that
+  classloader while a frame that belongs to it is on the stack.
+- `PluginDownloader.installDynamically` / `DynamicPlugins.unloadPlugin` unload with a
+  wait-for-classloader-GC step (verified in 261 source, §9). The still-running bridge retains the
+  old classloader, so GC cannot complete → the unload stalls/fails. A "detached" plugin-owned thread
+  retains it too. This is the classic self-unload hazard, and codex confirmed it is fatal here.
+- Even absent that, `checkCanUnloadWithoutRestart == null` can still be defeated at unload time by
+  vetoers, pre-existing restart state, dependency graphs, or listener errors — it is a *necessary*,
+  not *sufficient*, condition, and it flips the moment a future plugin release adds a non-dynamic
+  contribution. **Query it at runtime; never assume it.**
+
+**Consequence:** the smoothest-looking option (silent hot-swap) is off the table. Updates are
+restart-staged or delegated to the IDE's own update machinery (§4).
+
+### 2.2 REST `checkCompatibility` works silently from a localhost origin ⭐ (CONFIRMED)
+
+`GET /api/installPlugin` on the built-in server. Against GoLand (port 63344), with a localhost
+`Origin` header:
+
+```
+GET …?pluginId=com.jonnyzzz.mcp-steroid                          -> {"name":"GoLand 2026.1.4","buildNumber":"GO-261.26222.72"}
+GET …?pluginId=com.jonnyzzz.mcp-steroid&action=checkCompatibility -> {"compatible": true}
+GET …?pluginId=com.jonnyzzz.does-not-exist&action=checkCompatibility -> {"compatible": false}
+```
+
+- **No modal appeared.** `RestService.isHostTrusted` lets a localhost-`Origin` (or token-signed)
+  request through without the "trust unknown host?" prompt
+  (`community/.../org/jetbrains/ide/RestService.kt:271-333`).
+- `checkCompatibility` is a **pure Marketplace query** (`MarketplaceRequests.getLastCompatiblePluginUpdate`)
+  — it installs nothing; safe against a user's live IDE. `InstallPluginService.kt` is byte-identical
+  across 261/262/263 (codex-verified).
+- **Qualification:** an HTTP 200 does not by itself prove an install/dialog happened — for
+  `action=install` the endpoint returns OK immediately and does the work async, and returns OK even
+  when the service is busy or no candidate exists. Use `checkCompatibility` for the *decision*, not
+  the 200 of an `install` call for *confirmation*.
+
+### 2.3 The marker's `x-ijt` token is NOT reliably stable — prefer localhost `Origin` (CORRECTED)
+
+The recorded token happened to still return 200 in testing, but that only shows it was being
+continuously re-accessed. `BuiltInWebServerAuth` caches tokens with `expireAfterAccess(1, MINUTES)`;
+after one idle minute the entry is evicted and the next `acquireToken()` mints a **different** token
+(`community/.../builtInWebServer/BuiltInWebServerAuth.kt:63-67,92-105`, codex-verified). So a marker
+token can go stale. **Design rule:** treat the marker `x-ijt` as best-effort and always fall back to
+a localhost `Origin` header (which is accepted regardless). Only send the token over loopback; never
+log it; never send it to a non-localhost origin.
+
+### 2.4 No custom plugin-repository host is registered in these IDEs
+
+```
+UpdateSettings.storedPluginHosts -> []   ;   pluginHosts -> []   ;   idea.plugin.hosts sysprop -> null
+```
+
+So the custom-repo path (§4, "IDE self-update") requires devrig to **register**
+`https://devrig.dev/updatePlugins.xml` first — a persistent config change to the user's IDE. Heavier
+footprint; opt-in only.
+
+### 2.5 The install/update APIs exist but are NOT the silent local-install primitives the draft assumed (CORRECTED)
+
+Verified by reflection in the live 261 runtime **and** in `origin/261` source:
+
+| API (261) | Reality |
+|---|---|
+| `PluginInstaller.installFromDisk` | **package-private** `static void`, 6 params `(InstalledPluginsTableModel, PluginEnabler, Path, Project, JComponent, Consumer)`. Heavily **UI-coupled**: synchronous progress dialog, `checkThirdPartyPluginsAllowed`, multiple `MessagesEx.show*Dialog`, sets restart-required when an older install exists. This is the *"Install Plugin from Disk…" action*, not a headless API. |
+| `PluginInstaller.installWithoutRestart` | **private**; only unpacks files. Not callable, not a full install. |
+| `PluginInstaller.installAndLoadDynamicPlugin(Path, IdeaPluginDescriptorImpl)` | public — a genuine dynamic-load-from-file path, but for an **update** it must unload the old plugin first (→ the §2.1 self-unload hazard). Usable only where the plugin being loaded is *not* the one executing the call. |
+| `PluginDownloader.createDownloader(IdeaPluginDescriptor)` | public, but the URL-building overload with a null host **ignores a local file URL and constructs a Marketplace URL** — so `createDownloader(node).installDynamically()` does **not** install devrig's local bundled zip. |
+| `PluginDownloader.installDynamically(JComponent)` | public; gates on `allowLoadUnloadWithoutRestart` then `DynamicPlugins.unloadPlugin` (classloader-GC wait — §2.1). |
+| `MarketplaceRequests.getLastCompatiblePluginUpdate`, `RepositoryHelper.getCustomPluginRepositoryHosts`, `InstalledPluginsState.hasNewerVersion` | present; fine for read-only queries. |
+
+**API-stability caveat (261→263):** these are *internal* platform APIs and drift across baselines —
+e.g. `DynamicPlugins.checkCanUnloadWithoutRestart` returns `String?` in 261 but `Boolean` in 262
+(reason moves to `validateCanUnloadWithoutRestart`), and `installFromDisk` gains another parameter by
+263. Any code that touches them needs baseline-specific handling or reflection. **The recommended
+paths (§4) avoid the *worst* of these (no live self-swap, no `installFromDisk`)** — but they do **not**
+avoid internal surfaces entirely: the running-IDE *update* path (Path F) stages via the
+`@ApiStatus.Internal` `installAfterRestartAndKeepIfNecessary`, and persistent custom-repo registration
+(Path C) writes the internal `UpdateSettings.storedPluginHosts`. Only the **closed-IDE** paths
+(file-drop, headless starter) and REST `checkCompatibility` are fully-stable public/documented
+surfaces. Every internal-API use in §4 must be pinned per baseline and guarded by a fail-fast drift
+probe (§6). There is no fully-public SDK API for staging into a *running* IDE (§9-r2, §1 bottom line).
+
+### 2.6 Port scanning can miss IDEs — marker discovery is authoritative for mcp-steroid IDEs (CORRECTED)
+
+`IntelliJPortDiscovery` scans `63342..63361` + `64342..64361`. But the built-in server tries 20 ports
+then **binds any free port**, and `rpc.port` can override it (`BuiltInServerManagerImpl.kt:134`,
+`BuiltInServer.kt`). The live IDEA at **64463 is already outside both ranges** — proof the scan is
+not exhaustive. Implications:
+
+- For **mcp-steroid-aware** IDEs, marker discovery (`IdePidDiscoveryService`) is authoritative — the
+  marker carries the exact `intellijWebServer.port`, `x-ijt`, `pluginPath`, and installed version.
+- For a **fresh install** into an IDE with no plugin yet, there is no marker, and a pure port scan
+  may not find it. Widen/parameterize the ranges, and treat "no IDE found" as "ask the user / accept
+  partial coverage," never as "none running."
+- Also fix `IdePortDiscovery.kt`'s `//TODO: same IDE can be returned multiple times` (built-in +
+  MCP server of one IDE both answer) before shipping.
+
+### 2.7 devrig plumbing that already exists vs. the gaps
+
+Exists: `IntelliJPortDiscovery` (detection); `ClasspathBundledPluginResolver` (bundled artifact);
+`readBundledPluginBuildRange()` + `PluginBuildRange.accepts(build)` (compat gate);
+`mcp-core` version primitives (`DevrigVersion`, `Version`, `VersionComparatorUtil`);
+`ManagedBackend.deployMcpSteroidPlugin()` (file copy into a *managed* plugins dir);
+the authenticated Ktor bridge (transport for read-only in-IDE queries).
+
+Gaps this spec creates:
+
+- **G1** — devrig can't read the bundled plugin's `<version>` (only its build range). Needed for the
+  version decision. Fix: extend the zip reader (mirror website-gen's `extractPluginCoordinates`).
+- **G2** — no deploy/update path for running, *un-managed* IDEs (`deployMcpSteroidPlugin` targets
+  only managed dirs).
+- **G3** — `provision` only prints.
+- **G4** — nothing consumes `McpSteroidServerInfo.pluginPath` (the marker already records it — useful
+  for the file-drop / restart-staged path).
+
+---
+
+## 3. The full option space
+
+| # | Channel | IDE running? | Source | Version pin | Surprise | Verdict |
+|---|---|---|---|---|---|---|
+| **A** | REST `GET /api/installPlugin?action=install` | yes | Marketplace/registered repo | ❌ latest only | native install dialog always (`installAndEnable(showDialog=true)`) | **First-install default (running IDE)** |
+| **B** | In-process dynamic hot-swap via the bridge | yes | devrig bundle | ✅ | none — but **unsafe**: self-unload hazard (§2.1) | **Ruled out** |
+| **C** | Custom repo `updatePlugins.xml` + host registration | yes (IDE-driven) | devrig.dev | ✅ via XML | native update notification; needs persistent host reg (§2.4) | **Opt-in IDE self-update** |
+| **D** | File-drop into the plugins dir | **no** | devrig bundle | ✅ | none; applied next start (startup-only scan) | Closed-IDE install/update |
+| **E** | Headless `installPlugins` / `update` starter | **no** (fails if running) | Marketplace/custom repo | repo-dependent | none (CLI, exit-code contract) | Closed-IDE install/update |
+| **F** | **Restart-staged** install of the bundled zip | yes → applied on restart | devrig bundle | ✅ | none until the user restarts | **Running-IDE update default** |
+
+Why A is fine but not for the bundle: JetBrains' own "Install to IDE" button uses exactly A and
+*always* shows the install dialog — a good, native first-install UX — but it pulls the Marketplace
+build, so it cannot pin devrig's *bundled* artifact and cannot update silently.
+
+---
+
+## 4. Recommended design
+
+**Detect → identify → compare versions → pick the lightest *safe* path → act only with consent.**
+
+### 4.0 Detect & identify
+
+Join marker discovery (authoritative, §2.6) with a widened `IntelliJPortDiscovery` pass. Per running
+IDE resolve `{port, productCode, buildNumber, baseUrl, x-ijt (best-effort), pluginPath, installedVersion}`.
+Fix the dedup TODO first.
+
+### 4.1 Compare versions (the "is there a newer plugin?" decision) — CORRECTED
+
+1. **Bundled-vs-installed (authoritative for devrig's channel).** Read the bundled `<version>` (G1);
+   read the installed version (marker, or in-process `PluginManagerCore.getPlugin(id).version`).
+   The comparator choice is subtle and every off-the-shelf option has a trap:
+   - Raw `VersionComparatorUtil` orders the dev build `0.101.19999` **below** the release
+     `0.101-40690055` → it would flag dev SNAPSHOTs as "needing upgrade" and force-downgrade them.
+   - `BackendVersionSkew.versionBase` truncates to `major.minor`, collapsing all same-lane builds.
+   - **`DevrigVersion` ranks *every* snapshot above *every* release** — so it does **not** save you
+     either: a *bundled snapshot over an installed release* looks "newer" and would replace a stable
+     release with a dev build.
+   - **Rule (strengthened): only auto-replace when BOTH the installed and the bundled versions are
+     non-dev release builds, and the bundle is strictly newer.** If *either* side is a dev/SNAPSHOT
+     build (`-SNAPSHOT` suffix or the `19999` dev marker), do not auto-replace — report only. This is
+     the single gate; do not rely on the comparator alone to protect dev installs.
+2. **Marketplace availability (informational).** `action=checkCompatibility` (§2.2) tells you whether
+   Marketplace has a compatible build — used to choose between "offer bundled" and "offer
+   Marketplace/Path A", and to warn when the bundle is *older* than what's published.
+
+Compatibility gate for the bundle: `bundledPluginBuildRange.accepts(target.buildNumber)` (exists).
+Note it currently compares build *baselines* only; fine for `since-build="261"`, but move to full
+`BuildNumber` semantics if a future descriptor pins `since-build="261.NNNNN"`.
+
+### 4.2 Act
+
+- **First install, IDE running (plugin absent):** REST **Path A** —
+  `GET …?action=install&pluginId=com.jonnyzzz.mcp-steroid` from a localhost origin. The user gets the
+  native Marketplace install dialog (+ third-party-plugin consent). Best discovery UX; no bespoke
+  risk. (There is no bridge yet — the plugin isn't installed — so an in-process install is
+  impossible by definition.)
+- **Update, IDE running (plugin present, bundle strictly newer):** **Path F — restart-staged.** Stage
+  the bundled zip via `PluginInstaller.installAfterRestartAndKeepIfNecessary`
+  (`(IdeaPluginDescriptor, Path, Path)`), then **notify** "MCP Steroid update staged — restart your
+  IDE to apply." Never restart for the user. **Two caveats codex round-2 confirmed against 261 source:**
+  1. The method is Java-`public` but `@ApiStatus.Internal` — there is **no fully-public/stable SDK
+     surface** for staging an arbitrary local zip into a running IDE. The fallback if its signature
+     drifts is the plugins-auto-update staging dir / `action.script` convention (also internal). This
+     is an accepted, documented trade-off, not a stable public contract (§6/§7 honesty note).
+  2. The method schedules **deletion of its source archive** (`PluginInstaller.java:452-454`). devrig
+     must stage from a **disposable copy** of the bundled zip — never pass devrig's canonical
+     `ijPluginZip()` path, or the bundle is destroyed.
+  Staging performs no unload, so it does **not** hit the self-unload hazard (§2.1).
+- **IDE self-update (opt-in, release builds only):** **Path C** — persistently register
+  `devrig.dev/updatePlugins.xml` via **`UpdateSettings.storedPluginHosts`** (written to
+  `options/updates.xml`; consumed by the next update check with no restart). Do **not** rely on
+  `RepositoryHelper.amendPluginHostsProperty` — it is internal and only mutates the *current JVM's*
+  `idea.plugin.hosts` (transient, lost on restart). The IDE's own scheduled update checker then finds
+  new versions through **platform** code (no mcp-steroid frame on the stack), surfaced via the standard
+  update notification. **But live no-restart is still only best-effort, not guaranteed:** the platform
+  manual-update flow tries `installDynamically` and *falls back to restart staging*, and active bridge
+  work (esp. blocking kotlinc) can still retain the classloader past the ~5 s unload wait
+  (`PluginUpdateDialog`, `DynamicPlugins.kt:731-772`, `PluginAutoUpdateService.kt`). Path C also uses
+  IntelliJ's **raw `VersionComparatorUtil`**, which is *outside* devrig's version guard (§4.1) — so
+  **Path C must be disabled for dev/SNAPSHOT installs** to avoid re-introducing the snapshot-downgrade
+  trap. Requires a persistent, user-approved config change.
+- **Closed IDE:** **Path D** (copy the bundle into the discovered plugins dir; applied next start) or
+  **Path E** (headless `installPlugins`/`update` starter). Reuse `deployMcpSteroidPlugin`'s copy logic
+  against the discovered dir.
+
+### 4.3 Explicitly out
+
+**Path B (live in-process hot-swap of mcp-steroid via its own bridge).** Not safe (§2.1, §9). If a
+future release ever wants a live update, it must be driven by **platform-owned** machinery with no
+plugin frame on the stack (that is what Path C achieves) — not by a bridge script.
+
+---
+
+## 5. The "no surprises" contract
+
+The IDE's own precedent (source-verified): never install silently — Marketplace's own button uses
+`showDialog=true`, and non-JetBrains origins get a per-origin trust dialog. devrig, as a
+localhost/token caller, *could* bypass those, so restraint is devrig's responsibility.
+
+1. **Explicit, logged, once consent** before the first deploy/update into a user-opened IDE (mirrors
+   `--give-consent-to-use-third-party-plugins`). Record the grant per the `updates-check/` marker
+   pattern.
+2. **Never restart the user's IDE.** Updates are restart-staged (Path F) with a clear "restart to
+   apply" message; the user chooses when.
+3. **Version-monotonic; never downgrade; never touch SNAPSHOT/dev builds** (§4.1). When the bundle is
+   older than installed/Marketplace, *report*, don't act (`isDowngradeAllowed` stays off/private).
+4. **Idempotent + observable.** "Everything current" → clear no-op message. Every action names the
+   IDE, from→to version, and the path used.
+5. **Prefer the IDE's own machinery when a live update is wanted** (Path C) over any bespoke swap.
+
+---
+
+## 6. Implementation outline (proposed; not built)
+
+Ordered and each independently testable. **Honesty note on API stability (codex round-2):** the
+*detection and version-check* layer (steps 1–2, 6) is built entirely on stable/public surfaces. The
+*acting* layer is not uniformly so — Path A calls an existing (de-facto/internal) REST endpoint; Path
+F stages via an `@ApiStatus.Internal` method (with a disposable copy, §4.2); persistent Path C writes
+`UpdateSettings.storedPluginHosts`. Only the **closed-IDE paths (D/E)** are fully stable. Where an
+internal API is used, devrig must pin it per baseline and gate it behind a signature/version probe so
+drift fails fast rather than silently.
+
+1. **G1 — bundled `<version>` reader** in `PluginCompatibility.kt` (parse `<version>` alongside the
+   build range); unit-test with a fixture zip.
+2. **Pure version-decision function** `PluginDeployDecision(installed, bundled, marketplaceCompatible,
+   targetBuild, buildRange, isDevBuild) -> Action` where `Action ∈ {UpToDate, InstallFresh,
+   StageUpdateForRestart, ReportNewerAvailable, Skip(reason)}`. Uses `DevrigVersion` ordering + the
+   SNAPSHOT rule + `buildRange.accepts`. Fully unit-tested (incl. the `19999`-vs-`40690055` trap and
+   the dev-SNAPSHOT skip).
+3. **G2 — deploy/update command** for running, un-managed IDEs (working name
+   `devrig plugin deploy [--to <port|all>] [--dry-run]`): run the decision, then execute Path A
+   (fresh) or Path F (update), or Path D/E for closed IDEs. `--dry-run` prints the decision matrix.
+4. **Consent + record** (one-time), and the "restart to apply" notification for staged updates.
+5. **G3 — make `provision` act** (call into the new command; keep `--dry-run`/JSON).
+6. **Detection fixes** (§2.6): dedup, widened/parameterized ranges, marker-first resolution.
+7. **Optional Path C** command to register/unregister the custom repo, strictly opt-in.
+
+Testing: exhaustive unit coverage of the decision function; a `:test-integration` Docker case that
+(a) installs into a clean IDE via Path A and asserts the plugin loads, and (b) stages an update via
+Path F, restarts the container IDE, and asserts the new version is active. **No** detect-and-skip; fix
+infra if the Docker IDE lacks something (root CLAUDE.md).
+
+---
+
+## 7. Security & consent analysis (source-verified)
+
+- The built-in web server is a recurring CVE surface (2016 CSRF/CORS; 2019–2020 open-ports;
+  2022 file-read/NTLM; **CVE-2026-41882** arbitrary file read, fixed in 2026.1.1). The recommended
+  paths add **no** new HTTP surface: Path A only *calls* an existing endpoint; C/D/E/F use existing
+  install/update mechanisms. **Scope of mutation (corrected per codex round-2):** the mcp-steroid
+  *bridge* is used only for **read-only** version/compat queries — but the deploy/update actions are
+  **not** read-only overall. They mutate the target IDE's on-disk state (staged plugin files for
+  Path F; `options/updates.xml` for persistent Path C) through platform machinery, some of it
+  internal. The read-only claim applies to the bridge query path, not to the act step; the act step's
+  safety rests on the §5 consent contract + "never restart / never downgrade / never touch dev builds."
+- Trust model (`RestService.isHostTrusted`, `InstallPluginService`): token-signed or
+  localhost-`Origin` requests skip the trust dialog; JetBrains web properties are the only pre-trusted
+  external origins; 30 req/min rate limit. devrig is on the trusted (localhost) side — hence the §5
+  consent contract is devrig's responsibility.
+- Token handling per §2.3: marker `x-ijt` is best-effort, loopback-only, never logged; localhost
+  `Origin` is the reliable fallback.
+
+---
+
+## 8. Open questions / risks
+
+- **Q1 (settled NO).** Live in-process hot-swap of mcp-steroid via its own bridge — unsafe (§2.1,
+  §9). Do not implement.
+- **Q2.** Does Path A's async `installAndEnable` path perform a *dynamic* update of an already-loaded
+  mcp-steroid when the bridge is idle, or does it also stage a restart? Worth a Docker test, but not
+  load-bearing — Path F (restart-staged) is the committed update path regardless.
+- **Q3.** `installAfterRestartAndKeepIfNecessary` signature stability 261→263 (internal API). If it
+  drifts, fall back to the plugins-auto-update staging dir / `action.script` file (older, more
+  stable).
+- **Q4.** Custom-repo (Path C) auth/HTTPS and the IDE's 24h update cadence — acceptable latency for a
+  self-update channel? Document the trade-off vs. Path F's immediacy.
+- **Q5.** Port-scan coverage for fresh installs into IDEs on out-of-range ports (§2.6) — may require
+  a user hint or a wider scan.
+
+---
+
+## 9. Validation log (codex peer review, 2026-07-30)
+
+Two adversarial codex rounds (run via `run-agent.sh codex`) drove this spec from wrong to correct;
+every finding was **independently re-verified** here by reflection in the live 261 runtime and by
+reading `origin/261`/`262`/`263` source before folding in.
+
+### Round 1 — refuted the original "live hot-swap" (Path B)
+
+The first draft recommended a **live in-process dynamic swap** ("Path B") as the primary update path.
+Confirmed corrections:
+
+- **BLOCKER (confirmed):** the bridge cannot dynamically replace its own plugin —
+  `installDynamically`→`unloadPlugin` waits for classloader GC that can't complete while the bridge
+  holds the classloader (261 `PluginDownloader.installDynamically:302-411`, `DynamicPlugins.unloadPlugin`).
+- **BLOCKER (confirmed by reflection):** `installFromDisk` is package-private, UI-coupled, 6-arg,
+  `void`, restart-setting; `installWithoutRestart` is private/unpack-only; `createDownloader(node)`
+  with a null host builds a Marketplace URL, ignoring a local file. The draft's install snippet was
+  not viable.
+- **MAJOR (confirmed):** internal-API drift 261→263 (`checkCanUnloadWithoutRestart` `String?`→`Boolean`;
+  `installFromDisk` extra param) → prefer stable public surfaces.
+- **MAJOR (confirmed):** `checkCanUnloadWithoutRestart == null` is necessary, not sufficient.
+- **MAJOR (confirmed):** version ordering — raw `VersionComparatorUtil` puts `0.101.19999` below
+  `0.101-40690055`; `versionBase` over-truncates → adopt the "never auto-replace SNAPSHOT" +
+  `DevrigVersion` rule (§4.1).
+- **MAJOR (confirmed):** fixed port ranges miss IDEs (live 64463 example) → marker-first (§2.6).
+- **MINOR (confirmed):** marker `x-ijt` not reliably stable → localhost `Origin` fallback (§2.3).
+- **OK (confirmed):** the REST/consent model (§2.2, §5, §7) is accurate; `InstallPluginService`
+  byte-identical 261→263.
+
+### Round 2 — refuted the v2 rewrite's over-claims
+
+The v2 rewrite (Path B removed; Path F/C adopted) was re-submitted for a narrow "does the fix hold?"
+review. codex refuted three remaining claims and one consistency issue; **all folded into this v3:**
+
+- **BLOCKER — "Path F stages via a stable public mechanism" → REFUTE.** No fully-public SDK API
+  exists to stage an arbitrary local zip into a running IDE. `installAfterRestartAndKeepIfNecessary`
+  is `@ApiStatus.Internal`; `action.script` / `PluginAutoUpdateRepository` are internal formats;
+  `InstalledPluginsState` is in-memory bookkeeping only. → §4.2 Path F + §6/§7 now state this
+  explicitly and require per-baseline pinning + a drift probe (`PluginInstaller.java:148-185`).
+- **BLOCKER — "§4.1 version rule protects dev builds" → REFUTE.** `DevrigVersion` ranks *every*
+  snapshot above *every* release, so a bundled snapshot over an installed release looks "newer"; and
+  Path C's raw `VersionComparatorUtil` bypasses the guard entirely. → §4.1 now requires **both** sides
+  non-dev for auto-replace, and §4.2 **disables Path C for dev installs** (`DevrigVersion.kt`,
+  `UpdateChecker.kt:496-520`).
+- **BLOCKER — "Path C guarantees a live update" → REFUTE.** Platform ownership removes the *bridge
+  self-frame* hazard, but live unload is still best-effort: the manual flow falls back to restart
+  staging, and active bridge/kotlinc work can retain the classloader past the ~5 s wait. → §4.2 Path C
+  now says "best-effort, not guaranteed" (`DynamicPlugins.kt:731-772`, `PluginAutoUpdateService.kt`).
+- **MAJOR — restart-stage deletes its source archive → CONFIRM (qualified).** Staging avoids
+  self-unload, but normally schedules deletion of its source; passing devrig's canonical
+  `ijPluginZip()` would destroy the bundle. → §4.2 Path F now stages from a **disposable copy**
+  (`PluginInstaller.java:452-454`).
+- **MAJOR — repository registration mechanism → REFUTE (corrected).** `amendPluginHostsProperty` is
+  internal + JVM-transient; persistent registration is `UpdateSettings.storedPluginHosts` in
+  `options/updates.xml` (no restart needed). → §4.2 Path C corrected (`RepositoryHelper.java:64-80`,
+  `UpdateSettings.java:20-47`).
+- **MAJOR — §§6–7 "only stable public surfaces / read-only bridge" → REFUTE (over-claim).** Path F
+  and persistent Path C mutate in-IDE state via internal APIs. → §6/§7 honesty notes added.
+- **MINOR — REST first-install default → CONFIRM (qualified).** Best automated default, but
+  no-restart is not guaranteed and the endpoint is de-facto/internal, not documented-stable
+  (`InstallPluginService.kt:23-112`).
+
+**Overall:** the REST detection/version-check research is sound and retained. The update path was
+corrected across two rounds from "live hot-swap" → "restart-staged (Path F, disposable copy, internal
+API pinned) + opt-in IDE-self-update (Path C, `storedPluginHosts`, release-builds-only, best-effort)."
+The honest bottom line, stated up front (§1): **there is no fully-public/stable SDK API for
+programmatic staging into a running IDE** — the closed-IDE paths (D/E) are the only fully-stable ones,
+and every internal-API use is pinned per baseline behind a fail-fast drift probe. This v3 is the
+submitted research result.
+
+---
+
+## Appendix A — reproducible probes
+
+Localhost REST (safe; `checkCompatibility` never installs):
+
+```bash
+BASE=http://127.0.0.1:63344
+curl -s -H "Origin: http://localhost" "$BASE/api/installPlugin?pluginId=com.jonnyzzz.mcp-steroid&action=checkCompatibility"
+# -> {"compatible": true}
+```
+
+In-process dynamic-eligibility probe (read-only; via the bridge / steroid_execute_code):
+
+```kotlin
+val d = PluginManagerCore.getPlugin(PluginId.getId("com.jonnyzzz.mcp-steroid")) as IdeaPluginDescriptorImpl
+DynamicPlugins.checkCanUnloadWithoutRestart(d)   // 261: null (String?) => descriptor-eligible ONLY
+DynamicPlugins.allowLoadUnloadWithoutRestart(d)  // true — NOT a guarantee of a safe live swap (§2.1)
+```
+
+Custom repo currently live at `https://devrig.dev/updatePlugins.xml`:
+
+```xml
+<plugin id="com.jonnyzzz.mcp-steroid"
+        url="https://github.com/jonnyzzz/mcp-steroid/releases/download/v0.101/mcp-steroid-0.101-40690055.zip"
+        version="0.101-40690055">
+  <idea-version since-build="261"/>
+</plugin>
+```

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/BackendCommand.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/BackendCommand.kt
@@ -392,6 +392,11 @@ fun renderBackendOutput3(
             out.println("        MCP Steroid: not installed")
             if (s1Incompatible.size + index < group2Count - 1) out.println()
         }
+        // Promote the one-shot REST installer for every IDE above that lacks a compatible plugin.
+        // The IDE shows its own native confirmation dialog, so this is safe to surface unconditionally.
+        out.println()
+        out.println("  Install / update MCP Steroid in the IDE(s) above:  $INSTALL_PLUGIN_COMMAND")
+        out.println("        (each IDE shows a native \"Choose Plugins to Install or Enable\" dialog — nothing installs silently)")
     }
     out.println()
 
@@ -474,6 +479,7 @@ fun renderBackendJson3(
                     put("build", ide.ide.build)
                     put("pid", ide.pid)
                     put("compatible", false)
+                    put("installCommand", INSTALL_PLUGIN_COMMAND)
                 })
             }
             for (ide in s2Deduped.sortedBy { it.port }) {
@@ -483,6 +489,7 @@ fun renderBackendJson3(
                     ide.buildNumber?.let { put("build", it) }
                     put("port", ide.port)
                     put("compatible", false)
+                    put("installCommand", INSTALL_PLUGIN_COMMAND)
                 })
             }
         }

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/Cli.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/Cli.kt
@@ -80,6 +80,18 @@ sealed interface DevrigCommand {
         override val json: Boolean = false,
     ) : DevrigCommand
 
+    /**
+     * `devrig install plugin` — install the MCP Steroid plugin into locally-running JetBrains IDEs via
+     * each IDE's built-in REST endpoint (which shows the IDE's own native install dialog). [check] is a
+     * read-only dry-run: report which IDEs would be asked, show no dialog. Also invoked, best-effort, from
+     * `devrig install devrig`.
+     */
+    data class DevrigCommandInstallPlugin(
+        val check: Boolean = false,
+        override val debug: Boolean = false,
+        override val json: Boolean = false,
+    ) : DevrigCommand
+
     data class DevrigCommandHelp(
         override val debug: Boolean = false,
         override val json: Boolean = false,
@@ -237,14 +249,21 @@ private class InstallCommand(
     override fun run() {
         val options = options()
         if (agent == "devrig") {
-            if (checkFlag) throw UsageError("--check is only valid for an agent install (claude / codex / gemini)")
+            if (checkFlag) throw UsageError("--check is only valid for an agent install (claude / codex / gemini) or 'devrig install plugin'")
             select(DevrigCommand.DevrigCommandInstallDevrig(
                 installScript = installScript, jdkHome = jdkHome, debug = options.debug, json = options.json,
             ))
             return
         }
+        if (agent == "plugin") {
+            if (installScript != null || jdkHome != null) {
+                throw UsageError("--install-script / --jdk-home are only valid with 'devrig install devrig'")
+            }
+            select(DevrigCommand.DevrigCommandInstallPlugin(check = checkFlag, debug = options.debug, json = options.json))
+            return
+        }
         val target = AiAgentCli.parse(agent)
-            ?: throw UsageError("agent must be one of: claude, codex, gemini, devrig")
+            ?: throw UsageError("agent must be one of: claude, codex, gemini, devrig, plugin")
         if (installScript != null || jdkHome != null) {
             throw UsageError("--install-script / --jdk-home are only valid with 'devrig install devrig'")
         }
@@ -360,6 +379,7 @@ fun DevrigServices.runCli(command: DevrigCommand): Int {
             is DevrigCommand.DevrigCommandProject -> runProjectCommand(command)
             is DevrigCommand.DevrigCommandInstall -> runInstallCommand(command)
             is DevrigCommand.DevrigCommandInstallDevrig -> runInstallDevrigCommand(command)
+            is DevrigCommand.DevrigCommandInstallPlugin -> runInstallPluginCommand(command)
         }
     } catch (e: ManagedBackendLockException) {
         System.err.println(e.message)

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/DevrigBeacon.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/DevrigBeacon.kt
@@ -72,6 +72,7 @@ class DevrigBeacon(
             is DevrigCommand.DevrigCommandProject -> "project"
             is DevrigCommand.DevrigCommandInstall -> "install"
             is DevrigCommand.DevrigCommandInstallDevrig -> "install"
+            is DevrigCommand.DevrigCommandInstallPlugin -> "install"
             is DevrigCommand.DevrigCommandHelp -> null
             is DevrigCommand.DevrigCommandVersion -> null
             is DevrigCommand.DevrigCommandParseError -> null

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/InstallCommand.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/InstallCommand.kt
@@ -55,6 +55,11 @@ fun DevrigServices.runInstallDevrigCommand(command: DevrigCommand.DevrigCommandI
         return 64
     }
     System.err.println("[mcp-steroid] devrig is on PATH via $launcher")
+
+    // Also offer the MCP Steroid plugin to any IDE already running: fire each IDE's native install
+    // dialog over REST. Best-effort and fully non-interactive (the IDE — not devrig — shows the dialog),
+    // so it is safe inside the `curl | sh` bootstrap: it never reads stdin and never fails the install.
+    tryInstallPluginIntoRunningIdesQuietly()
     return 0
 }
 

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/InstallPluginCommand.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/InstallPluginCommand.kt
@@ -27,6 +27,13 @@ import org.slf4j.LoggerFactory
 const val MCP_STEROID_PLUGIN_ID = "com.jonnyzzz.mcp-steroid"
 
 /**
+ * The one-shot command that installs (or updates) MCP Steroid into every running JetBrains IDE over
+ * REST — each IDE then shows its own native "Choose Plugins to Install or Enable" dialog. Promoted from
+ * every CLI listing that surfaces an IDE without a compatible plugin (`devrig backend`, `devrig project`).
+ */
+const val INSTALL_PLUGIN_COMMAND = "devrig install plugin"
+
+/**
  * Origin sent on every `/api/installPlugin` request. The built-in server trusts any request whose
  * Origin host is localhost (`RestService.isLocalhost`), so this bypasses the *host-trust* dialog while
  * leaving the plugin-install confirmation modal (`installAndEnable(..., showDialog=true)`) intact — that

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/InstallPluginCommand.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/InstallPluginCommand.kt
@@ -1,0 +1,325 @@
+/* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
+package com.jonnyzzz.mcpSteroid.devrig
+
+import com.jonnyzzz.mcpSteroid.devrig.monitor.DiscoveredIde
+import com.jonnyzzz.mcpSteroid.devrig.monitor.DiscoveredIdeByPort
+import com.jonnyzzz.mcpSteroid.devrig.monitor.IntelliJPortDiscovery
+import com.jonnyzzz.mcpSteroid.devrig.monitor.aboutJson
+import io.ktor.client.HttpClient
+import io.ktor.client.request.accept
+import io.ktor.client.request.get
+import io.ktor.client.request.header
+import io.ktor.client.request.parameter
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.isSuccess
+import java.io.PrintStream
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.booleanOrNull
+import kotlinx.serialization.json.jsonObject
+import org.slf4j.LoggerFactory
+
+/** The MCP Steroid plugin id, as declared in `ij-plugin/.../META-INF/plugin.xml`. */
+const val MCP_STEROID_PLUGIN_ID = "com.jonnyzzz.mcp-steroid"
+
+/**
+ * Origin sent on every `/api/installPlugin` request. The built-in server trusts any request whose
+ * Origin host is localhost (`RestService.isLocalhost`), so this bypasses the *host-trust* dialog while
+ * leaving the plugin-install confirmation modal (`installAndEnable(..., showDialog=true)`) intact — that
+ * modal is the consent gate we deliberately keep.
+ */
+private const val LOCALHOST_ORIGIN = "http://localhost"
+
+/** What happened (or would happen) for one IDE during `devrig install plugin`. */
+enum class PluginInstallOutcome {
+    /** `install`: the IDE accepted the request and is (or will be) showing its native install dialog. */
+    REQUESTED,
+    /** `--check`: compatible; a real run would ask this IDE to open its install dialog. */
+    WOULD_REQUEST,
+    /** The IDE already has the MCP Steroid plugin (matched via a `~/.mcp-steroid` marker). */
+    ALREADY_INSTALLED,
+    /** Marketplace has no build of the plugin compatible with this IDE. */
+    INCOMPATIBLE,
+    /** The IDE did not answer the compatibility probe (not reachable / not the expected server). */
+    UNREACHABLE,
+    /** The IDE was reached but rejected the install request. */
+    FAILED,
+}
+
+data class PluginInstallReport(
+    val ide: DiscoveredIdeByPort,
+    val outcome: PluginInstallOutcome,
+)
+
+/**
+ * REST seam for the plugin-install endpoint. Extracted so the orchestrator can be unit-tested with a
+ * fake — the real implementation ([KtorPluginRestClient]) needs a live [HttpClient].
+ */
+interface PluginRestClient {
+    /**
+     * `action=checkCompatibility` — a pure Marketplace query (no dialog, no install). Returns whether
+     * a compatible build exists, or `null` when the IDE could not be reached / did not answer with the
+     * expected JSON.
+     */
+    suspend fun checkCompatibility(baseUrl: String, pluginId: String): Boolean?
+
+    /**
+     * `action=install` — asks the IDE to open its native install confirmation dialog. Returns `true`
+     * when the IDE accepted the request (HTTP OK); the actual install still requires the user to approve
+     * the dialog inside the IDE.
+     */
+    suspend fun requestInstall(baseUrl: String, pluginId: String): Boolean
+}
+
+class KtorPluginRestClient(private val httpClient: HttpClient) : PluginRestClient {
+    private val log = LoggerFactory.getLogger(KtorPluginRestClient::class.java)
+
+    override suspend fun checkCompatibility(baseUrl: String, pluginId: String): Boolean? {
+        // A not-running / refused IDE is a normal "unreachable" outcome, not an error: log at debug and
+        // return null (never swallow silently) so the caller reports UNREACHABLE and moves on.
+        val body = try {
+            val response = httpClient.get("${baseUrl.trimEnd('/')}/api/installPlugin") {
+                parameter("pluginId", pluginId)
+                parameter("action", "checkCompatibility")
+                accept(ContentType.Application.Json)
+                header(HttpHeaders.Origin, LOCALHOST_ORIGIN)
+            }
+            if (!response.status.isSuccess()) {
+                log.debug("checkCompatibility at {} returned HTTP {}", baseUrl, response.status.value)
+                return null
+            }
+            response.bodyAsText()
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            log.debug("checkCompatibility at {} failed: {}", baseUrl, e.message)
+            return null
+        }
+        val obj = try {
+            aboutJson.parseToJsonElement(body).jsonObject
+        } catch (e: Exception) {
+            log.debug("checkCompatibility at {} returned non-JSON body: {}", baseUrl, e.message)
+            return null
+        }
+        // Single-id form collapses to {"compatible": <bool>}; the multi-id form keys by plugin id. Accept
+        // either so a future endpoint tweak doesn't silently read as "incompatible".
+        val flag = obj["compatible"] ?: obj[pluginId]
+        return (flag as? JsonPrimitive)?.booleanOrNull
+    }
+
+    override suspend fun requestInstall(baseUrl: String, pluginId: String): Boolean {
+        val response = httpClient.get("${baseUrl.trimEnd('/')}/api/installPlugin") {
+            parameter("pluginId", pluginId)
+            parameter("action", "install")
+            header(HttpHeaders.Origin, LOCALHOST_ORIGIN)
+        }
+        return response.status.isSuccess()
+    }
+}
+
+/**
+ * `devrig install plugin` — install the MCP Steroid plugin into every locally-running JetBrains IDE that
+ * doesn't already have it, by driving each IDE's built-in REST `/api/installPlugin` endpoint (which opens
+ * the IDE's own native install dialog). Discovery reuses the port scan behind `devrig backend provision`
+ * (widened to cover sandbox / unit-test IDEs at 64463), cross-referenced with the `~/.mcp-steroid` markers
+ * so IDEs that already have the plugin are skipped.
+ *
+ * Non-interactive: devrig itself never prompts. The IDE's modal is the only confirmation, and it is shown
+ * by the IDE, not devrig — so this is safe to call from the fully non-interactive `devrig install devrig`
+ * path (see [tryInstallPluginIntoRunningIdesQuietly]).
+ */
+fun DevrigServices.runInstallPluginCommand(command: DevrigCommand.DevrigCommandInstallPlugin): Int {
+    val markers = scanMarkersOnce()
+    runBlocking(Dispatchers.IO) {
+        val targets = detectProvisionTargets(portDiscovery)
+        installPluginIntoRunningIdes(
+            out = mcpStdout,
+            err = System.err,
+            check = command.check,
+            pluginId = MCP_STEROID_PLUGIN_ID,
+            targets = targets,
+            markers = markers,
+            client = KtorPluginRestClient(commandHttpClient),
+        )
+    }
+    // Best-effort by design: per-IDE status is printed above, and the real install completes only when the
+    // user approves each IDE's dialog. A blanket exit 0 keeps the command safe to chain from `install devrig`.
+    return 0
+}
+
+/**
+ * Best-effort plugin install into running IDEs, called from `devrig install devrig`. Silent when no IDE is
+ * running; never throws (any failure is logged to stderr and swallowed) so it can never fail the bootstrap
+ * install, and never reads stdin.
+ */
+fun DevrigServices.tryInstallPluginIntoRunningIdesQuietly() {
+    try {
+        val markers = scanMarkersOnce()
+        runBlocking(Dispatchers.IO) {
+            val targets = detectProvisionTargets(portDiscovery)
+            // Nothing running → say nothing. The bootstrap installer output stays quiet unless there is an
+            // IDE we can actually act on.
+            if (targets.isEmpty()) return@runBlocking
+            mcpStdout.println()
+            installPluginIntoRunningIdes(
+                out = mcpStdout,
+                err = System.err,
+                check = false,
+                pluginId = MCP_STEROID_PLUGIN_ID,
+                targets = targets,
+                markers = markers,
+                client = KtorPluginRestClient(commandHttpClient),
+            )
+        }
+    } catch (e: Exception) {
+        System.err.println(
+            "[mcp-steroid] installing the plugin into running IDEs was skipped: ${e.message ?: e::class.simpleName}",
+        )
+    }
+}
+
+/**
+ * The pure orchestrator: narrates what is about to happen, skips already-provisioned IDEs, then for each
+ * remaining IDE checks Marketplace compatibility and (unless [check]) fires the native install dialog.
+ * Returns one [PluginInstallReport] per IDE considered. Prints to [out]; per-IDE failures go to [err].
+ */
+suspend fun installPluginIntoRunningIdes(
+    out: PrintStream,
+    err: PrintStream,
+    check: Boolean,
+    pluginId: String,
+    targets: List<ProvisionTarget>,
+    markers: List<DiscoveredIde>,
+    client: PluginRestClient,
+): List<PluginInstallReport> {
+    val candidates = filterAlreadyProvisionedTargets(targets, markers)
+    val candidateIds = candidates.map { it.id }.toSet()
+    val already = targets.filter { it.id !in candidateIds }
+
+    if (candidates.isEmpty()) {
+        if (targets.isEmpty()) {
+            out.println("No running JetBrains IDE answered on the scanned ports " +
+                "(${describePortRanges(IntelliJPortDiscovery.DEFAULT_PORT_RANGES)}).")
+            out.println("If an IDE is running, it may use a non-default port. Open it and retry, or install")
+            out.println("from Settings -> Plugins -> Marketplace -> search \"MCP Steroid\" -> Install.")
+            return emptyList()
+        }
+        out.println("Every running IDE already has the MCP Steroid plugin — nothing to install:")
+        already.forEach { out.println("  - ${describeTarget(it)}") }
+        return already.map { PluginInstallReport(it.ide, PluginInstallOutcome.ALREADY_INSTALLED) }
+    }
+
+    printPreamble(out, check)
+
+    if (already.isNotEmpty()) {
+        out.println("Already have the MCP Steroid plugin (skipped):")
+        already.forEach { out.println("  - ${describeTarget(it)}") }
+        out.println()
+    }
+
+    out.println(
+        if (check) "IDEs that could receive the plugin:"
+        else "Requesting the install dialog in ${candidates.size} IDE(s):",
+    )
+    val reports = candidates.map { target -> processTarget(out, err, check, pluginId, target, client) }
+    out.println()
+
+    if (check) {
+        val ready = reports.count { it.outcome == PluginInstallOutcome.WOULD_REQUEST }
+        out.println(
+            if (ready > 0) "$ready IDE(s) would be asked to open the install dialog. " +
+                "Run 'devrig install plugin' (no --check) to do it."
+            else "No IDE is ready for an automatic install right now.",
+        )
+    } else {
+        val requested = reports.count { it.outcome == PluginInstallOutcome.REQUESTED }
+        if (requested > 0) {
+            out.println("Asked $requested IDE(s) to install MCP Steroid.")
+            out.println("Each IDE now shows its OWN \"Choose Plugins to Install or Enable\" dialog — switch to")
+            out.println("the IDE window, click OK to confirm, and restart the IDE if it asks. devrig never")
+            out.println("installs silently.")
+        } else {
+            out.println("No install dialog could be opened. See the per-IDE notes above.")
+        }
+    }
+
+    return reports + already.map { PluginInstallReport(it.ide, PluginInstallOutcome.ALREADY_INSTALLED) }
+}
+
+private suspend fun processTarget(
+    out: PrintStream,
+    err: PrintStream,
+    check: Boolean,
+    pluginId: String,
+    target: ProvisionTarget,
+    client: PluginRestClient,
+): PluginInstallReport {
+    val label = describeTarget(target)
+    val compatible = try {
+        client.checkCompatibility(target.ide.baseUrl, pluginId)
+    } catch (e: Exception) {
+        err.println("[mcp-steroid] $label: compatibility check failed: ${e.message ?: e::class.simpleName}")
+        null
+    }
+    return when (compatible) {
+        null -> {
+            out.println("  - $label: could not reach the IDE — skipped.")
+            PluginInstallReport(target.ide, PluginInstallOutcome.UNREACHABLE)
+        }
+        false -> {
+            out.println("  - $label: Marketplace has no compatible MCP Steroid build for this IDE — skipped.")
+            PluginInstallReport(target.ide, PluginInstallOutcome.INCOMPATIBLE)
+        }
+        true -> {
+            if (check) {
+                out.println("  - $label: compatible — would open the IDE's install dialog.")
+                return PluginInstallReport(target.ide, PluginInstallOutcome.WOULD_REQUEST)
+            }
+            out.println("  - $label: compatible -> asking the IDE to open its install dialog now…")
+            val accepted = try {
+                client.requestInstall(target.ide.baseUrl, pluginId)
+            } catch (e: Exception) {
+                err.println("[mcp-steroid] $label: install request failed: ${e.message ?: e::class.simpleName}")
+                false
+            }
+            if (accepted) {
+                out.println("      dialog requested — approve it in the IDE window.")
+                PluginInstallReport(target.ide, PluginInstallOutcome.REQUESTED)
+            } else {
+                out.println("      the IDE did not accept the request — skipped.")
+                PluginInstallReport(target.ide, PluginInstallOutcome.FAILED)
+            }
+        }
+    }
+}
+
+private fun printPreamble(out: PrintStream, check: Boolean) {
+    if (check) {
+        out.println("Checking which running IDEs could receive the MCP Steroid plugin.")
+        out.println("Read-only: no install dialog is shown — devrig only asks each IDE / Marketplace")
+        out.println("about compatibility.")
+        out.println()
+        return
+    }
+    out.println("Installing the MCP Steroid plugin into your running JetBrains IDE(s).")
+    out.println()
+    out.println("What will happen (this is NOT a silent install):")
+    out.println("  - For each compatible IDE, devrig asks it — over that IDE's own local REST server —")
+    out.println("    to install the plugin.")
+    out.println("  - The IDE then shows its OWN native plugin dialog — the standard JetBrains")
+    out.println("    \"Choose Plugins to Install or Enable\" window, exactly like installing from")
+    out.println("    Marketplace. Switch to the IDE window to see it, then click OK to confirm.")
+    out.println("  - Nothing is installed until you approve that dialog. Restart the IDE if it asks.")
+    out.println("  - devrig never installs silently and never restarts your IDE for you.")
+    out.println()
+}
+
+private fun describeTarget(target: ProvisionTarget): String =
+    "${portBackendDisplayName(target.ide)} (${portBackendLocatorLabel(target.ide)})"
+
+private fun describePortRanges(ranges: List<IntRange>): String =
+    ranges.joinToString(", ") { "${it.first}-${it.last}" }

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/Main.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/Main.kt
@@ -149,7 +149,8 @@ private fun DevrigCommand.runsTool(): Boolean = when (this) {
     is DevrigCommand.DevrigCommandBackendProvision,
     is DevrigCommand.DevrigCommandProject,
     is DevrigCommand.DevrigCommandInstall,
-    is DevrigCommand.DevrigCommandInstallDevrig -> true
+    is DevrigCommand.DevrigCommandInstallDevrig,
+    is DevrigCommand.DevrigCommandInstallPlugin -> true
     is DevrigCommand.DevrigCommandHelp,
     is DevrigCommand.DevrigCommandVersion,
     is DevrigCommand.DevrigCommandParseError -> false

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/ProjectCommand.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/ProjectCommand.kt
@@ -97,6 +97,8 @@ private fun renderPortSkippedFooter(
     for (ide in portIdes.sortedBy { it.port }) {
         out.println("  - ${portBackendDisplayName(ide)} (${portBackendLocatorLabel(ide)}): MCP Steroid: not installed")
     }
+    out.println()
+    out.println("Install MCP Steroid into the IDE(s) above (each shows a confirmation dialog): $INSTALL_PLUGIN_COMMAND")
 }
 
 /**

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/monitor/IdePortDiscovery.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/monitor/IdePortDiscovery.kt
@@ -67,9 +67,14 @@ fun interface PortDiscovery {
  *
  * Scope of the scan: by default 63342..63361 (the IntelliJ Platform's
  * Netty built-in server picks the first free port starting at 63342
- * with up to 19 fallback ports) and 64342..64361 (the bundled MCP
+ * with up to 19 fallback ports), 64342..64361 (the bundled MCP
  * Server plugin uses the same 20-port fallback scheme on top of
- * `DEFAULT_MCP_PORT = 64342`).
+ * `DEFAULT_MCP_PORT = 64342`), and 64463..64482 — the built-in server's
+ * default when the IDE runs in unit-test / sandbox mode, where
+ * `BuiltInServerManagerImpl.getDefaultPort()` returns `64463` (again with
+ * the 20-port `PORTS_COUNT` window). That covers Gradle `runIde` sandboxes
+ * and Docker `:test-integration` IDEs, which otherwise fall outside the
+ * two production ranges.
  *
  * **Parallelism is bounded** via `Dispatchers.IO.limitedParallelism([parallelism])`. Probes run on
  * IO's daemon worker threads, and each probe is independently capped by [probeTimeout]
@@ -160,14 +165,24 @@ class IntelliJPortDiscovery(
 
     companion object {
         /**
-         * Default scan ranges. Tracks both built-in HTTP server's
-         * fallback range and the bundled MCP Server plugin's fallback
-         * range — both pick the first free port in a 20-port window
-         * above their default.
+         * Default scan ranges. Tracks the built-in HTTP server's
+         * production fallback range, the bundled MCP Server plugin's
+         * fallback range, and the built-in server's unit-test / sandbox
+         * default range — each is a 20-port window above the respective
+         * default port (`PORTS_COUNT = 20` in `BuiltInServerManagerImpl`).
+         *
+         * Port scanning is best-effort by design: the built-in server
+         * ultimately binds *any* free port once its window is exhausted
+         * (`tryAnyPort = true`), so marker discovery
+         * ([IdePidDiscoveryService]) — not this scan — is authoritative
+         * for `mcp-steroid`-aware IDEs. These ranges just maximize the
+         * odds of finding an IDE that has *no* marker yet (a fresh
+         * install target).
          */
         val DEFAULT_PORT_RANGES: List<IntRange> = listOf(
             63342..63361,
             64342..64361,
+            64463..64482,
         )
     }
 }

--- a/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/BackendCommandJsonRenderTest.kt
+++ b/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/BackendCommandJsonRenderTest.kt
@@ -187,6 +187,20 @@ class BackendCommandJsonRenderTest {
     }
 
     @Test
+    fun `otherIdes entries promote the install command so scripts can act on plugin-less IDEs`() {
+        // Both an incompatible marker (old plugin) and a port-discovered IDE (no plugin) must expose the
+        // one-shot REST installer — that is the actionable next step for every non-compatible IDE.
+        val incompatible = markerIde(pid = 1L, build = "IU-261.1", ideHome = null)
+        val port = portIde(port = 63342, buildNumber = "GO-261.999")
+        val others = render(s1 = listOf(incompatible), s2 = setOf(port))["otherIdes"]!!.jsonArray
+        assertEquals(2, others.size)
+        for (entry in others) {
+            assertEquals("devrig install plugin", entry.jsonObject["installCommand"]?.jsonPrimitive?.contentOrNull,
+                "every otherIdes entry must promote the install command; entry=$entry")
+        }
+    }
+
+    @Test
     fun `otherIdes entry omits build when buildNumber is null`() {
         val ide = portIde(buildNumber = null)
         val root = render(s2 = setOf(ide))

--- a/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/BackendCommandRenderTest.kt
+++ b/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/BackendCommandRenderTest.kt
@@ -178,6 +178,30 @@ class BackendCommandRenderTest {
     }
 
     @Test
+    fun `group 2 promotes the install command for a plugin-less port IDE`() {
+        val text = render(s2 = setOf(portIde(port = 63342)))
+        assertTrue(text.contains("Install / update MCP Steroid in the IDE(s) above:  devrig install plugin"),
+            "expected the install-command promotion under group 2; got:\n$text")
+        assertTrue(text.contains("Choose Plugins to Install or Enable"),
+            "promotion must set the user's expectation of a native confirmation dialog; got:\n$text")
+    }
+
+    @Test
+    fun `group 2 promotes the install command for an incompatible (old plugin) marker`() {
+        val incompatible = markerIde("IntelliJ IDEA", "2025.3.3", pid = 1L, ideHome = null)
+        val text = render(s1 = listOf(incompatible))
+        assertTrue(text.contains("Install / update MCP Steroid in the IDE(s) above:  devrig install plugin"),
+            "an incompatible marker must also be offered the install/update command; got:\n$text")
+    }
+
+    @Test
+    fun `no install-command promotion when group 2 is empty`() {
+        val text = render(s1 = listOf(markerIde("IntelliJ IDEA", "2026.1", 1L)))
+        assertFalse(text.contains("devrig install plugin"),
+            "the promotion must not appear when every IDE already has a compatible plugin; got:\n$text")
+    }
+
+    @Test
     fun `S2 port IDEs are sorted by port`() {
         val text = render(s2 = setOf(portIde(port = 63350), portIde(port = 63342)))
         val idx342 = text.indexOf("port 63342")

--- a/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/InstallPluginCommandTest.kt
+++ b/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/InstallPluginCommandTest.kt
@@ -1,0 +1,268 @@
+/* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
+package com.jonnyzzz.mcpSteroid.devrig
+
+import com.jonnyzzz.mcpSteroid.IdeInfo
+import com.jonnyzzz.mcpSteroid.PluginInfo
+import com.jonnyzzz.mcpSteroid.devrig.monitor.DiscoveredIde
+import com.jonnyzzz.mcpSteroid.devrig.monitor.DiscoveredIdeByPort
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.cio.CIO
+import io.ktor.client.plugins.HttpTimeout
+import io.ktor.http.ContentType
+import io.ktor.server.cio.CIO as ServerCIO
+import io.ktor.server.engine.EmbeddedServer
+import io.ktor.server.engine.embeddedServer
+import io.ktor.server.request.uri
+import io.ktor.server.response.respondText
+import io.ktor.server.routing.get
+import io.ktor.server.routing.routing
+import java.io.ByteArrayOutputStream
+import java.io.PrintStream
+import java.net.ServerSocket
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class InstallPluginCommandTest {
+    private val servers = mutableListOf<EmbeddedServer<*, *>>()
+    private val clients = mutableListOf<HttpClient>()
+
+    @AfterEach
+    fun tearDown() {
+        clients.forEach { it.close() }
+        servers.forEach { it.stop(0L, 0L) }
+    }
+
+    // --- KtorPluginRestClient against a fake built-in server ---------------------------------------
+
+    @Test
+    fun `checkCompatibility parses the single-id compatible=true form`() = runBlocking {
+        val port = freePort()
+        servers += installPluginServer(port, compatibleBody = """{"compatible": true}""")
+        val client = KtorPluginRestClient(httpClient())
+
+        assertEquals(true, client.checkCompatibility("http://127.0.0.1:$port", MCP_STEROID_PLUGIN_ID))
+    }
+
+    @Test
+    fun `checkCompatibility parses compatible=false`() = runBlocking {
+        val port = freePort()
+        servers += installPluginServer(port, compatibleBody = """{"compatible": false}""")
+        val client = KtorPluginRestClient(httpClient())
+
+        assertEquals(false, client.checkCompatibility("http://127.0.0.1:$port", MCP_STEROID_PLUGIN_ID))
+    }
+
+    @Test
+    fun `checkCompatibility returns null when the IDE is unreachable`() = runBlocking {
+        val client = KtorPluginRestClient(httpClient())
+        // Nothing is bound on this port — a refused connection must surface as null, not an exception.
+        assertNull(client.checkCompatibility("http://127.0.0.1:${freePort()}", MCP_STEROID_PLUGIN_ID))
+    }
+
+    @Test
+    fun `requestInstall hits action=install with a localhost Origin and returns true on 200`() = runBlocking {
+        val port = freePort()
+        val recorded = RecordedRequests()
+        servers += installPluginServer(port, compatibleBody = """{"compatible": true}""", recorded = recorded)
+        val client = KtorPluginRestClient(httpClient())
+
+        assertTrue(client.requestInstall("http://127.0.0.1:$port", MCP_STEROID_PLUGIN_ID))
+        // The Origin header is what bypasses the IDE's host-trust dialog (isLocalhost) while the plugin
+        // install modal still appears — assert we actually send it.
+        assertEquals("http://localhost", recorded.installOrigin)
+        assertTrue(recorded.installUri.orEmpty().contains("action=install"), recorded.installUri)
+        assertTrue(recorded.installUri.orEmpty().contains("pluginId=com.jonnyzzz.mcp-steroid"), recorded.installUri)
+    }
+
+    // --- orchestrator (fake client) ---------------------------------------------------------------
+
+    @Test
+    fun `install fires the dialog for a compatible IDE and narrates the modal`() {
+        val target = portTarget(63342)
+        val fake = FakePluginRestClient(compatibility = { true })
+
+        val (text, reports) = orchestrate(check = false, targets = listOf(target), client = fake)
+
+        assertEquals(listOf("http://127.0.0.1:63342"), fake.installCalls)
+        assertEquals(PluginInstallOutcome.REQUESTED, reports.single().outcome)
+        // The user must be prepared for the native modal before it appears. The wording must match the
+        // real IDE dialog title ("Choose Plugins to Install or Enable") — verified live on a 261 build.
+        assertTrue(text.contains("\"Choose Plugins to Install or Enable\""), text)
+        assertTrue(text.contains("never installs silently"), text)
+        assertTrue(text.contains("asking the IDE to open its install dialog now"), text)
+    }
+
+    @Test
+    fun `install skips an IDE whose build already matches a marker`() {
+        val target = portTarget(63342, buildNumber = "261.23567.138")
+        val markers = listOf(markerIde(build = "IU-261.23567.138"))
+        val fake = FakePluginRestClient(compatibility = { true })
+
+        val (text, reports) = orchestrate(check = false, targets = listOf(target), markers = markers, client = fake)
+
+        assertTrue(fake.installCalls.isEmpty(), "already-provisioned IDE must not be asked to install")
+        assertEquals(PluginInstallOutcome.ALREADY_INSTALLED, reports.single().outcome)
+        assertTrue(text.contains("already has the MCP Steroid plugin"), text)
+    }
+
+    @Test
+    fun `install reports incompatible and unreachable IDEs without firing a dialog`() {
+        val compatible = portTarget(63342)
+        val incompatible = portTarget(63343)
+        val unreachable = portTarget(63344)
+        val fake = FakePluginRestClient(compatibility = { baseUrl ->
+            when (baseUrl) {
+                "http://127.0.0.1:63342" -> true
+                "http://127.0.0.1:63343" -> false
+                else -> null
+            }
+        })
+
+        val (text, reports) = orchestrate(
+            check = false,
+            targets = listOf(compatible, incompatible, unreachable),
+            client = fake,
+        )
+
+        assertEquals(listOf("http://127.0.0.1:63342"), fake.installCalls)
+        val byPort = reports.associate { it.ide.port to it.outcome }
+        assertEquals(PluginInstallOutcome.REQUESTED, byPort[63342])
+        assertEquals(PluginInstallOutcome.INCOMPATIBLE, byPort[63343])
+        assertEquals(PluginInstallOutcome.UNREACHABLE, byPort[63344])
+        assertTrue(text.contains("no compatible MCP Steroid build"), text)
+        assertTrue(text.contains("could not reach the IDE"), text)
+    }
+
+    @Test
+    fun `check mode never fires the install and shows no modal preamble`() {
+        val target = portTarget(63342)
+        val fake = FakePluginRestClient(compatibility = { true })
+
+        val (text, reports) = orchestrate(check = true, targets = listOf(target), client = fake)
+
+        assertTrue(fake.installCalls.isEmpty(), "--check must be read-only")
+        assertEquals(PluginInstallOutcome.WOULD_REQUEST, reports.single().outcome)
+        assertTrue(text.contains("no install dialog is shown"), text)
+        assertFalse(text.contains("\"Choose Plugins to Install or Enable\""), text)
+        assertTrue(text.contains("Run 'devrig install plugin'"), text)
+    }
+
+    @Test
+    fun `no running IDE prints a helpful fallback`() {
+        val fake = FakePluginRestClient(compatibility = { true })
+
+        val (text, reports) = orchestrate(check = false, targets = emptyList(), client = fake)
+
+        assertTrue(reports.isEmpty())
+        assertTrue(text.contains("No running JetBrains IDE answered"), text)
+        assertTrue(text.contains("Settings -> Plugins -> Marketplace"), text)
+    }
+
+    // --- helpers ----------------------------------------------------------------------------------
+
+    private fun orchestrate(
+        check: Boolean,
+        targets: List<ProvisionTarget>,
+        markers: List<DiscoveredIde> = emptyList(),
+        client: PluginRestClient,
+    ): Pair<String, List<PluginInstallReport>> {
+        val buf = ByteArrayOutputStream()
+        val err = ByteArrayOutputStream()
+        val reports = runBlocking {
+            installPluginIntoRunningIdes(
+                out = PrintStream(buf, true, Charsets.UTF_8),
+                err = PrintStream(err, true, Charsets.UTF_8),
+                check = check,
+                pluginId = MCP_STEROID_PLUGIN_ID,
+                targets = targets,
+                markers = markers,
+                client = client,
+            )
+        }
+        return buf.toString(Charsets.UTF_8).replace("\r\n", "\n") to reports
+    }
+
+    private fun portTarget(
+        port: Int,
+        buildNumber: String? = "261.23567.138",
+        productFullName: String? = "IntelliJ IDEA 2026.1.1",
+        productName: String? = "IDEA",
+    ) = ProvisionTarget(
+        id = provisionTargetId(port),
+        ide = DiscoveredIdeByPort(
+            port = port,
+            baseUrl = "http://127.0.0.1:$port",
+            productName = productName,
+            productFullName = productFullName,
+            edition = null,
+            baselineVersion = 261,
+            buildNumber = buildNumber,
+        ),
+    )
+
+    private fun markerIde(
+        name: String = "IntelliJ IDEA",
+        version: String = "2026.1.1",
+        pid: Long = 1234L,
+        build: String = "IU-261.23567.138",
+    ): DiscoveredIde = DiscoveredIde(
+        pid = pid,
+        rpcBaseUrl = testDevrigEndpoint("http://localhost:6315/mcp").rpcBaseUrl,
+        bridgeHeaders = emptyMap(),
+        ide = IdeInfo(name = name, version = version, build = build),
+        plugin = PluginInfo(id = MCP_STEROID_PLUGIN_ID, name = "MCP Steroid", version = "0.0.0-test"),
+        backendName = "mock-backend-name-$pid",
+    )
+
+    private fun freePort(): Int = ServerSocket(0).use { it.localPort }
+
+    private fun httpClient(): HttpClient = HttpClient(CIO) {
+        install(HttpTimeout) {
+            connectTimeoutMillis = 2_000
+            requestTimeoutMillis = 5_000
+            socketTimeoutMillis = 5_000
+        }
+        expectSuccess = false
+    }.also { clients += it }
+
+    private class RecordedRequests {
+        var installOrigin: String? = null
+        var installUri: String? = null
+    }
+
+    private fun installPluginServer(
+        port: Int,
+        compatibleBody: String,
+        recorded: RecordedRequests = RecordedRequests(),
+    ): EmbeddedServer<*, *> = embeddedServer(ServerCIO, port = port, host = "127.0.0.1") {
+        routing {
+            get("/api/installPlugin") {
+                val action = call.request.queryParameters["action"]
+                if (action == "install") {
+                    recorded.installOrigin = call.request.headers["Origin"]
+                    recorded.installUri = call.request.uri
+                    call.respondText("OK", ContentType.Text.Plain)
+                } else {
+                    call.respondText(compatibleBody, ContentType.Application.Json)
+                }
+            }
+        }
+    }.also { it.start(wait = false) }
+
+    private class FakePluginRestClient(
+        private val compatibility: (String) -> Boolean?,
+        private val installAllowed: Boolean = true,
+    ) : PluginRestClient {
+        val installCalls = mutableListOf<String>()
+        override suspend fun checkCompatibility(baseUrl: String, pluginId: String): Boolean? = compatibility(baseUrl)
+        override suspend fun requestInstall(baseUrl: String, pluginId: String): Boolean {
+            installCalls += baseUrl
+            return installAllowed
+        }
+    }
+}

--- a/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/ProjectCommandRenderTest.kt
+++ b/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/ProjectCommandRenderTest.kt
@@ -186,6 +186,8 @@ class ProjectCommandRenderTest {
             "expected no-plugin footer; got:\n$text")
         assertTrue(text.contains("IntelliJ IDEA Ultimate (build IU-253.21581.142, port 63342): MCP Steroid: not installed"),
             "expected port IDE identity; got:\n$text")
+        assertTrue(text.contains("Install MCP Steroid into the IDE(s) above (each shows a confirmation dialog): devrig install plugin"),
+            "skipped footer must promote the one-shot REST installer; got:\n$text")
     }
 
     @Test

--- a/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/monitor/IntelliJPortDiscoveryTest.kt
+++ b/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/monitor/IntelliJPortDiscoveryTest.kt
@@ -137,6 +137,19 @@ class IntelliJPortDiscoveryTest {
     }
 
     @Test
+    fun `default scan ranges cover the built-in, MCP, and unit-test-mode sandbox ports`() {
+        val covered = IntelliJPortDiscovery.DEFAULT_PORT_RANGES.flatMap { it.toList() }.toSet()
+        // Production built-in HTTP server default + MCP Server plugin default.
+        assertTrue(63342 in covered, "built-in server default port must be scanned")
+        assertTrue(64342 in covered, "MCP Server plugin default port must be scanned")
+        // The unit-test / sandbox built-in-server default (BuiltInServerManagerImpl.getDefaultPort()
+        // returns 64463 when isUnitTestMode) — this is the IU-261 sandbox seen at port 64463, which
+        // the previous two-range scan missed. Cover its whole 20-port window.
+        assertTrue(64463 in covered, "unit-test/sandbox built-in-server default port (64463) must be scanned")
+        assertTrue(64482 in covered, "top of the unit-test/sandbox 20-port window must be scanned")
+    }
+
+    @Test
     fun `a port that hangs past the probe timeout does not discard results from fast ports`() = runBlocking {
         // A port whose /api/about never answers within probeTimeout must not
         // cancel the whole scan: the IDE detected on a fast port must still surface.


### PR DESCRIPTION
## What

Adds **`devrig install plugin`** — a one-shot command that installs (or
updates) the MCP Steroid plugin into every locally-running JetBrains IDE
over the built-in web server's REST endpoint, with a **no-surprises** UX:
each IDE shows its **own** native *"Choose Plugins to Install or Enable"*
dialog, so nothing is ever installed silently.

The same install step is now run **best-effort at the end of `devrig
install devrig`**, so the standard `curl … | sh` bootstrap also offers to
wire the plugin into any IDE that is already open (non-interactive, safe to
skip when nothing is running).

Every CLI listing that surfaces an IDE **without** a compatible plugin now
**promotes the command** so the next step is obvious.

Builds on the design spec (`docs/ide-plugin-deploy-and-update-spec.md`,
first commit here) that this PR was opened for.

## How it works

- **Discovery** — reuse the existing marker discovery (authoritative: IDEs
  that already have the plugin) plus a widened built-in-server **port scan**
  so a freshly-installed, markerless IDE is still found. The scan range now
  also covers `64463..64482` (the built-in server's unit-test/sandbox
  default) — matching the IDE from the spec's worked example.
- **Compatibility** — per target, `GET /api/installPlugin?action=checkCompatibility`
  (a pure Marketplace query; no dialog). IDEs whose build already matches a
  marker are skipped (already installed).
- **Install** — `GET /api/installPlugin?action=install` with an
  `Origin: http://localhost` header. That header satisfies the built-in
  server's `isLocalhost` host-trust check (no host-trust prompt) while the
  plugin-install confirmation modal (`installAndEnable(showDialog=true)`)
  is deliberately kept as the consent gate. The endpoint returns 200
  immediately; the user approves in the IDE.
- **`--check`** — read-only: reports what *would* be installed and never
  fires a dialog.

## Promotion in CLI listings

- `devrig backend` (text): group 2 ("Other IDEs — incompatible or no MCP
  Steroid") gains a promotion line after the entries.
- `devrig backend --json`: each `otherIdes[]` entry gains an
  `"installCommand"` field so scripts can act on plugin-less IDEs.
- `devrig project`: the "Skipped … with MCP Steroid not installed" footer
  gains the same promotion line.
- Shared `INSTALL_PLUGIN_COMMAND` constant so the CLI string has one home.

Note: the older `devrig backend provision <id>` only prints manual
Marketplace / file-copy instructions — `devrig install plugin` actually
drives the install over REST, which is why it is now the promoted path.

## Testing

- **Unit** — `:npx-kt:test` green. New/updated coverage: REST client
  (`checkCompatibility` parsing, `action=install` + localhost Origin,
  unreachable→null), orchestrator (fires dialog / skips already-installed /
  reports incompatible+unreachable / `--check` read-only / no-IDE
  fallback), narration wording pinned to the real dialog title, port-scan
  range, and the new promotion in the backend text/json + project
  renderers.
- **Live, cross-version** — validated end-to-end on **261** (modal
  screenshotted), **262** (262.9750 RC) and **263** (263.2527 EAP, full
  `devrig install plugin` e2e): `checkCompatibility=true` + `action=install`
  → HTTP 200 + native modal on each; marker dedup correctly skipped the
  already-provisioned IDEs. The real dialog title is *"Choose Plugins to
  Install or Enable"* (confirm = **OK**); narration was corrected to match.

## Design notes / prior validation

The spec doc records the research behind this (live probes against running
IDEs, cross-checks against IntelliJ `261`/`262`/`263` source, two
adversarial codex review rounds). Bottom line: there is no fully-public SDK
API for staging a ZIP into a *running* IDE, so this PR uses the de-facto
REST `installPlugin` endpoint (Marketplace-backed, native consent modal) —
the safest running-IDE path — and leaves restart-staged bundle replacement
to the follow-ups the spec lists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)