### PR TITLE
Rename settings tab to lead with Devrig; fix settings-page facts

### DIFF
--- a/ai-agents/src/main/kotlin/com/jonnyzzz/mcpSteroid/aiAgents/McpServerConfig.kt
+++ b/ai-agents/src/main/kotlin/com/jonnyzzz/mcpSteroid/aiAgents/McpServerConfig.kt
@@ -16,7 +16,7 @@ data class McpConnectionInfo(
     val serverUrl: String,
     val commands: Map<String, String>,
     val jsonConfig: String,
-    val feedbackUrl: String = "https://devrig.dev",
+    val feedbackUrl: String = "https://github.com/jonnyzzz/mcp-steroid/issues",
 ) {
     fun toMarkdown(): String = buildString {
         appendLine("# MCP Steroid Server")
@@ -37,7 +37,7 @@ data class McpConnectionInfo(
         appendLine()
         appendLine("## Feedback")
         appendLine()
-        appendLine("Report issues, join the Discord community: $feedbackUrl")
+        appendLine("Report issues: $feedbackUrl")
         appendLine()
     }
 

--- a/ai-agents/src/main/kotlin/com/jonnyzzz/mcpSteroid/aiAgents/McpServerConfig.kt
+++ b/ai-agents/src/main/kotlin/com/jonnyzzz/mcpSteroid/aiAgents/McpServerConfig.kt
@@ -37,7 +37,7 @@ data class McpConnectionInfo(
         appendLine()
         appendLine("## Feedback")
         appendLine()
-        appendLine("Report issues, Join Slack & Community: $feedbackUrl")
+        appendLine("Report issues, join the Discord community: $feedbackUrl")
         appendLine()
     }
 

--- a/ij-plugin/src/main/kotlin/com/jonnyzzz/mcpSteroid/settings/McpSteroidConfigurable.kt
+++ b/ij-plugin/src/main/kotlin/com/jonnyzzz/mcpSteroid/settings/McpSteroidConfigurable.kt
@@ -22,7 +22,7 @@ import javax.swing.text.AttributeSet
 import javax.swing.text.DocumentFilter
 
 /**
- * Application-level settings page: Settings | Tools | MCP Steroid — devrig.
+ * Application-level settings page: Settings | Tools | Devrig — MCP Steroid.
  *
  * Purely informational — no persistent state, no mutable options. The page exists so users
  * can confirm the plugin is installed and connect an AI agent:
@@ -47,8 +47,10 @@ class McpSteroidConfigurable : BoundConfigurable(DISPLAY_NAME) {
         val server = ApplicationManager.getApplication().getServiceIfCreated(SteroidsMcpServer::class.java)
         val port = server?.port ?: 0
         val info = if (server != null && port > 0) McpConnectionInfo.build(server.mcpUrl) else null
-        // Prose references only the actual bound port ($port), so every message matches the Status
-        // block. No hard-coded default here — 6315 lives solely in the registry config.
+        // Prose references only the actual bound port, so every message matches the Status block;
+        // with no bound port (server not running) it degrades to a generic phrase instead of "port 0".
+        // No hard-coded default here — 6315 lives solely in the registry config.
+        val portPhrase = if (port > 0) "on port <b>$port</b>" else "on its HTTP port"
 
         return panel {
             row {
@@ -61,7 +63,7 @@ class McpSteroidConfigurable : BoundConfigurable(DISPLAY_NAME) {
                 )
             }
             row {
-                browserLink("Report issues, Join Slack & Community", FEEDBACK_URL)
+                browserLink("Report issues, join the Discord community", FEEDBACK_URL)
             }.topGap(TopGap.SMALL)
 
             group("Status") {
@@ -97,8 +99,8 @@ class McpSteroidConfigurable : BoundConfigurable(DISPLAY_NAME) {
                 }
                 row {
                     text(
-                        "The direct HTTP server below also works, but it is tied to <b>this</b> IDE on port " +
-                            "<b>$port</b> — that can change when the IDE restarts or the port is taken, and every " +
+                        "The direct HTTP server below also works, but it is tied to <b>this</b> IDE " +
+                            "$portPhrase — that can change when the IDE restarts or the port is taken, and every " +
                             "agent must be wired up by hand. Devrig handles all of that for you, so it is the way " +
                             "we recommend connecting."
                     )
@@ -127,8 +129,8 @@ class McpSteroidConfigurable : BoundConfigurable(DISPLAY_NAME) {
                 row {
                     icon(AllIcons.General.Warning)
                     text(
-                        "<b>Not recommended.</b> These manual HTTP commands point at <b>this</b> IDE on port " +
-                            "<b>$port</b> — they stop working when the IDE restarts or that port is reassigned, " +
+                        "<b>Not recommended.</b> These manual HTTP commands point at <b>this</b> IDE " +
+                            "$portPhrase — they stop working when the IDE restarts or that port is reassigned, " +
                             "and every agent must be set up by hand. Use devrig instead: it reaches every running " +
                             "IDE automatically and keeps working across restarts and port changes."
                     )
@@ -202,7 +204,7 @@ class McpSteroidConfigurable : BoundConfigurable(DISPLAY_NAME) {
         const val CONFIGURABLE_ID = "com.jonnyzzz.mcp-steroid.settings"
 
         /** Must match the displayName attribute of the applicationConfigurable EP in plugin.xml. */
-        const val DISPLAY_NAME = "MCP Steroid — devrig"
+        const val DISPLAY_NAME = "Devrig — MCP Steroid"
 
         const val DEVRIG_DOCS_URL = "https://devrig.dev/docs/devrig/"
 

--- a/ij-plugin/src/main/kotlin/com/jonnyzzz/mcpSteroid/settings/McpSteroidConfigurable.kt
+++ b/ij-plugin/src/main/kotlin/com/jonnyzzz/mcpSteroid/settings/McpSteroidConfigurable.kt
@@ -63,7 +63,7 @@ class McpSteroidConfigurable : BoundConfigurable(DISPLAY_NAME) {
                 )
             }
             row {
-                browserLink("Report issues, join the Discord community", FEEDBACK_URL)
+                browserLink("Report issues on GitHub", FEEDBACK_URL)
             }.topGap(TopGap.SMALL)
 
             group("Status") {
@@ -212,6 +212,6 @@ class McpSteroidConfigurable : BoundConfigurable(DISPLAY_NAME) {
         const val DEVRIG_INSTALL_SH = "curl -fsSL https://devrig.dev/install.sh | sh"
         const val DEVRIG_INSTALL_PS1 = "irm https://devrig.dev/install.ps1 | iex"
 
-        const val FEEDBACK_URL = "https://devrig.dev"
+        const val FEEDBACK_URL = "https://github.com/jonnyzzz/mcp-steroid/issues"
     }
 }

--- a/ij-plugin/src/main/resources/META-INF/plugin.xml
+++ b/ij-plugin/src/main/resources/META-INF/plugin.xml
@@ -96,11 +96,11 @@
         <notificationGroup id="jonnyzzz.mcp.steroid.updates"
                            displayType="BALLOON"/>
 
-        <!-- Settings | Tools | MCP Steroid — devrig: informational page promoting the devrig CLI
+        <!-- Settings | Tools | Devrig — MCP Steroid: informational page promoting the devrig CLI
              setup, showing the MCP server status, and keeping the legacy HTTP connection info. -->
         <applicationConfigurable parentId="tools"
                                  id="com.jonnyzzz.mcp-steroid.settings"
-                                 displayName="MCP Steroid — devrig"
+                                 displayName="Devrig — MCP Steroid"
                                  instance="com.jonnyzzz.mcpSteroid.settings.McpSteroidConfigurable"/>
 
         <!-- Registry keys for configuration -->

--- a/ij-plugin/src/test/kotlin/com/jonnyzzz/mcpSteroid/settings/McpSteroidConfigurableTest.kt
+++ b/ij-plugin/src/test/kotlin/com/jonnyzzz/mcpSteroid/settings/McpSteroidConfigurableTest.kt
@@ -43,9 +43,9 @@ class McpSteroidConfigurableTest : BasePlatformTestCase() {
             assertContainsText(texts, "AI Agents")
             assertContainsText(texts, "Devrig")
 
-            // The feedback link references the actual community channels (GitHub issues + Discord,
-            // both linked from devrig.dev). There is no Slack workspace.
-            assertContainsText(texts, "Discord")
+            // The feedback link points at GitHub issues only. There is no Slack workspace —
+            // the old label falsely promised one.
+            assertContainsText(texts, "Report issues on GitHub")
             assertFalse("No Slack workspace exists — the label must not mention Slack", joined.contains("Slack"))
 
             // devrig install is implemented: the panel shows the copyable one-liners for both

--- a/ij-plugin/src/test/kotlin/com/jonnyzzz/mcpSteroid/settings/McpSteroidConfigurableTest.kt
+++ b/ij-plugin/src/test/kotlin/com/jonnyzzz/mcpSteroid/settings/McpSteroidConfigurableTest.kt
@@ -5,6 +5,7 @@ import com.intellij.openapi.options.Configurable
 import com.intellij.testFramework.fixtures.BasePlatformTestCase
 import java.awt.Component
 import java.awt.Container
+import javax.swing.AbstractButton
 import javax.swing.JLabel
 import javax.swing.text.JTextComponent
 
@@ -17,6 +18,10 @@ class McpSteroidConfigurableTest : BasePlatformTestCase() {
 
         assertEquals("tools", ep.parentId)
         assertEquals(McpSteroidConfigurable.DISPLAY_NAME, ep.displayName)
+        assertTrue(
+            "Settings tab name must lead with the Devrig product name; got '${McpSteroidConfigurable.DISPLAY_NAME}'",
+            McpSteroidConfigurable.DISPLAY_NAME.startsWith("Devrig"),
+        )
 
         val configurable = ep.createConfigurable()
         assertNotNull("ConfigurableEP must instantiate the settings page", configurable)
@@ -37,6 +42,11 @@ class McpSteroidConfigurableTest : BasePlatformTestCase() {
             // The intro leads with the "AI Agents" framing and promotes devrig as the recommended path.
             assertContainsText(texts, "AI Agents")
             assertContainsText(texts, "Devrig")
+
+            // The feedback link references the actual community channels (GitHub issues + Discord,
+            // both linked from devrig.dev). There is no Slack workspace.
+            assertContainsText(texts, "Discord")
+            assertFalse("No Slack workspace exists — the label must not mention Slack", joined.contains("Slack"))
 
             // devrig install is implemented: the panel shows the copyable one-liners for both
             // macOS/Linux (curl … | sh) and Windows (irm … | iex), plus the agent-registration hint.
@@ -82,6 +92,8 @@ class McpSteroidConfigurableTest : BasePlatformTestCase() {
             // Icon-only labels (e.g. the warning sign) have null text — skip them.
             is JTextComponent -> component.text?.let { out.add(it) }
             is JLabel -> component.text?.let { out.add(it) }
+            // browserLink(...) renders as an ActionLink (a JButton subclass).
+            is AbstractButton -> component.text?.let { out.add(it) }
         }
         if (component is Container) {
             for (child in component.components) {

--- a/website/content/docs/settings-connection-info.md
+++ b/website/content/docs/settings-connection-info.md
@@ -9,14 +9,14 @@ group: "Reference"
 
 ## Overview
 
-MCP Steroid includes a built-in **Settings panel** — **Tools → MCP Steroid — devrig** (reinstated in 0.101) — that explains how your **AI Agents** drive the IDE, promotes the recommended [devrig CLI](/docs/devrig/) (the one bridge that reaches every running IDE and survives restarts and port changes — see the docs to get started), shows the live MCP server status (port and URL), and keeps the legacy direct-HTTP connection details: ready-to-paste CLI commands for Claude, Codex, and Gemini, and a full JSON config block you can drop directly into your MCP client's config file.
+MCP Steroid includes a built-in **Settings panel** — **Tools → Devrig — MCP Steroid** (reinstated in 0.101, renamed to lead with Devrig in 0.102) — that explains how your **AI Agents** drive the IDE, promotes the recommended [devrig CLI](/docs/devrig/) (the one bridge that reaches every running IDE and survives restarts and port changes — see the docs to get started), shows the live MCP server status (port and URL), and keeps the legacy direct-HTTP connection details: ready-to-paste CLI commands for Claude, Codex, and Gemini, and a full JSON config block you can drop directly into your MCP client's config file.
 
 Starting from **0.89.0**, the MCP server starts as soon as IntelliJ starts — before any project opens. The Settings page reflects this: the connection URL is always there, whether or not you have a project open.
 
 ## Opening the Settings Panel
 
 1. In IntelliJ, go to **Settings** (`⌘,` on macOS / `Ctrl+Alt+S` on Windows/Linux)
-2. Navigate to **Tools → MCP Steroid — devrig**
+2. Navigate to **Tools → Devrig — MCP Steroid** (called **Tools → MCP Steroid — devrig** in 0.101)
 
 You will see the connection panel immediately, no project needs to be open.
 


### PR DESCRIPTION
## What

Renames the settings page **Tools → MCP Steroid — devrig** to **Tools → Devrig — MCP Steroid**, plus factual fixes found while reviewing the page content.

## Why

The project is moving toward the **Devrig** name (README: "gradually moving toward the Devrig name"); the tab now leads with it. Side benefit: the entry moves from **M** to **D** in the alphabetically sorted Tools tree.

Settings-content review findings fixed here:
- **Feedback link told the truth to nobody.** It claimed a Slack community (none exists — the community is Discord) while pointing at the devrig.dev homepage. After review: the link is now simply **"Report issues on GitHub" → the issues page** — the one durable, direct feedback channel (jonnyzzz.com has no Discord link to route through, and a raw discord.gg invite baked into releases would break if the invite rotates). Same fix in `McpConnectionInfo.toMarkdown()`, which writes `.idea/mcp-steroid.md` into every project.
- **"on port 0".** With the MCP server not running, the Devrig/Legacy prose interpolated the unbound port as `port 0`; it now degrades to a generic phrase.

Everything else on the page verified accurate: install one-liners, docs URL (HTTP 200), registry keys, `devrig install claude|codex|gemini`.

## Verification

- Test-first: `McpSteroidConfigurableTest` pins the Devrig-first name and the GitHub-issues label / no-Slack (red → green); `collectTexts` now also visits `AbstractButton` so `browserLink` labels are asserted.
- **Deployed to a live IDEA 2026.1** (hot reload) and reviewed the rendered dialog twice (initial rename + final link change): tree entry, breadcrumb, link label, and port-prose/Status consistency all correct.
- Reviewed by a 3-lens workflow (codex CLI + rendered-UI + text-precision reviewers, each finding adversarially verified). Confirmed findings included (the `toMarkdown()` missed occurrence; the website-doc version claim scoped to "in 0.101" — the composite name shipped only in 0.101). Refuted suggestions (exact-string name assertion, a port-0 UI test that would be vacuous/order-dependent) intentionally not taken.
- Full `:ij-plugin:test` + `:ai-agents:test`: **BUILD SUCCESSFUL** (7m46s, 0 failures).

Known accepted nit: in the server-not-running state the pre-existing sentence "The direct HTTP server below also works" is slightly optimistic; left as-is (pre-existing prose, not a regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)