### PR TITLE
Rewrite plugin description around the core value

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,13 @@
 # TODO
 
+- [ ] **Tool/resource counts drift across surfaces** (found during the 2026-07-31 plugin-description
+  rewrite review). The MCP tool surface is **8** (`docs/PHILOSOPHY.md` Tenet 1, canonical; confirmed
+  against live registrations), but root `CLAUDE.md` and `ij-plugin/CLAUDE.md` say "10 today", and
+  `README.md` still carries "### 8 MCP Tools" plus a stale "### 58 MCP Resources" heading with
+  per-category counts summing to 60 while there are 106 prompt articles. Reconcile the CLAUDE.md
+  numbers with PHILOSOPHY.md and de-count the README sections (headings without volatile numbers),
+  the way the Marketplace description now does.
+
 - [ ] **KtBlock matrix ignores the production kotlinc language/api pin (drift).**
   `CodeEvalManager` compiles every `steroid_execute_code` script with the
   `mcp.steroid.kotlinc.parameters` registry extras (`-language-version 2.3 -api-version 2.3` since

--- a/ij-plugin/src/main/resources/META-INF/plugin.xml
+++ b/ij-plugin/src/main/resources/META-INF/plugin.xml
@@ -4,35 +4,22 @@
     <vendor>jonnyzzz.com</vendor>
 
     <description><![CDATA[
-    <p><strong>MCP Steroid</strong> brings the full power of the IntelliJ Platform to AI agents through the Model Context Protocol (MCP).</p>
+    <p><strong>MCP Steroid</strong> gives AI agents the whole IDE, not just the files.</p>
 
-    <p><b>IntelliJ platform works for AI agents as great as for human developers.</b></p>
+    <p>It runs a Model Context Protocol (MCP) server inside your IDE. Connected agents — Claude Code,
+    Codex, Gemini CLI, or any MCP-compatible agent — execute Kotlin against the live IntelliJ Platform:
+    semantic navigation, inspections, refactorings, the debugger, and test runs. Screenshots let the
+    agent see the IDE. Guides bundled with the plugin teach the agent these APIs as it works.</p>
 
-    <p>MCP Steroid is an independent research project by Eugene Petrenko (<a href="https://jonnyzz.com">@jonnyzzz</a>). Not affiliated with, endorsed by, or supported by JetBrains s.r.o.</p>
+    <p>The recommended way to connect an agent is the <a href="https://devrig.dev/docs/devrig/">devrig CLI</a>:
+    one bridge that reaches every IDE you have open and keeps working across restarts and port changes.
+    Documentation and examples: <a href="https://devrig.dev">devrig.dev</a>.</p>
 
-    <h3>What You Get</h3>
-    <ul>
-        <li><b>8 MCP Tools:</b> Control IntelliJ IDEA programmatically - execute code, take screenshots, debug, and more</li>
-        <li><b>80+ MCP Resources:</b> Comprehensive guides covering LSP, IDE operations, debugger, tests, VCS, and more</li>
-        <li><b>Vision Capabilities:</b> AI agents can see your IDE with screenshots and OCR (unique to MCP Steroid)</li>
-        <li><b>Deep Integration:</b> Access PSI, inspections, refactorings, and full IntelliJ Platform API</li>
-    </ul>
+    <p>MCP Steroid is an independent research project by Eugene Petrenko
+    (<a href="https://jonnyzzz.com">@jonnyzzz</a>). Not affiliated with, endorsed by, or supported by
+    JetBrains s.r.o.</p>
 
-    <h3>Why MCP Steroid?</h3>
-    <p>Unlike LSP-only solutions, MCP Steroid gives AI agents the same powerful IDE capabilities that developers use - semantic understanding, advanced refactorings, debugging, test running, and visual awareness.</p>
-
-    <p><b>Compatible with all IntelliJ Platform-based IDEs:</b> IntelliJ IDEA, PyCharm, WebStorm, GoLand, CLion, Rider, and more.</p>
-
-    <p><b>Requirements:</b> IntelliJ IDEA 2026.1 or newer (build 261 or later)</p>
-
-    <br />
-    <h3>Demo: CodeDozer & IntelliJ Debugger</h3>
-    <iframe width="560" height="315" src="https://www.youtube.com/embed/8MjogrpfXLU" frameborder="0" allowfullscreen></iframe>
-    <br /><br />
-
-    <p>Visit <a href="https://devrig.dev">https://devrig.dev</a> for documentation and examples.</p>
-
-    <p><small>IntelliJ IDEA, IntelliJ Platform, PyCharm, WebStorm, and JetBrains are trademarks of JetBrains s.r.o.</small></p>
+    <p><small>IntelliJ Platform and JetBrains are trademarks of JetBrains s.r.o.</small></p>
     ]]></description>
 
     <depends>com.intellij.modules.platform</depends>

--- a/website-gen/src/main/kotlin/com/jonnyzzz/mcpSteroid/websitegen/WebsiteArtifacts.kt
+++ b/website-gen/src/main/kotlin/com/jonnyzzz/mcpSteroid/websitegen/WebsiteArtifacts.kt
@@ -124,19 +124,20 @@ private fun readZipEntry(zipBytes: ByteArray, predicate: (String) -> Boolean): B
     return null
 }
 
