### PR TITLE
Triage quick wins: installer next-steps + session PATH, install overview

### DIFF
--- a/installer-gen/src/main/resources/templates/install.ps1.tmpl
+++ b/installer-gen/src/main/resources/templates/install.ps1.tmpl
@@ -158,10 +158,17 @@ if ($LASTEXITCODE -ne 0) { Fail "'devrig install devrig' failed (exit $LASTEXITC
 
 # -- done. We do NOT auto-register devrig with agents - that edits agent configs, so it is an
 #    explicit user step. --
+# `devrig install devrig` registers $BinDir on the persistent user PATH (HKCU\Environment), which only
+# reaches NEW shells - but `irm | iex` runs in the caller's session and the guidance below tells the
+# user to run `devrig install <agent>` right away. Prepend $BinDir in THIS session so that works.
+# ';' + case-insensitive -notcontains are Windows PATH semantics (the pwsh-on-Linux run is smoke only).
+if (($env:PATH -split ';') -notcontains $BinDir) { $env:PATH = "$BinDir;$env:PATH" }
 Write-Log "devrig binary is ready."
 Write-Log ""
-Write-Log "To register devrig with your agents (Claude, Codex, Gemini), run:"
-Write-Log "    devrig install"
+Write-Log "To register devrig with your agent, run one of:"
+Write-Log "    devrig install claude"
+Write-Log "    devrig install codex"
+Write-Log "    devrig install gemini"
 }
 finally {
   # Restore the caller's progress preference so `irm | iex` leaves the session as it found it.

--- a/installer-gen/src/main/resources/templates/install.sh.tmpl
+++ b/installer-gen/src/main/resources/templates/install.sh.tmpl
@@ -185,8 +185,10 @@ main() {
   #    explicit user step. --
   log "devrig binary is ready."
   log ""
-  log "To register devrig with your agents (Claude, Codex, Gemini), run:"
-  log "    devrig install"
+  log "To register devrig with your agent, run one of:"
+  log "    devrig install claude"
+  log "    devrig install codex"
+  log "    devrig install gemini"
 }
 
 main "$@"

--- a/installer-gen/src/test/kotlin/com/jonnyzzz/mcpSteroid/installer/InstallerGeneratorTest.kt
+++ b/installer-gen/src/test/kotlin/com/jonnyzzz/mcpSteroid/installer/InstallerGeneratorTest.kt
@@ -116,6 +116,35 @@ class InstallerGeneratorTest {
     }
 
     @Test
+    fun `final guidance recommends agent-qualified install commands, never bare devrig install`() {
+        // jonnyzzz/mcp-steroid#320: `devrig install` has a required <agent> argument, so the old
+        // "run: devrig install" next-step guidance errored on every fresh install. Both scripts must
+        // print agent-qualified commands instead.
+        val scripts = renderInstallerScripts(jdkScriptTable(fullModel()), devrig, "1.2.3")
+
+        listOf("devrig install claude", "devrig install codex", "devrig install gemini").forEach {
+            assertTrue(scripts.sh.contains(it), "install.sh guidance missing '$it'")
+            assertTrue(scripts.ps.contains(it), "install.ps1 guidance missing '$it'")
+        }
+        // A bare `devrig install` right before the closing quote is the broken recommendation.
+        assertTrue(!scripts.sh.contains("devrig install\""), "install.sh must not recommend bare 'devrig install'")
+        assertTrue(!scripts.ps.contains("devrig install\""), "install.ps1 must not recommend bare 'devrig install'")
+    }
+
+    @Test
+    fun `install_ps1 prepends BinDir to the current session PATH after the devrig handoff`() {
+        // jonnyzzz/mcp-steroid#275: `devrig install devrig` registers the bin dir persistently
+        // (HKCU\Environment), which only reaches NEW shells — but `irm | iex` runs in the caller's
+        // session and the script tells the user to run `devrig install <agent>` immediately. The
+        // template must make devrig resolvable in the calling session itself.
+        val scripts = renderInstallerScripts(jdkScriptTable(fullModel()), devrig, "1.2.3")
+        assertTrue(
+            scripts.ps.contains("\$env:PATH = \"\$BinDir;\$env:PATH\""),
+            "install.ps1 must prepend \$BinDir to the current session \$env:PATH",
+        )
+    }
+
+    @Test
     fun `install dirs are named by each artifact's own version - jdk folder carries the JDK version`() {
         // jonnyzzz/mcp-steroid#362: the JDK used to unpack into jdk-<key>-<DEVRIG VERSION>-<sha12>. Both
         // scripts must thread a per-artifact version into the install-dir name: $VERSION for devrig, the

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/Cli.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/Cli.kt
@@ -69,6 +69,17 @@ sealed interface DevrigCommand {
     ) : DevrigCommand
 
     /**
+     * Bare `devrig install` — no target given. Lists the valid install targets (with per-agent CLI
+     * detection) and exits 0 instead of failing with a missing-argument usage error: the bootstrap
+     * installers historically recommended the bare command, so it must guide, not error
+     * (jonnyzzz/mcp-steroid#277). Informational like `help`; ignores --json.
+     */
+    data class DevrigCommandInstallOverview(
+        override val debug: Boolean = false,
+        override val json: Boolean = false,
+    ) : DevrigCommand
+
+    /**
      * `devrig install devrig` — register devrig's OWN `~/.mcp-steroid/bin` launcher + PATH (NOT an agent).
      * The install scripts call this with every non-trivial parameter explicit: [installScript] (the
      * install-tree launcher the wrapper execs) and [jdkHome] (pinned as `DEVRIG_JAVA_HOME`).
@@ -236,7 +247,7 @@ private class InstallCommand(
     selected: SelectedDevrigCommand,
     parent: DevrigCliktCommand,
 ) : DevrigCliktCommand("install", selected, parent) {
-    private val agent by argument("agent")
+    private val agent by argument("agent").optional()
     // Only meaningful for `install devrig` (the install scripts pass them); rejected for agents below.
     private val installScript: String? by option("--install-script")
     private val jdkHome: String? by option("--jdk-home")
@@ -248,6 +259,15 @@ private class InstallCommand(
 
     override fun run() {
         val options = options()
+        val agent = agent ?: run {
+            // Bare `devrig install`: overview mode (#277). Target-specific flags still need a target —
+            // silently ignoring them would hide a typo like `devrig install --check claude` gone wrong.
+            if (checkFlag || installScript != null || jdkHome != null) {
+                throw UsageError("--check / --install-script / --jdk-home require an install target (claude / codex / gemini / plugin / devrig)")
+            }
+            select(DevrigCommand.DevrigCommandInstallOverview(debug = options.debug, json = options.json))
+            return
+        }
         if (agent == "devrig") {
             if (checkFlag) throw UsageError("--check is only valid for an agent install (claude / codex / gemini) or 'devrig install plugin'")
             select(DevrigCommand.DevrigCommandInstallDevrig(
@@ -378,6 +398,7 @@ fun DevrigServices.runCli(command: DevrigCommand): Int {
             is DevrigCommand.DevrigCommandBackendProvision -> runBackendProvisionCommand(command)
             is DevrigCommand.DevrigCommandProject -> runProjectCommand(command)
             is DevrigCommand.DevrigCommandInstall -> runInstallCommand(command)
+            is DevrigCommand.DevrigCommandInstallOverview -> runInstallOverviewCommand()
             is DevrigCommand.DevrigCommandInstallDevrig -> runInstallDevrigCommand(command)
             is DevrigCommand.DevrigCommandInstallPlugin -> runInstallPluginCommand(command)
         }

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/DevrigBeacon.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/DevrigBeacon.kt
@@ -73,6 +73,9 @@ class DevrigBeacon(
             is DevrigCommand.DevrigCommandInstall -> "install"
             is DevrigCommand.DevrigCommandInstallDevrig -> "install"
             is DevrigCommand.DevrigCommandInstallPlugin -> "install"
+            // Overview is informational (help-like); captureStarted is only reached for runsTool()
+            // commands anyway, so this stays a non-event.
+            is DevrigCommand.DevrigCommandInstallOverview -> null
             is DevrigCommand.DevrigCommandHelp -> null
             is DevrigCommand.DevrigCommandVersion -> null
             is DevrigCommand.DevrigCommandParseError -> null

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/HelpCommand.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/HelpCommand.kt
@@ -24,6 +24,9 @@ fun printHelp(out: PrintStream) : Int {
                                          `--json` emits a single machine-readable
                                          object on stdout; default is human text.
 
+          devrig install                 list install targets and which agent
+                                         CLIs are present on PATH
+
           devrig install claude|codex|gemini [--check]
                                          register this devrig binary as the
                                          mcp-steroid stdio MCP server in the

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/InstallOverviewCommand.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/InstallOverviewCommand.kt
@@ -1,0 +1,52 @@
+/* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
+package com.jonnyzzz.mcpSteroid.devrig
+
+import com.jonnyzzz.mcpSteroid.aiAgents.AiAgentCli
+import java.io.File
+import java.nio.file.Files
+import java.nio.file.Path
+
+/**
+ * Bare `devrig install` — overview mode (jonnyzzz/mcp-steroid#277): list every valid install target,
+ * tell the user which agent CLIs are actually reachable on PATH, exit 0.
+ */
+fun DevrigServices.runInstallOverviewCommand(): Int {
+    val detected = AiAgentCli.entries.associateWith { findCliOnPath(it.binary) }
+    mcpStdout.print(renderInstallOverview(detected))
+    return 0
+}
+
+fun renderInstallOverview(detected: Map<AiAgentCli, Path?>): String = buildString {
+    appendLine("Usage: devrig install <target> [--check]")
+    appendLine()
+    appendLine("Targets:")
+    for (agent in AiAgentCli.entries) {
+        val status = detected[agent]?.let { "${agent.binary} CLI found: $it" }
+            ?: "${agent.binary} CLI not found on PATH"
+        appendLine("  ${agent.binary.padEnd(8)} register devrig as the mcp-steroid MCP server in ${agent.displayName} ($status)")
+    }
+    appendLine("  ${"plugin".padEnd(8)} install the MCP Steroid plugin into locally-running JetBrains IDEs")
+    appendLine("  ${"devrig".padEnd(8)} re-register devrig's own launcher and PATH (used by the install scripts)")
+    appendLine()
+    appendLine("Example: devrig install claude")
+}
+
+/**
+ * Resolve [binary] against a PATH-style environment value, mirroring what the OS shell would launch.
+ * Pure lookup for testability: PATH content and platform behavior arrive as parameters. On Windows a
+ * bare name launches `<name>.exe|.cmd|.bat` ([windowsExtensions]); executability is only checked where
+ * the OS reports it (Files.isExecutable is always true on Windows).
+ */
+fun findCliOnPath(
+    binary: String,
+    pathEnv: String? = System.getenv("PATH"),
+    windowsExtensions: Boolean = System.getProperty("os.name").startsWith("Windows"),
+): Path? {
+    if (pathEnv.isNullOrBlank()) return null
+    val names = if (windowsExtensions) listOf(binary, "$binary.exe", "$binary.cmd", "$binary.bat") else listOf(binary)
+    return pathEnv.split(File.pathSeparator)
+        .filter { it.isNotBlank() }
+        .asSequence()
+        .flatMap { dir -> names.map { Path.of(dir).resolve(it) } }
+        .firstOrNull { Files.isRegularFile(it) && Files.isExecutable(it) }
+}

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/InstallOverviewCommand.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/InstallOverviewCommand.kt
@@ -32,10 +32,15 @@ fun renderInstallOverview(detected: Map<AiAgentCli, Path?>): String = buildStrin
 }
 
 /**
- * Resolve [binary] against a PATH-style environment value, mirroring what the OS shell would launch.
+ * Resolve [binary] against a PATH-style environment value, mirroring what the OS SHELL would launch.
  * Pure lookup for testability: PATH content and platform behavior arrive as parameters. On Windows a
  * bare name launches `<name>.exe|.cmd|.bat` ([windowsExtensions]); executability is only checked where
  * the OS reports it (Files.isExecutable is always true on Windows).
+ *
+ * Caveat: shell semantics, not ProcessBuilder semantics. A `.cmd`/`.bat` npm shim found here is real
+ * (the user's shell runs it via PATHEXT), but ProcessAiAgentCliRunner spawns the bare name and
+ * CreateProcess cannot execute batch files - those need `cmd.exe /d /c` (see DevrigUserLauncher).
+ * Routing the runner's batch-shim launches through cmd.exe is tracked in jonnyzzz/mcp-steroid#342.
  */
 fun findCliOnPath(
     binary: String,

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/Main.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/Main.kt
@@ -165,6 +165,7 @@ private fun DevrigCommand.runsTool(): Boolean = when (this) {
     is DevrigCommand.DevrigCommandInstall,
     is DevrigCommand.DevrigCommandInstallDevrig,
     is DevrigCommand.DevrigCommandInstallPlugin -> true
+    is DevrigCommand.DevrigCommandInstallOverview,
     is DevrigCommand.DevrigCommandHelp,
     is DevrigCommand.DevrigCommandVersion,
     is DevrigCommand.DevrigCommandParseError -> false

--- a/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/DevrigCommandTest.kt
+++ b/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/DevrigCommandTest.kt
@@ -106,6 +106,20 @@ class DevrigCommandTest {
     }
 
     @Test
+    fun `bare install selects the overview listing - flags still require a target`() {
+        // jonnyzzz/mcp-steroid#277: the bootstrap installers historically recommended a bare
+        // `devrig install`, so it must guide (list targets + detected CLIs), not error.
+        assertIs<DevrigCommand.DevrigCommandInstallOverview>(command("install"))
+        val overview = assertIs<DevrigCommand.DevrigCommandInstallOverview>(command("--debug", "install", "--json"))
+        assertTrue(overview.debug)
+        assertTrue(overview.json)
+        // Target-specific flags without a target stay an error, not a silent overview.
+        assertIs<DevrigCommand.DevrigCommandParseError>(command("install", "--check"))
+        assertIs<DevrigCommand.DevrigCommandParseError>(command("install", "--install-script=/x"))
+        assertIs<DevrigCommand.DevrigCommandParseError>(command("install", "--jdk-home=/x"))
+    }
+
+    @Test
     fun `install --check selects the read-only check for an agent and is rejected for devrig`() {
         // --check sets the read-only flag on an agent install…
         val checked = assertIs<DevrigCommand.DevrigCommandInstall>(command("install", "claude", "--check"))

--- a/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/InstallOverviewCommandTest.kt
+++ b/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/InstallOverviewCommandTest.kt
@@ -1,0 +1,55 @@
+/* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
+package com.jonnyzzz.mcpSteroid.devrig
+
+import com.jonnyzzz.mcpSteroid.aiAgents.AiAgentCli
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.io.path.createDirectories
+import kotlin.io.path.writeText
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+
+class InstallOverviewCommandTest {
+    @Test
+    fun `overview lists every install target and one runnable example`() {
+        val text = renderInstallOverview(AiAgentCli.entries.associateWith { null })
+        listOf("claude", "codex", "gemini", "plugin", "devrig").forEach {
+            assertTrue(text.contains("  $it"), "overview must list target '$it':\n$text")
+        }
+        assertTrue(text.contains("devrig install claude"), "overview must show a runnable example:\n$text")
+    }
+
+    @Test
+    fun `overview marks detected CLIs with their path and missing ones as not found`() {
+        val claudePath = Path.of("/opt/homebrew/bin/claude")
+        val text = renderInstallOverview(
+            mapOf(AiAgentCli.CLAUDE to claudePath, AiAgentCli.CODEX to null, AiAgentCli.GEMINI to null),
+        )
+        assertTrue(text.contains(claudePath.toString()), "detected CLI path must be shown:\n$text")
+        assertTrue(text.contains("not found on PATH"), "missing CLIs must be called out:\n$text")
+    }
+
+    @Test
+    fun `findCliOnPath finds an executable in a PATH directory and returns null when absent`(@TempDir dir: Path) {
+        val bin = dir.resolve("bin").createDirectories()
+        val cli = bin.resolve("claude")
+        cli.writeText("#!/bin/sh\n")
+        cli.toFile().setExecutable(true)
+
+        val pathEnv = listOf(dir.toString(), bin.toString()).joinToString(java.io.File.pathSeparator)
+        assertEquals(cli, findCliOnPath("claude", pathEnv))
+        assertNull(findCliOnPath("codex", pathEnv))
+        assertNull(findCliOnPath("claude", null))
+    }
+
+    @Test
+    fun `findCliOnPath resolves Windows launcher extensions`(@TempDir dir: Path) {
+        val cmd = dir.resolve("codex.cmd")
+        cmd.writeText("@echo off\n")
+        cmd.toFile().setExecutable(true)
+        assertEquals(cmd, findCliOnPath("codex", dir.toString(), windowsExtensions = true))
+    }
+}


### PR DESCRIPTION
Three quick-win fixes from the 2026-07-31 full-backlog triage (110 open issues, map-reduce research + adversarial verification). Each commit is atomic and test-first.

Fixes #275, fixes #277, fixes #320.

Scope notes:
- An optional-`reason` commit (#12) originally rode this PR and was removed by owner decision 2026-07-31: `reason` stays required on `steroid_execute_code` (the audit/telemetry value outweighs the per-call token cost). #12 closed accordingly.
- A plugin.xml description rewrite (#355) and a website-gen since-build derivation (#321) were dropped in favor of the concurrent, user-directed PR #395.

## What changed

| Commit | Issue | Change |
|---|---|---|
| b4052ce5 | #320 #275 | Installer final guidance prints `devrig install claude\|codex\|gemini` (bare `devrig install` errored); install.ps1 also prepends `$BinDir` to the CURRENT session `$env:PATH` so the printed command works in the very shell that ran `irm \| iex` |
| 95e543db | #277 | Bare `devrig install` now prints an overview (targets + per-agent CLI PATH detection) and exits 0 instead of a missing-argument usage error; target-specific flags without a target stay a UsageError |
| 4cd0d0f9 | — | Review follow-up: document findCliOnPath's shell-vs-ProcessBuilder gap (see below) |

## Verification

- `:installer-gen:test`, `:npx-kt:test`, `:mcp-steroid-server:test` green locally (re-run after each rebase).
- Dual-model adversarial review over the original range:
  - **Fable-5**: APPROVE — all six requested lenses (PowerShell StrictMode/finally, Clikt parse edges incl. the generated-installer `install devrig --install-script` contract, MCP schema compat, plugin.xml validity, CLAUDE.md banned patterns) traced through the implementation, no findings.
  - **gpt-5.6-sol**: REQUEST-CHANGES — one MAJOR: `findCliOnPath` counts Windows `.cmd`/`.bat` npm shims as found, while `ProcessAiAgentCliRunner` spawns bare names that CreateProcess cannot resolve to batch files. Resolution: the spawn gap predates this branch (it equally breaks `devrig install <agent>` for npm-shim installs) and the fix needs `cmd.exe /d /c` quoting care + real-Windows verification — documented in code (4cd0d0f9) and tracked with a concrete plan on #342 (0.102, P1). All other lenses: explicitly no findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
