### PR TITLE
0.102 reliability: devrig mcp orphan watchdog, friendly missing-CLI errors, EDT-safe VFS refresh

### DIFF
--- a/ai-agents/src/main/kotlin/com/jonnyzzz/mcpSteroid/aiAgents/AiAgentCli.kt
+++ b/ai-agents/src/main/kotlin/com/jonnyzzz/mcpSteroid/aiAgents/AiAgentCli.kt
@@ -1,6 +1,7 @@
 /* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
 package com.jonnyzzz.mcpSteroid.aiAgents
 
+import java.io.IOException
 import java.nio.file.Files
 import java.util.concurrent.TimeUnit
 import kotlin.time.Duration
@@ -53,6 +54,18 @@ fun interface AiAgentCliRunner {
 }
 
 /**
+ * The agent CLI process could not be LAUNCHED — the binary is missing from PATH, or is a shape the
+ * OS cannot spawn directly (a Windows `.cmd` npm shim needs `cmd.exe /d /c`). Distinct from other
+ * IOExceptions (temp-file creation, output read) so callers can turn exactly this case into
+ * "install the CLI first" guidance (jonnyzzz/mcp-steroid#342) without masking infrastructure
+ * failures as a missing CLI.
+ */
+class AgentCliNotLaunchableException(
+    val binary: String,
+    cause: IOException,
+) : IOException("could not launch '$binary': ${cause.message}", cause)
+
+/**
  * Runs an agent CLI to completion with a hard [timeout].
  *
  * Output goes to a TEMP FILE, not a pipe: with a pipe, draining via
@@ -73,10 +86,14 @@ class ProcessAiAgentCliRunner(
     override fun run(invocation: AiAgentCliInvocation): AiAgentCliResult {
         val outputFile = Files.createTempFile("devrig-agent-cli-", ".out")
         try {
-            val process = ProcessBuilder(listOf(invocation.binary) + invocation.args)
-                .redirectErrorStream(true)
-                .redirectOutput(outputFile.toFile())
-                .start()
+            val process = try {
+                ProcessBuilder(listOf(invocation.binary) + invocation.args)
+                    .redirectErrorStream(true)
+                    .redirectOutput(outputFile.toFile())
+                    .start()
+            } catch (e: IOException) {
+                throw AgentCliNotLaunchableException(invocation.binary, e)
+            }
             runCatching { process.outputStream.close() } // stdin: immediate EOF
             if (!process.waitFor(timeout.inWholeMilliseconds, TimeUnit.MILLISECONDS)) {
                 process.destroyForcibly()

--- a/ij-plugin/src/main/kotlin/com/jonnyzzz/mcpSteroid/execution/McpScriptContextImpl.kt
+++ b/ij-plugin/src/main/kotlin/com/jonnyzzz/mcpSteroid/execution/McpScriptContextImpl.kt
@@ -307,8 +307,14 @@ class McpScriptContextImpl(
                 withContext(Dispatchers.EDT) {
                     PsiDocumentManager.getInstance(project).commitAllDocuments()
                     FileDocumentManager.getInstance().saveAllDocuments()
-                    project.vfsRefreshService.awaitRefresh()
                 }
+                // #318: the recursive refresh must be awaited OUTSIDE the EDT context. Despite
+                // RefreshQueue's suspend overload being documented as background, the captured
+                // 31s freeze stack shows the directory scan executing on AWT-EventQueue-0 when
+                // awaited from Dispatchers.EDT. Awaiting here (the execution's background
+                // dispatcher) keeps the UI responsive with the same consistency contract — we
+                // still suspend until the refresh completes before returning.
+                project.vfsRefreshService.awaitRefresh()
             }
         } catch (_: TimeoutCancellationException) {
             captureThreadDump("syncDocuments-timeout")

--- a/ij-plugin/src/main/kotlin/com/jonnyzzz/mcpSteroid/execution/VfsRefreshService.kt
+++ b/ij-plugin/src/main/kotlin/com/jonnyzzz/mcpSteroid/execution/VfsRefreshService.kt
@@ -99,9 +99,12 @@ class VfsRefreshService(
         // PerformanceWatcher freeze attributed to this plugin was captured with the RefreshWorker
         // traversal on AWT-EventQueue-0. Fail fast so no caller can reintroduce that: every await
         // must happen on a background dispatcher (syncDocuments awaits AFTER its EDT commit/save
-        // block; CodeEvalManager's pre-compile path is background already).
-        check(!ApplicationManager.getApplication().isDispatchThread) {
-            "awaitRefresh must not be awaited from the EDT — the recursive VFS scan would freeze the UI (#318)"
+        // block; CodeEvalManager's pre-compile path is background already). Plain if+throw on
+        // purpose — this guard is unconditional, fixed behavior, never elidable.
+        if (ApplicationManager.getApplication().isDispatchThread) {
+            throw IllegalStateException(
+                "awaitRefresh must not be awaited from the EDT — the recursive VFS scan would freeze the UI (#318)",
+            )
         }
         val base = projectBaseVf() ?: return
         // Use the platform's coroutine-native [RefreshQueue.refresh] (suspend

--- a/ij-plugin/src/main/kotlin/com/jonnyzzz/mcpSteroid/execution/VfsRefreshService.kt
+++ b/ij-plugin/src/main/kotlin/com/jonnyzzz/mcpSteroid/execution/VfsRefreshService.kt
@@ -1,6 +1,7 @@
 /* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
 package com.jonnyzzz.mcpSteroid.execution
 
+import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.components.Service
 import com.intellij.openapi.components.service
 import com.intellij.openapi.diagnostic.thisLogger
@@ -94,6 +95,14 @@ class VfsRefreshService(
      * pathological refresh cannot hang compilation forever.
      */
     suspend fun awaitRefresh() {
+        // #318: a recursive project-root scan awaited from the EDT monopolizes it — a 31s
+        // PerformanceWatcher freeze attributed to this plugin was captured with the RefreshWorker
+        // traversal on AWT-EventQueue-0. Fail fast so no caller can reintroduce that: every await
+        // must happen on a background dispatcher (syncDocuments awaits AFTER its EDT commit/save
+        // block; CodeEvalManager's pre-compile path is background already).
+        check(!ApplicationManager.getApplication().isDispatchThread) {
+            "awaitRefresh must not be awaited from the EDT — the recursive VFS scan would freeze the UI (#318)"
+        }
         val base = projectBaseVf() ?: return
         // Use the platform's coroutine-native [RefreshQueue.refresh] (suspend
         // overload). The callback-based variant uses an EDT-side

--- a/ij-plugin/src/test/kotlin/com/jonnyzzz/mcpSteroid/execution/VfsRefreshServiceTest.kt
+++ b/ij-plugin/src/test/kotlin/com/jonnyzzz/mcpSteroid/execution/VfsRefreshServiceTest.kt
@@ -1,10 +1,13 @@
 /* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
 package com.jonnyzzz.mcpSteroid.execution
 
+import com.intellij.openapi.application.EDT
 import com.intellij.testFramework.common.timeoutRunBlocking
 import com.intellij.testFramework.fixtures.BasePlatformTestCase
 import kotlin.system.measureTimeMillis
 import kotlin.time.Duration.Companion.seconds
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 
 /**
  * Contract for [VfsRefreshService]. These tests pin the two guarantees the
@@ -63,6 +66,23 @@ class VfsRefreshServiceTest : BasePlatformTestCase() {
         service.scheduleAsyncRefresh()
         service.scheduleAsyncRefresh()
         // If we got here without an exception, the contract holds.
+    }
+
+    fun testAwaitRefreshFromTheEdtFailsFast(): Unit = timeoutRunBlocking(30.seconds) {
+        // jonnyzzz/mcp-steroid#318: awaiting the recursive refresh from the EDT ran the
+        // RefreshWorker directory scan ON AWT-EventQueue-0 (31s captured freeze). The guard must
+        // fail fast — long before any traversal — so no caller can reintroduce the freeze.
+        val service = project.vfsRefreshService
+        val failure = try {
+            withContext(Dispatchers.EDT) { service.awaitRefresh() }
+            null
+        } catch (e: IllegalStateException) {
+            e
+        }
+        assertTrue(
+            "awaitRefresh from the EDT must throw IllegalStateException, got: $failure",
+            failure is IllegalStateException && failure.message!!.contains("#318"),
+        )
     }
 
     fun testAwaitRefreshWithNoProjectBasePathIsNoOp(): Unit = timeoutRunBlocking(5.seconds) {

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/Cli.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/Cli.kt
@@ -10,6 +10,7 @@ import com.github.ajalt.clikt.parameters.arguments.argument
 import com.github.ajalt.clikt.parameters.arguments.optional
 import com.github.ajalt.clikt.parameters.options.flag
 import com.github.ajalt.clikt.parameters.options.option
+import com.jonnyzzz.mcpSteroid.aiAgents.AgentCliNotLaunchableException
 import com.jonnyzzz.mcpSteroid.aiAgents.AiAgentCli
 
 const val NO_BACKENDS_DETECTED_MESSAGE: String = "No backends detected."
@@ -425,6 +426,9 @@ fun DevrigServices.runCli(command: DevrigCommand): Int {
             is DevrigCommand.DevrigCommandInstallConfig -> runInstallConfigCommand()
             is DevrigCommand.DevrigCommandInstallPlugin -> runInstallPluginCommand(command)
         }
+    } catch (e: AgentCliNotLaunchableException) {
+        // #342: a missing/unspawnable agent CLI must read as guidance, not a raw stacktrace.
+        reportAgentCliNotLaunchable(e, System.err)
     } catch (e: ManagedBackendLockException) {
         System.err.println(e.message)
         64

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/HelpCommand.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/HelpCommand.kt
@@ -24,13 +24,12 @@ fun printHelp(out: PrintStream) : Int {
                                          `--json` emits a single machine-readable
                                          object on stdout; default is human text.
 
-          devrig install                 list install targets and which agent
-                                         CLIs are present on PATH
-
-          devrig install claude|codex|gemini [--check]
+          devrig install [claude|codex|gemini] [--check]
                                          register this devrig binary as the
                                          mcp-steroid stdio MCP server in the
-                                         selected coding agent. `--check` is a
+                                         selected coding agent. With no agent:
+                                         list the install targets and which agent
+                                         CLIs are present on PATH. `--check` is a
                                          read-only dry-run: it reports the current
                                          registration, the changes install would
                                          apply, and how many IDE backends with the

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/InstallCommand.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/InstallCommand.kt
@@ -1,6 +1,7 @@
 /* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
 package com.jonnyzzz.mcpSteroid.devrig
 
+import com.jonnyzzz.mcpSteroid.aiAgents.AgentCliNotLaunchableException
 import com.jonnyzzz.mcpSteroid.aiAgents.AiAgentCli
 import com.jonnyzzz.mcpSteroid.aiAgents.AiAgentCliResult
 import com.jonnyzzz.mcpSteroid.aiAgents.AiAgentCliRunner
@@ -9,7 +10,6 @@ import com.jonnyzzz.mcpSteroid.aiAgents.StdioMcpCommand
 import com.jonnyzzz.mcpSteroid.aiAgents.mcpAddStdioInvocation
 import com.jonnyzzz.mcpSteroid.aiAgents.mcpListInvocation
 import com.jonnyzzz.mcpSteroid.aiAgents.mcpRemoveInvocation
-import java.io.IOException
 import java.io.PrintStream
 import java.nio.file.Path
 import kotlin.io.path.isRegularFile
@@ -246,16 +246,17 @@ fun runInstallCommand(
 
 /**
  * jonnyzzz/mcp-steroid#342: when the agent CLI is not installed (or not spawnable — e.g. a Windows
- * .cmd npm shim), ProcessBuilder throws IOException ("Cannot run program \"claude\": error=2").
- * That must read as guidance, never a raw stacktrace. Inline so the wrapped bodies keep their
- * non-local returns.
+ * .cmd npm shim), the runner throws [AgentCliNotLaunchableException]. That must read as guidance,
+ * never a raw stacktrace. Only the typed launch failure is translated — other IOExceptions (temp
+ * files, output reads) are infrastructure errors and keep propagating. Inline so the wrapped
+ * bodies keep their non-local returns.
  */
 private inline fun withFriendlyMissingCliError(agent: AiAgentCli, err: PrintStream, body: () -> Int): Int =
     try {
         body()
-    } catch (e: IOException) {
+    } catch (e: AgentCliNotLaunchableException) {
         err.println()
-        err.println("ERROR: could not run the '${agent.binary}' CLI: ${e.message}")
+        err.println("ERROR: could not run the '${agent.binary}' CLI: ${e.cause?.message ?: e.message}")
         err.println(
             "Is the ${agent.displayName} CLI installed and on PATH? Install it first, then re-run " +
                 "'devrig install ${agent.binary}'.",

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/InstallCommand.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/InstallCommand.kt
@@ -9,6 +9,7 @@ import com.jonnyzzz.mcpSteroid.aiAgents.StdioMcpCommand
 import com.jonnyzzz.mcpSteroid.aiAgents.mcpAddStdioInvocation
 import com.jonnyzzz.mcpSteroid.aiAgents.mcpListInvocation
 import com.jonnyzzz.mcpSteroid.aiAgents.mcpRemoveInvocation
+import java.io.IOException
 import java.io.PrintStream
 import java.nio.file.Path
 import kotlin.io.path.isRegularFile
@@ -165,7 +166,7 @@ fun runInstallCommand(
     out: PrintStream,
     err: PrintStream,
     runner: AiAgentCliRunner,
-): Int {
+): Int = withFriendlyMissingCliError(command.agent, err) {
     val agent = command.agent
     val renderedCommand = "${mcpCommand.command} ${mcpCommand.args.joinToString(" ")}"
 
@@ -243,6 +244,25 @@ fun runInstallCommand(
     return 0
 }
 
+/**
+ * jonnyzzz/mcp-steroid#342: when the agent CLI is not installed (or not spawnable — e.g. a Windows
+ * .cmd npm shim), ProcessBuilder throws IOException ("Cannot run program \"claude\": error=2").
+ * That must read as guidance, never a raw stacktrace. Inline so the wrapped bodies keep their
+ * non-local returns.
+ */
+private inline fun withFriendlyMissingCliError(agent: AiAgentCli, err: PrintStream, body: () -> Int): Int =
+    try {
+        body()
+    } catch (e: IOException) {
+        err.println()
+        err.println("ERROR: could not run the '${agent.binary}' CLI: ${e.message}")
+        err.println(
+            "Is the ${agent.displayName} CLI installed and on PATH? Install it first, then re-run " +
+                "'devrig install ${agent.binary}'.",
+        )
+        64
+    }
+
 private fun emitAgentOutput(result: AiAgentCliResult, err: PrintStream) {
     if (result.output.isNotBlank()) {
         err.print(result.output)
@@ -314,7 +334,7 @@ fun runInstallCheckCommand(
     ideReachability: () -> IdeReachabilityReport,
     /** Non-null = the devrig launcher does not exist yet at this path (reported as a diagnostic). */
     missingLauncherPath: Path? = null,
-): Int {
+): Int = withFriendlyMissingCliError(command.agent, err) {
     val agent = command.agent
     val renderedCommand = "${mcpCommand.command} ${mcpCommand.args.joinToString(" ")}"
 

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/InstallCommand.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/InstallCommand.kt
@@ -166,7 +166,7 @@ fun runInstallCommand(
     out: PrintStream,
     err: PrintStream,
     runner: AiAgentCliRunner,
-): Int = withFriendlyMissingCliError(command.agent, err) {
+): Int {
     val agent = command.agent
     val renderedCommand = "${mcpCommand.command} ${mcpCommand.args.joinToString(" ")}"
 
@@ -247,22 +247,21 @@ fun runInstallCommand(
 /**
  * jonnyzzz/mcp-steroid#342: when the agent CLI is not installed (or not spawnable — e.g. a Windows
  * .cmd npm shim), the runner throws [AgentCliNotLaunchableException]. That must read as guidance,
- * never a raw stacktrace. Only the typed launch failure is translated — other IOExceptions (temp
- * files, output reads) are infrastructure errors and keep propagating. Inline so the wrapped
- * bodies keep their non-local returns.
+ * never a raw stacktrace. Handled centrally in [runCli]'s typed-exception catches — the same
+ * pattern as ManagedBackend*Exception — so every command that spawns an agent CLI gets the same
+ * treatment. Only the typed launch failure is translated; other IOExceptions (temp files, output
+ * reads) are infrastructure errors and keep propagating to the generic handler.
  */
-private inline fun withFriendlyMissingCliError(agent: AiAgentCli, err: PrintStream, body: () -> Int): Int =
-    try {
-        body()
-    } catch (e: AgentCliNotLaunchableException) {
-        err.println()
-        err.println("ERROR: could not run the '${agent.binary}' CLI: ${e.cause?.message ?: e.message}")
-        err.println(
-            "Is the ${agent.displayName} CLI installed and on PATH? Install it first, then re-run " +
-                "'devrig install ${agent.binary}'.",
-        )
-        64
-    }
+fun reportAgentCliNotLaunchable(e: AgentCliNotLaunchableException, err: PrintStream): Int {
+    val displayName = AiAgentCli.parse(e.binary)?.displayName ?: e.binary
+    err.println()
+    err.println("ERROR: could not run the '${e.binary}' CLI: ${e.cause?.message ?: e.message}")
+    err.println(
+        "Is the $displayName CLI installed and on PATH? Install it first, then re-run " +
+            "'devrig install ${e.binary}'.",
+    )
+    return 64
+}
 
 private fun emitAgentOutput(result: AiAgentCliResult, err: PrintStream) {
     if (result.output.isNotBlank()) {
@@ -335,7 +334,7 @@ fun runInstallCheckCommand(
     ideReachability: () -> IdeReachabilityReport,
     /** Non-null = the devrig launcher does not exist yet at this path (reported as a diagnostic). */
     missingLauncherPath: Path? = null,
-): Int = withFriendlyMissingCliError(command.agent, err) {
+): Int {
     val agent = command.agent
     val renderedCommand = "${mcpCommand.command} ${mcpCommand.args.joinToString(" ")}"
 

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/Main.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/Main.kt
@@ -131,6 +131,18 @@ suspend fun DevrigServices.mainImpl2(
     }
 
     if (command is DevrigCommand.MCP) {
+        // Orphan back-stop (#132): stdin EOF only reaps a parent that CLOSES the pipe; a SIGKILL'd
+        // agent leaves this JVM alive forever. exitProcess (not scope cancellation) because the read
+        // loop is parked in a blocking stream read that cancellation cannot interrupt.
+        ParentDeathWatchdog(
+            parentAlive = currentParentLiveness(),
+            onParentDeath = {
+                val message = "parent process died without closing stdin — exiting orphaned 'devrig mcp'"
+                System.err.println("[mcp-steroid] $message")
+                logger<ParentDeathWatchdog>().warn(message)
+                exitProcess(0)
+            },
+        ).launchIn(backgroundScope)
         beacon.runHeartbeat()
         try {
             mainImplMcp(onServerReady = { mcpServerReady.complete(it) })

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/Main.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/Main.kt
@@ -135,7 +135,7 @@ suspend fun DevrigServices.mainImpl2(
         // agent leaves this JVM alive forever. exitProcess (not scope cancellation) because the read
         // loop is parked in a blocking stream read that cancellation cannot interrupt.
         ParentDeathWatchdog(
-            parentAlive = currentParentLiveness(),
+            ancestorsAlive = watchedAncestorLiveness(),
             onParentDeath = {
                 val message = "parent process died without closing stdin — exiting orphaned 'devrig mcp'"
                 System.err.println("[mcp-steroid] $message")

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/ParentDeathWatchdog.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/ParentDeathWatchdog.kt
@@ -1,0 +1,60 @@
+/* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
+package com.jonnyzzz.mcpSteroid.devrig
+
+import com.jonnyzzz.mcpSteroid.logger
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+
+/**
+ * Parent-death watchdog for `devrig mcp` (jonnyzzz/mcp-steroid#132).
+ *
+ * The stdio server's read loop exits on stdin EOF, which covers a parent that CLOSES the pipe.
+ * A parent that dies WITHOUT closing it (a SIGKILL'd claude/codex session, `taskkill /F`) leaves
+ * this JVM orphaned forever — observed piling up at ~250 MB each for days. ProcessHandle liveness
+ * polling is the one JDK-portable mechanism across macOS/Linux/Windows (POSIX reparenting checks
+ * and Windows Job Objects are platform-specific), so it complements EOF as the orphan back-stop.
+ */
+class ParentDeathWatchdog(
+    /** Liveness probe for the recorded parent; null = parent unknown → watchdog stays off (never false-positive). */
+    private val parentAlive: (() -> Boolean)?,
+    private val onParentDeath: () -> Unit,
+    private val pollInterval: Duration = 5.seconds,
+    /** Consecutive dead readings required before firing — one transient platform hiccup must not kill the server. */
+    private val confirmations: Int = 2,
+) {
+    fun launchIn(scope: CoroutineScope) {
+        val probe = parentAlive ?: run {
+            log.info("parent process unknown — parent-death watchdog disabled")
+            return
+        }
+        scope.launch {
+            var consecutiveDead = 0
+            while (true) {
+                delay(pollInterval)
+                consecutiveDead = if (probe()) 0 else consecutiveDead + 1
+                if (consecutiveDead >= confirmations) {
+                    onParentDeath()
+                    return@launch
+                }
+            }
+        }
+    }
+
+    companion object {
+        private val log = logger<ParentDeathWatchdog>()
+    }
+}
+
+/**
+ * Liveness probe for THIS process's launching parent, or null when the platform reports none.
+ * The handle is captured once: ProcessHandle identity is pinned to the original process (pid +
+ * start time on mainstream platforms), so `isAlive` stays false after death even if the pid is
+ * reused by a new process.
+ */
+fun currentParentLiveness(): (() -> Boolean)? {
+    val parent = ProcessHandle.current().parent().orElse(null) ?: return null
+    return parent::isAlive
+}

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/ParentDeathWatchdog.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/ParentDeathWatchdog.kt
@@ -18,15 +18,19 @@ import kotlinx.coroutines.launch
  * and Windows Job Objects are platform-specific), so it complements EOF as the orphan back-stop.
  */
 class ParentDeathWatchdog(
-    /** Liveness probe for the recorded parent; null = parent unknown → watchdog stays off (never false-positive). */
-    private val parentAlive: (() -> Boolean)?,
+    /**
+     * Liveness probes for the watched ancestors (see [watchedAncestorLiveness]); the process is
+     * orphaned when ANY of them dies. Empty = ancestry unknown → watchdog stays off (never
+     * false-positive).
+     */
+    private val ancestorsAlive: List<() -> Boolean>,
     private val onParentDeath: () -> Unit,
     private val pollInterval: Duration = 5.seconds,
     /** Consecutive dead readings required before firing — one transient platform hiccup must not kill the server. */
     private val confirmations: Int = 2,
 ) {
     fun launchIn(scope: CoroutineScope) {
-        val probe = parentAlive ?: run {
+        if (ancestorsAlive.isEmpty()) {
             log.info("parent process unknown — parent-death watchdog disabled")
             return
         }
@@ -34,7 +38,7 @@ class ParentDeathWatchdog(
             var consecutiveDead = 0
             while (true) {
                 delay(pollInterval)
-                consecutiveDead = if (probe()) 0 else consecutiveDead + 1
+                consecutiveDead = if (ancestorsAlive.all { it() }) 0 else consecutiveDead + 1
                 if (consecutiveDead >= confirmations) {
                     onParentDeath()
                     return@launch
@@ -49,12 +53,27 @@ class ParentDeathWatchdog(
 }
 
 /**
- * Liveness probe for THIS process's launching parent, or null when the platform reports none.
- * The handle is captured once: ProcessHandle identity is pinned to the original process (pid +
+ * Liveness probes for THIS process's watched ancestors; empty when the platform reports none.
+ *
+ * Always watches the immediate parent. On Windows the `~\.mcp-steroid\bin\devrig.cmd` launcher
+ * cannot `exec` like its POSIX sibling, so a live `cmd.exe` wrapper sits between the agent and
+ * this JVM — and `taskkill /F` on the agent leaves that wrapper alive, waiting on us. When the
+ * parent is a `cmd.exe` wrapper the GRANDPARENT (the agent) is therefore watched too; either one
+ * dying means this server is orphaned.
+ *
+ * Handles are captured once: ProcessHandle identity is pinned to the original process (pid +
  * start time on mainstream platforms), so `isAlive` stays false after death even if the pid is
  * reused by a new process.
  */
-fun currentParentLiveness(): (() -> Boolean)? {
-    val parent = ProcessHandle.current().parent().orElse(null) ?: return null
-    return parent::isAlive
+fun watchedAncestorLiveness(): List<() -> Boolean> {
+    val parent = ProcessHandle.current().parent().orElse(null) ?: return emptyList()
+    val probes = mutableListOf<() -> Boolean>(parent::isAlive)
+    if (isCmdExe(parent.info().command().orElse(""))) {
+        parent.parent().orElse(null)?.let { agent -> probes += agent::isAlive }
+    }
+    return probes
 }
+
+/** True when [command] is a `cmd.exe` path — the Windows batch-launcher wrapper shape. */
+fun isCmdExe(command: String): Boolean =
+    command.substringAfterLast('\\').substringAfterLast('/').equals("cmd.exe", ignoreCase = true)

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/ParentDeathWatchdog.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/ParentDeathWatchdog.kt
@@ -29,6 +29,8 @@ class ParentDeathWatchdog(
     /** Consecutive dead readings required before firing — one transient platform hiccup must not kill the server. */
     private val confirmations: Int = 2,
 ) {
+    private val log = logger<ParentDeathWatchdog>()
+
     fun launchIn(scope: CoroutineScope) {
         if (ancestorsAlive.isEmpty()) {
             log.info("parent process unknown — parent-death watchdog disabled")
@@ -47,9 +49,6 @@ class ParentDeathWatchdog(
         }
     }
 
-    companion object {
-        private val log = logger<ParentDeathWatchdog>()
-    }
 }
 
 /**

--- a/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/DevrigCommandOutputTest.kt
+++ b/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/DevrigCommandOutputTest.kt
@@ -86,7 +86,8 @@ class DevrigCommandOutputTest {
         assertFalse(out.contains("devrig mpc"), "help must NOT advertise the hidden mpc alias; got:\n$out")
         assertTrue(out.contains("--version"), "help should advertise --version; got:\n$out")
         assertTrue(out.contains("--help"), "help should advertise --help itself; got:\n$out")
-        assertTrue(out.contains("devrig install claude|codex|gemini"), "help should advertise agent install; got:\n$out")
+        // ONE merged install entry (PR #397 review): the bare and agent-qualified forms share it.
+        assertTrue(out.contains("devrig install [claude|codex|gemini] [--check]"), "help should advertise agent install; got:\n$out")
         assertTrue(out.contains("devrig install config"), "help should advertise the manual-config printer; got:\n$out")
         assertTrue(out.contains("backend download [<id>] [--version <v>] [--json]"), "help should advertise download version override; got:\n$out")
         assertTrue(out.contains("no id → list IDEs available for download"), "help should explain download without id; got:\n$out")

--- a/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/InstallCommandTest.kt
+++ b/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/InstallCommandTest.kt
@@ -10,6 +10,7 @@ import java.io.PrintStream
 import java.nio.file.Path
 import kotlin.test.assertContains
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 import org.junit.jupiter.api.Test
@@ -412,38 +413,48 @@ class InstallCommandTest {
     }
 
     @Test
-    fun `install with a missing agent CLI prints a friendly error - not a stacktrace`() {
+    fun `install and check propagate the typed missing-CLI exception to runCli's central handler`() {
+        // The friendly translation lives in runCli (PR #397 review: one handler up the stack, the
+        // ManagedBackend*Exception pattern) — the pure command functions must PROPAGATE the typed
+        // exception untouched, never swallow it.
         val stdout = ByteArrayOutputStream()
         val stderr = ByteArrayOutputStream()
-        val exitCode = runInstallCommand(
-            command = DevrigCommand.DevrigCommandInstall(AiAgentCli.CLAUDE),
-            mcpCommand = mcpCommand,
-            out = PrintStream(stdout, true, Charsets.UTF_8),
-            err = PrintStream(stderr, true, Charsets.UTF_8),
-            runner = missingCliRunner,
+        assertFailsWith<com.jonnyzzz.mcpSteroid.aiAgents.AgentCliNotLaunchableException> {
+            runInstallCommand(
+                command = DevrigCommand.DevrigCommandInstall(AiAgentCli.CLAUDE),
+                mcpCommand = mcpCommand,
+                out = PrintStream(stdout, true, Charsets.UTF_8),
+                err = PrintStream(stderr, true, Charsets.UTF_8),
+                runner = missingCliRunner,
+            )
+        }
+        assertFailsWith<com.jonnyzzz.mcpSteroid.aiAgents.AgentCliNotLaunchableException> {
+            runInstallCheckCommand(
+                command = DevrigCommand.DevrigCommandInstall(AiAgentCli.CLAUDE, check = true),
+                mcpCommand = mcpCommand,
+                out = PrintStream(stdout, true, Charsets.UTF_8),
+                err = PrintStream(stderr, true, Charsets.UTF_8),
+                runner = missingCliRunner,
+                ideReachability = { IdeReachabilityReport(reachable = 0, discovered = 0) },
+            )
+        }
+    }
+
+    @Test
+    fun `reportAgentCliNotLaunchable prints guidance - not a stacktrace - and exits 64`() {
+        val stderr = ByteArrayOutputStream()
+        val exitCode = reportAgentCliNotLaunchable(
+            com.jonnyzzz.mcpSteroid.aiAgents.AgentCliNotLaunchableException(
+                "claude",
+                java.io.IOException("Cannot run program \"claude\": error=2, No such file or directory"),
+            ),
+            PrintStream(stderr, true, Charsets.UTF_8),
         )
         assertEquals(64, exitCode)
         val err = stderr.toString(Charsets.UTF_8)
         assertContains(err, "could not run the 'claude' CLI")
         assertContains(err, "Is the Claude CLI installed and on PATH?")
-        assertFalse(err.contains("\tat "), "stacktrace leaked to stderr:\n$err")
-    }
-
-    @Test
-    fun `check with a missing agent CLI prints a friendly error - not a stacktrace`() {
-        val stdout = ByteArrayOutputStream()
-        val stderr = ByteArrayOutputStream()
-        val exitCode = runInstallCheckCommand(
-            command = DevrigCommand.DevrigCommandInstall(AiAgentCli.CLAUDE, check = true),
-            mcpCommand = mcpCommand,
-            out = PrintStream(stdout, true, Charsets.UTF_8),
-            err = PrintStream(stderr, true, Charsets.UTF_8),
-            runner = missingCliRunner,
-            ideReachability = { IdeReachabilityReport(reachable = 0, discovered = 0) },
-        )
-        assertEquals(64, exitCode)
-        val err = stderr.toString(Charsets.UTF_8)
-        assertContains(err, "could not run the 'claude' CLI")
+        assertContains(err, "re-run 'devrig install claude'")
         assertFalse(err.contains("\tat "), "stacktrace leaked to stderr:\n$err")
     }
 

--- a/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/InstallCommandTest.kt
+++ b/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/InstallCommandTest.kt
@@ -380,10 +380,35 @@ class InstallCommandTest {
         val stderr: String,
     )
 
-    // jonnyzzz/mcp-steroid#342: a missing agent CLI (ProcessBuilder throws IOException,
-    // "Cannot run program \"claude\": error=2") must produce guidance, never a raw stacktrace.
+    // jonnyzzz/mcp-steroid#342: a missing agent CLI (ProcessAiAgentCliRunner wraps the spawn
+    // IOException into AgentCliNotLaunchableException) must produce guidance, never a raw
+    // stacktrace — while OTHER IOExceptions (temp files, output reads) keep propagating.
     private val missingCliRunner = AiAgentCliRunner {
-        throw java.io.IOException("Cannot run program \"claude\": error=2, No such file or directory")
+        throw com.jonnyzzz.mcpSteroid.aiAgents.AgentCliNotLaunchableException(
+            "claude",
+            java.io.IOException("Cannot run program \"claude\": error=2, No such file or directory"),
+        )
+    }
+
+    @Test
+    fun `an infrastructure IOException is NOT masked as a missing CLI`() {
+        val runner = AiAgentCliRunner { throw java.io.IOException("temp file creation failed") }
+        val stdout = ByteArrayOutputStream()
+        val stderr = ByteArrayOutputStream()
+        val thrown = try {
+            runInstallCommand(
+                command = DevrigCommand.DevrigCommandInstall(AiAgentCli.CLAUDE),
+                mcpCommand = mcpCommand,
+                out = PrintStream(stdout, true, Charsets.UTF_8),
+                err = PrintStream(stderr, true, Charsets.UTF_8),
+                runner = runner,
+            )
+            null
+        } catch (e: java.io.IOException) {
+            e
+        }
+        assertTrue(thrown != null, "a plain IOException must propagate, not become 'install the CLI'")
+        assertFalse(stderr.toString(Charsets.UTF_8).contains("installed and on PATH"))
     }
 
     @Test

--- a/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/InstallCommandTest.kt
+++ b/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/InstallCommandTest.kt
@@ -380,6 +380,48 @@ class InstallCommandTest {
         val stderr: String,
     )
 
+    // jonnyzzz/mcp-steroid#342: a missing agent CLI (ProcessBuilder throws IOException,
+    // "Cannot run program \"claude\": error=2") must produce guidance, never a raw stacktrace.
+    private val missingCliRunner = AiAgentCliRunner {
+        throw java.io.IOException("Cannot run program \"claude\": error=2, No such file or directory")
+    }
+
+    @Test
+    fun `install with a missing agent CLI prints a friendly error - not a stacktrace`() {
+        val stdout = ByteArrayOutputStream()
+        val stderr = ByteArrayOutputStream()
+        val exitCode = runInstallCommand(
+            command = DevrigCommand.DevrigCommandInstall(AiAgentCli.CLAUDE),
+            mcpCommand = mcpCommand,
+            out = PrintStream(stdout, true, Charsets.UTF_8),
+            err = PrintStream(stderr, true, Charsets.UTF_8),
+            runner = missingCliRunner,
+        )
+        assertEquals(64, exitCode)
+        val err = stderr.toString(Charsets.UTF_8)
+        assertContains(err, "could not run the 'claude' CLI")
+        assertContains(err, "Is the Claude CLI installed and on PATH?")
+        assertFalse(err.contains("\tat "), "stacktrace leaked to stderr:\n$err")
+    }
+
+    @Test
+    fun `check with a missing agent CLI prints a friendly error - not a stacktrace`() {
+        val stdout = ByteArrayOutputStream()
+        val stderr = ByteArrayOutputStream()
+        val exitCode = runInstallCheckCommand(
+            command = DevrigCommand.DevrigCommandInstall(AiAgentCli.CLAUDE, check = true),
+            mcpCommand = mcpCommand,
+            out = PrintStream(stdout, true, Charsets.UTF_8),
+            err = PrintStream(stderr, true, Charsets.UTF_8),
+            runner = missingCliRunner,
+            ideReachability = { IdeReachabilityReport(reachable = 0, discovered = 0) },
+        )
+        assertEquals(64, exitCode)
+        val err = stderr.toString(Charsets.UTF_8)
+        assertContains(err, "could not run the 'claude' CLI")
+        assertFalse(err.contains("\tat "), "stacktrace leaked to stderr:\n$err")
+    }
+
     private fun runInstall(agent: AiAgentCli, runner: RecordingRunner): InstallRunResult {
         val stdout = ByteArrayOutputStream()
         val stderr = ByteArrayOutputStream()

--- a/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/ParentDeathWatchdogTest.kt
+++ b/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/ParentDeathWatchdogTest.kt
@@ -1,0 +1,92 @@
+/* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
+package com.jonnyzzz.mcpSteroid.devrig
+
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.seconds
+import kotlinx.coroutines.cancelChildren
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+
+class ParentDeathWatchdogTest {
+    @Test
+    fun `fires once after the configured number of consecutive dead readings`() = runTest {
+        val fired = AtomicInteger()
+        ParentDeathWatchdog(
+            parentAlive = { false },
+            onParentDeath = { fired.incrementAndGet() },
+            pollInterval = 5.seconds,
+            confirmations = 2,
+        ).launchIn(this)
+
+        advanceTimeBy(6.seconds) // one dead reading — below the confirmation bar
+        assertEquals(0, fired.get(), "one dead reading must not fire yet")
+        advanceTimeBy(5.seconds) // second consecutive dead reading
+        assertEquals(1, fired.get(), "two consecutive dead readings must fire")
+        advanceTimeBy(60.seconds) // watchdog stops after firing
+        assertEquals(1, fired.get(), "the watchdog must fire exactly once")
+        coroutineContext.cancelChildren()
+    }
+
+    @Test
+    fun `never fires while the parent stays alive`() = runTest {
+        val fired = AtomicInteger()
+        ParentDeathWatchdog(
+            parentAlive = { true },
+            onParentDeath = { fired.incrementAndGet() },
+            pollInterval = 5.seconds,
+        ).launchIn(this)
+
+        advanceTimeBy(10_000.seconds)
+        assertEquals(0, fired.get())
+        coroutineContext.cancelChildren()
+    }
+
+    @Test
+    fun `a transient dead reading resets on the next alive reading`() = runTest {
+        val fired = AtomicInteger()
+        var alive = false
+        ParentDeathWatchdog(
+            parentAlive = { alive },
+            onParentDeath = { fired.incrementAndGet() },
+            pollInterval = 5.seconds,
+            confirmations = 2,
+        ).launchIn(this)
+
+        advanceTimeBy(6.seconds) // one dead reading
+        alive = true // platform hiccup over — parent is alive
+        advanceTimeBy(100.seconds)
+        assertEquals(0, fired.get(), "a single transient dead reading must not accumulate")
+
+        alive = false // now the parent really dies
+        advanceTimeBy(11.seconds)
+        assertEquals(1, fired.get())
+        coroutineContext.cancelChildren()
+    }
+
+    @Test
+    fun `disabled when the parent process is unknown`() = runTest {
+        val fired = AtomicInteger()
+        ParentDeathWatchdog(
+            parentAlive = null,
+            onParentDeath = { fired.incrementAndGet() },
+            pollInterval = 5.seconds,
+        ).launchIn(this)
+
+        advanceTimeBy(10_000.seconds)
+        assertEquals(0, fired.get(), "no parent handle → watchdog must stay silent, never false-positive")
+        coroutineContext.cancelChildren()
+    }
+
+    @Test
+    fun `currentParentLiveness sees this test JVM's real parent as alive`() {
+        // The gradle test worker always has a live parent (the daemon); exercises the real
+        // ProcessHandle path that production wires in.
+        val probe = currentParentLiveness()
+        assertNotNull(probe, "a gradle worker JVM must have a resolvable parent")
+        assertTrue(probe(), "the gradle daemon parent must be alive while the test runs")
+    }
+}

--- a/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/ParentDeathWatchdogTest.kt
+++ b/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/ParentDeathWatchdogTest.kt
@@ -3,7 +3,7 @@ package com.jonnyzzz.mcpSteroid.devrig
 
 import java.util.concurrent.atomic.AtomicInteger
 import kotlin.test.assertEquals
-import kotlin.test.assertNotNull
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.cancelChildren
@@ -16,7 +16,7 @@ class ParentDeathWatchdogTest {
     fun `fires once after the configured number of consecutive dead readings`() = runTest {
         val fired = AtomicInteger()
         ParentDeathWatchdog(
-            parentAlive = { false },
+            ancestorsAlive = listOf({ false }),
             onParentDeath = { fired.incrementAndGet() },
             pollInterval = 5.seconds,
             confirmations = 2,
@@ -32,10 +32,10 @@ class ParentDeathWatchdogTest {
     }
 
     @Test
-    fun `never fires while the parent stays alive`() = runTest {
+    fun `never fires while every watched ancestor stays alive`() = runTest {
         val fired = AtomicInteger()
         ParentDeathWatchdog(
-            parentAlive = { true },
+            ancestorsAlive = listOf({ true }, { true }),
             onParentDeath = { fired.incrementAndGet() },
             pollInterval = 5.seconds,
         ).launchIn(this)
@@ -46,11 +46,32 @@ class ParentDeathWatchdogTest {
     }
 
     @Test
+    fun `a dead grandparent fires even while the wrapper parent stays alive`() = runTest {
+        // The Windows launcher shape (#132): agent -> cmd.exe wrapper -> this JVM. taskkill /F on
+        // the agent leaves cmd.exe alive waiting on us — the grandparent probe must still fire.
+        val fired = AtomicInteger()
+        var agentAlive = true
+        ParentDeathWatchdog(
+            ancestorsAlive = listOf({ true }, { agentAlive }),
+            onParentDeath = { fired.incrementAndGet() },
+            pollInterval = 5.seconds,
+            confirmations = 2,
+        ).launchIn(this)
+
+        advanceTimeBy(100.seconds)
+        assertEquals(0, fired.get())
+        agentAlive = false
+        advanceTimeBy(11.seconds)
+        assertEquals(1, fired.get(), "a dead agent behind a live cmd.exe wrapper must fire")
+        coroutineContext.cancelChildren()
+    }
+
+    @Test
     fun `a transient dead reading resets on the next alive reading`() = runTest {
         val fired = AtomicInteger()
         var alive = false
         ParentDeathWatchdog(
-            parentAlive = { alive },
+            ancestorsAlive = listOf({ alive }),
             onParentDeath = { fired.incrementAndGet() },
             pollInterval = 5.seconds,
             confirmations = 2,
@@ -68,25 +89,35 @@ class ParentDeathWatchdogTest {
     }
 
     @Test
-    fun `disabled when the parent process is unknown`() = runTest {
+    fun `disabled when the ancestry is unknown`() = runTest {
         val fired = AtomicInteger()
         ParentDeathWatchdog(
-            parentAlive = null,
+            ancestorsAlive = emptyList(),
             onParentDeath = { fired.incrementAndGet() },
             pollInterval = 5.seconds,
         ).launchIn(this)
 
         advanceTimeBy(10_000.seconds)
-        assertEquals(0, fired.get(), "no parent handle → watchdog must stay silent, never false-positive")
+        assertEquals(0, fired.get(), "no ancestry → watchdog must stay silent, never false-positive")
         coroutineContext.cancelChildren()
     }
 
     @Test
-    fun `currentParentLiveness sees this test JVM's real parent as alive`() {
+    fun `watchedAncestorLiveness sees this test JVM's real ancestors as alive`() {
         // The gradle test worker always has a live parent (the daemon); exercises the real
         // ProcessHandle path that production wires in.
-        val probe = currentParentLiveness()
-        assertNotNull(probe, "a gradle worker JVM must have a resolvable parent")
-        assertTrue(probe(), "the gradle daemon parent must be alive while the test runs")
+        val probes = watchedAncestorLiveness()
+        assertTrue(probes.isNotEmpty(), "a gradle worker JVM must have a resolvable parent")
+        probes.forEach { probe -> assertTrue(probe(), "every watched ancestor must be alive while the test runs") }
+    }
+
+    @Test
+    fun `isCmdExe matches the Windows wrapper shape only`() {
+        assertTrue(isCmdExe("""C:\Windows\System32\cmd.exe"""))
+        assertTrue(isCmdExe("CMD.EXE"))
+        assertFalse(isCmdExe("/bin/zsh"))
+        assertFalse(isCmdExe("""C:\Program Files\PowerShell\7\pwsh.exe"""))
+        assertFalse(isCmdExe("""C:\tools\notcmd.exe"""))
+        assertFalse(isCmdExe(""))
     }
 }


### PR DESCRIPTION
Three 0.102 reliability fixes from the "try the remaining 0.102 issues" round. Test-first; each commit atomic.

Fixes #132, fixes #342, fixes #318.

Scope note: a fourth fix (#179, inspection-sweep cancellation) was built, dual-reviewed, then **parked and fully reverted by owner decision** — and subsequently re-validated as **obsolete on IU-2026.1**: live probes show `ProgressManager.checkCanceled()` now observes job cancellation even under an installed `EmptyProgressIndicator` (details + probe data on the closed issue).

## What changed

| Commit | Issue | Change |
|---|---|---|
| 7cfa00cc | #132 | `ParentDeathWatchdog` for `devrig mcp`: ProcessHandle liveness poll (5s × 2 confirmations) on the launching ancestors; orphans self-terminate when the agent dies without closing stdin. Unknown ancestry → disabled (never false-positive) |
| 9dbd4397 | #342 | `devrig install <agent>` / `--check` with a missing CLI prints guidance + exit 64 instead of a raw IOException stacktrace |
| 2bec3232 | #318 | `syncDocuments()` awaits the recursive VFS refresh OFF the EDT (commit/save stay on it); `awaitRefresh` fails fast if ever awaited from the EDT again (the captured 31s RefreshWorker-on-EDT freeze) |
| e8106829 | — | Review fixes: Windows `cmd.exe`-wrapper grandparent watching for #132 (the .cmd launcher can't exec, so `taskkill /F` on the agent leaves the wrapper alive); typed `AgentCliNotLaunchableException` so infrastructure IOExceptions are not misreported as a missing CLI |

## Verification

- `:npx-kt:test`, `:ai-agents:test` green; `:ij-plugin:test` full suite green (282 tests) on the pre-revert tree, scoped re-run green after the #179 revert.
- Dual-model adversarial review (Fable-5 + gpt-5.6-sol) over the pre-revert range:
  - gpt-5.6-sol: 2 findings on the surviving fixes, both applied (#132 Windows-wrapper grandparent watching — real-Windows verification still pending on the issue; #342 typed launch exception). Its remaining findings targeted the reverted #179 work.
  - Fable-5: explicitly no findings on #132/#342/#318 across all lenses (ProcessHandle semantics, IOException scoping, VFS/read-action rules, CLAUDE.md conventions). Its single BLOCKER targeted the reverted #179 work and was empirically refuted before the revert.
- Windows note: the #132 grandparent-watch logic is unit-tested; a real `taskkill /F` process-tree verification on eugene-x220 is tracked on the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
