### PR TITLE
Bump kotlinc default -language-version/-api-version 2.2 -> 2.3

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,16 @@
 # TODO
 
+- [ ] **KtBlock matrix ignores the production kotlinc language/api pin (drift).**
+  `CodeEvalManager` compiles every `steroid_execute_code` script with the
+  `mcp.steroid.kotlinc.parameters` registry extras (`-language-version 2.3 -api-version 2.3` since
+  2026-07-31; was 2.2), but `KtBlockCompilationTestBase.compileAgainst` passes only
+  `-Werror`/`-jvm-target`/`-no-stdlib` — despite its "must match what KotlincCommandLineBuilder
+  produces" comment. A prompt fence using a language feature/stdlib API newer than the pin passes the
+  matrix yet fails at runtime. Fix: add the same LV/api flags to both the kotlinc invocation and the
+  `compilerOptions` cache-key list in `KtBlockCompilationTestBase`. NOTE: this invalidates the whole
+  KtBlock compile cache (60–120 min recompile) — land it right after a `kotlincVersion` bump (which
+  invalidates the cache anyway), never casually.
+
 - [ ] **steroid_input / take_screenshot #309 follow-ups** (the three core defects — modal-EDT hang,
   window-relative click coordinates, wrong window_id echo — are fixed and guarded by
   `SteroidInputDialogIntegrationTest`; remaining hardening surfaced by the 2026-07-30 review):

--- a/ij-plugin/src/main/resources/META-INF/plugin.xml
+++ b/ij-plugin/src/main/resources/META-INF/plugin.xml
@@ -139,8 +139,8 @@
             description="Toggles minimalistic analytics from the plugin"/>
 
         <!-- Kotlinc configuration -->
-        <registryKey key="mcp.steroid.kotlinc.parameters" defaultValue="-language-version 2.2 -api-version 2.2"
-            description="Additional kotlinc command-line parameters (space-separated). Default: -language-version 2.2 -api-version 2.2. For example: -Xskip-metadata-version-check"/>
+        <registryKey key="mcp.steroid.kotlinc.parameters" defaultValue="-language-version 2.3 -api-version 2.3"
+            description="Additional kotlinc command-line parameters (space-separated). Default: -language-version 2.3 -api-version 2.3 — the Kotlin bundled by the oldest supported IDE (2026.1 ships 2.3.20). For example: -Xskip-metadata-version-check"/>
         <registryKey key="mcp.steroid.kotlinc.home" defaultValue=""
             description="Path to external kotlinc home directory. When set, overrides the bundled kotlinc. Useful when the IDE ships a newer Kotlin version than the plugin bundles."/>
 