+// Keep aligned with the <description> CDATA in ij-plugin/src/main/resources/META-INF/plugin.xml.
 private const val DESCRIPTION_HTML =
-    "<p><b>MCP Steroid</b> brings the full power of the IntelliJ Platform to AI agents through the Model " +
-        "Context Protocol (MCP).</p>\n" +
-        "<p>IntelliJ platform works for AI agents as great as for human developers.</p>\n" +
-        "<ul>\n" +
-        "<li><b>MCP Tools:</b> Control IntelliJ IDEA programmatically — execute code, take screenshots, debug, and more</li>\n" +
-        "<li><b>MCP Resources:</b> Comprehensive guides covering LSP, IDE operations, debugger, tests, VCS, and more</li>\n" +
-        "<li><b>Vision Capabilities:</b> AI agents can see your IDE with screenshots and OCR</li>\n" +
-        "<li><b>Deep Integration:</b> Access PSI, inspections, refactorings, and full IntelliJ Platform API</li>\n" +
-        "</ul>\n" +
-        "<p>Compatible with all IntelliJ Platform-based IDEs: IntelliJ IDEA, PyCharm, WebStorm, GoLand, CLion, Rider, and more.</p>\n" +
-        "<p>Requirements: IntelliJ IDEA 2025.3 or newer (build 253 or later).</p>\n" +
-        "<p>Visit <a href=\"https://devrig.dev\">devrig.dev</a> for documentation and examples.</p>"
+    "<p><strong>MCP Steroid</strong> gives AI agents the whole IDE, not just the files.</p>\n" +
+        "<p>It runs a Model Context Protocol (MCP) server inside your IDE. Connected agents — Claude Code, " +
+        "Codex, Gemini CLI, or any MCP-compatible agent — execute Kotlin against the live IntelliJ Platform: " +
+        "semantic navigation, inspections, refactorings, the debugger, and test runs. Screenshots let the " +
+        "agent see the IDE. Guides bundled with the plugin teach the agent these APIs as it works.</p>\n" +
+        "<p>The recommended way to connect an agent is the <a href=\"https://devrig.dev/docs/devrig/\">devrig CLI</a>: " +
+        "one bridge that reaches every IDE you have open and keeps working across restarts and port changes. " +
+        "Documentation and examples: <a href=\"https://devrig.dev\">devrig.dev</a>.</p>\n" +
+        "<p>MCP Steroid is an independent research project by Eugene Petrenko " +
+        "(<a href=\"https://jonnyzzz.com\">@jonnyzzz</a>). Not affiliated with, endorsed by, or supported by " +
+        "JetBrains s.r.o.</p>\n" +
+        "<p><small>IntelliJ Platform and JetBrains are trademarks of JetBrains s.r.o.</small></p>"
 
 /** Convert release-notes markdown (`release/notes/<version>.md`) to the change-notes HTML fragment. */
 fun markdownToHtml(notes: String?, version: String): String {


### PR DESCRIPTION
## What

Rewrites the Marketplace `<description>` in `plugin.xml` and the matching `DESCRIPTION_HTML` in `:website-gen` (the `updatePlugins.xml` custom-repo feed) to a minimal, core-value pitch.

## Why

The old description had drifted:
- hardcoded feature counts that go stale ("8 MCP Tools", "80+ MCP Resources")
- listed IDE names (IDEA, PyCharm, WebStorm, GoLand, CLion, Rider)
- duplicated a Requirements line the Marketplace already renders from `since-build` — and the website-gen copy claimed **build 253+** while the plugin ships `since-build` 261
- linked **jonnyzz.com** — a typo domain that does not resolve (fixed to jonnyzzz.com)
- embedded a demo iframe and a "Why MCP Steroid?" section

The new text keeps only the core value: agents get the whole IDE — Kotlin against the live IntelliJ Platform (navigation, inspections, refactorings, debugger, tests), screenshots to see the IDE, bundled guides — plus the devrig CLI as the recommended connection path, links, and the unchanged non-affiliation disclaimer. Nothing left to go stale.

The website-gen copy now also carries the non-affiliation disclaimer + trademark note it previously lacked (its alignment comment was otherwise untrue).

## Verification

- Every sentence fact-checked against the repo by a 3-lens review workflow (precision + minimalism + codex CLI reviewers; findings adversarially verified): tagline matches `docs/PHILOSOPHY.md`'s canonical framing, all six capabilities backed by shipped tools/recipes, agent names match README, URLs resolve.
- The review also caught that **my own draft commit message** repeated a wrong tool count ("the surface is 10" — PHILOSOPHY.md pins it at 8); the count drift across README/CLAUDE.md is logged in `TODO.md` as a follow-up rather than widened into this PR.
- Refuted suggestions intentionally not taken: dropping agent brand names (they answer "does my agent work?" at install time; user ask banned IDE names only), narrowing the "every IDE you have open" phrasing (it is the product's canonical tagline).
- `:website-gen:test` green; `McpSteroidConfigurableTest` (boots the full plugin descriptor, catches malformed CDATA/XML) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)