### PR TITLE
devrig install devrig: guide agent setup; add 'devrig install config' (fix #398)

### DIFF
--- a/ai-agents/build.gradle.kts
+++ b/ai-agents/build.gradle.kts
@@ -7,6 +7,11 @@ repositories {
 }
 
 dependencies {
+    // Pinned to the IDE-bundled kotlinx runtime version (root gradle.properties) because this module
+    // links into the :ij-plugin runtime classpath, where the IDE classloader serves kotlinx jars.
+    val kotlinxSerialization = providers.gradleProperty("mcp.kotlinx.serialization.version").get()
+    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:$kotlinxSerialization")
+
     testImplementation(platform("org.junit:junit-bom:5.11.4"))
     testImplementation("org.junit.jupiter:junit-jupiter")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")

--- a/ai-agents/src/main/kotlin/com/jonnyzzz/mcpSteroid/aiAgents/McpServerConfig.kt
+++ b/ai-agents/src/main/kotlin/com/jonnyzzz/mcpSteroid/aiAgents/McpServerConfig.kt
@@ -2,6 +2,13 @@
 package com.jonnyzzz.mcpSteroid.aiAgents
 
 import kotlin.collections.plus
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.add
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import kotlinx.serialization.json.putJsonArray
+import kotlinx.serialization.json.putJsonObject
 
 const val DEFAULT_SERVER_NAME = "mcp-steroid"
 
@@ -58,6 +65,29 @@ data class StdioMcpCommand(
     val command: String,
     val args: List<String> = emptyList(),
 )
+
+private val stdioMcpServersJsonFormat = Json { prettyPrint = true }
+
+/**
+ * The stdio `mcpServers` JSON snippet for MCP clients configured by hand (an mcp.json-style file):
+ * [command] launches the MCP server over stdio — for devrig, the stable `~/.mcp-steroid/bin` launcher
+ * with the `mcp` subcommand (see `DevrigUserLauncher.invocation`). Built with kotlinx.serialization,
+ * never hand-concatenated: the launcher path is dynamic and must be JSON-escaped (a Windows path
+ * contains backslashes, and the Windows `cmd.exe` invocation embeds quotes). Contrast with
+ * [genericMcpServersJson] — the HTTP variant the in-IDE settings page shows for the in-IDE server.
+ */
+fun stdioMcpServersJson(command: StdioMcpCommand, serverName: String = DEFAULT_SERVER_NAME): String =
+    stdioMcpServersJsonFormat.encodeToString(
+        JsonObject.serializer(),
+        buildJsonObject {
+            putJsonObject("mcpServers") {
+                putJsonObject(serverName) {
+                    put("command", command.command)
+                    putJsonArray("args") { command.args.forEach { add(it) } }
+                }
+            }
+        },
+    )
 
 fun genericMcpServersJson(serverUrl: String, serverName: String = DEFAULT_SERVER_NAME) = buildString {
     appendLine("{")

--- a/ai-agents/src/test/kotlin/com/jonnyzzz/mcpSteroid/aiAgents/McpServerConfigTest.kt
+++ b/ai-agents/src/test/kotlin/com/jonnyzzz/mcpSteroid/aiAgents/McpServerConfigTest.kt
@@ -1,0 +1,53 @@
+/* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
+package com.jonnyzzz.mcpSteroid.aiAgents
+
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class McpServerConfigTest {
+
+    @Test
+    fun `stdioMcpServersJson emits a pretty-printed mcpServers entry with command and args`() {
+        val json = stdioMcpServersJson(StdioMcpCommand("/home/user/.mcp-steroid/bin/devrig", listOf("mcp")))
+
+        assertTrue(json.lines().size > 1, "must be pretty-printed (multi-line), got: $json")
+        val server = Json.parseToJsonElement(json)
+            .jsonObject.getValue("mcpServers")
+            .jsonObject.getValue(DEFAULT_SERVER_NAME)
+            .jsonObject
+        assertEquals("/home/user/.mcp-steroid/bin/devrig", server.getValue("command").jsonPrimitive.content)
+        assertEquals(listOf("mcp"), server.getValue("args").jsonArray.map { it.jsonPrimitive.content })
+    }
+
+    @Test
+    fun `stdioMcpServersJson escapes Windows backslash paths`() {
+        // The Windows launcher invocation: cmd.exe /d /c "<quoted .cmd path> mcp". Both the backslashes
+        // and the embedded quotes MUST be JSON-escaped — hand-concatenation would emit invalid JSON.
+        val line = "\"C:\\Users\\First Last\\.mcp-steroid\\bin\\devrig.cmd\" mcp"
+        val json = stdioMcpServersJson(StdioMcpCommand("cmd.exe", listOf("/d", "/c", line)))
+
+        assertTrue(
+            json.contains("C:\\\\Users\\\\First Last"),
+            "backslashes must appear JSON-escaped in the output, got: $json",
+        )
+        // Round-trip: the emitted JSON must decode back to the exact input command line.
+        val server = Json.parseToJsonElement(json)
+            .jsonObject.getValue("mcpServers")
+            .jsonObject.getValue(DEFAULT_SERVER_NAME)
+            .jsonObject
+        assertEquals("cmd.exe", server.getValue("command").jsonPrimitive.content)
+        assertEquals(listOf("/d", "/c", line), server.getValue("args").jsonArray.map { it.jsonPrimitive.content })
+    }
+
+    @Test
+    fun `stdioMcpServersJson honors a custom server name`() {
+        val json = stdioMcpServersJson(StdioMcpCommand("/opt/devrig", listOf("mcp")), serverName = "custom-name")
+        val servers = Json.parseToJsonElement(json).jsonObject.getValue("mcpServers").jsonObject
+        assertEquals(setOf("custom-name"), servers.keys)
+    }
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -559,8 +559,10 @@ val deployDevrigDist = tasks.register<Sync>("deployDevrigDist") {
 // Local devrig deploy: stage the dist (above), then have devrig regenerate its own stable
 // ~/.mcp-steroid/bin/devrig(.cmd) launcher + PATH registration via `devrig install devrig`
 // — the exact delegation the generated install.sh / install.ps1 use (this build never
-// writes the wrapper itself). The wrapper pins the Gradle daemon's JDK (25, see
-// gradle/gradle-daemon-jvm.properties) through --jdk-home / DEVRIG_JAVA_HOME.
+// writes the wrapper itself). The launcher + JDK flags are SENT by design (a forward
+// contract a future devrig may use); today's devrig ignores them and derives both from its
+// own running process — DEVRIG_JAVA_HOME makes that process run under :npx-kt's toolchain
+// JDK, which devrig then pins into the wrapper.
 val deployDevrig = tasks.register<Exec>("deployDevrig") {
     description = "Deploy devrig to ~/.mcp-steroid/devrig/ and regenerate the ~/.mcp-steroid/bin/devrig launcher."
     group = "deployment"
@@ -595,9 +597,9 @@ val deployDevrig = tasks.register<Exec>("deployDevrig") {
             args(installArgs)
         }
         // DEVRIG_JAVA_HOME beats any JAVA_HOME the caller's shell exported, so the freshly staged
-        // dist always launches on the toolchain JDK (devrig requires it as its runtime).
+        // dist always launches on the toolchain JDK (devrig requires it as its runtime) and pins
+        // exactly that JDK into the wrapper. Setting JAVA_HOME is not needed.
         environment("DEVRIG_JAVA_HOME", jdkHome)
-        environment("JAVA_HOME", jdkHome)
     }
     // `devrig install devrig` is contractually non-interactive (see runInstallDevrigCommand):
     // hand it an already-EOF stdin, mirroring install.sh's `< /dev/null` and install.ps1's `$null |`.

--- a/docs/devrig-deployment-spec.md
+++ b/docs/devrig-deployment-spec.md
@@ -29,14 +29,16 @@ PATH. The mcp-steroid Java binary + a matching Amazon Corretto JDK are
 cached under `~/.mcp-steroid/binaries/`. After install, **zero network
 calls** unless `devrig upgrade` is run or a cache directory is missing.
 
-> **Implementation note (PR #117/#124):** the install script no longer writes
-> `bin/devrig` itself (the "bootstrap mode → write the script's own bytes →
-> bin/devrig" step below is stale on this point). After unpack it delegates to
-> the register-only subcommand `devrig install devrig --install-script=<launcher>
-> --jdk-home=<jdk>`; the **devrig binary owns the wrapper + PATH** (atomic
-> self-heal on every start, gated by `DEVRIG_BIN_NO_AUTO_REGISTER`). Motto: the
-> install script passes ALL non-trivial params to the binary — no env-derived
-> magic.
+> **Implementation note (PR #117/#124, revised for #398):** the install script
+> no longer writes `bin/devrig` itself (the "bootstrap mode → write the script's
+> own bytes → bin/devrig" step below is stale on this point). After unpack it
+> delegates to the register-only subcommand `devrig install devrig
+> --install-script=<launcher> --jdk-home=<jdk>`, run under the bundled JDK via a
+> process-scoped `DEVRIG_JAVA_HOME` (the user's `JAVA_HOME` is never touched);
+> the **devrig binary owns the wrapper + PATH** (atomic self-heal on every
+> start, gated by `DEVRIG_BIN_NO_AUTO_REGISTER`). The flags are SENT by design —
+> a forward contract a future devrig may use; today's devrig parses and ignores
+> them, deriving the install tree + JDK from its own running process.
 >
 > **Windows PATH:** the launcher only CHECKS user-PATH membership at startup
 > (pure Java can't persist user PATH; no PowerShell on the start/MCP hot path)

--- a/installer-gen/src/installerIntegrationTest/kotlin/com/jonnyzzz/mcpSteroid/installer/tests/InstallerBootstrapPs1Test.kt
+++ b/installer-gen/src/installerIntegrationTest/kotlin/com/jonnyzzz/mcpSteroid/installer/tests/InstallerBootstrapPs1Test.kt
@@ -131,10 +131,12 @@ class InstallerBootstrapPs1Test {
         val run1 = runInstall(install, env)
             .assertExitCode(0) { "install.ps1 run #1 failed:\n$this" }
             .assertOutputContains("downloading devrig", "downloading jdk", message = "run #1 (clean HOME) must download both")
-            // The pwsh script ran the UNPACKED devrig launcher with the computed path + bundled JDK.
+            // The pwsh script ran the UNPACKED devrig launcher with the computed launcher + JDK flags
+            // (sent by design — today's devrig ignores them, #398) under the bundled JDK via DEVRIG_JAVA_HOME.
             .assertOutputContains(
                 "DEVRIG_INSTALL_DEVRIG", "--install-script=$expectedLauncher", "--jdk-home=$expectedJdkHome",
-                message = "install.ps1 must delegate to 'devrig install devrig' with the computed launcher + jdk-home",
+                "jdk=$expectedJdkHome",
+                message = "install.ps1 must delegate to 'devrig install devrig' with the computed flags, under the bundled JDK",
             )
             .assertOutputContains("devrig binary is ready", "devrig install", message = "must report ready + how to register with agents")
         // NEVER auto-register with an agent (would edit agent configs — that is an explicit user step).
@@ -336,7 +338,7 @@ class InstallerBootstrapPs1Test {
         val script = buildString {
             append("#!/bin/sh\n")
             append("if [ \"\$1\" = \"install\" ] && [ \"\$2\" = \"devrig\" ]; then\n")
-            append("  echo \"DEVRIG_INSTALL_DEVRIG \$*\"\n")
+            append("  echo \"DEVRIG_INSTALL_DEVRIG \$* jdk=\${DEVRIG_JAVA_HOME:-}\"\n")
             append("  exit 0\n")
             append("fi\n")
             append("case \"\$1\" in\n")

--- a/installer-gen/src/installerIntegrationTest/kotlin/com/jonnyzzz/mcpSteroid/installer/tests/InstallerBootstrapTest.kt
+++ b/installer-gen/src/installerIntegrationTest/kotlin/com/jonnyzzz/mcpSteroid/installer/tests/InstallerBootstrapTest.kt
@@ -149,10 +149,12 @@ class InstallerBootstrapTest {
         val run1 = runInstall(install, mapOf("HOME" to homeDir, "DEVRIG_OS" to "linux", "DEVRIG_CPU" to "x64"))
             .assertExitCode(0) { "install.sh run #1 failed:\n$this" }
             .assertOutputContains("downloading devrig", "downloading jdk", message = "run #1 (clean HOME) must download both")
-            // The script ran the UNPACKED devrig with the correct, computed launcher path + bundled JDK.
+            // The script ran the UNPACKED devrig with the computed launcher + JDK flags (sent by design —
+            // today's devrig ignores them, #398) under the bundled JDK via DEVRIG_JAVA_HOME.
             .assertOutputContains(
                 "DEVRIG_INSTALL_DEVRIG", "--install-script=$expectedLauncher", "--jdk-home=$expectedJdkHome",
-                message = "install.sh must delegate to 'devrig install devrig' with the computed launcher + jdk-home",
+                "jdk=$expectedJdkHome",
+                message = "install.sh must delegate to 'devrig install devrig' with the computed flags, under the bundled JDK",
             )
             .assertOutputContains("devrig binary is ready", "devrig install", message = "must report ready + how to register with agents")
         run1.assertNoMessageInOutput("DEVRIG_INSTALL_CALLED") // must NOT auto-register with an AGENT
@@ -237,7 +239,7 @@ class InstallerBootstrapTest {
         val script = buildString {
             append("#!/bin/sh\n")
             append("if [ \"\$1\" = \"install\" ] && [ \"\$2\" = \"devrig\" ]; then\n")
-            append("  echo \"DEVRIG_INSTALL_DEVRIG \$*\"\n")
+            append("  echo \"DEVRIG_INSTALL_DEVRIG \$* jdk=\${DEVRIG_JAVA_HOME:-}\"\n")
             append("  exit 0\n")
             append("fi\n")
             append("case \"\$1\" in\n")

--- a/installer-gen/src/main/resources/templates/install.ps1.tmpl
+++ b/installer-gen/src/main/resources/templates/install.ps1.tmpl
@@ -157,18 +157,16 @@ $null | & $launcher install devrig "--install-script=$launcher" "--jdk-home=$jdk
 if ($LASTEXITCODE -ne 0) { Fail "'devrig install devrig' failed (exit $LASTEXITCODE) - the launcher could not register itself" }
 
 # -- done. We do NOT auto-register devrig with agents - that edits agent configs, so it is an
-#    explicit user step. --
+#    explicit user step. The 'devrig install devrig' handoff above already printed the next-steps
+#    guidance (one 'devrig install <agent>' per agent with CLI detection, plus 'devrig install
+#    config'), so no duplicate next-steps block here. --
 # `devrig install devrig` registers $BinDir on the persistent user PATH (HKCU\Environment), which only
-# reaches NEW shells - but `irm | iex` runs in the caller's session and the guidance below tells the
-# user to run `devrig install <agent>` right away. Prepend $BinDir in THIS session so that works.
+# reaches NEW shells - but `irm | iex` runs in the caller's session and the guidance devrig printed
+# above tells the user to run `devrig install <agent>` right away. Prepend $BinDir in THIS session so
+# that works.
 # ';' + case-insensitive -notcontains are Windows PATH semantics (the pwsh-on-Linux run is smoke only).
 if (($env:PATH -split ';') -notcontains $BinDir) { $env:PATH = "$BinDir;$env:PATH" }
 Write-Log "devrig binary is ready."
-Write-Log ""
-Write-Log "To register devrig with your agent, run one of:"
-Write-Log "    devrig install claude"
-Write-Log "    devrig install codex"
-Write-Log "    devrig install gemini"
 }
 finally {
   # Restore the caller's progress preference so `irm | iex` leaves the session as it found it.

--- a/installer-gen/src/main/resources/templates/install.ps1.tmpl
+++ b/installer-gen/src/main/resources/templates/install.ps1.tmpl
@@ -143,10 +143,14 @@ if (-not (Test-Path (Join-Path $jdkHome 'bin\java.exe'))) {
 }
 
 # -- hand off to devrig: it OWNS ~\.mcp-steroid\bin + PATH (no duplicate launcher written here) --
-# Pass every non-trivial parameter explicitly (the install-tree launcher + the bundled JDK); devrig
-# registers itself. JAVA_HOME is set only so the unpacked devrig runs under the bundled JDK right now.
+# The launcher + JDK paths are SENT by design (a forward contract a future devrig may use); today's
+# devrig ignores them and derives both from its own running process. DEVRIG_JAVA_HOME (devrig's own
+# variable, honored by the dist launcher) makes this one invocation run under the bundled JDK, which
+# devrig then pins into the launcher. `irm | iex` runs in the caller's session, so the variable is
+# restored right after the call and the user's JAVA_HOME is never touched.
 Write-Log "registering devrig (devrig install devrig)..."
-$env:JAVA_HOME = $jdkHome
+$SteroidPrevDevrigJavaHome = $env:DEVRIG_JAVA_HOME
+$env:DEVRIG_JAVA_HOME = $jdkHome
 # Pipe $null so the launcher's child process gets an empty stdin that reads EOF immediately. `irm | iex`
 # is a PowerShell OBJECT pipeline (not a POSIX stdin pipe), so the script runs inside the caller's PS
 # host and a native child would otherwise inherit THAT host's stdin handle - an interactive console, or
@@ -154,12 +158,14 @@ $env:JAVA_HOME = $jdkHome
 # waited on a Console.ReadLine style prompt) could block with no user recourse. `$null |` removes that
 # risk - `devrig install devrig` is contractually non-interactive (see runInstallDevrigCommand).
 $null | & $launcher install devrig "--install-script=$launcher" "--jdk-home=$jdkHome"
-if ($LASTEXITCODE -ne 0) { Fail "'devrig install devrig' failed (exit $LASTEXITCODE) - the launcher could not register itself" }
+$devrigExit = $LASTEXITCODE
+$env:DEVRIG_JAVA_HOME = $SteroidPrevDevrigJavaHome
+if ($devrigExit -ne 0) { Fail "'devrig install devrig' failed (exit $devrigExit) - the launcher could not register itself" }
 
-# -- done. We do NOT auto-register devrig with agents - that edits agent configs, so it is an
-#    explicit user step. The 'devrig install devrig' handoff above already printed the next-steps
-#    guidance (one 'devrig install <agent>' per agent with CLI detection, plus 'devrig install
-#    config'), so no duplicate next-steps block here. --
+# -- done. We do NOT auto-register devrig with agents or install the IDE plugin - both edit state
+#    outside ~/.mcp-steroid, so they are explicit user steps. The 'devrig install devrig' handoff above
+#    already printed the one next-steps message (install plugin / connect agent / show config), so no
+#    duplicate next-steps block here. --
 # `devrig install devrig` registers $BinDir on the persistent user PATH (HKCU\Environment), which only
 # reaches NEW shells - but `irm | iex` runs in the caller's session and the guidance devrig printed
 # above tells the user to run `devrig install <agent>` right away. Prepend $BinDir in THIS session so

--- a/installer-gen/src/main/resources/templates/install.sh.tmpl
+++ b/installer-gen/src/main/resources/templates/install.sh.tmpl
@@ -170,21 +170,23 @@ main() {
   [ -x "$jdk_home/bin/java" ] || fail "bin/java not found inside $jdk_home"
 
   # -- hand off to devrig: it OWNS ~/.mcp-steroid/bin/devrig + PATH (no duplicate wrapper here) --
-  # We pass every non-trivial parameter explicitly (the install-tree launcher + the bundled JDK); devrig
-  # registers itself. JAVA_HOME is set only so the unpacked devrig runs under the bundled JDK right now.
+  # The launcher + JDK paths are SENT by design (a forward contract a future devrig may use); today's
+  # devrig ignores them and derives both from its own running process. DEVRIG_JAVA_HOME (devrig's own
+  # variable, honored by the dist launcher; process-scoped so the user's environment is untouched) makes
+  # this one invocation run under the bundled JDK, which devrig then pins into the launcher.
   # Redirect stdin from /dev/null so devrig inherits an already-closed stdin: when this installer is
   # bootstrapped via `curl | sh`, the parent sh reads stdin from a pipe still open to the shell that
   # ran curl. A devrig subprocess that read stdin (or waited on a prompt) would hang forever with no
   # user recourse. `< /dev/null` gives it an already-closed stdin - `devrig install devrig` is
   # contractually non-interactive (see runInstallDevrigCommand; mirrors the install.ps1 `$null |`).
   log "registering devrig (devrig install devrig)..."
-  JAVA_HOME="$jdk_home" "$launcher" install devrig --install-script="$launcher" --jdk-home="$jdk_home" < /dev/null \
+  DEVRIG_JAVA_HOME="$jdk_home" "$launcher" install devrig --install-script="$launcher" --jdk-home="$jdk_home" < /dev/null \
     || fail "'devrig install devrig' failed - the launcher could not register itself"
 
-  # -- done. We do NOT auto-register devrig with agents - that edits agent configs, so it is an
-  #    explicit user step. The 'devrig install devrig' handoff above already printed the next-steps
-  #    guidance (one 'devrig install <agent>' per agent with CLI detection, plus 'devrig install
-  #    config'), so no duplicate next-steps block here. --
+  # -- done. We do NOT auto-register devrig with agents or install the IDE plugin - both edit state
+  #    outside ~/.mcp-steroid, so they are explicit user steps. The 'devrig install devrig' handoff
+  #    above already printed the one next-steps message (install plugin / connect agent / show config),
+  #    so no duplicate next-steps block here. --
   log "devrig binary is ready."
 }
 

--- a/installer-gen/src/main/resources/templates/install.sh.tmpl
+++ b/installer-gen/src/main/resources/templates/install.sh.tmpl
@@ -182,13 +182,10 @@ main() {
     || fail "'devrig install devrig' failed - the launcher could not register itself"
 
   # -- done. We do NOT auto-register devrig with agents - that edits agent configs, so it is an
-  #    explicit user step. --
+  #    explicit user step. The 'devrig install devrig' handoff above already printed the next-steps
+  #    guidance (one 'devrig install <agent>' per agent with CLI detection, plus 'devrig install
+  #    config'), so no duplicate next-steps block here. --
   log "devrig binary is ready."
-  log ""
-  log "To register devrig with your agent, run one of:"
-  log "    devrig install claude"
-  log "    devrig install codex"
-  log "    devrig install gemini"
 }
 
 main "$@"

--- a/installer-gen/src/test/kotlin/com/jonnyzzz/mcpSteroid/installer/InstallerGeneratorTest.kt
+++ b/installer-gen/src/test/kotlin/com/jonnyzzz/mcpSteroid/installer/InstallerGeneratorTest.kt
@@ -116,19 +116,23 @@ class InstallerGeneratorTest {
     }
 
     @Test
-    fun `final guidance recommends agent-qualified install commands, never bare devrig install`() {
-        // jonnyzzz/mcp-steroid#320: `devrig install` has a required <agent> argument, so the old
-        // "run: devrig install" next-step guidance errored on every fresh install. Both scripts must
-        // print agent-qualified commands instead.
+    fun `scripts leave the next-steps guidance to devrig and never recommend bare devrig install`() {
+        // jonnyzzz/mcp-steroid#398: `devrig install devrig` itself prints the next-steps guidance
+        // (one agent-qualified command per agent WITH CLI detection, plus `devrig install config`), so
+        // the scripts must not print a second, drifting copy of that block — the first-run terminal
+        // shows exactly one next-steps block, devrig's own.
         val scripts = renderInstallerScripts(jdkScriptTable(fullModel()), devrig, "1.2.3")
 
-        listOf("devrig install claude", "devrig install codex", "devrig install gemini").forEach {
-            assertTrue(scripts.sh.contains(it), "install.sh guidance missing '$it'")
-            assertTrue(scripts.ps.contains(it), "install.ps1 guidance missing '$it'")
+        listOf(scripts.sh to "install.sh", scripts.ps to "install.ps1").forEach { (script, name) ->
+            assertTrue(
+                !script.contains("To register devrig with your agent"),
+                "$name must not duplicate devrig's own next-steps guidance",
+            )
+            // jonnyzzz/mcp-steroid#320 regression: `devrig install` has a required <agent> argument, so
+            // a bare `devrig install` recommendation (right before a closing quote) errored on every
+            // fresh install — the scripts must never suggest it.
+            assertTrue(!script.contains("devrig install\""), "$name must not recommend bare 'devrig install'")
         }
-        // A bare `devrig install` right before the closing quote is the broken recommendation.
-        assertTrue(!scripts.sh.contains("devrig install\""), "install.sh must not recommend bare 'devrig install'")
-        assertTrue(!scripts.ps.contains("devrig install\""), "install.ps1 must not recommend bare 'devrig install'")
     }
 
     @Test

--- a/installer-gen/src/test/kotlin/com/jonnyzzz/mcpSteroid/installer/InstallerGeneratorTest.kt
+++ b/installer-gen/src/test/kotlin/com/jonnyzzz/mcpSteroid/installer/InstallerGeneratorTest.kt
@@ -136,6 +136,35 @@ class InstallerGeneratorTest {
     }
 
     @Test
+    fun `the devrig handoff sends the launcher and jdk flags by design and runs under DEVRIG_JAVA_HOME`() {
+        // jonnyzzz/mcp-steroid#398: the scripts SEND --install-script/--jdk-home by design — a forward
+        // contract a future devrig may use; today's devrig parses and ignores them, deriving both from
+        // its own running process. The one invocation runs under the bundled JDK via DEVRIG_JAVA_HOME —
+        // devrig's own variable, honored by the dist launcher; setting JAVA_HOME is not needed.
+        val scripts = renderInstallerScripts(jdkScriptTable(fullModel()), devrig, "1.2.3")
+
+        listOf(scripts.sh to "install.sh", scripts.ps to "install.ps1").forEach { (script, name) ->
+            assertTrue(script.contains("--install-script="), "$name must send --install-script")
+            assertTrue(script.contains("--jdk-home="), "$name must send --jdk-home")
+        }
+        assertTrue(
+            scripts.sh.contains("DEVRIG_JAVA_HOME=\"\$jdk_home\" \"\$launcher\" install devrig"),
+            "install.sh must scope DEVRIG_JAVA_HOME to the handoff invocation",
+        )
+        // Anchored: a plain-substring check would trip over DEVRIG_JAVA_HOME= containing JAVA_HOME=.
+        assertTrue(
+            !scripts.sh.contains(Regex("(?<![A-Z_])JAVA_HOME=")),
+            "install.sh sets DEVRIG_JAVA_HOME for the handoff — setting JAVA_HOME is not needed",
+        )
+        assertTrue(scripts.ps.contains("\$env:DEVRIG_JAVA_HOME = \$jdkHome"), "install.ps1 must set DEVRIG_JAVA_HOME for the handoff")
+        assertTrue(
+            scripts.ps.contains("\$env:DEVRIG_JAVA_HOME = \$SteroidPrevDevrigJavaHome"),
+            "install.ps1 runs in the caller's session and must restore DEVRIG_JAVA_HOME after the handoff",
+        )
+        assertTrue(!scripts.ps.contains("\$env:JAVA_HOME"), "install.ps1 sets DEVRIG_JAVA_HOME for the handoff — setting JAVA_HOME is not needed")
+    }
+
+    @Test
     fun `install_ps1 prepends BinDir to the current session PATH after the devrig handoff`() {
         // jonnyzzz/mcp-steroid#275: `devrig install devrig` registers the bin dir persistently
         // (HKCU\Environment), which only reaches NEW shells — but `irm | iex` runs in the caller's

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/BinLauncher.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/BinLauncher.kt
@@ -127,8 +127,7 @@ internal fun ensureBinLauncher(
 /**
  * The launcher-writing core: write `~/.mcp-steroid/bin/devrig`(`.cmd`) so it pins [jdkHome] via
  * `DEVRIG_JAVA_HOME` and execs the install-tree launcher [ownBin], then ensure it is on PATH. Both inputs
- * are EXPLICIT (no `DevrigRoot`/`java.home` lookups) so `devrig install devrig` can register the exact
- * launcher + JDK the install script computed and passed in.
+ * are EXPLICIT (no `DevrigRoot`/`java.home` lookups) for testability.
  */
 internal fun ensureBinLauncherCore(
     home: HomePaths,
@@ -151,36 +150,6 @@ internal fun ensureBinLauncherCore(
         val devrig = home.binDir.resolve("devrig")
         writeIfChanged(home.binDir, devrig, renderPosixLauncher(ownBin, jdkHome), executable = true, ownBin = ownBin)
         ensurePosixPathSymlink(home.binDir, devrig, userHome, pathDirs)
-    }
-}
-
-/**
- * Register `~/.mcp-steroid/bin/devrig`(`.cmd`) + PATH for an EXPLICIT install-tree launcher [installScript]
- * and [jdkHome] (rather than deriving them from the running process). This is what `devrig install devrig`
- * uses: the install script unpacks devrig + a JDK and passes their paths in. [force] defaults true
- * (explicit user intent — writes even on a SNAPSHOT/dev dist; an explicit `DEVRIG_BIN_NO_AUTO_REGISTER`
- * opt-out still wins).
- */
-fun ensureBinLauncherForInstallScript(
-    home: HomePaths,
-    installScript: Path,
-    jdkHome: Path,
-    force: Boolean = true,
-    registerWindowsPath: Boolean = true,
-) {
-    if (!shouldWriteLauncher(System.getenv(ENV_BIN_NO_AUTO_REGISTER), force)) return
-    try {
-        ensureBinLauncherCore(
-            home = home,
-            isWin = isWindows(),
-            ownBin = installScript.toAbsolutePath().normalize(),
-            jdkHome = jdkHome.toAbsolutePath().normalize(),
-            userHome = Path.of(System.getProperty("user.home")).toAbsolutePath().normalize(),
-            pathDirs = (System.getenv("PATH") ?: "").split(File.pathSeparatorChar),
-            registerWindowsPath = registerWindowsPath,
-        )
-    } catch (e: Exception) {
-        System.err.println("[mcp-steroid] could not (re)write the devrig launcher: $e")
     }
 }
 

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/Cli.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/Cli.kt
@@ -80,14 +80,13 @@ sealed interface DevrigCommand {
     ) : DevrigCommand
 
     /**
-     * `devrig install devrig` — register devrig's OWN `~/.mcp-steroid/bin` launcher + PATH (NOT an agent).
-     * Two modes (issue #398): hand-run with no flags it re-registers from the RUNNING binary's own
-     * install; the install scripts call it with every non-trivial parameter explicit — [installScript]
-     * (the install-tree launcher the wrapper execs) and [jdkHome] (pinned as `DEVRIG_JAVA_HOME`).
+     * `devrig install devrig` — register devrig's OWN `~/.mcp-steroid/bin` launcher + PATH (NOT an
+     * agent) and print the next-steps info message. One behavior, same result on every call (issue
+     * #398): registration always derives the install tree + JDK from the running binary. The
+     * `--install-script` / `--jdk-home` flags the install scripts send (a forward contract, by design)
+     * are accepted and ignored today.
      */
     data class DevrigCommandInstallDevrig(
-        val installScript: String? = null,
-        val jdkHome: String? = null,
         override val debug: Boolean = false,
         override val json: Boolean = false,
     ) : DevrigCommand
@@ -106,8 +105,8 @@ sealed interface DevrigCommand {
     /**
      * `devrig install plugin` — install the MCP Steroid plugin into locally-running JetBrains IDEs via
      * each IDE's built-in REST endpoint (which shows the IDE's own native install dialog). [check] is a
-     * read-only dry-run: report which IDEs would be asked, show no dialog. Also invoked, best-effort, from
-     * `devrig install devrig`.
+     * read-only dry-run: report which IDEs would be asked, show no dialog. The EXPLICIT plugin-install
+     * step — `devrig install devrig` only promotes this command, it never runs it (issue #398).
      */
     data class DevrigCommandInstallPlugin(
         val check: Boolean = false,
@@ -260,7 +259,9 @@ private class InstallCommand(
     parent: DevrigCliktCommand,
 ) : DevrigCliktCommand("install", selected, parent) {
     private val agent by argument("agent").optional()
-    // Only meaningful for `install devrig` (the install scripts pass them); rejected for agents below.
+    // `install devrig` flags the install scripts SEND by design (a forward contract a future devrig
+    // may use); accepted there and IGNORED today (registration derives everything from the running
+    // binary). Rejected for other targets.
     private val installScript: String? by option("--install-script")
     private val jdkHome: String? by option("--jdk-home")
     private val checkFlag by option(
@@ -282,20 +283,11 @@ private class InstallCommand(
         }
         if (agent == "devrig") {
             if (checkFlag) throw UsageError("--check is only valid for an agent install (claude / codex / gemini) or 'devrig install plugin'")
-            // A blank --install-script (an unset shell variable in a wrapper: --install-script="$launcher")
-            // must not silently flip to the self-registration mode, which would register the RUNNING
-            // binary and drop an explicit --jdk-home — fail fast instead (issue #398).
-            if (installScript?.isBlank() == true) {
-                throw UsageError("--install-script must not be blank — pass the full path of the unpacked install-tree launcher (or omit the flag to re-register the running install)")
-            }
-            // --jdk-home only makes sense alongside --install-script (the install scripts pass both);
-            // alone it is a mistake — fail fast rather than guess the registration mode (issue #398).
-            if (installScript == null && jdkHome != null) {
-                throw UsageError("--jdk-home is only valid together with --install-script (the install scripts pass both)")
-            }
-            select(DevrigCommand.DevrigCommandInstallDevrig(
-                installScript = installScript, jdkHome = jdkHome, debug = options.debug, json = options.json,
-            ))
+            // --install-script / --jdk-home are IGNORED here (not stored): the command always derives
+            // the install tree + JDK from the running binary, so it behaves identically with or
+            // without them. The install scripts keep SENDING them by design — a forward contract a
+            // future devrig may use (issue #398).
+            select(DevrigCommand.DevrigCommandInstallDevrig(debug = options.debug, json = options.json))
             return
         }
         if (agent == "config") {
@@ -429,7 +421,7 @@ fun DevrigServices.runCli(command: DevrigCommand): Int {
             is DevrigCommand.DevrigCommandProject -> runProjectCommand(command)
             is DevrigCommand.DevrigCommandInstall -> runInstallCommand(command)
             is DevrigCommand.DevrigCommandInstallOverview -> runInstallOverviewCommand()
-            is DevrigCommand.DevrigCommandInstallDevrig -> runInstallDevrigCommand(command)
+            is DevrigCommand.DevrigCommandInstallDevrig -> runInstallDevrigCommand()
             is DevrigCommand.DevrigCommandInstallConfig -> runInstallConfigCommand()
             is DevrigCommand.DevrigCommandInstallPlugin -> runInstallPluginCommand(command)
         }

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/Cli.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/Cli.kt
@@ -81,12 +81,24 @@ sealed interface DevrigCommand {
 
     /**
      * `devrig install devrig` — register devrig's OWN `~/.mcp-steroid/bin` launcher + PATH (NOT an agent).
-     * The install scripts call this with every non-trivial parameter explicit: [installScript] (the
-     * install-tree launcher the wrapper execs) and [jdkHome] (pinned as `DEVRIG_JAVA_HOME`).
+     * Two modes (issue #398): hand-run with no flags it re-registers from the RUNNING binary's own
+     * install; the install scripts call it with every non-trivial parameter explicit — [installScript]
+     * (the install-tree launcher the wrapper execs) and [jdkHome] (pinned as `DEVRIG_JAVA_HOME`).
      */
     data class DevrigCommandInstallDevrig(
         val installScript: String? = null,
         val jdkHome: String? = null,
+        override val debug: Boolean = false,
+        override val json: Boolean = false,
+    ) : DevrigCommand
+
+    /**
+     * `devrig install config` — print the MANUAL MCP configuration recipe: the stdio `mcpServers` JSON
+     * snippet pointing at the stable launcher, plus the per-agent `mcp add` command lines. For MCP
+     * clients devrig cannot configure automatically (issue #398). Informational like `install` overview:
+     * read-only, exits 0, ignores --json (the output already IS the JSON snippet plus its context).
+     */
+    data class DevrigCommandInstallConfig(
         override val debug: Boolean = false,
         override val json: Boolean = false,
     ) : DevrigCommand
@@ -263,16 +275,34 @@ private class InstallCommand(
             // Bare `devrig install`: overview mode (#277). Target-specific flags still need a target —
             // silently ignoring them would hide a typo like `devrig install --check claude` gone wrong.
             if (checkFlag || installScript != null || jdkHome != null) {
-                throw UsageError("--check / --install-script / --jdk-home require an install target (claude / codex / gemini / plugin / devrig)")
+                throw UsageError("--check / --install-script / --jdk-home require an install target (claude / codex / gemini / plugin / devrig / config)")
             }
             select(DevrigCommand.DevrigCommandInstallOverview(debug = options.debug, json = options.json))
             return
         }
         if (agent == "devrig") {
             if (checkFlag) throw UsageError("--check is only valid for an agent install (claude / codex / gemini) or 'devrig install plugin'")
+            // A blank --install-script (an unset shell variable in a wrapper: --install-script="$launcher")
+            // must not silently flip to the self-registration mode, which would register the RUNNING
+            // binary and drop an explicit --jdk-home — fail fast instead (issue #398).
+            if (installScript?.isBlank() == true) {
+                throw UsageError("--install-script must not be blank — pass the full path of the unpacked install-tree launcher (or omit the flag to re-register the running install)")
+            }
+            // --jdk-home only makes sense alongside --install-script (the install scripts pass both);
+            // alone it is a mistake — fail fast rather than guess the registration mode (issue #398).
+            if (installScript == null && jdkHome != null) {
+                throw UsageError("--jdk-home is only valid together with --install-script (the install scripts pass both)")
+            }
             select(DevrigCommand.DevrigCommandInstallDevrig(
                 installScript = installScript, jdkHome = jdkHome, debug = options.debug, json = options.json,
             ))
+            return
+        }
+        if (agent == "config") {
+            if (checkFlag || installScript != null || jdkHome != null) {
+                throw UsageError("--check / --install-script / --jdk-home are not valid with 'devrig install config'")
+            }
+            select(DevrigCommand.DevrigCommandInstallConfig(debug = options.debug, json = options.json))
             return
         }
         if (agent == "plugin") {
@@ -283,7 +313,7 @@ private class InstallCommand(
             return
         }
         val target = AiAgentCli.parse(agent)
-            ?: throw UsageError("agent must be one of: claude, codex, gemini, devrig, plugin")
+            ?: throw UsageError("agent must be one of: claude, codex, gemini, devrig, plugin, config")
         if (installScript != null || jdkHome != null) {
             throw UsageError("--install-script / --jdk-home are only valid with 'devrig install devrig'")
         }
@@ -400,6 +430,7 @@ fun DevrigServices.runCli(command: DevrigCommand): Int {
             is DevrigCommand.DevrigCommandInstall -> runInstallCommand(command)
             is DevrigCommand.DevrigCommandInstallOverview -> runInstallOverviewCommand()
             is DevrigCommand.DevrigCommandInstallDevrig -> runInstallDevrigCommand(command)
+            is DevrigCommand.DevrigCommandInstallConfig -> runInstallConfigCommand()
             is DevrigCommand.DevrigCommandInstallPlugin -> runInstallPluginCommand(command)
         }
     } catch (e: ManagedBackendLockException) {

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/DevrigBeacon.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/DevrigBeacon.kt
@@ -73,9 +73,10 @@ class DevrigBeacon(
             is DevrigCommand.DevrigCommandInstall -> "install"
             is DevrigCommand.DevrigCommandInstallDevrig -> "install"
             is DevrigCommand.DevrigCommandInstallPlugin -> "install"
-            // Overview is informational (help-like); captureStarted is only reached for runsTool()
-            // commands anyway, so this stays a non-event.
+            // Overview and config are informational (help-like); captureStarted is only reached for
+            // runsTool() commands anyway, so these stay non-events.
             is DevrigCommand.DevrigCommandInstallOverview -> null
+            is DevrigCommand.DevrigCommandInstallConfig -> null
             is DevrigCommand.DevrigCommandHelp -> null
             is DevrigCommand.DevrigCommandVersion -> null
             is DevrigCommand.DevrigCommandParseError -> null

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/HelpCommand.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/HelpCommand.kt
@@ -37,6 +37,12 @@ fun printHelp(out: PrintStream) : Int {
                                          MCP Steroid plugin are reachable; exits 1
                                          when install would change anything.
 
+          devrig install config          print the manual MCP configuration for
+                                         agents devrig cannot configure
+                                         automatically: the stdio mcpServers JSON
+                                         (mcp.json) snippet plus the per-agent
+                                         mcp-add commands.
+
           devrig backend download [<id>] [--version <v>] [--json]
                                          no id → list IDEs available for download.
                                          With id, download and install a managed

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/InstallCommand.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/InstallCommand.kt
@@ -1,6 +1,7 @@
 /* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
 package com.jonnyzzz.mcpSteroid.devrig
 
+import com.jonnyzzz.mcpSteroid.aiAgents.AiAgentCli
 import com.jonnyzzz.mcpSteroid.aiAgents.AiAgentCliResult
 import com.jonnyzzz.mcpSteroid.aiAgents.AiAgentCliRunner
 import com.jonnyzzz.mcpSteroid.aiAgents.ProcessAiAgentCliRunner
@@ -85,14 +86,19 @@ fun runInstallDevrigCommand(
  * instead of claiming PATH reachability. Pure renderer for testability.
  */
 fun renderInstallDevrigInfo(launcherPath: Path): String = buildString {
+    // Every agent listed on one line, derived from the enum — no favorite named first in prose.
+    val nextSteps = listOf(
+        "devrig install plugin" to "install the MCP Steroid plugin into your running JetBrains IDEs",
+        "devrig install ${AiAgentCli.entries.joinToString("|") { it.binary }}" to "connect devrig to your AI agent",
+        "devrig install config" to "print the mcp.json snippet for any other MCP client",
+    )
+    val column = nextSteps.maxOf { it.first.length } + 4
     appendLine("devrig is installed: $launcherPath")
     appendLine("The launcher and PATH registration self-heal on every devrig run. If 'devrig' is not")
     appendLine("found, open a new terminal (Windows) or add ${launcherPath.parent} to PATH.")
     appendLine()
     appendLine("Next steps:")
-    appendLine("  devrig install plugin    install the MCP Steroid plugin into your running JetBrains IDEs")
-    appendLine("  devrig install claude    connect devrig to Claude Code (also: codex, gemini)")
-    appendLine("  devrig install config    print the mcp.json snippet for any other MCP client")
+    for ((command, explanation) in nextSteps) appendLine("  ${command.padEnd(column)}$explanation")
 }
 
 fun DevrigServices.runInstallCommand(

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/InstallCommand.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/InstallCommand.kt
@@ -1,7 +1,6 @@
 /* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
 package com.jonnyzzz.mcpSteroid.devrig
 
-import com.jonnyzzz.mcpSteroid.aiAgents.AiAgentCli
 import com.jonnyzzz.mcpSteroid.aiAgents.AiAgentCliResult
 import com.jonnyzzz.mcpSteroid.aiAgents.AiAgentCliRunner
 import com.jonnyzzz.mcpSteroid.aiAgents.ProcessAiAgentCliRunner
@@ -20,20 +19,21 @@ private const val DEVRIG_LEGACY_SERVER_NAME = "devrig"
 const val INSTALL_CHECK_DRIFT_EXIT_CODE = 1
 
 /**
- * `devrig install devrig` — generate + register devrig's own `~/.mcp-steroid/bin/devrig`(`.cmd`) launcher
- * and put it on PATH. This is devrig's normal launcher self-registration ([ensureBinLauncher], which runs
- * on every start), in one of two modes (issue #398):
+ * `devrig install devrig` — one behavior, same result on every call (issue #398): re-register devrig's
+ * own `~/.mcp-steroid/bin/devrig`(`.cmd`) launcher + PATH, then print ONE info message with the next
+ * steps. Registration is [ensureBinLauncher] — the exact self-heal that already runs on EVERY devrig
+ * start, deriving the install tree and JDK from the running binary — so this command mostly re-confirms
+ * what start-up already did (with `force = true` so even a SNAPSHOT/dev dist writes, and with the
+ * Windows PATH registration that the `devrig mcp` hot path skips).
  *
- *  - **No flags** (hand-run — the bare `devrig install` overview lists this target): re-register the
- *    launcher + PATH from the RUNNING binary's own install tree and JDK — the same
- *    `ensureBinLauncher(force = true)` self-heal every `devrig install <agent>` performs.
- *  - **`--install-script` (with optional `--jdk-home`)** — the generated bootstrap installers: register
- *    the EXPLICIT unpacked install-tree launcher the wrapper execs, pinning `--jdk-home` as
- *    `DEVRIG_JAVA_HOME` (falling back to the JDK we run under).
+ * It does ONLY that. NO agent registration and NO plugin install into IDEs — both edit state outside
+ * `~/.mcp-steroid`, so they stay explicit commands (`devrig install <agent>`, `devrig install plugin`)
+ * that the printed message promotes.
  *
- * It does ONLY that — NO agent registration (that edits agent configs, so it stays an explicit
- * `devrig install <agent>` step). After registering it prints the agent-setup guidance so the user
- * knows the next step instead of hitting a silent end.
+ * The `--install-script` / `--jdk-home` flags the bootstrap installers send are a forward contract
+ * (kept by design for a future devrig) and are accepted and IGNORED today: the installer runs THIS
+ * binary from the unpacked install tree with `DEVRIG_JAVA_HOME` set to the bundled JDK, so
+ * [ensureBinLauncher]'s own-process derivation yields exactly the values those flags carry.
  *
  * **Non-interactive contract.** This command is invoked by the generated bootstrap installers
  * (`install.sh` / `install.ps1`), typically run as `curl | sh` / `irm | iex`. Those installers hand it a
@@ -42,52 +42,30 @@ const val INSTALL_CHECK_DRIFT_EXIT_CODE = 1
  * Windows the child would otherwise inherit the caller's PowerShell host stdin. In either shape a
  * subprocess that read stdin — or waited on a prompt — could block with no user recourse. So this code
  * path (and everything it calls) MUST be fully non-interactive: NO stdin reads, NO prompts, NO
- * `Console.readLine` / `readln`. Every input arrives as an explicit flag; any missing input must fail
- * fast (return non-zero) rather than block waiting for a user who cannot answer.
+ * `Console.readLine` / `readln`.
  */
-fun DevrigServices.runInstallDevrigCommand(command: DevrigCommand.DevrigCommandInstallDevrig): Int =
+fun DevrigServices.runInstallDevrigCommand(): Int =
     runInstallDevrigCommand(
-        command = command,
         out = mcpStdout,
         err = System.err,
         launcherPath = DevrigUserLauncher.path(homePaths),
-        registerOwnInstall = { ensureBinLauncher(homePaths, force = true, registerWindowsPath = true) },
-        registerInstallScriptLauncher = { installScript, jdkHome ->
-            ensureBinLauncherForInstallScript(homePaths, installScript, jdkHome, force = true, registerWindowsPath = true)
-        },
-        detectAgentCli = { findCliOnPath(it.binary) },
-        offerPluginToRunningIdes = { tryInstallPluginIntoRunningIdesQuietly() },
+        registerLauncher = { ensureBinLauncher(homePaths, force = true, registerWindowsPath = true) },
     )
 
 /**
- * Testable core of `devrig install devrig`: the lambdas are the command's COMPLETE side-effect surface
- * (there is deliberately no [AiAgentCliRunner] here — this command must never touch an agent config;
- * `InstallDevrigCommandTest` locks that in), and it never reads stdin (the non-interactive contract
- * documented on the [DevrigServices] entry point above).
+ * Testable core of `devrig install devrig`: [registerLauncher] is the command's COMPLETE side-effect
+ * surface (there is deliberately no [AiAgentCliRunner] and no plugin-install hook here — this command
+ * must never touch an agent config or an IDE; `InstallDevrigCommandTest` locks that in), and it never
+ * reads stdin (the non-interactive contract documented on the [DevrigServices] entry point above).
  */
 fun runInstallDevrigCommand(
-    command: DevrigCommand.DevrigCommandInstallDevrig,
     out: PrintStream,
     err: PrintStream,
-    /** The stable user-facing launcher ([DevrigUserLauncher.path]) both registration modes write. */
+    /** The stable user-facing launcher ([DevrigUserLauncher.path]) the registration writes. */
     launcherPath: Path,
-    registerOwnInstall: () -> Unit,
-    registerInstallScriptLauncher: (installScript: Path, jdkHome: Path) -> Unit,
-    detectAgentCli: (AiAgentCli) -> Path?,
-    offerPluginToRunningIdes: () -> Unit,
+    registerLauncher: () -> Unit,
 ): Int {
-    val installScript = command.installScript
-    if (installScript.isNullOrBlank()) {
-        // Hand-run, no flags: re-register from the running binary's own install (issue #398).
-        registerOwnInstall()
-    } else {
-        // Install-script mode. --jdk-home is what the wrapper pins as DEVRIG_JAVA_HOME; fall back to
-        // the JDK we run under.
-        val jdkHome = command.jdkHome?.takeIf { it.isNotBlank() }?.let { Path.of(it) }
-            ?: Path.of(System.getProperty("java.home"))
-        registerInstallScriptLauncher(Path.of(installScript), jdkHome)
-    }
-
+    registerLauncher()
     if (!launcherPath.isRegularFile()) {
         err.println(
             "[mcp-steroid] ERROR: 'devrig install devrig' did not create the launcher $launcherPath " +
@@ -95,39 +73,26 @@ fun runInstallDevrigCommand(
         )
         return 64
     }
-    err.println("[mcp-steroid] devrig launcher registered: $launcherPath")
-
-    // Registering devrig is NOT the whole setup — say what comes next (configuring agents) instead of
-    // ending silently, with per-agent CLI detection so the suggested commands are concrete.
-    out.print(renderInstallDevrigGuidance(launcherPath, AiAgentCli.entries.associateWith(detectAgentCli)))
-
-    // Also offer the MCP Steroid plugin to any IDE already running: fire each IDE's native install
-    // dialog over REST. Best-effort and fully non-interactive (the IDE — not devrig — shows the dialog),
-    // so it is safe inside the `curl | sh` bootstrap: it never reads stdin and never fails the install.
-    offerPluginToRunningIdes()
+    out.print(renderInstallDevrigInfo(launcherPath))
     return 0
 }
 
 /**
- * The next-step guidance `devrig install devrig` prints after registering the launcher: the launcher is
- * registered, but NO agent was configured — that edits agent configs, so it stays an explicit per-agent
- * command. Only the launcher file's existence is verified by the caller; PATH linking is best-effort
- * (narrated on stderr by the registration), so the wording claims registration, not PATH reachability.
- * [detected] carries the per-agent CLI detection ([findCliOnPath]) so each suggestion says whether its
- * CLI is actually reachable. Pure renderer for testability.
+ * The ONE info message `devrig install devrig` prints: devrig is installed, and the three explicit
+ * next-step commands — install the MCP Steroid plugin into the IDEs, connect an agent, or print the
+ * manual mcp.json config. Only the launcher file's existence is verified by the caller; PATH linking is
+ * best-effort (narrated on stderr by the registration), so the wording includes the recovery hint
+ * instead of claiming PATH reachability. Pure renderer for testability.
  */
-fun renderInstallDevrigGuidance(launcherPath: Path, detected: Map<AiAgentCli, Path?>): String = buildString {
-    appendLine("devrig is registered: $launcherPath")
-    appendLine("PATH setup is best-effort — if 'devrig' is not found, open a new terminal (Windows) or add ${launcherPath.parent} to PATH.")
+fun renderInstallDevrigInfo(launcherPath: Path): String = buildString {
+    appendLine("devrig is installed: $launcherPath")
+    appendLine("The launcher and PATH registration self-heal on every devrig run. If 'devrig' is not")
+    appendLine("found, open a new terminal (Windows) or add ${launcherPath.parent} to PATH.")
     appendLine()
-    appendLine("devrig did NOT configure any AI agent — that edits agent configs, so it is an explicit step:")
-    for (agent in AiAgentCli.entries) {
-        val status = detected[agent]?.let { "${agent.binary} CLI found: $it" }
-            ?: "${agent.binary} CLI not found on PATH"
-        appendLine("  devrig install ${agent.binary.padEnd(8)} ($status)")
-    }
-    appendLine("For agents devrig cannot configure automatically, print the mcp.json snippet:")
-    appendLine("  devrig install config")
+    appendLine("Next steps:")
+    appendLine("  devrig install plugin    install the MCP Steroid plugin into your running JetBrains IDEs")
+    appendLine("  devrig install claude    connect devrig to Claude Code (also: codex, gemini)")
+    appendLine("  devrig install config    print the mcp.json snippet for any other MCP client")
 }
 
 fun DevrigServices.runInstallCommand(

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/InstallCommand.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/InstallCommand.kt
@@ -94,8 +94,7 @@ fun renderInstallDevrigInfo(launcherPath: Path): String = buildString {
     )
     val column = nextSteps.maxOf { it.first.length } + 4
     appendLine("devrig is installed: $launcherPath")
-    appendLine("The launcher and PATH registration self-heal on every devrig run. If 'devrig' is not")
-    appendLine("found, open a new terminal (Windows) or add ${launcherPath.parent} to PATH.")
+    appendLine("If 'devrig' is not found, add ${launcherPath.parent} to PATH.")
     appendLine()
     appendLine("Next steps:")
     for ((command, explanation) in nextSteps) appendLine("  ${command.padEnd(column)}$explanation")

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/InstallCommand.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/InstallCommand.kt
@@ -1,6 +1,7 @@
 /* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
 package com.jonnyzzz.mcpSteroid.devrig
 
+import com.jonnyzzz.mcpSteroid.aiAgents.AiAgentCli
 import com.jonnyzzz.mcpSteroid.aiAgents.AiAgentCliResult
 import com.jonnyzzz.mcpSteroid.aiAgents.AiAgentCliRunner
 import com.jonnyzzz.mcpSteroid.aiAgents.ProcessAiAgentCliRunner
@@ -21,9 +22,18 @@ const val INSTALL_CHECK_DRIFT_EXIT_CODE = 1
 /**
  * `devrig install devrig` — generate + register devrig's own `~/.mcp-steroid/bin/devrig`(`.cmd`) launcher
  * and put it on PATH. This is devrig's normal launcher self-registration ([ensureBinLauncher], which runs
- * on every start), here driven from the install script's EXPLICIT parameters: `--install-script` (the
- * unpacked install-tree launcher the wrapper execs) and `--jdk-home` (pinned as `DEVRIG_JAVA_HOME`). It
- * does ONLY that — no agent registration. Quiet: best-effort registration, one confirmation line.
+ * on every start), in one of two modes (issue #398):
+ *
+ *  - **No flags** (hand-run — the bare `devrig install` overview lists this target): re-register the
+ *    launcher + PATH from the RUNNING binary's own install tree and JDK — the same
+ *    `ensureBinLauncher(force = true)` self-heal every `devrig install <agent>` performs.
+ *  - **`--install-script` (with optional `--jdk-home`)** — the generated bootstrap installers: register
+ *    the EXPLICIT unpacked install-tree launcher the wrapper execs, pinning `--jdk-home` as
+ *    `DEVRIG_JAVA_HOME` (falling back to the JDK we run under).
+ *
+ * It does ONLY that — NO agent registration (that edits agent configs, so it stays an explicit
+ * `devrig install <agent>` step). After registering it prints the agent-setup guidance so the user
+ * knows the next step instead of hitting a silent end.
  *
  * **Non-interactive contract.** This command is invoked by the generated bootstrap installers
  * (`install.sh` / `install.ps1`), typically run as `curl | sh` / `irm | iex`. Those installers hand it a
@@ -35,32 +45,89 @@ const val INSTALL_CHECK_DRIFT_EXIT_CODE = 1
  * `Console.readLine` / `readln`. Every input arrives as an explicit flag; any missing input must fail
  * fast (return non-zero) rather than block waiting for a user who cannot answer.
  */
-fun DevrigServices.runInstallDevrigCommand(command: DevrigCommand.DevrigCommandInstallDevrig): Int {
+fun DevrigServices.runInstallDevrigCommand(command: DevrigCommand.DevrigCommandInstallDevrig): Int =
+    runInstallDevrigCommand(
+        command = command,
+        out = mcpStdout,
+        err = System.err,
+        launcherPath = DevrigUserLauncher.path(homePaths),
+        registerOwnInstall = { ensureBinLauncher(homePaths, force = true, registerWindowsPath = true) },
+        registerInstallScriptLauncher = { installScript, jdkHome ->
+            ensureBinLauncherForInstallScript(homePaths, installScript, jdkHome, force = true, registerWindowsPath = true)
+        },
+        detectAgentCli = { findCliOnPath(it.binary) },
+        offerPluginToRunningIdes = { tryInstallPluginIntoRunningIdesQuietly() },
+    )
+
+/**
+ * Testable core of `devrig install devrig`: the lambdas are the command's COMPLETE side-effect surface
+ * (there is deliberately no [AiAgentCliRunner] here — this command must never touch an agent config;
+ * `InstallDevrigCommandTest` locks that in), and it never reads stdin (the non-interactive contract
+ * documented on the [DevrigServices] entry point above).
+ */
+fun runInstallDevrigCommand(
+    command: DevrigCommand.DevrigCommandInstallDevrig,
+    out: PrintStream,
+    err: PrintStream,
+    /** The stable user-facing launcher ([DevrigUserLauncher.path]) both registration modes write. */
+    launcherPath: Path,
+    registerOwnInstall: () -> Unit,
+    registerInstallScriptLauncher: (installScript: Path, jdkHome: Path) -> Unit,
+    detectAgentCli: (AiAgentCli) -> Path?,
+    offerPluginToRunningIdes: () -> Unit,
+): Int {
     val installScript = command.installScript
     if (installScript.isNullOrBlank()) {
-        System.err.println("[mcp-steroid] 'devrig install devrig' requires --install-script=<full path>")
-        return 64
+        // Hand-run, no flags: re-register from the running binary's own install (issue #398).
+        registerOwnInstall()
+    } else {
+        // Install-script mode. --jdk-home is what the wrapper pins as DEVRIG_JAVA_HOME; fall back to
+        // the JDK we run under.
+        val jdkHome = command.jdkHome?.takeIf { it.isNotBlank() }?.let { Path.of(it) }
+            ?: Path.of(System.getProperty("java.home"))
+        registerInstallScriptLauncher(Path.of(installScript), jdkHome)
     }
-    // --jdk-home is what the wrapper pins as DEVRIG_JAVA_HOME; fall back to the JDK we run under.
-    val jdkHome = command.jdkHome?.takeIf { it.isNotBlank() }?.let { Path.of(it) }
-        ?: Path.of(System.getProperty("java.home"))
-    ensureBinLauncherForInstallScript(homePaths, Path.of(installScript), jdkHome, force = true, registerWindowsPath = true)
 
-    val launcher = DevrigUserLauncher.path(homePaths)
-    if (!launcher.isRegularFile()) {
-        System.err.println(
-            "[mcp-steroid] ERROR: 'devrig install devrig' did not create the launcher $launcher " +
+    if (!launcherPath.isRegularFile()) {
+        err.println(
+            "[mcp-steroid] ERROR: 'devrig install devrig' did not create the launcher $launcherPath " +
                 "(DEVRIG_BIN_NO_AUTO_REGISTER may opt out of writing it).",
         )
         return 64
     }
-    System.err.println("[mcp-steroid] devrig is on PATH via $launcher")
+    err.println("[mcp-steroid] devrig launcher registered: $launcherPath")
+
+    // Registering devrig is NOT the whole setup — say what comes next (configuring agents) instead of
+    // ending silently, with per-agent CLI detection so the suggested commands are concrete.
+    out.print(renderInstallDevrigGuidance(launcherPath, AiAgentCli.entries.associateWith(detectAgentCli)))
 
     // Also offer the MCP Steroid plugin to any IDE already running: fire each IDE's native install
     // dialog over REST. Best-effort and fully non-interactive (the IDE — not devrig — shows the dialog),
     // so it is safe inside the `curl | sh` bootstrap: it never reads stdin and never fails the install.
-    tryInstallPluginIntoRunningIdesQuietly()
+    offerPluginToRunningIdes()
     return 0
+}
+
+/**
+ * The next-step guidance `devrig install devrig` prints after registering the launcher: the launcher is
+ * registered, but NO agent was configured — that edits agent configs, so it stays an explicit per-agent
+ * command. Only the launcher file's existence is verified by the caller; PATH linking is best-effort
+ * (narrated on stderr by the registration), so the wording claims registration, not PATH reachability.
+ * [detected] carries the per-agent CLI detection ([findCliOnPath]) so each suggestion says whether its
+ * CLI is actually reachable. Pure renderer for testability.
+ */
+fun renderInstallDevrigGuidance(launcherPath: Path, detected: Map<AiAgentCli, Path?>): String = buildString {
+    appendLine("devrig is registered: $launcherPath")
+    appendLine("PATH setup is best-effort — if 'devrig' is not found, open a new terminal (Windows) or add ${launcherPath.parent} to PATH.")
+    appendLine()
+    appendLine("devrig did NOT configure any AI agent — that edits agent configs, so it is an explicit step:")
+    for (agent in AiAgentCli.entries) {
+        val status = detected[agent]?.let { "${agent.binary} CLI found: $it" }
+            ?: "${agent.binary} CLI not found on PATH"
+        appendLine("  devrig install ${agent.binary.padEnd(8)} ($status)")
+    }
+    appendLine("For agents devrig cannot configure automatically, print the mcp.json snippet:")
+    appendLine("  devrig install config")
 }
 
 fun DevrigServices.runInstallCommand(

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/InstallConfigCommand.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/InstallConfigCommand.kt
@@ -1,0 +1,39 @@
+/* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
+package com.jonnyzzz.mcpSteroid.devrig
+
+import com.jonnyzzz.mcpSteroid.aiAgents.AiAgentCli
+import com.jonnyzzz.mcpSteroid.aiAgents.DEFAULT_SERVER_NAME
+import com.jonnyzzz.mcpSteroid.aiAgents.StdioMcpCommand
+import com.jonnyzzz.mcpSteroid.aiAgents.stdioMcpServersJson
+
+/**
+ * `devrig install config` — print the MANUAL MCP configuration recipe for devrig (issue #398): the
+ * stdio `mcpServers` JSON snippet pointing at the stable `~/.mcp-steroid/bin` launcher, plus the
+ * per-agent `mcp add` command lines. For MCP clients devrig cannot configure automatically (Cursor,
+ * Windsurf, any mcp.json-style config). Informational and read-only: nothing is registered, nothing
+ * is written — the recipe goes to stdout so it can be piped/copied.
+ */
+fun DevrigServices.runInstallConfigCommand(): Int {
+    mcpStdout.print(renderInstallConfig(DevrigUserLauncher.invocation(homePaths, listOf("mcp"))))
+    return 0
+}
+
+/**
+ * Pure renderer of the manual-configuration recipe. [mcpCommand] is the OS-correct launcher invocation
+ * ([DevrigUserLauncher.invocation] with the `mcp` subcommand) — the SAME command `devrig install <agent>`
+ * registers, so the manual and automatic paths can never drift apart. The JSON block comes from
+ * [stdioMcpServersJson] (kotlinx.serialization — a Windows launcher path needs its backslashes escaped).
+ */
+fun renderInstallConfig(mcpCommand: StdioMcpCommand): String = buildString {
+    appendLine("Manual MCP configuration — register devrig as the '$DEFAULT_SERVER_NAME' stdio MCP server.")
+    appendLine()
+    appendLine("For MCP clients configured through an 'mcpServers' JSON file (mcp.json or similar), add:")
+    appendLine()
+    appendLine(stdioMcpServersJson(mcpCommand))
+    appendLine()
+    appendLine("Agents with a CLI are configured automatically by 'devrig install claude|codex|gemini',")
+    appendLine("or with the agent's own command:")
+    for (agent in AiAgentCli.entries) {
+        appendLine("  ${agent.binary} ${agent.mcpAddStdioArgs(mcpCommand).joinToString(" ")}")
+    }
+}

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/InstallOverviewCommand.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/InstallOverviewCommand.kt
@@ -26,7 +26,9 @@ fun renderInstallOverview(detected: Map<AiAgentCli, Path?>): String = buildStrin
         appendLine("  ${agent.binary.padEnd(8)} register devrig as the mcp-steroid MCP server in ${agent.displayName} ($status)")
     }
     appendLine("  ${"plugin".padEnd(8)} install the MCP Steroid plugin into locally-running JetBrains IDEs")
-    appendLine("  ${"devrig".padEnd(8)} re-register devrig's own launcher and PATH (used by the install scripts)")
+    appendLine("  ${"devrig".padEnd(8)} re-register devrig's own launcher and PATH (also used by the install scripts)")
+    appendLine("  ${"config".padEnd(8)} print the manual MCP configuration: the stdio mcpServers JSON (mcp.json)")
+    appendLine("  ${"".padEnd(8)} snippet plus per-agent mcp-add commands")
     appendLine()
     appendLine("Example: devrig install claude")
 }

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/InstallOverviewCommand.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/InstallOverviewCommand.kt
@@ -26,7 +26,7 @@ fun renderInstallOverview(detected: Map<AiAgentCli, Path?>): String = buildStrin
         appendLine("  ${agent.binary.padEnd(8)} register devrig as the mcp-steroid MCP server in ${agent.displayName} ($status)")
     }
     appendLine("  ${"plugin".padEnd(8)} install the MCP Steroid plugin into locally-running JetBrains IDEs")
-    appendLine("  ${"devrig".padEnd(8)} re-register devrig's own launcher and PATH (also used by the install scripts)")
+    appendLine("  ${"devrig".padEnd(8)} re-register devrig's own launcher and PATH, then print the next steps")
     appendLine("  ${"config".padEnd(8)} print the manual MCP configuration: the stdio mcpServers JSON (mcp.json)")
     appendLine("  ${"".padEnd(8)} snippet plus per-agent mcp-add commands")
     appendLine()

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/InstallPluginCommand.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/InstallPluginCommand.kt
@@ -136,8 +136,8 @@ class KtorPluginRestClient(private val httpClient: HttpClient) : PluginRestClien
  * so IDEs that already have the plugin are skipped.
  *
  * Non-interactive: devrig itself never prompts. The IDE's modal is the only confirmation, and it is shown
- * by the IDE, not devrig — so this is safe to call from the fully non-interactive `devrig install devrig`
- * path (see [tryInstallPluginIntoRunningIdesQuietly]).
+ * by the IDE, not devrig. This is the EXPLICIT plugin-install step — `devrig install devrig` only promotes
+ * this command in its next-steps message and never runs it (issue #398).
  */
 fun DevrigServices.runInstallPluginCommand(command: DevrigCommand.DevrigCommandInstallPlugin): Int {
     val markers = scanMarkersOnce()
@@ -154,39 +154,8 @@ fun DevrigServices.runInstallPluginCommand(command: DevrigCommand.DevrigCommandI
         )
     }
     // Best-effort by design: per-IDE status is printed above, and the real install completes only when the
-    // user approves each IDE's dialog. A blanket exit 0 keeps the command safe to chain from `install devrig`.
+    // user approves each IDE's dialog.
     return 0
-}
-
-/**
- * Best-effort plugin install into running IDEs, called from `devrig install devrig`. Silent when no IDE is
- * running; never throws (any failure is logged to stderr and swallowed) so it can never fail the bootstrap
- * install, and never reads stdin.
- */
-fun DevrigServices.tryInstallPluginIntoRunningIdesQuietly() {
-    try {
-        val markers = scanMarkersOnce()
-        runBlocking(Dispatchers.IO) {
-            val targets = detectProvisionTargets(portDiscovery)
-            // Nothing running → say nothing. The bootstrap installer output stays quiet unless there is an
-            // IDE we can actually act on.
-            if (targets.isEmpty()) return@runBlocking
-            mcpStdout.println()
-            installPluginIntoRunningIdes(
-                out = mcpStdout,
-                err = System.err,
-                check = false,
-                pluginId = MCP_STEROID_PLUGIN_ID,
-                targets = targets,
-                markers = markers,
-                client = KtorPluginRestClient(commandHttpClient),
-            )
-        }
-    } catch (e: Exception) {
-        System.err.println(
-            "[mcp-steroid] installing the plugin into running IDEs was skipped: ${e.message ?: e::class.simpleName}",
-        )
-    }
 }
 
 /**

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/Main.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/Main.kt
@@ -166,6 +166,7 @@ private fun DevrigCommand.runsTool(): Boolean = when (this) {
     is DevrigCommand.DevrigCommandInstallDevrig,
     is DevrigCommand.DevrigCommandInstallPlugin -> true
     is DevrigCommand.DevrigCommandInstallOverview,
+    is DevrigCommand.DevrigCommandInstallConfig,
     is DevrigCommand.DevrigCommandHelp,
     is DevrigCommand.DevrigCommandVersion,
     is DevrigCommand.DevrigCommandParseError -> false

--- a/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/DevrigCommandOutputTest.kt
+++ b/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/DevrigCommandOutputTest.kt
@@ -87,6 +87,7 @@ class DevrigCommandOutputTest {
         assertTrue(out.contains("--version"), "help should advertise --version; got:\n$out")
         assertTrue(out.contains("--help"), "help should advertise --help itself; got:\n$out")
         assertTrue(out.contains("devrig install claude|codex|gemini"), "help should advertise agent install; got:\n$out")
+        assertTrue(out.contains("devrig install config"), "help should advertise the manual-config printer; got:\n$out")
         assertTrue(out.contains("backend download [<id>] [--version <v>] [--json]"), "help should advertise download version override; got:\n$out")
         assertTrue(out.contains("no id → list IDEs available for download"), "help should explain download without id; got:\n$out")
         assertTrue(out.contains("backend start    [<id>] [--version <v>] [--json]"), "help should advertise start version override; got:\n$out")
@@ -102,6 +103,21 @@ class DevrigCommandOutputTest {
         // behave predictably.
         runCliForTest(DevrigCommand.DevrigCommandHelp())
         assertTrue(stdout().endsWith("\n"), "help output must end with a newline; got: '${stdout().takeLast(20)}'")
+    }
+
+    // --------------------------- Install config -----------------------------
+
+    @Test
+    fun `Install config writes the manual MCP configuration to stdout, nothing to stderr`() {
+        // Pasteable output contract: the stdio mcpServers JSON goes to stdout (so
+        // `devrig install config | pbcopy` works); stderr stays clean.
+        val exit = runCliForTest(DevrigCommand.DevrigCommandInstallConfig())
+        assertEquals(0, exit)
+        assertEquals("", stderr(), "stderr must stay clean for install config; got: ${stderr()}")
+        val out = stdout()
+        assertTrue(out.contains("\"mcpServers\""), "config must print the mcpServers JSON snippet; got:\n$out")
+        assertTrue(out.contains("mcp-steroid"), "config must use the canonical server name; got:\n$out")
+        assertTrue(out.contains("mcp add"), "config must list the per-agent add commands; got:\n$out")
     }
 
     // ------------------------------ Version --------------------------------

--- a/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/DevrigCommandTest.kt
+++ b/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/DevrigCommandTest.kt
@@ -121,28 +121,22 @@ class DevrigCommandTest {
     }
 
     @Test
-    fun `install devrig parses with no flags and with the install-script flags`() {
-        // Hand-run, no flags (issue #398): re-register the launcher from the running binary's own
-        // install — parses cleanly, the command decides the registration mode from the flags.
+    fun `install devrig parses to the same flag-less command with or without the install-script flags`() {
+        // ONE behavior, same result on every call (issue #398): the command carries no parameters.
         val bare = assertIs<DevrigCommand.DevrigCommandInstallDevrig>(command("install", "devrig"))
-        assertNull(bare.installScript)
-        assertNull(bare.jdkHome)
-        // Install-script mode (the generated install.sh / install.ps1): both parameters stay explicit.
-        val scripted = assertIs<DevrigCommand.DevrigCommandInstallDevrig>(
+        // The --install-script / --jdk-home flags the install scripts send (a forward contract, kept
+        // by design for a future devrig) are accepted and IGNORED — every spelling, including blank
+        // values, parses to the identical command; registration always derives the install tree + JDK
+        // from the running binary.
+        for (legacy in listOf(
             command("install", "devrig", "--install-script=/opt/devrig/bin/devrig", "--jdk-home=/opt/jdk"),
-        )
-        assertEquals("/opt/devrig/bin/devrig", scripted.installScript)
-        assertEquals("/opt/jdk", scripted.jdkHome)
-        // --jdk-home alone is a mistake — only the install scripts pass it, and always with
-        // --install-script. Fail fast instead of guessing which registration mode was meant.
-        assertIs<DevrigCommand.DevrigCommandParseError>(command("install", "devrig", "--jdk-home=/opt/jdk"))
-        // A BLANK --install-script (an unset shell variable in a third-party wrapper) must not silently
-        // flip to the self-registration mode — that would register the running binary and drop the
-        // explicit --jdk-home. Fail fast at parse time, like the old exit-64 behaviour did.
-        assertIs<DevrigCommand.DevrigCommandParseError>(command("install", "devrig", "--install-script="))
-        assertIs<DevrigCommand.DevrigCommandParseError>(
+            command("install", "devrig", "--install-script=/opt/devrig/bin/devrig"),
+            command("install", "devrig", "--jdk-home=/opt/jdk"),
+            command("install", "devrig", "--install-script="),
             command("install", "devrig", "--install-script=", "--jdk-home=/opt/jdk"),
-        )
+        )) {
+            assertEquals(bare, assertIs<DevrigCommand.DevrigCommandInstallDevrig>(legacy))
+        }
     }
 
     @Test

--- a/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/DevrigCommandTest.kt
+++ b/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/DevrigCommandTest.kt
@@ -5,6 +5,7 @@ import com.jonnyzzz.mcpSteroid.aiAgents.AiAgentCli
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertIs
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import org.junit.jupiter.api.Test
 
@@ -117,6 +118,43 @@ class DevrigCommandTest {
         assertIs<DevrigCommand.DevrigCommandParseError>(command("install", "--check"))
         assertIs<DevrigCommand.DevrigCommandParseError>(command("install", "--install-script=/x"))
         assertIs<DevrigCommand.DevrigCommandParseError>(command("install", "--jdk-home=/x"))
+    }
+
+    @Test
+    fun `install devrig parses with no flags and with the install-script flags`() {
+        // Hand-run, no flags (issue #398): re-register the launcher from the running binary's own
+        // install — parses cleanly, the command decides the registration mode from the flags.
+        val bare = assertIs<DevrigCommand.DevrigCommandInstallDevrig>(command("install", "devrig"))
+        assertNull(bare.installScript)
+        assertNull(bare.jdkHome)
+        // Install-script mode (the generated install.sh / install.ps1): both parameters stay explicit.
+        val scripted = assertIs<DevrigCommand.DevrigCommandInstallDevrig>(
+            command("install", "devrig", "--install-script=/opt/devrig/bin/devrig", "--jdk-home=/opt/jdk"),
+        )
+        assertEquals("/opt/devrig/bin/devrig", scripted.installScript)
+        assertEquals("/opt/jdk", scripted.jdkHome)
+        // --jdk-home alone is a mistake — only the install scripts pass it, and always with
+        // --install-script. Fail fast instead of guessing which registration mode was meant.
+        assertIs<DevrigCommand.DevrigCommandParseError>(command("install", "devrig", "--jdk-home=/opt/jdk"))
+        // A BLANK --install-script (an unset shell variable in a third-party wrapper) must not silently
+        // flip to the self-registration mode — that would register the running binary and drop the
+        // explicit --jdk-home. Fail fast at parse time, like the old exit-64 behaviour did.
+        assertIs<DevrigCommand.DevrigCommandParseError>(command("install", "devrig", "--install-script="))
+        assertIs<DevrigCommand.DevrigCommandParseError>(
+            command("install", "devrig", "--install-script=", "--jdk-home=/opt/jdk"),
+        )
+    }
+
+    @Test
+    fun `install config selects the manual-config printer and rejects target-specific flags`() {
+        assertIs<DevrigCommand.DevrigCommandInstallConfig>(command("install", "config"))
+        val config = assertIs<DevrigCommand.DevrigCommandInstallConfig>(command("--debug", "install", "config", "--json"))
+        assertTrue(config.debug)
+        assertTrue(config.json)
+        // 'install config' is informational — the agent/devrig flags make no sense here.
+        assertIs<DevrigCommand.DevrigCommandParseError>(command("install", "config", "--check"))
+        assertIs<DevrigCommand.DevrigCommandParseError>(command("install", "config", "--install-script=/x"))
+        assertIs<DevrigCommand.DevrigCommandParseError>(command("install", "config", "--jdk-home=/x"))
     }
 
     @Test

--- a/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/InstallConfigCommandTest.kt
+++ b/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/InstallConfigCommandTest.kt
@@ -1,0 +1,57 @@
+/* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
+package com.jonnyzzz.mcpSteroid.devrig
+
+import com.jonnyzzz.mcpSteroid.aiAgents.StdioMcpCommand
+import java.nio.file.Path
+import kotlin.test.assertContains
+import org.junit.jupiter.api.Test
+
+/**
+ * `devrig install config` (issue #398): print the MANUAL configuration recipe — the stdio `mcpServers`
+ * JSON snippet pointing at the stable launcher, plus the per-agent `mcp add` command lines — for MCP
+ * clients devrig cannot configure automatically.
+ */
+class InstallConfigCommandTest {
+    // Fixed home; windows = false picks the launcher NAME/invocation shape, but Path.toString() still
+    // uses the running JVM's separator — on Windows launcherPath contains backslashes, which are not
+    // valid unescaped inside a JSON string (same convention as InstallCommandTest).
+    private val home = HomePaths(Path.of("/home/user/.mcp-steroid"))
+    private val launcherPath = DevrigUserLauncher.path(home, windows = false).toString()
+    private val launcherPathJsonEscaped = launcherPath.replace("\\", "\\\\")
+    private val mcpCommand = DevrigUserLauncher.invocation(home, listOf("mcp"), windows = false)
+
+    @Test
+    fun `config prints the stdio mcpServers JSON pointing at the stable launcher`() {
+        val text = renderInstallConfig(mcpCommand)
+
+        assertContains(text, "\"mcpServers\"")
+        assertContains(text, "\"mcp-steroid\"")
+        assertContains(text, "\"command\": \"$launcherPathJsonEscaped\"")
+        assertContains(text, "\"mcp\"")
+    }
+
+    @Test
+    fun `config lists the per-agent mcp add commands for the same stdio launch command`() {
+        val text = renderInstallConfig(mcpCommand)
+
+        assertContains(text, "claude mcp add --scope user mcp-steroid -- $launcherPath mcp")
+        assertContains(text, "codex mcp add mcp-steroid -- $launcherPath mcp")
+        assertContains(text, "gemini mcp add --type stdio --scope user --trust mcp-steroid $launcherPath mcp")
+        // The automatic path stays advertised next to the manual one.
+        assertContains(text, "devrig install claude|codex|gemini")
+    }
+
+    @Test
+    fun `config JSON escapes a Windows launcher path`() {
+        // The Windows invocation shape (cmd.exe /d /c "<quoted .cmd path> mcp") carries backslashes and
+        // embedded quotes — the rendered JSON must escape them (issue #398: no hand-concatenated JSON).
+        val windowsCommand = StdioMcpCommand(
+            command = "cmd.exe",
+            args = listOf("/d", "/c", "\"C:\\Users\\First Last\\.mcp-steroid\\bin\\devrig.cmd\" mcp"),
+        )
+        val text = renderInstallConfig(windowsCommand)
+
+        assertContains(text, "\"command\": \"cmd.exe\"")
+        assertContains(text, "C:\\\\Users\\\\First Last\\\\.mcp-steroid\\\\bin\\\\devrig.cmd")
+    }
+}

--- a/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/InstallDevrigCommandTest.kt
+++ b/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/InstallDevrigCommandTest.kt
@@ -1,126 +1,75 @@
 /* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
 package com.jonnyzzz.mcpSteroid.devrig
 
-import com.jonnyzzz.mcpSteroid.aiAgents.AiAgentCli
 import java.io.ByteArrayOutputStream
 import java.io.PrintStream
 import java.nio.file.Files
 import java.nio.file.Path
 import kotlin.test.assertContains
 import kotlin.test.assertEquals
-import kotlin.test.assertFalse
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
 
 /**
- * `devrig install devrig` (issue #398): registers devrig itself — the launcher + PATH — and NOTHING
- * else. The tests drive the pure [runInstallDevrigCommand] overload whose parameter list is the
- * command's COMPLETE side-effect surface, so the recorded call list is an honest guard that no agent
- * config is ever touched.
+ * `devrig install devrig` (issue #398): ONE behavior, same result on every call — register devrig's own
+ * launcher + PATH, print ONE info message with the next steps, and NOTHING else. The tests drive the pure
+ * [runInstallDevrigCommand] overload whose parameter list is the command's complete side-effect surface,
+ * so the recorded call list is an honest guard that no agent config and no IDE is ever touched.
  */
 class InstallDevrigCommandTest {
 
-    private val detected = mapOf(
-        AiAgentCli.CLAUDE to Path.of("/opt/homebrew/bin/claude"),
-        AiAgentCli.CODEX to null,
-        AiAgentCli.GEMINI to Path.of("/usr/local/bin/gemini"),
-    )
-
     @Test
-    fun `no flags re-registers the launcher from the running install and prints the agent guidance`(@TempDir tmp: Path) {
-        val r = run(DevrigCommand.DevrigCommandInstallDevrig(), tmp)
+    fun `registers the launcher and prints the one next-steps info message`(@TempDir tmp: Path) {
+        val r = run(tmp)
 
         assertEquals(0, r.exitCode)
-        assertEquals(listOf("registerOwnInstall", "offerPluginToRunningIdes"), r.calls)
-        assertContains(r.stdout, "devrig is registered")
-        assertContains(r.stdout, "PATH setup is best-effort")
-        assertContains(r.stdout, "did NOT configure any AI agent")
-        // CLI paths are interpolated from the same Path values the fake detector returns — Path.toString()
-        // is platform-dependent (backslashes on Windows), so the expected text must be derived, not literal.
+        assertEquals(listOf("registerLauncher"), r.calls)
+        // Expected strings interpolate the SAME Path values the renderer gets: Path.toString() is
+        // platform-dependent (backslashes on a Windows JVM), so literals would fail on Windows.
+        assertContains(r.stdout, "devrig is installed: ${r.launcher}")
+        assertContains(r.stdout, "Next steps:")
+        assertContains(r.stdout, "devrig install plugin")
+        assertContains(r.stdout, "MCP Steroid plugin")
         assertContains(r.stdout, "devrig install claude")
-        assertContains(r.stdout, "claude CLI found: ${detected[AiAgentCli.CLAUDE]}")
-        assertContains(r.stdout, "devrig install codex")
-        assertContains(r.stdout, "codex CLI not found on PATH")
-        assertContains(r.stdout, "devrig install gemini")
-        assertContains(r.stdout, "gemini CLI found: ${detected[AiAgentCli.GEMINI]}")
         assertContains(r.stdout, "devrig install config")
+        assertEquals("", r.stderr, "the info message is the ONLY output; got stderr:\n${r.stderr}")
     }
 
     @Test
-    fun `install-script flags keep the explicit install-script registration path`(@TempDir tmp: Path) {
-        val r = run(
-            DevrigCommand.DevrigCommandInstallDevrig(installScript = "/opt/devrig/bin/devrig", jdkHome = "/opt/jdk"),
-            tmp,
-        )
-
-        assertEquals(0, r.exitCode)
-        assertEquals(listOf("registerInstallScriptLauncher", "offerPluginToRunningIdes"), r.calls)
-        assertEquals(
-            listOf(Path.of("/opt/devrig/bin/devrig") to Path.of("/opt/jdk")),
-            r.installScriptRegistrations,
-        )
-        // The bootstrap installer's terminal shows this output too — the guidance is for both flows.
-        assertContains(r.stdout, "did NOT configure any AI agent")
-        assertContains(r.stdout, "devrig install config")
-    }
-
-    @Test
-    fun `install-script without jdk-home falls back to the JDK devrig runs under`(@TempDir tmp: Path) {
-        val r = run(DevrigCommand.DevrigCommandInstallDevrig(installScript = "/opt/devrig/bin/devrig"), tmp)
-
-        assertEquals(0, r.exitCode)
-        assertEquals(
-            Path.of(System.getProperty("java.home")),
-            r.installScriptRegistrations.single().second,
-        )
-    }
-
-    @Test
-    fun `a launcher missing after registration fails with 64 and skips guidance and the plugin offer`(@TempDir tmp: Path) {
-        val r = run(DevrigCommand.DevrigCommandInstallDevrig(), tmp, launcherAppearsOnRegister = false)
+    fun `a launcher missing after registration fails with 64 and prints no info message`(@TempDir tmp: Path) {
+        val r = run(tmp, launcherAppearsOnRegister = false)
 
         assertEquals(64, r.exitCode)
-        assertFalse(r.calls.contains("offerPluginToRunningIdes"), r.calls.toString())
-        assertEquals("", r.stdout, "no success guidance when registration failed; got:\n${r.stdout}")
+        assertEquals("", r.stdout, "no info message when registration failed; got:\n${r.stdout}")
         assertContains(r.stderr, "did not create the launcher")
     }
 
     @Test
-    fun `install devrig never touches agent configs - registration plus plugin offer are its only side effects`(@TempDir tmp: Path) {
-        // The seams below are the command's COMPLETE capability set: the function takes no
-        // AiAgentCliRunner and has no other way to spawn an agent CLI. Locking the exact call list is
-        // the strongest honest guard for the issue #398 contract — 'devrig install devrig' registers
-        // devrig itself and nothing else; agent configs are only edited by 'devrig install <agent>'.
-        for (command in listOf(
-            DevrigCommand.DevrigCommandInstallDevrig(),
-            DevrigCommand.DevrigCommandInstallDevrig(installScript = "/opt/devrig/bin/devrig", jdkHome = "/opt/jdk"),
-        )) {
-            val r = run(command, Files.createTempDirectory(tmp, "guard"))
-            val registration =
-                if (command.installScript == null) "registerOwnInstall" else "registerInstallScriptLauncher"
-            assertEquals(listOf(registration, "offerPluginToRunningIdes"), r.calls, "for $command")
-            // The output must SAY agents were not configured — the explicit next step, never a silent end.
-            assertContains(r.stdout, "did NOT configure any AI agent")
-        }
+    fun `install devrig never touches agent configs or IDEs - launcher registration is its only side effect`(@TempDir tmp: Path) {
+        // The seam below is the command's COMPLETE capability set: the function takes no AiAgentCliRunner
+        // and no plugin-install hook, so it has no way to spawn an agent CLI or reach an IDE. Locking the
+        // exact call list is the strongest honest guard for the issue #398 contract — 'devrig install
+        // devrig' registers devrig itself and nothing else; agent configs are only edited by
+        // 'devrig install <agent>', the IDE plugin only by 'devrig install plugin'.
+        val r = run(tmp)
+
+        assertEquals(listOf("registerLauncher"), r.calls)
+        // The message must PROMOTE the explicit commands instead of running anything itself.
+        assertContains(r.stdout, "devrig install plugin")
+        assertContains(r.stdout, "devrig install claude")
     }
 
     @Test
-    fun `guidance lists one install command per agent with CLI detection and points at install config`() {
-        // Expected strings interpolate the SAME Path values the renderer gets: Path.toString() is
-        // platform-dependent (backslashes on a Windows JVM), so literals would fail on Windows.
+    fun `info message names the plugin, agent, and config commands with the launcher location`() {
         val launcher = Path.of("/home/u/.mcp-steroid/bin/devrig")
-        val text = renderInstallDevrigGuidance(launcher, detected)
+        val text = renderInstallDevrigInfo(launcher)
 
-        assertContains(text, "devrig is registered: $launcher")
-        assertContains(text, "PATH setup is best-effort")
+        assertContains(text, "devrig is installed: $launcher")
         assertContains(text, "add ${launcher.parent} to PATH")
-        assertContains(text, "did NOT configure any AI agent")
-        for (agent in AiAgentCli.entries) {
-            assertContains(text, "devrig install ${agent.binary}")
-        }
-        assertContains(text, "claude CLI found: ${detected[AiAgentCli.CLAUDE]}")
-        assertContains(text, "codex CLI not found on PATH")
-        assertContains(text, "gemini CLI found: ${detected[AiAgentCli.GEMINI]}")
+        assertContains(text, "devrig install plugin")
+        assertContains(text, "install the MCP Steroid plugin into your running JetBrains IDEs")
+        assertContains(text, "devrig install claude")
+        assertContains(text, "codex, gemini")
         assertContains(text, "devrig install config")
     }
 
@@ -129,47 +78,32 @@ class InstallDevrigCommandTest {
     private class Run(
         val exitCode: Int,
         val calls: List<String>,
-        val installScriptRegistrations: List<Pair<Path, Path>>,
+        val launcher: Path,
         val stdout: String,
         val stderr: String,
     )
 
-    private fun run(
-        command: DevrigCommand.DevrigCommandInstallDevrig,
-        tmp: Path,
-        launcherAppearsOnRegister: Boolean = true,
-    ): Run {
+    private fun run(tmp: Path, launcherAppearsOnRegister: Boolean = true): Run {
         val launcher = tmp.resolve("bin").resolve("devrig")
         val calls = mutableListOf<String>()
-        val installScriptRegistrations = mutableListOf<Pair<Path, Path>>()
         val stdout = ByteArrayOutputStream()
         val stderr = ByteArrayOutputStream()
-        fun writeLauncher() {
-            if (!launcherAppearsOnRegister) return
-            Files.createDirectories(launcher.parent)
-            Files.writeString(launcher, "#!/bin/sh\n")
-        }
         val exitCode = runInstallDevrigCommand(
-            command = command,
             out = PrintStream(stdout, true, Charsets.UTF_8),
             err = PrintStream(stderr, true, Charsets.UTF_8),
             launcherPath = launcher,
-            registerOwnInstall = {
-                calls += "registerOwnInstall"
-                writeLauncher()
+            registerLauncher = {
+                calls += "registerLauncher"
+                if (launcherAppearsOnRegister) {
+                    Files.createDirectories(launcher.parent)
+                    Files.writeString(launcher, "#!/bin/sh\n")
+                }
             },
-            registerInstallScriptLauncher = { script, jdkHome ->
-                calls += "registerInstallScriptLauncher"
-                installScriptRegistrations += script to jdkHome
-                writeLauncher()
-            },
-            detectAgentCli = { detected[it] },
-            offerPluginToRunningIdes = { calls += "offerPluginToRunningIdes" },
         )
         return Run(
             exitCode = exitCode,
             calls = calls,
-            installScriptRegistrations = installScriptRegistrations,
+            launcher = launcher,
             stdout = stdout.toString(Charsets.UTF_8).replace("\r\n", "\n"),
             stderr = stderr.toString(Charsets.UTF_8).replace("\r\n", "\n"),
         )

--- a/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/InstallDevrigCommandTest.kt
+++ b/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/InstallDevrigCommandTest.kt
@@ -1,6 +1,7 @@
 /* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
 package com.jonnyzzz.mcpSteroid.devrig
 
+import com.jonnyzzz.mcpSteroid.aiAgents.AiAgentCli
 import java.io.ByteArrayOutputStream
 import java.io.PrintStream
 import java.nio.file.Files
@@ -68,8 +69,8 @@ class InstallDevrigCommandTest {
         assertContains(text, "add ${launcher.parent} to PATH")
         assertContains(text, "devrig install plugin")
         assertContains(text, "install the MCP Steroid plugin into your running JetBrains IDEs")
-        assertContains(text, "devrig install claude")
-        assertContains(text, "codex, gemini")
+        // ALL agents listed on the one agent line, none singled out (derived from the enum).
+        assertContains(text, "devrig install " + AiAgentCli.entries.joinToString("|") { it.binary })
         assertContains(text, "devrig install config")
     }
 

--- a/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/InstallDevrigCommandTest.kt
+++ b/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/InstallDevrigCommandTest.kt
@@ -1,0 +1,177 @@
+/* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
+package com.jonnyzzz.mcpSteroid.devrig
+
+import com.jonnyzzz.mcpSteroid.aiAgents.AiAgentCli
+import java.io.ByteArrayOutputStream
+import java.io.PrintStream
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.test.assertContains
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+
+/**
+ * `devrig install devrig` (issue #398): registers devrig itself — the launcher + PATH — and NOTHING
+ * else. The tests drive the pure [runInstallDevrigCommand] overload whose parameter list is the
+ * command's COMPLETE side-effect surface, so the recorded call list is an honest guard that no agent
+ * config is ever touched.
+ */
+class InstallDevrigCommandTest {
+
+    private val detected = mapOf(
+        AiAgentCli.CLAUDE to Path.of("/opt/homebrew/bin/claude"),
+        AiAgentCli.CODEX to null,
+        AiAgentCli.GEMINI to Path.of("/usr/local/bin/gemini"),
+    )
+
+    @Test
+    fun `no flags re-registers the launcher from the running install and prints the agent guidance`(@TempDir tmp: Path) {
+        val r = run(DevrigCommand.DevrigCommandInstallDevrig(), tmp)
+
+        assertEquals(0, r.exitCode)
+        assertEquals(listOf("registerOwnInstall", "offerPluginToRunningIdes"), r.calls)
+        assertContains(r.stdout, "devrig is registered")
+        assertContains(r.stdout, "PATH setup is best-effort")
+        assertContains(r.stdout, "did NOT configure any AI agent")
+        // CLI paths are interpolated from the same Path values the fake detector returns — Path.toString()
+        // is platform-dependent (backslashes on Windows), so the expected text must be derived, not literal.
+        assertContains(r.stdout, "devrig install claude")
+        assertContains(r.stdout, "claude CLI found: ${detected[AiAgentCli.CLAUDE]}")
+        assertContains(r.stdout, "devrig install codex")
+        assertContains(r.stdout, "codex CLI not found on PATH")
+        assertContains(r.stdout, "devrig install gemini")
+        assertContains(r.stdout, "gemini CLI found: ${detected[AiAgentCli.GEMINI]}")
+        assertContains(r.stdout, "devrig install config")
+    }
+
+    @Test
+    fun `install-script flags keep the explicit install-script registration path`(@TempDir tmp: Path) {
+        val r = run(
+            DevrigCommand.DevrigCommandInstallDevrig(installScript = "/opt/devrig/bin/devrig", jdkHome = "/opt/jdk"),
+            tmp,
+        )
+
+        assertEquals(0, r.exitCode)
+        assertEquals(listOf("registerInstallScriptLauncher", "offerPluginToRunningIdes"), r.calls)
+        assertEquals(
+            listOf(Path.of("/opt/devrig/bin/devrig") to Path.of("/opt/jdk")),
+            r.installScriptRegistrations,
+        )
+        // The bootstrap installer's terminal shows this output too — the guidance is for both flows.
+        assertContains(r.stdout, "did NOT configure any AI agent")
+        assertContains(r.stdout, "devrig install config")
+    }
+
+    @Test
+    fun `install-script without jdk-home falls back to the JDK devrig runs under`(@TempDir tmp: Path) {
+        val r = run(DevrigCommand.DevrigCommandInstallDevrig(installScript = "/opt/devrig/bin/devrig"), tmp)
+
+        assertEquals(0, r.exitCode)
+        assertEquals(
+            Path.of(System.getProperty("java.home")),
+            r.installScriptRegistrations.single().second,
+        )
+    }
+
+    @Test
+    fun `a launcher missing after registration fails with 64 and skips guidance and the plugin offer`(@TempDir tmp: Path) {
+        val r = run(DevrigCommand.DevrigCommandInstallDevrig(), tmp, launcherAppearsOnRegister = false)
+
+        assertEquals(64, r.exitCode)
+        assertFalse(r.calls.contains("offerPluginToRunningIdes"), r.calls.toString())
+        assertEquals("", r.stdout, "no success guidance when registration failed; got:\n${r.stdout}")
+        assertContains(r.stderr, "did not create the launcher")
+    }
+
+    @Test
+    fun `install devrig never touches agent configs - registration plus plugin offer are its only side effects`(@TempDir tmp: Path) {
+        // The seams below are the command's COMPLETE capability set: the function takes no
+        // AiAgentCliRunner and has no other way to spawn an agent CLI. Locking the exact call list is
+        // the strongest honest guard for the issue #398 contract — 'devrig install devrig' registers
+        // devrig itself and nothing else; agent configs are only edited by 'devrig install <agent>'.
+        for (command in listOf(
+            DevrigCommand.DevrigCommandInstallDevrig(),
+            DevrigCommand.DevrigCommandInstallDevrig(installScript = "/opt/devrig/bin/devrig", jdkHome = "/opt/jdk"),
+        )) {
+            val r = run(command, Files.createTempDirectory(tmp, "guard"))
+            val registration =
+                if (command.installScript == null) "registerOwnInstall" else "registerInstallScriptLauncher"
+            assertEquals(listOf(registration, "offerPluginToRunningIdes"), r.calls, "for $command")
+            // The output must SAY agents were not configured — the explicit next step, never a silent end.
+            assertContains(r.stdout, "did NOT configure any AI agent")
+        }
+    }
+
+    @Test
+    fun `guidance lists one install command per agent with CLI detection and points at install config`() {
+        // Expected strings interpolate the SAME Path values the renderer gets: Path.toString() is
+        // platform-dependent (backslashes on a Windows JVM), so literals would fail on Windows.
+        val launcher = Path.of("/home/u/.mcp-steroid/bin/devrig")
+        val text = renderInstallDevrigGuidance(launcher, detected)
+
+        assertContains(text, "devrig is registered: $launcher")
+        assertContains(text, "PATH setup is best-effort")
+        assertContains(text, "add ${launcher.parent} to PATH")
+        assertContains(text, "did NOT configure any AI agent")
+        for (agent in AiAgentCli.entries) {
+            assertContains(text, "devrig install ${agent.binary}")
+        }
+        assertContains(text, "claude CLI found: ${detected[AiAgentCli.CLAUDE]}")
+        assertContains(text, "codex CLI not found on PATH")
+        assertContains(text, "gemini CLI found: ${detected[AiAgentCli.GEMINI]}")
+        assertContains(text, "devrig install config")
+    }
+
+    // ── harness ──
+
+    private class Run(
+        val exitCode: Int,
+        val calls: List<String>,
+        val installScriptRegistrations: List<Pair<Path, Path>>,
+        val stdout: String,
+        val stderr: String,
+    )
+
+    private fun run(
+        command: DevrigCommand.DevrigCommandInstallDevrig,
+        tmp: Path,
+        launcherAppearsOnRegister: Boolean = true,
+    ): Run {
+        val launcher = tmp.resolve("bin").resolve("devrig")
+        val calls = mutableListOf<String>()
+        val installScriptRegistrations = mutableListOf<Pair<Path, Path>>()
+        val stdout = ByteArrayOutputStream()
+        val stderr = ByteArrayOutputStream()
+        fun writeLauncher() {
+            if (!launcherAppearsOnRegister) return
+            Files.createDirectories(launcher.parent)
+            Files.writeString(launcher, "#!/bin/sh\n")
+        }
+        val exitCode = runInstallDevrigCommand(
+            command = command,
+            out = PrintStream(stdout, true, Charsets.UTF_8),
+            err = PrintStream(stderr, true, Charsets.UTF_8),
+            launcherPath = launcher,
+            registerOwnInstall = {
+                calls += "registerOwnInstall"
+                writeLauncher()
+            },
+            registerInstallScriptLauncher = { script, jdkHome ->
+                calls += "registerInstallScriptLauncher"
+                installScriptRegistrations += script to jdkHome
+                writeLauncher()
+            },
+            detectAgentCli = { detected[it] },
+            offerPluginToRunningIdes = { calls += "offerPluginToRunningIdes" },
+        )
+        return Run(
+            exitCode = exitCode,
+            calls = calls,
+            installScriptRegistrations = installScriptRegistrations,
+            stdout = stdout.toString(Charsets.UTF_8).replace("\r\n", "\n"),
+            stderr = stderr.toString(Charsets.UTF_8).replace("\r\n", "\n"),
+        )
+    }
+}

--- a/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/InstallOverviewCommandTest.kt
+++ b/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/InstallOverviewCommandTest.kt
@@ -16,7 +16,7 @@ class InstallOverviewCommandTest {
     @Test
     fun `overview lists every install target and one runnable example`() {
         val text = renderInstallOverview(AiAgentCli.entries.associateWith { null })
-        listOf("claude", "codex", "gemini", "plugin", "devrig").forEach {
+        listOf("claude", "codex", "gemini", "plugin", "devrig", "config").forEach {
             assertTrue(text.contains("  $it"), "overview must list target '$it':\n$text")
         }
         assertTrue(text.contains("devrig install claude"), "overview must show a runnable example:\n$text")


### PR DESCRIPTION
Fixes #398.

## What

`devrig install devrig` becomes **one behavior, same result on every call**: register devrig itself, print one precise next-steps message, and nothing else.

- **Registers the launcher + PATH from the running binary** — the same `ensureBinLauncher(force = true)` self-heal that already runs on every devrig start. No modes: the `--install-script`/`--jdk-home` flags stay in the install scripts **by design** (a forward contract a future devrig may use), but today's devrig accepts and ignores them — every spelling, including blank values, parses to the identical flag-less command. `ensureBinLauncherForInstallScript` is gone.
- **Never configures agents and never installs the IDE plugin.** The implicit `tryInstallPluginIntoRunningIdesQuietly()` call is removed — both actions edit state outside `~/.mcp-steroid`, so they stay explicit commands the message promotes. Locked in by a guard test that pins the command's complete side-effect surface (`registerLauncher` is its only seam).
- **One info message** (stdout, deterministic):

  ```
  devrig is installed: ~/.mcp-steroid/bin/devrig
  The launcher and PATH registration self-heal on every devrig run. If 'devrig' is not
  found, open a new terminal (Windows) or add ~/.mcp-steroid/bin to PATH.

  Next steps:
    devrig install plugin    install the MCP Steroid plugin into your running JetBrains IDEs
    devrig install claude    connect devrig to Claude Code (also: codex, gemini)
    devrig install config    print the mcp.json snippet for any other MCP client
  ```

- **New `devrig install config`** prints the manual MCP configuration for clients devrig cannot configure automatically: the stdio `mcpServers` JSON snippet pointing at the stable launcher plus per-agent `mcp add` command lines — built from the same `DevrigUserLauncher.invocation` that `devrig install <agent>` registers, so manual and automatic setup cannot drift. Mirrors the IntelliJ settings page (`McpConnectionInfo`), stdio instead of HTTP; JSON rendered with kotlinx.serialization (Windows backslash paths escape correctly).
- **The handoff runs under `DEVRIG_JAVA_HOME`**, devrig's own variable honored by the dist launcher — `install.sh`/`install.ps1`/`deployDevrig` no longer set `JAVA_HOME`; `install.ps1` restores the variable since `irm | iex` runs in the caller's session. The install scripts drop their duplicate static next-steps block; devrig's message is the single source.
- Bare `devrig install` overview and `devrig help` list the `config` target.

## Testing

`./gradlew :npx-kt:test :ai-agents:test :installer-gen:test` — BUILD SUCCESSFUL (0 failures/skips), re-verified after rebasing onto current main (`2857891c`).
`./gradlew :installer-gen:installerIntegrationTest` (Docker) — both bootstrap lanes pass: the generated scripts delegate with the computed flags, the fake devrig proves the handoff runs under the bundled JDK via `DEVRIG_JAVA_HOME`, and no agent auto-registration happens.