--- a/ij-plugin/src/test/kotlin/com/jonnyzzz/mcpSteroid/koltinc/KotlincRegistryDefaultsTest.kt
+++ b/ij-plugin/src/test/kotlin/com/jonnyzzz/mcpSteroid/koltinc/KotlincRegistryDefaultsTest.kt
@@ -5,9 +5,14 @@ import com.intellij.openapi.util.registry.Registry
 import com.intellij.testFramework.fixtures.BasePlatformTestCase
 
 class KotlincRegistryDefaultsTest : BasePlatformTestCase() {
-    fun testDefaultKotlincParametersTargetKotlin22() {
+    fun testDefaultKotlincParametersTargetKotlin23() {
+        // 2.3 = the Kotlin bundled by the oldest supported IDE (sinceBuild=261 ships
+        // kotlin-stdlib/reflect 2.3.20, metadata 2.3.0). Bump this pin together with
+        // sinceBuild: the pin must stay at the FLOOR of the supported IDE range so a
+        // script compiles identically on every IDE and its metadata stays readable by
+        // the oldest bundled kotlin-reflect.
         assertEquals(
-            "-language-version 2.2 -api-version 2.2",
+            "-language-version 2.3 -api-version 2.3",
             Registry.stringValue("mcp.steroid.kotlinc.parameters")
         )
     }

--- a/kotlin-cli/src/main/kotlin/com/jonnyzzz/mcpSteroid/koltinc/KotlincCommandLineBuilder.kt
+++ b/kotlin-cli/src/main/kotlin/com/jonnyzzz/mcpSteroid/koltinc/KotlincCommandLineBuilder.kt
@@ -103,14 +103,15 @@ class KotlincCommandLineBuilder(
          * JVM that owns this process — `java.specification.version` is `"21"`
          * on JDK 21, `"25"` on JDK 25, etc. The kotlinc inline-bytecode
          * compatibility rule requires the script's target to be ≥ the target
-         * of any inline function it calls; the IntelliJ Platform 261.* (EAP
-         * for 2026.1.x) ships inline functions compiled at target 25, so a
-         * fixed target of "21" rejects them with `cannot inline bytecode
-         * built with JVM target 25 into bytecode that is being built with
-         * JVM target 21`. Deriving from the live JVM keeps the script's
-         * target in lock-step with whatever JDK Gradle / the test runner
-         * happens to run on — bumping the Gradle daemon JVM is then the
-         * single lever that controls the kotlinc target.
+         * of any inline function it calls. Platform class-file versions as of
+         * 2026-07-30: 261.* is v65 (Java 21), 262.* and 263.* are v69
+         * (Java 25) — so a fixed target of "21" would reject 262+ platform
+         * inline functions with `cannot inline bytecode built with JVM
+         * target 25 into bytecode that is being built with JVM target 21`.
+         * Deriving from the live JVM keeps the script's target in lock-step
+         * with the JVM the IDE / Gradle / the test runner actually runs on
+         * (an IDE never runs on a JBR older than its own bytecode), so the
+         * host JVM is the single lever that controls the kotlinc target.
          *
          * Defaults to `"21"` only as a last-resort fallback when the property
          * is unset (e.g. an unusual embedding).


### PR DESCRIPTION
## What

- `mcp.steroid.kotlinc.parameters` registry default: `-language-version 2.2 -api-version 2.2` → `-language-version 2.3 -api-version 2.3` (plugin.xml + `KotlincRegistryDefaultsTest`, which now documents the pin rule).
- Refresh the stale `DEFAULT_JVM_TARGET` KDoc in `KotlincCommandLineBuilder`: 261 final ships platform bytecode at v65 (Java 21), not target 25; 262/263 are v69 (Java 25). The derive-from-live-JVM design is unchanged.
- Log the KtBlock-matrix drift in `TODO.md` (see Deferred below).

## Why

The 2.2 pin dates from Feb 2026 when `sinceBuild` was 253 (Kotlin 2.2.x IDEs). Two later bumps left it behind: `sinceBuild` 253 → 261 (262-EAP work) and bundled kotlinc 2.3.20 → 2.4.10 (#359). The pin still compiled fine, but needlessly capped every `steroid_execute_code` script at Kotlin 2.2 language features and stdlib API while every supported IDE ships Kotlin ≥ 2.3.20.

**Why 2.3, not 2.4:** the pin must sit at the floor of the supported IDE range (`sinceBuild=261` bundles kotlin-stdlib/reflect 2.3.20, metadata 2.3.0):

- scripts compile identically under the bundled kotlinc 2.4.10 **and** under a `mcp.steroid.kotlinc.home` override pointing at 261's IDE kotlinc (2.3.10);
- the script's emitted metadata stays readable by the oldest bundled kotlin-reflect.

Bump this pin together with future `sinceBuild` bumps.

## Verification

- Production-shaped compile with the real dist: kotlinc 2.4.10, `-no-stdlib`, IU-2026.1 classpath, new flags → exit 0, zero warnings, emitted class carries `mv=2.3` (readable by 261's kotlin-reflect 2.3.20, which reads ≤ 2.4).
- `./gradlew :ij-plugin:test --tests '*KotlincRegistryDefaultsTest*'` green (includes `buildPlugin` + `verifyClassFileVersions` against the edited plugin.xml).
- `./gradlew :ij-plugin:verifyBundledKotlinCompatibility` green: bundled 2.4.10 vs IDE 2.3.20, minor diff 1 ≤ 1; 2.4.10 is the latest stable release.

## Deferred (logged in TODO.md)

`KtBlockCompilationTestBase` compiles prompt fences without the registry language/api pin, despite its "must match what KotlincCommandLineBuilder produces" comment — a fence using a too-new feature could pass the matrix yet fail in production. Fixing it changes the compile-cache key and invalidates the 60–120 min KtBlock matrix, so it should land together with the next `kotlincVersion` bump, not casually.