### PR TITLE
Run IU 262 as a devrig Remote Development backend

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -105,6 +105,8 @@
     download/start/stop with one operation lock and refuse to rewrite the plugin of a live target.
   - Make failed-start cleanup diagnostics distinguish a deliberate identity-change refusal from a
     termination failure.
+  - Move legacy archive migration under the global backend-operation lock, or prove the current
+    idempotent moves safe when two fresh `BackendManager` instances initialize concurrently.
   - Revalidate the native Remote Development launcher for baseline 263+, using cold-CI telemetry to
     tune the 180-second readiness bound and the caller-cancellation behavior before widening support.
   - Put the pure Remote Development NDJSON parser/workflow contracts on a normal CI-backed task; the

--- a/TODO.md
+++ b/TODO.md
@@ -94,6 +94,19 @@
     touching the argument list.
 
 - [ ] Backend management follow-ups (deferred, surfaced during the design):
+  - [x] Launch managed IntelliJ Ultimate 2026.2 as a native Remote Development backend and prove the
+    clean-machine Claude/Codex Keycloak hierarchy flow described in
+    `docs/devrig-remote-development-backend-e2e.md`.
+  - Apply the secret-safe environment allowlist to standard managed launches too, while explicitly
+    retaining `http_proxy` / `https_proxy` / `no_proxy` variants needed by IDE networking.
+  - Replace hardcoded `/usr/bin/setsid` / `/bin/setsid` lookup with a portable executable search so
+    detached managed launches work on non-FHS systems such as NixOS.
+  - Snapshot PID + start identity before launch instead of excluding raw PIDs, and make failed-start
+    cleanup diagnostics distinguish a deliberate identity-change refusal from a termination failure.
+  - Revalidate the native Remote Development launcher for baseline 263+, using cold-CI telemetry to
+    tune the 180-second readiness bound and the caller-cancellation behavior before widening support.
+  - Put the pure Remote Development NDJSON parser/workflow contracts on a normal CI-backed task; the
+    experimental task's direct-invocation guard currently keeps them out of aggregate CI runs.
   - Stream download progress to the agent (downloads can take minutes; CLI is silent until done).
   - Consider enriching `backend --json` / `backend download --json` with release date + download channel so agents can reason about staleness; consider exposing `IdeProduct` metadata (license tier, launcher) for richer IDE choice.
   - Optional explicit `open_project` target (by managed-backend id / pid) for the case where the agent wants a specific backend even when several are running — today the global lock makes "prefer managed" sufficient.

--- a/TODO.md
+++ b/TODO.md
@@ -101,8 +101,10 @@
     retaining `http_proxy` / `https_proxy` / `no_proxy` variants needed by IDE networking.
   - Replace hardcoded `/usr/bin/setsid` / `/bin/setsid` lookup with a portable executable search so
     detached managed launches work on non-FHS systems such as NixOS.
-  - Snapshot PID + start identity before launch instead of excluding raw PIDs, and make failed-start
-    cleanup diagnostics distinguish a deliberate identity-change refusal from a termination failure.
+  - [x] Snapshot PID + start identity before launch instead of excluding raw PIDs; serialize
+    download/start/stop with one operation lock and refuse to rewrite the plugin of a live target.
+  - Make failed-start cleanup diagnostics distinguish a deliberate identity-change refusal from a
+    termination failure.
   - Revalidate the native Remote Development launcher for baseline 263+, using cold-CI telemetry to
     tune the 180-second readiness bound and the caller-cancellation behavior before widening support.
   - Put the pure Remote Development NDJSON parser/workflow contracts on a normal CI-backed task; the

--- a/docs/devrig-remote-development-backend-e2e.md
+++ b/docs/devrig-remote-development-backend-e2e.md
@@ -367,8 +367,8 @@ inspection when one process listing transiently omits a live tracked process.
 
 The next Codex quorum caught a newly advanced `origin/main` commit whose
 `TODO-TC-COVERAGE-AUDIT.md` appeared deleted in the branch diff. The verified iteration was committed
-and rebased again; the branch is now zero commits behind `origin/main`, four commits ahead, and
-preserves that upstream audit file.
+and rebased again; the branch is zero commits behind `origin/main` and preserves that upstream audit
+file.
 
 ### Final three-model quorum — PASS
 

--- a/docs/devrig-remote-development-backend-e2e.md
+++ b/docs/devrig-remote-development-backend-e2e.md
@@ -339,9 +339,9 @@ than merely mentioning it.
   but this corpus did not reproduce it.
 - The final independent re-audit added terminal evidence to #20, #91, #207, #280, #402, #403, and
   #405. The last new caller runtime failure was an inspection-loop `IndexOutOfBoundsException`; its
-  duplicated diagnostics and generic hint belong to #91 rather than a new issue. Two independent
-  auditors agreed exactly on the terminal census and mapping. No genuinely untracked defect remained,
-  so no duplicate issue was created.
+  duplicated diagnostics and generic hint belong to #91 rather than a new issue. Four independent
+  auditors ultimately agreed exactly on the terminal census and mapping. No genuinely untracked defect
+  remained, so no duplicate issue was created.
 
 ## Review log
 
@@ -389,8 +389,10 @@ acceptance surface and produced the persisted PASS verdicts above.
 
 ### Complete execute-code audit review — PASS
 
-Three independent execute-code auditors rechecked the corpus and every proposed issue against existing
+Four independent execute-code auditors rechecked the corpus and every proposed issue against existing
 GitHub ownership. The terminal two-agent reconciliation agreed exactly on 1,108 calls, the 39-error
-taxonomy, timing, and counters. They agreed that #402–#405 are distinct defects and that every remaining
-observation belongs to #20, #66, #91, #207, #215, or #280. The final audit verdict was PASS with no
-untracked finding.
+taxonomy, timing, and counters. A fourth post-delivery auditor independently recomputed the same census
+from the frozen 5,962-event raw artifact and its `call_id`-deduplicated form, including all eleven
+successful calls lasting at least 60 seconds. The auditors agreed that #402–#405 are distinct defects
+and that every remaining observation belongs to #20, #66, #91, #207, #215, or #280. The final audit
+verdict was PASS with no untracked finding.

--- a/docs/devrig-remote-development-backend-e2e.md
+++ b/docs/devrig-remote-development-backend-e2e.md
@@ -266,8 +266,9 @@ than merely mentioning it.
 
 ### 2026-07-31 — final verification
 
-- After the final PID-identity iteration, `BackendManagerStartStopTest` passed 36/36. On the rebased
-  branch the complete `:npx-kt:test` suite discovered 1,439 tests: 1,435 executed and passed, with four
+- After the final PID-identity and operation-lock iteration, the four focused backend regression
+  classes passed 58/58. On the rebased branch the complete `:npx-kt:test` suite discovered 1,444 tests:
+  1,440 executed and passed, with four
   pre-existing platform-guarded skips and no failures or errors.
 - The pure agent-output parser/workflow contracts passed 9/9, and the volume-isolation/log-stream
   infrastructure contracts passed 5/5. All `:test-experiments` and `:test-integration` invocations
@@ -276,8 +277,10 @@ than merely mentioning it.
   absent from one `ProcessHandle` snapshot. `terminateFailedBackendStart` now repeats bounded process
   discovery until three consecutive scans are quiet, so a failed start cannot leave a launcher or
   backend process behind.
-- Direct IntelliJ inspections ran on all 25 modified Kotlin production/test files before and after the
-  rebase with no failed tools and no remaining diagnostics.
+- Direct IntelliJ inspections ran on all 25 modified Kotlin production/test files with no failed tools.
+  The post-quorum sweep found four `BlockingMethodInNonBlockingContext` findings after `stopLocked`
+  became suspendable; keeping its blocking body non-suspending under the caller's `Dispatchers.IO`
+  context removed all four, and the terminal inspection was clean.
 - Claude passed from a fresh Docker home, used the installed
   `/home/agent/.mcp-steroid/bin/devrig`, registered the user-scope MCP server, downloaded and started
   IU `2026.2.0.1`, opened Keycloak, and returned 70 subtypes in both the independently parsed tool
@@ -294,16 +297,22 @@ than merely mentioning it.
   paths stopped IU and left no Docker containers or managed backend processes.
 - Both preserved `managed-backend-idea.log` artifacts were sanitized and rechecked: neither contains
   an unredacted Bearer credential.
+- A post-quorum Docker rerun reached the fresh-home fixture but could not launch Claude because this
+  shell had none of `ANTHROPIC_API_KEY`, `CLAUDE_EVAL_API_KEY`, or `~/.anthropic`; the test failed hard
+  as designed and no skip was added. A separate Docker process-scan probe then proved the new teardown
+  matcher detects an exact managed-bundle launcher argv while rejecting an unrelated shell whose
+  command merely contains the same path. The earlier credentialed Claude/Codex Docker passes remain the
+  end-to-end evidence.
 
 ### 2026-07-31 — complete `steroid_execute_code` call audit
 
-- The terminal audit froze after `eid_20260731T092845-devrig-remote-backend-post-rebase` and deduplicated
-  inherited fork history by `call_id` across 21 root/sub-agent rollout logs. It found 1,065 unique calls:
-  1,028 successful, 37 failed, and 4,697.498 aggregate tool-seconds. The earlier 464-call number was a
+- The terminal audit froze after `eid_20260731T100732-devrig-remote-backend-final-verification` and
+  deduplicated 5,355 raw events by `call_id` across 22 root/sub-agent rollout logs. It found 1,080 unique
+  calls: 1,042 successful, 38 failed, and 5,172.326 aggregate tool-seconds. The earlier 464-call number was a
   narrower snapshot of the single primary rollout, not the complete multi-agent corpus.
-- The 37 errors were 20 caller-script compilation errors, 12 caller-script runtime errors, four
-  transient route-disappearance errors, and one dropped `/tools/call/stream` result. Three calls ran at
-  least 60 seconds and all succeeded; no script timeout occurred. The corpus contained 342 scripts that
+- The 38 errors were 21 caller-script compilation errors, 12 caller-script runtime errors, four
+  transient route-disappearance errors, and one dropped `/tools/call/stream` result. Seven calls ran at
+  least 60 seconds and all succeeded; no script timeout occurred. The corpus contained 352 scripts that
   used `RunContentManager`.
 - Four non-duplicate problems were filed:
   - [#402](https://github.com/jonnyzzz/mcp-steroid/issues/402) — IU 262 Gradle recipes can lose test
@@ -322,6 +331,10 @@ than merely mentioning it.
   indices [#280](https://github.com/jonnyzzz/mcp-steroid/issues/280). The seven-case correction was also
   added to #404. Timeout dump work remains [#215](https://github.com/jonnyzzz/mcp-steroid/issues/215),
   but this corpus did not reproduce it.
+- The final independent re-audit added terminal evidence to #20, #91, #207, and #403. The last new
+  caller compile failure duplicated its type-mismatch diagnostics and then falsely suggested EDT; that
+  belongs to #91 rather than a new issue. No genuinely untracked defect remained, so no duplicate issue
+  was created.
 
 ## Review log
 

--- a/docs/devrig-remote-development-backend-e2e.md
+++ b/docs/devrig-remote-development-backend-e2e.md
@@ -1,0 +1,357 @@
+# devrig Remote Development backend E2E
+
+Status: implementation complete; final review and PR in progress
+Owner branch: `feat/devrig-remote-backend-e2e`
+Worktree: `/Users/jonnyzzz/Work/mcp-steroid-wt-devrig-remote-backend`
+Started: 2026-07-31
+
+## Goal
+
+Prove the complete first-use devrig story on a clean Docker machine for both Claude Code and Codex:
+
+1. A prepared Keycloak checkout and JDK are present, with dependency/build caches warm enough that the
+   scenario measures IDE/agent behavior rather than public repository availability.
+2. Only locally built devrig installation inputs are preloaded. The simulated user installs devrig into
+   a fresh home and registers it with the selected agent through the real CLI.
+3. The user asks the agent for the existing Keycloak `Authenticator` type-hierarchy result. The task is
+   deliberately expensive to solve reliably without a Java IDE and its indices.
+4. The agent invokes devrig. devrig downloads IntelliJ IDEA Ultimate 2026.2 (build line 262), installs
+   the bundled MCP Steroid plugin, and starts the IDE as a Remote Development backend.
+5. The backend opens Keycloak, finishes project import/indexing, and exposes the normal MCP Steroid
+   project and `steroid_execute_code` surfaces without any Remote Development frontend.
+6. The agent returns a hierarchy result that passes the existing semantic scorer.
+
+The product behavior belongs in devrig. The E2E belongs in `:test-experiments` because it downloads and
+starts a full IDE, launches a real external agent, and is intentionally long-running.
+
+## Acceptance criteria
+
+The work is complete only when all of these are demonstrated:
+
+- Two explicit tests exist: Claude Code and Codex. They run sequentially, never concurrently.
+- Each test starts with an ephemeral agent home and ephemeral `~/.mcp-steroid` state.
+- The agent registration is performed with the installed devrig CLI; the test does not hand-write an MCP
+  registration that bypasses the user flow.
+- The IDE archive may come from a host-mounted download cache, but the managed backend install, config,
+  system, log, plugin, marker, and agent-registration state begin empty.
+- IntelliJ IDEA Ultimate is pinned to `2026.2.0.1` (`IU-262.8665.337`). An unavailable exact build fails clearly; it
+  must not silently fall back to 261 or a different product.
+- devrig launches the native Remote Development entry point:
+  `bin/remote-dev-server run` on Linux/macOS or `bin/remote-dev-server.exe run` on Windows.
+- The launch does not pass a project path. devrig waits for MCP discovery and then routes the existing
+  `steroid_open_project` call, avoiding the marker-before-project-open race. Because this is a
+  devrig-managed backend opening a path explicitly requested by the user, the process sets
+  `REMOTE_DEV_NON_INTERACTIVE=1` and `REMOTE_DEV_TRUST_PROJECTS=1`.
+- The discovered marker identifies the managed 262 Ultimate installation and the managed MCP Steroid
+  plugin directory.
+- `idea.log` identifies `IdeProductMode.REMOTE_DEV_SERVER` / the MCP Steroid run mode as remote
+  development backend.
+- `steroid_open_project`, `steroid_list_projects`, and `steroid_execute_code` work against Keycloak
+  without a frontend client.
+- The reused hierarchy scorer finds at least 40 inheritors of
+  `org.keycloak.authentication.Authenticator`, including:
+  `UsernamePasswordForm`, `OTPFormAuthenticator`, and `IdpConfirmLinkAuthenticator`.
+- All unit/contract tests and both Docker cases pass from the dedicated worktree, with no ignored warning
+  or unexplained error in the relevant IDE/devrig logs.
+- A three-reviewer quorum, including Claude `claude-fable-5` and `claude-opus-5`, reports no blockers
+  after the final iteration.
+
+## Confirmed IntelliJ 262 launch contract
+
+Research against `/Users/jonnyzzz/Work/intellij` established:
+
+- `bin/remote-dev-server.sh run [project]` is the wrapper entry point, but it is not appropriate for
+  devrig PID ownership because it can restart and retain a parent wrapper process.
+- The native entry point is `bin/remote-dev-server run [project]` on Unix and
+  `bin/remote-dev-server.exe run [project]` on Windows.
+- `run` maps to the `remoteDevHost` starter. Starting without a project is supported.
+- The native 262 launcher reads the existing adjacent `<IDE_HOME>.vmoptions` file used by devrig.
+  Therefore the managed config/system/log/plugin/storage locations remain effective.
+- MCP Steroid already treats the process as a Remote Development backend. The unattended starter calls
+  `appFrameCreated`, so the lifecycle listener can start Ktor and publish the PID marker before a project
+  is open.
+- The marker can appear before a launcher-supplied project finishes opening. The chosen launch passes no
+  project and retains the existing explicit `steroid_open_project` route.
+- Direct native launch is preferred for the first implementation because devrig's pid file, stop path,
+  and marker validation all assume the spawned PID is the IDE PID. The shell wrapper would make the
+  tracked PID a parent wrapper and needs separate process-tree work.
+
+Primary source anchors:
+
+- `build/resources/linux/scripts/remote-dev-server.sh`
+- `community/native/XPlatLauncher/src/remote_dev.rs`
+- `community/native/XPlatLauncher/src/default.rs`
+- `community/platform/core-api/src/com/intellij/idea/WellKnownCommand.java`
+- `remote-dev/cwm-host-unattended/.../UnattendedHostStarter.kt`
+- `remote-dev/remote-dev-worker/src/utils/ide_{linux,darwin,windows}.go`
+- `remote-dev/remote-dev-server-plugin/.../launcher.sh`
+
+## Implemented launch behavior
+
+`BackendManager.startLocked` now resolves a `ManagedBackendLaunchSpec` containing the executable,
+ordered arguments, working directory, and launch environment. For Remote Development launches it blocks
+until a matching live MCP Steroid marker appears, then writes the marker/backend PID to
+`state/<backend-id>.pid`. This explicitly supports the native launcher handing work to a different PID;
+the short-lived launcher PID is never published as a ready backend.
+
+Remote Development selection is intentionally narrow:
+
+| Product/build | Launcher | Arguments | Extra environment |
+|---|---|---|---|
+| `idea-ultimate`, baseline `262` | native `bin/remote-dev-server[.exe]` | `run` | `REMOTE_DEV_JDK_DETECTION=false`, `REMOTE_DEV_NON_INTERACTIVE=1`, `REMOTE_DEV_TRUST_PROJECTS=1` |
+| IDEA Ultimate 261/263 | descriptor's standard launcher | none | none |
+| IDEA Community, every build | descriptor's standard launcher | none | none |
+| Every other product | descriptor's standard launcher | none | none |
+
+For IU 262, a missing native launcher or `plugins/remote-dev-server` is a validation failure. There is
+no silent fallback to the standard launcher. Other products/builds are not required to ship those assets.
+
+`writeBackendVmOptions` places `<bundle-dir-name>.vmoptions` next to the managed IDE bundle and
+sets isolated config, system, log, plugin, and MCP execution-storage paths. The native launcher uses
+that same adjacent user-VM-options location on every supported OS; no Remote-Development-specific
+mirror is needed. `deployMcpSteroidPlugin` installs the current bundled plugin below the managed
+cache's `plugins/mcp-steroid` directory before every cold start.
+
+The 262 native launcher normally enables `jdk.configure.existing` for Remote Development. On an empty
+profile, `ExistingJdkConfigurationActivity` calls `AddJdkService.createIncompleteJdk` from a background
+write action; `SdkConfigurationUtil.createSdk` then uses `invokeAndWait` and the platform logs a deadlock
+SEVERE. devrig sets the launcher's supported `REMOTE_DEV_JDK_DETECTION=false` opt-out. The clean-machine
+fixture still contains JDK 21 and uses it for the verified online/offline Maven builds; only the broken
+workstation-style automatic SDK registration is disabled in the unattended backend.
+
+The exact version `2026.2.0.1` is a released stable build and resolves to `IU-262.8665.337`; no EAP
+channel or moving alias is involved.
+
+## Implementation design
+
+### Launch description
+
+Represent a managed backend launch as an executable, ordered arguments, working directory, and
+environment. The installed-product resolver validates Remote Development assets only for IU baseline
+262, then selects the native launcher with the single `run` argument and both non-interactive trust flags.
+
+The spawn layer must accept arguments on Unix and Windows. Windows WMI command-line construction must
+quote each argument without changing the existing detached-lifetime behavior. Process discovery and
+stop validation must continue to recognize both the executable and its managed-bundle arguments.
+
+No shell wrapper is used in this scope. musl support, if required later, needs explicit wrapper child-PID
+tracking and is not silently emulated here.
+
+### Download selection
+
+The E2E requests `devrig backend download idea-ultimate --version 2026.2.0.1`, so resolution cannot
+select 2026.1 or a different product. The descriptor must report product code `IU` and build baseline 262.
+
+### Project opening
+
+Managed backend startup remains project-agnostic:
+
+1. Start `remote-dev-server run`.
+2. Wait for a live MCP Steroid marker matching the exact managed IDE home, build, plugin id, and devrig
+   bridge endpoint. Persist and return that marker PID, which may differ from the launcher PID.
+3. Route `steroid_open_project`; the managed backend already trusts user-requested project paths through
+   `REMOTE_DEV_TRUST_PROJECTS=1`.
+4. Poll the project/window readiness surface and then run the semantic task.
+
+This keeps the existing agent-facing contract and avoids duplicate project-open requests.
+
+### Docker fixture
+
+The scenario uses Keycloak 26.6.4 at commit `dc1bfc54bf1462f7e79822adb4c59aba7e25d50f`
+and its existing hierarchy task/scorer. Each ephemeral container clones the pinned revision from the
+host bare-repository cache and uses JDK 21. Maven/Gradle dependency caches are mounted separately from
+the otherwise-clean home. The fixture proves an online and then offline warm build with:
+
+`./mvnw -q -DskipTests -pl server-spi-private,services -am compile`
+
+Keycloak 26.6.4 pins `maven-build-cache-extension:1.2.0`, whose `CacheConfigImpl` eagerly injects
+`MavenSession`. IDEA's Maven embedder enumerates lifecycle participants before a session is seeded, so
+that version logs a Guice `ProvisionException`. The fixture upgrades only that extension to `1.2.1`
+before warming caches. Version 1.2.1 changes the constructor to `Provider<MavenSession>` and defers
+session access until initialization; caching remains enabled and both online and offline builds remain
+mandatory.
+
+The container receives local devrig installation artifacts and a persistent IDE archive download cache,
+but the user home and devrig managed state are new for every test method.
+
+Claude and Codex use the repository's real agent-session drivers and real API credentials. The prompt
+states the user task and required output markers, but does not hand the agent the hierarchy answer or a
+filesystem-grep recipe. Raw NDJSON is retained so the test can prove the agent called devrig/MCP rather
+than merely mentioning it.
+
+## Test-first work plan
+
+- [x] Create a clean worktree and branch.
+- [x] Read root, `docs`, `test-experiments`, and shared `test-integration` guides.
+- [x] Research the 262 native Remote Development entry point, VM-options precedence, lifecycle, and
+  marker timing in IntelliJ sources.
+- [ ] Obtain final independent reviews from Claude Fable 5, Claude Opus 5, and a third
+  reviewer; record decisions below.
+- [x] Add failing unit tests for native launcher resolution, required distribution contents, ordered
+  launch arguments, Windows quoting, and PID/process recognition.
+- [x] Implement the IU-262-only native Remote Development launch path.
+- [x] Confirm exact stable version `2026.2.0.1` resolves to `IU-262.8665.337`.
+- [x] Build a narrow Docker feasibility probe: start the managed native backend, observe its marker, open
+  Keycloak, and execute one `ClassInheritorsSearch` without a frontend.
+- [x] Add the clean-machine fixture and explicit Claude/Codex `:test-experiments` cases.
+- [x] Run scoped unit/contract tests and the complete `:npx-kt:test` suite before and after rebasing.
+- [x] Add and pass focused launcher-PID → marker-PID handoff, marker-timeout, Remote Development
+  environment, Docker-volume, log-stream teardown, and NDJSON parser tests.
+- [x] Run Claude E2E and Codex E2E separately. Apply the one-minute hang rule and capture live dumps
+  before terminating any stuck run.
+- [x] Inspect relevant source diagnostics and runtime logs; fix every warning/error in scope.
+- [ ] Run final three-reviewer quorum, iterate on blockers, and repeat affected tests.
+- [ ] Record final evidence, update TODOs, commit atomically, push, and open a PR.
+
+## Risks and explicit non-goals
+
+- Remote Development is an Ultimate capability. Community distributions are not accepted as substitutes.
+- Linux native Remote Development excludes musl. Supporting musl is a follow-up unless the target Docker
+  base proves to be musl.
+- Backend startup may be allowed without a connected frontend, but licensing behavior under long-lived
+  use must be observed rather than guessed. The expected 262 code path ties licensing to connected CWM
+  sessions, not MCP-only startup.
+- Screenshot/window tooling may be incomplete without a frontend. Acceptance relies on project routing
+  and `steroid_execute_code`, not GUI rendering.
+- This work adds no `steroid_*` tool, no `McpScriptContext` method, and no IntelliJ API wrapper.
+
+## Evidence log
+
+### 2026-07-31 — initial research
+
+- Confirmed native `remote-dev-server run` maps to `remoteDevHost` and accepts no project.
+- Confirmed adjacent managed VM options and plugin path apply to the native launcher.
+- Confirmed MCP Steroid lifecycle startup is compatible with `IdeProductMode.isBackend`.
+- Identified marker-before-project-open race and selected explicit post-discovery project opening.
+- Identified exact-PID constraint that rules out the shell wrapper for the first implementation.
+- Identified stable-channel resolver risk for an unreleased 2026.2 build.
+
+### 2026-07-31 — live IU 262 Docker proof
+
+- Resolved stable IntelliJ IDEA Ultimate `2026.2.0.1`, build `IU-262.8665.337`.
+- Started the native `bin/remote-dev-server run` process without a project argument or frontend.
+- Observed `IDE run mode: remote development (backend)` in the IDE log.
+- Confirmed the devrig state PID equals the MCP Steroid marker PID.
+- Opened Keycloak afterward through `steroid_open_project`.
+- Executed deep `ClassInheritorsSearch` for `org.keycloak.authentication.Authenticator` and received
+  72 classes, including all three required indirect implementors.
+- Confirmed the shell wrapper is unsuitable because its restart loop breaks exact PID ownership.
+
+### 2026-07-31 — keyed Claude clean-machine run
+
+- Installed devrig for Claude at user scope inside a fresh Docker home.
+- Downloaded and verified the 1.544 GB stable IU `2026.2.0.1` archive, installed MCP Steroid, and
+  launched `remote-dev-server run` with the non-interactive trusted-project environment.
+- Opened the pinned Keycloak checkout without a Remote Development frontend and returned all 72
+  deep `Authenticator` inheritors, including the three required indirect classes.
+- The agent workflow and backend itself completed successfully and PID 2661 stopped cleanly. The test
+  remained red only because its post-run verifier incorrectly expected native-launcher JVM options in
+  `ps` argv. The 262 launcher embeds libjvm, so the corrected verifier checks the effective managed
+  plugin/cache properties recorded in `idea.log` and preserves that log for the final audit.
+- Artifacts: `test-experiments/build/test-logs/test/run-20260731-123121-devrig-remote-backend-keycloak-claude`.
+
+### 2026-07-31 — diagnostic and readiness iteration
+
+- Reproduced the Codex double-start race: the shell start returned launcher PID 1881 before readiness;
+  `steroid_open_project` triggered another start whose real MCP marker used PID 2032.
+- `backend start` now waits for a matching live marker and persists its PID. Unit coverage forces an
+  intentional launcher/backend PID handoff and proves stop targets the backend PID.
+- Source-traced the clean-profile JDK SEVERE to `ExistingJdkConfigurationActivity` plus
+  `SdkConfigurationUtil.createSdk`; selected the native launcher's supported
+  `REMOTE_DEV_JDK_DETECTION=false` setting.
+- Source-traced Keycloak's Maven `ProvisionException` to build-cache extension 1.2.0 eager
+  `MavenSession` injection; selected 1.2.1, which uses a provider and keeps caching active.
+- The E2E now fails on any IDEA SEVERE, the known Maven core-extension exception signatures, or any
+  unexpected MCP Steroid WARN/ERROR/SEVERE, while preserving both IDEA and launcher logs.
+
+### 2026-07-31 — final verification
+
+- After the final PID-identity iteration, `BackendManagerStartStopTest` passed 36/36. On the rebased
+  branch the complete `:npx-kt:test` suite discovered 1,439 tests: 1,435 executed and passed, with four
+  pre-existing platform-guarded skips and no failures or errors.
+- The pure agent-output parser/workflow contracts passed 9/9, and the volume-isolation/log-stream
+  infrastructure contracts passed 5/5. All `:test-experiments` and `:test-integration` invocations
+  were serialized.
+- A deterministic regression reproduced an unsuccessful Remote Development launch whose launcher was
+  absent from one `ProcessHandle` snapshot. `terminateFailedBackendStart` now repeats bounded process
+  discovery until three consecutive scans are quiet, so a failed start cannot leave a launcher or
+  backend process behind.
+- Direct IntelliJ inspections ran on all 25 modified Kotlin production/test files before and after the
+  rebase with no failed tools and no remaining diagnostics.
+- Claude passed from a fresh Docker home, used the installed
+  `/home/agent/.mcp-steroid/bin/devrig`, registered the user-scope MCP server, downloaded and started
+  IU `2026.2.0.1`, opened Keycloak, and returned 70 subtypes in both the independently parsed tool
+  result and independently parsed final answer in 175 seconds. Artifact:
+  `test-experiments/build/test-logs/test/run-20260731-173006-devrig-remote-backend-keycloak-claude`.
+- Codex then passed alone from another fresh Docker home and returned 70 subtypes in both independently
+  parsed channels in 144 seconds. Artifact:
+  `test-experiments/build/test-logs/test/run-20260731-173355-devrig-remote-backend-keycloak-codex`.
+- A separate raw-NDJSON audit extracted only the user-visible final response from each artifact and
+  independently counted 70 unique `SUBTYPE:` entries with all three required transitive classes for
+  both Claude and Codex.
+- Both runs crossed the one-minute threshold while making progress, so live screenshots and
+  in-container JVM thread dumps were captured before they were allowed to continue. Both teardown
+  paths stopped IU and left no Docker containers or managed backend processes.
+- Both preserved `managed-backend-idea.log` artifacts were sanitized and rechecked: neither contains
+  an unredacted Bearer credential.
+
+### 2026-07-31 — complete `steroid_execute_code` call audit
+
+- The terminal audit froze after `eid_20260731T092845-devrig-remote-backend-post-rebase` and deduplicated
+  inherited fork history by `call_id` across 21 root/sub-agent rollout logs. It found 1,065 unique calls:
+  1,028 successful, 37 failed, and 4,697.498 aggregate tool-seconds. The earlier 464-call number was a
+  narrower snapshot of the single primary rollout, not the complete multi-agent corpus.
+- The 37 errors were 20 caller-script compilation errors, 12 caller-script runtime errors, four
+  transient route-disappearance errors, and one dropped `/tools/call/stream` result. Three calls ran at
+  least 60 seconds and all succeeded; no script timeout occurred. The corpus contained 342 scripts that
+  used `RunContentManager`.
+- Four non-duplicate problems were filed:
+  - [#402](https://github.com/jonnyzzz/mcp-steroid/issues/402) — IU 262 Gradle recipes can lose test
+    results and pre-test failure output.
+  - [#403](https://github.com/jonnyzzz/mcp-steroid/issues/403) — the prompt corpus contradicts itself
+    about client, script, transport, and orchestration timeouts.
+  - [#404](https://github.com/jonnyzzz/mcp-steroid/issues/404) — the no-output hint falsely diagnoses
+    legitimate conditional zero-result scripts as missing `println`.
+  - [#405](https://github.com/jonnyzzz/mcp-steroid/issues/405) — production marker logging exposes MCP
+    Authorization headers.
+- Existing owners received complete-corpus evidence instead of duplicate issues: process completion
+  polling [#20](https://github.com/jonnyzzz/mcp-steroid/issues/20), recurring FilenameIndex directory
+  crashes [#66](https://github.com/jonnyzzz/mcp-steroid/issues/66) (reopened), route resilience and
+  misleading compile hints [#91](https://github.com/jonnyzzz/mcp-steroid/issues/91), compilation latency
+  [#207](https://github.com/jonnyzzz/mcp-steroid/issues/207), and execution storage appearing in project
+  indices [#280](https://github.com/jonnyzzz/mcp-steroid/issues/280). The seven-case correction was also
+  added to #404. Timeout dump work remains [#215](https://github.com/jonnyzzz/mcp-steroid/issues/215),
+  but this corpus did not reproduce it.
+
+## Review log
+
+### Independent implementation review — BLOCKER (pre-final iteration)
+
+The read-only `independent_review` sub-agent found retry-sensitive `firstOrNull` assertions, premature
+exit-code handling, missing `steroid_list_projects` proof, an unnecessary macOS VM-options mirror, the
+misleading standard-launcher download message, and the verifier's invalid `ps`-argv assumption. The
+iteration now accepts any successful retry, proves Keycloak through `steroid_list_projects`, defers the
+Codex-137 decision until all evidence passes, validates effective managed properties in `idea.log`,
+removes the mirror, reports the effective launcher, and gives every shell invariant a named failure
+diagnostic.
+
+Final Fable 5, Opus 5, and independent-review verdicts remain pending. Each final entry must identify
+its persisted run, state `PASS` or `BLOCKER`, and list any resulting changes. Reviewers inspect the
+current branch read-only and do not run Docker integration tests.
+
+### Final static sub-agent review — PASS after iteration
+
+The final static reviewer identified launcher/interpreter false ownership, list commands that trusted a
+live reused PID without comparing `startInstant`, unsafe raw marker diagnostics, and delivery/rebase
+gaps. Deterministic regressions failed before the lifecycle/list fixes and passed afterward. Marker
+diagnostics now project only safe fields; tool and final-answer scores are independent; the branch was
+rebased cleanly onto `origin/main` while preserving all upstream `TODO.md` additions. A follow-up
+iteration also made marker validation lazy for durable JSON PID identity and falls back to direct PID
+inspection when one process listing transiently omits a live tracked process.
+
+### Complete execute-code audit review — PASS
+
+Three independent execute-code auditors rechecked the frozen corpus and every proposed issue against
+existing GitHub ownership. They agreed that #402–#405 are distinct defects and that every remaining
+observation belongs to #20, #66, #91, #207, #215, or #280. The final audit verdict was PASS with no
+untracked finding.

--- a/docs/devrig-remote-development-backend-e2e.md
+++ b/docs/devrig-remote-development-backend-e2e.md
@@ -185,7 +185,7 @@ than merely mentioning it.
 - [x] Read root, `docs`, `test-experiments`, and shared `test-integration` guides.
 - [x] Research the 262 native Remote Development entry point, VM-options precedence, lifecycle, and
   marker timing in IntelliJ sources.
-- [ ] Obtain final independent reviews from Claude Fable 5, Claude Opus 5, and a third
+- [x] Obtain final independent reviews from Claude Fable 5, Claude Opus 5, and a third
   reviewer; record decisions below.
 - [x] Add failing unit tests for native launcher resolution, required distribution contents, ordered
   launch arguments, Windows quoting, and PID/process recognition.
@@ -200,7 +200,7 @@ than merely mentioning it.
 - [x] Run Claude E2E and Codex E2E separately. Apply the one-minute hang rule and capture live dumps
   before terminating any stuck run.
 - [x] Inspect relevant source diagnostics and runtime logs; fix every warning/error in scope.
-- [ ] Run final three-reviewer quorum, iterate on blockers, and repeat affected tests.
+- [x] Run final three-reviewer quorum, iterate on blockers, and repeat affected tests.
 - [ ] Record final evidence, update TODOs, commit atomically, push, and open a PR.
 
 ## Risks and explicit non-goals
@@ -266,21 +266,23 @@ than merely mentioning it.
 
 ### 2026-07-31 — final verification
 
-- After the final PID-identity and operation-lock iteration, the four focused backend regression
-  classes passed 58/58. On the rebased branch the complete `:npx-kt:test` suite discovered 1,444 tests:
-  1,440 executed and passed, with four
-  pre-existing platform-guarded skips and no failures or errors.
-- The pure agent-output parser/workflow contracts passed 9/9, and the volume-isolation/log-stream
+- After the final readiness, PID-identity, shell-ownership, and operation-lock iterations, the focused
+  lifecycle/list classes passed 50/50. On the rebased branch the terminal `:npx-kt:test` suite discovered
+  1,445 tests: 1,441 executed and passed, with four pre-existing Windows-only skips and no failures or
+  errors.
+- The terminal Remote Development workflow contracts passed 4/4, the wider pure agent-output
+  parser/workflow contracts passed 9/9, and the volume-isolation/log-stream
   infrastructure contracts passed 5/5. All `:test-experiments` and `:test-integration` invocations
   were serialized.
 - A deterministic regression reproduced an unsuccessful Remote Development launch whose launcher was
   absent from one `ProcessHandle` snapshot. `terminateFailedBackendStart` now repeats bounded process
   discovery until three consecutive scans are quiet, so a failed start cannot leave a launcher or
   backend process behind.
-- Direct IntelliJ inspections ran on all 25 modified Kotlin production/test files with no failed tools.
+- Direct IntelliJ inspections ran on every modified Kotlin production/test file with no failed tools.
   The post-quorum sweep found four `BlockingMethodInNonBlockingContext` findings after `stopLocked`
   became suspendable; keeping its blocking body non-suspending under the caller's `Dispatchers.IO`
-  context removed all four, and the terminal inspection was clean.
+  context removed all four. The terminal eight-file inspection was clean with zero findings and zero
+  failed tools.
 - Claude passed from a fresh Docker home, used the installed
   `/home/agent/.mcp-steroid/bin/devrig`, registered the user-scope MCP server, downloaded and started
   IU `2026.2.0.1`, opened Keycloak, and returned 70 subtypes in both the independently parsed tool
@@ -295,8 +297,10 @@ than merely mentioning it.
 - Both runs crossed the one-minute threshold while making progress, so live screenshots and
   in-container JVM thread dumps were captured before they were allowed to continue. Both teardown
   paths stopped IU and left no Docker containers or managed backend processes.
-- Both preserved `managed-backend-idea.log` artifacts were sanitized and rechecked: neither contains
-  an unredacted Bearer credential.
+- Both preserved idea and launcher logs are sanitized for Bearer headers, IntelliJ `_ijt` URL tokens,
+  and `x-ijt` JSON header values while retaining safe diagnostics. The four artifacts from both passing
+  Docker runs were re-sanitized locally and verify at zero marker-credential matches. Production full-
+  marker logging remains tracked by [#405](https://github.com/jonnyzzz/mcp-steroid/issues/405).
 - A post-quorum Docker rerun reached the fresh-home fixture but could not launch Claude because this
   shell had none of `ANTHROPIC_API_KEY`, `CLAUDE_EVAL_API_KEY`, or `~/.anthropic`; the test failed hard
   as designed and no skip was added. A separate Docker process-scan probe then proved the new teardown
@@ -306,14 +310,15 @@ than merely mentioning it.
 
 ### 2026-07-31 — complete `steroid_execute_code` call audit
 
-- The terminal audit froze after `eid_20260731T100732-devrig-remote-backend-final-verification` and
-  deduplicated 5,355 raw events by `call_id` across 22 root/sub-agent rollout logs. It found 1,080 unique
-  calls: 1,042 successful, 38 failed, and 5,172.326 aggregate tool-seconds. The earlier 464-call number was a
-  narrower snapshot of the single primary rollout, not the complete multi-agent corpus.
-- The 38 errors were 21 caller-script compilation errors, 12 caller-script runtime errors, four
-  transient route-disappearance errors, and one dropped `/tools/call/stream` result. Seven calls ran at
-  least 60 seconds and all succeeded; no script timeout occurred. The corpus contained 352 scripts that
-  used `RunContentManager`.
+- The terminal audit froze after
+  `eid_20260731T103836-eid_20260731T100732-devrig-remote-backend-final-verification` and deduplicated
+  5,962 raw events by `call_id` across 23 root/sub-agent rollout logs. It found 1,108 unique calls:
+  1,069 successful, 39 failed, and 5,794.748 aggregate tool-seconds. The earlier 464- and 1,080-call
+  numbers were narrower snapshots, not the complete terminal corpus.
+- The 39 errors were 21 caller-script compilation errors, 13 caller-script runtime errors, four
+  transient route-disappearance errors, and one dropped `/tools/call/stream` result. Eleven calls ran
+  at least 60 seconds and all succeeded; no script timeout occurred. The corpus contained 362 scripts
+  that used `RunContentManager`.
 - Four non-duplicate problems were filed:
   - [#402](https://github.com/jonnyzzz/mcp-steroid/issues/402) — IU 262 Gradle recipes can lose test
     results and pre-test failure output.
@@ -321,8 +326,8 @@ than merely mentioning it.
     about client, script, transport, and orchestration timeouts.
   - [#404](https://github.com/jonnyzzz/mcp-steroid/issues/404) — the no-output hint falsely diagnoses
     legitimate conditional zero-result scripts as missing `println`.
-  - [#405](https://github.com/jonnyzzz/mcp-steroid/issues/405) — production marker logging exposes MCP
-    Authorization headers.
+  - [#405](https://github.com/jonnyzzz/mcp-steroid/issues/405) — production marker logging exposes all
+    marker credentials: Authorization headers, `_ijt` URL tokens, and `x-ijt` header values.
 - Existing owners received complete-corpus evidence instead of duplicate issues: process completion
   polling [#20](https://github.com/jonnyzzz/mcp-steroid/issues/20), recurring FilenameIndex directory
   crashes [#66](https://github.com/jonnyzzz/mcp-steroid/issues/66) (reopened), route resilience and
@@ -331,10 +336,11 @@ than merely mentioning it.
   indices [#280](https://github.com/jonnyzzz/mcp-steroid/issues/280). The seven-case correction was also
   added to #404. Timeout dump work remains [#215](https://github.com/jonnyzzz/mcp-steroid/issues/215),
   but this corpus did not reproduce it.
-- The final independent re-audit added terminal evidence to #20, #91, #207, and #403. The last new
-  caller compile failure duplicated its type-mismatch diagnostics and then falsely suggested EDT; that
-  belongs to #91 rather than a new issue. No genuinely untracked defect remained, so no duplicate issue
-  was created.
+- The final independent re-audit added terminal evidence to #20, #91, #207, #280, #402, #403, and
+  #405. The last new caller runtime failure was an inspection-loop `IndexOutOfBoundsException`; its
+  duplicated diagnostics and generic hint belong to #91 rather than a new issue. Two independent
+  auditors agreed exactly on the terminal census and mapping. No genuinely untracked defect remained,
+  so no duplicate issue was created.
 
 ## Review log
 
@@ -348,10 +354,6 @@ Codex-137 decision until all evidence passes, validates effective managed proper
 removes the mirror, reports the effective launcher, and gives every shell invariant a named failure
 diagnostic.
 
-Final Fable 5, Opus 5, and independent-review verdicts remain pending. Each final entry must identify
-its persisted run, state `PASS` or `BLOCKER`, and list any resulting changes. Reviewers inspect the
-current branch read-only and do not run Docker integration tests.
-
 ### Final static sub-agent review — PASS after iteration
 
 The final static reviewer identified launcher/interpreter false ownership, list commands that trusted a
@@ -362,9 +364,32 @@ rebased cleanly onto `origin/main` while preserving all upstream `TODO.md` addit
 iteration also made marker validation lazy for durable JSON PID identity and falls back to direct PID
 inspection when one process listing transiently omits a live tracked process.
 
+The next Codex quorum caught a newly advanced `origin/main` commit whose
+`TODO-TC-COVERAGE-AUDIT.md` appeared deleted in the branch diff. The verified iteration was committed
+and rebased again; the branch is now zero commits behind `origin/main`, four commits ahead, and
+preserves that upstream audit file.
+
+### Final three-model quorum — PASS
+
+- Claude Fable 5: `run_20260731-175744-47024`, PASS. It verified all six bounded acceptance claims
+  and reported only two already tracked deferrals: applying the environment allowlist to standard
+  managed launches and revalidating native Remote Development for baseline 263+.
+- Claude Opus 5: `run_20260731-180448-50119`, PASS. It verified all six claims and reported five
+  non-blocking observations. The unstaged evidence doc is committed during delivery; readiness
+  liveness/timing and legacy-migration locking are recorded in `TODO.md`; the remaining scoring and
+  broken-install-list observations are pre-existing or expected behavior.
+- Codex: `run_20260731-175744-47025`, PASS with no findings. Its preceding full review
+  (`run_20260731-173936-39114`) correctly blocked because `origin/main` had advanced with
+  `TODO-TC-COVERAGE-AUDIT.md`; rebasing preserved that file and the bounded rerun passed.
+
+The first full Fable attempt failed with repeated 529 capacity errors and the first full Opus attempt
+hit the 900-second runner wall without a review. Both were rerun independently against the same bounded
+acceptance surface and produced the persisted PASS verdicts above.
+
 ### Complete execute-code audit review — PASS
 
-Three independent execute-code auditors rechecked the frozen corpus and every proposed issue against
-existing GitHub ownership. They agreed that #402–#405 are distinct defects and that every remaining
+Three independent execute-code auditors rechecked the corpus and every proposed issue against existing
+GitHub ownership. The terminal two-agent reconciliation agreed exactly on 1,108 calls, the 39-error
+taxonomy, timing, and counters. They agreed that #402–#405 are distinct defects and that every remaining
 observation belongs to #20, #66, #91, #207, #215, or #280. The final audit verdict was PASS with no
 untracked finding.

--- a/docs/devrig-remote-development-backend-e2e.md
+++ b/docs/devrig-remote-development-backend-e2e.md
@@ -201,7 +201,8 @@ than merely mentioning it.
   before terminating any stuck run.
 - [x] Inspect relevant source diagnostics and runtime logs; fix every warning/error in scope.
 - [x] Run final three-reviewer quorum, iterate on blockers, and repeat affected tests.
-- [ ] Record final evidence, update TODOs, commit atomically, push, and open a PR.
+- [x] Record final evidence, update TODOs, commit atomically, push, and open
+  [PR #411](https://github.com/jonnyzzz/mcp-steroid/pull/411).
 
 ## Risks and explicit non-goals
 

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/BackendCommand.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/BackendCommand.kt
@@ -5,7 +5,6 @@ import com.jonnyzzz.mcpSteroid.devrig.monitor.DiscoveredIde
 import com.jonnyzzz.mcpSteroid.devrig.monitor.DiscoveredIdeByPort
 import com.jonnyzzz.mcpSteroid.devrig.monitor.IdePidDiscoveryService
 import com.jonnyzzz.mcpSteroid.devrig.monitor.PortDiscovery
-import com.jonnyzzz.mcpSteroid.server.backendNameForMarker
 import java.io.OutputStream
 import java.io.PrintStream
 import kotlin.system.measureTimeMillis
@@ -106,9 +105,11 @@ fun runBackendDownloadCommand(
     val result = runBlocking(Dispatchers.IO) {
         backendService.download(backendId)
     }
+    val bundleDir = result.backendDir.resolve(result.descriptor.bundleDirName)
+    val launcher = ManagedBackendLauncherResolver().resolve(result.descriptor, bundleDir).executable
     out.println("id: ${result.id}")
     out.println("install: ${result.backendDir}")
-    out.println("launcher: ${result.backendDir.resolve(result.descriptor.bundleDirName).resolve(result.descriptor.launcherPath)}")
+    out.println("launcher: $launcher")
     out.println("vmoptions: ${result.vmOptionsPath}")
     return 0
 }

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/BackendLocalListCommand.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/BackendLocalListCommand.kt
@@ -119,7 +119,7 @@ private fun installedBackendRowOrNull(
     val descriptorFile = descriptorPath(dir)
     if (!Files.isRegularFile(descriptorFile) || !Files.isReadable(descriptorFile)) return null
     readDescriptorOrNull(descriptorFile) ?: return null
-    val alivePid = readBackendPidOrNull(homePaths.pidFile(parsed.id))?.takeIf { processInspector.isAlive(it) }
+    val alivePid = liveManagedBackendPidOrNull(homePaths.pidFile(parsed.id), processInspector)
     return InstalledBackendListRow(
         id = parsed.id,
         productKey = parsed.product.id,
@@ -139,13 +139,25 @@ private fun runningBackendRowOrNull(
 ): RunningBackendListRow? {
     val id = pidFile.name.removeSuffix(".pid")
     val parsed = parseConcreteBackendDirectoryNameOrNull(id) ?: return null
-    val pid = readBackendPidOrNull(pidFile)?.takeIf { processInspector.isAlive(it) } ?: return null
+    val pid = liveManagedBackendPidOrNull(pidFile, processInspector) ?: return null
     return RunningBackendListRow(
         id = parsed.id,
         pid = pid,
         displayName = parsed.displayName,
         logPath = homePaths.cacheDir(parsed.id).resolve("logs/managed.log"),
     )
+}
+
+private fun liveManagedBackendPidOrNull(
+    pidFile: Path,
+    processInspector: ManagedProcessInspector,
+): Long? {
+    val processState = readManagedBackendProcessState(pidFile) ?: return null
+    if (!processInspector.isAlive(processState.pid)) return null
+    if (processState.startInstant == null) return processState.pid
+    return processState.pid.takeIf {
+        processState.matchesProcessSnapshot(processInspector.snapshot(processState.pid))
+    }
 }
 
 private fun parseConcreteBackendDirectoryNameOrNull(raw: String): ParsedConcreteBackendId? {
@@ -156,13 +168,6 @@ private fun parseConcreteBackendDirectoryNameOrNull(raw: String): ParsedConcrete
     val version = raw.removePrefix("${product.id}-")
     if (!isSupportedBackendVersion(version)) return null
     return ParsedConcreteBackendId(product, version)
-}
-
-private fun readBackendPidOrNull(path: Path): Long? {
-    if (!Files.isRegularFile(path)) return null
-    val text = Files.readString(path).trim()
-    if (text.isBlank()) return null
-    return text.toLongOrNull()
 }
 
 private fun backendProductSortIndex(productKey: String): Int =

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/BackendLocalListCommand.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/BackendLocalListCommand.kt
@@ -118,8 +118,16 @@ private fun installedBackendRowOrNull(
     val parsed = parseConcreteBackendDirectoryNameOrNull(dir.name) ?: return null
     val descriptorFile = descriptorPath(dir)
     if (!Files.isRegularFile(descriptorFile) || !Files.isReadable(descriptorFile)) return null
-    readDescriptorOrNull(descriptorFile) ?: return null
-    val alivePid = liveManagedBackendPidOrNull(homePaths.pidFile(parsed.id), processInspector)
+    val descriptor = readDescriptorOrNull(descriptorFile) ?: return null
+    if (descriptor.id != parsed.id || descriptor.productKey != parsed.product.id || descriptor.version != parsed.version) {
+        return null
+    }
+    val alivePid = liveManagedBackendPidOrNull(
+        pidFile = homePaths.pidFile(parsed.id),
+        backendDir = dir,
+        descriptor = descriptor,
+        processInspector = processInspector,
+    )
     return InstalledBackendListRow(
         id = parsed.id,
         productKey = parsed.product.id,
@@ -139,7 +147,12 @@ private fun runningBackendRowOrNull(
 ): RunningBackendListRow? {
     val id = pidFile.name.removeSuffix(".pid")
     val parsed = parseConcreteBackendDirectoryNameOrNull(id) ?: return null
-    val pid = liveManagedBackendPidOrNull(pidFile, processInspector) ?: return null
+    val backendDir = homePaths.backendDir(parsed.id)
+    val descriptor = readDescriptorOrNull(descriptorPath(backendDir)) ?: return null
+    if (descriptor.id != parsed.id || descriptor.productKey != parsed.product.id || descriptor.version != parsed.version) {
+        return null
+    }
+    val pid = liveManagedBackendPidOrNull(pidFile, backendDir, descriptor, processInspector) ?: return null
     return RunningBackendListRow(
         id = parsed.id,
         pid = pid,
@@ -150,13 +163,58 @@ private fun runningBackendRowOrNull(
 
 private fun liveManagedBackendPidOrNull(
     pidFile: Path,
+    backendDir: Path,
+    descriptor: BackendDescriptor,
     processInspector: ManagedProcessInspector,
 ): Long? {
     val processState = readManagedBackendProcessState(pidFile) ?: return null
     if (!processInspector.isAlive(processState.pid)) return null
-    if (processState.startInstant == null) return processState.pid
-    return processState.pid.takeIf {
-        processState.matchesProcessSnapshot(processInspector.snapshot(processState.pid))
+    val snapshot = processInspector.snapshot(processState.pid) ?: return null
+    if (processState.startInstant != null) {
+        return processState.pid.takeIf { processState.matchesProcessSnapshot(snapshot) }
+    }
+    return processState.pid.takeIf { legacyProcessSnapshotMatchesBackend(snapshot, backendDir, descriptor) }
+}
+
+private fun legacyProcessSnapshotMatchesBackend(
+    snapshot: ProcessSnapshot,
+    backendDir: Path,
+    descriptor: BackendDescriptor,
+): Boolean {
+    val bundleDir = backendDir.resolve(descriptor.bundleDirName).toAbsolutePath().normalize()
+    val expectedLaunchers = setOf(
+        bundleDir.resolve(descriptor.launcherPath).normalize(),
+        bundleDir.resolve("bin/remote-dev-server").normalize(),
+        bundleDir.resolve("Contents/bin/remote-dev-server").normalize(),
+    )
+    val command = parseAbsoluteLegacyProcessPath(snapshot.command)
+    if (command in expectedLaunchers) return true
+    val managedRuntimeRoots = listOf(
+        bundleDir.resolve("jbr").normalize(),
+        bundleDir.resolve("Contents/jbr").normalize(),
+    )
+    if (command != null && managedRuntimeRoots.any(command::startsWith)) return true
+
+    val interpreter = command?.fileName?.toString()?.lowercase()
+    if (interpreter !in setOf("sh", "bash", "dash", "zsh", "ksh", "cmd", "cmd.exe")) return false
+    val launcherArgument = when (interpreter) {
+        "cmd", "cmd.exe" -> {
+            if (!snapshot.arguments.getOrNull(0).equals("/c", ignoreCase = true)) return false
+            snapshot.arguments.getOrNull(1)
+        }
+
+        else -> snapshot.arguments.firstOrNull()
+    }
+    return parseAbsoluteLegacyProcessPath(launcherArgument) in expectedLaunchers
+}
+
+private fun parseAbsoluteLegacyProcessPath(raw: String?): Path? {
+    if (raw.isNullOrBlank()) return null
+    return try {
+        Path.of(raw).takeIf { it.isAbsolute }?.toAbsolutePath()?.normalize()
+    } catch (e: Exception) {
+        System.err.println("WARN: ignored an invalid legacy managed-backend process path: ${e.javaClass.simpleName}")
+        null
     }
 }
 

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/InstalledBackends.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/InstalledBackends.kt
@@ -103,10 +103,7 @@ fun DevrigServices.installedBackends(): List<InstalledBackend> {
                     val descriptor = readDescriptorOrNull(descriptorPath(dir)) ?: return@mapNotNull null
                     val bundleDir = homePaths.backendDir(descriptor.id).resolve(descriptor.bundleDirName)
                     if (!Files.isDirectory(bundleDir)) return@mapNotNull null
-                    val launcher = bundleDir.resolve(descriptor.launcherPath)
-                    // Guard against incomplete installs: a missing or non-file launcher means
-                    // the backend cannot be started and must not appear as a startable candidate.
-                    if (!Files.isRegularFile(launcher)) return@mapNotNull null
+                    val launchSpec = ManagedBackendLauncherResolver().resolve(descriptor, bundleDir)
                     val ide = IdeInfo(
                         name = descriptor.productKey,
                         version = descriptor.version,
@@ -116,7 +113,7 @@ fun DevrigServices.installedBackends(): List<InstalledBackend> {
                         id = descriptor.id,
                         ide = ide,
                         ideHome = normalizeHome(resolveIdeHome(bundleDir).toString()),
-                        launcher = launcher,
+                        launcher = launchSpec.executable,
                     )
                 } catch (e: Exception) {
                     log.warn("failed to read installed backend from $dir", e)

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/ManagedBackend.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/ManagedBackend.kt
@@ -339,9 +339,21 @@ class BackendManager(
 
     override suspend fun download(id: BackendId): DownloadResult = withContext(Dispatchers.IO) {
         homePaths.mkdirsAll()
+        withGlobalBackendOperationLock {
+            downloadLocked(id)
+        }
+    }
+
+    private suspend fun downloadLocked(id: BackendId): DownloadResult {
         val resolution = downloader.resolve(id)
         requirePluginCompatibleBuild(resolution.product, resolution.version, resolution.build)
         val resolved = ResolvedBackendId(resolution.product, resolution.version)
+        val running = scanRunningManagedProcesses().firstOrNull { it.backendId == resolved.id }
+        if (running != null) {
+            throw ManagedBackendLockException(
+                "managed backend ${resolved.id} is running (pid ${running.pid}); stop it before downloading that backend",
+            )
+        }
         val backendDir = homePaths.backendDir(resolved.id)
         val descriptorPath = descriptorPath(backendDir)
         val existingDescriptor = readDescriptorOrNull(descriptorPath)
@@ -452,7 +464,7 @@ class BackendManager(
         )
         writeDescriptor(descriptorPath, descriptor)
         deployMcpSteroidPlugin(resolved.id)
-        DownloadResult(resolved.id, descriptor, backendDir, vmOptionsPath)
+        return DownloadResult(resolved.id, descriptor, backendDir, vmOptionsPath)
     }
 
     /**
@@ -548,8 +560,15 @@ class BackendManager(
         if (other != null) {
             throw ManagedBackendLockException(lockConflictMessage(other))
         }
-        val existing = running.firstOrNull { it.backendId == resolved.id }
+        val existing = running.firstOrNull { it.backendId == resolved.id && it.ready }
+            ?: running.firstOrNull { it.backendId == resolved.id }
         if (existing != null) {
+            if (!existing.ready) {
+                throw ManagedBackendLockException(
+                    "error: managed backend ${existing.backendId} (pid ${existing.pid}) is not ready; " +
+                        "wait for its MCP Steroid Remote Development marker or stop it before starting again",
+                )
+            }
             if (existing.untracked) {
                 val startInstant = existing.startInstant ?: throw ManagedBackendLockException(lockConflictMessage(existing))
                 writePidFile(pidFile, existing.pid, startInstant)
@@ -583,7 +602,7 @@ class BackendManager(
 
         val managedLog = logDir.resolve("managed.log")
         val expectedPluginHome = cacheDir.resolve("plugins/mcp-steroid")
-        val preLaunchPids = processInspector.allProcesses().mapTo(mutableSetOf()) { it.pid }
+        val preLaunchProcesses = processInspector.allProcesses().associateBy { it.pid }
         var launcherPid: Long? = null
         var backendPid: Long? = null
         try {
@@ -604,7 +623,7 @@ class BackendManager(
                     expectedIdeHome = launchSpec.workingDirectory,
                     expectedPluginHome = expectedPluginHome,
                     launcherPid = spawnedPid,
-                    excludedPids = preLaunchPids,
+                    preLaunchProcesses = preLaunchProcesses,
                 ).pid
             } else {
                 spawnedPid
@@ -632,7 +651,7 @@ class BackendManager(
                         launcherPid = launcherPid,
                         knownBackendPid = backendPid,
                         pidFile = pidFile,
-                        excludedPids = preLaunchPids,
+                        preLaunchProcesses = preLaunchProcesses,
                     )
                 } catch (cleanupError: Exception) {
                     System.err.println(
@@ -682,7 +701,7 @@ class BackendManager(
         expectedIdeHome: Path,
         expectedPluginHome: Path,
         launcherPid: Long,
-        excludedPids: Set<Long>,
+        preLaunchProcesses: Map<Long, ProcessSnapshot>,
     ): PidMarker {
         val deadlineNanos = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(remoteDevelopmentStartupTimeoutMillis)
         val warnedMarkers = mutableSetOf<Path>()
@@ -692,7 +711,7 @@ class BackendManager(
                 expectedIdeHome,
                 expectedPluginHome,
                 warnedMarkers,
-                excludedPids,
+                preLaunchProcesses,
             )?.let { return it }
             delay(100.milliseconds)
         }
@@ -703,7 +722,7 @@ class BackendManager(
             expectedIdeHome,
             expectedPluginHome,
             warnedMarkers,
-            excludedPids,
+            preLaunchProcesses,
         )?.let { return it }
         val launcherAlive = processInspector.isAlive(launcherPid)
         throw ManagedBackendValidationException(
@@ -719,7 +738,7 @@ class BackendManager(
         expectedIdeHome: Path,
         expectedPluginHome: Path,
         warnedMarkers: MutableSet<Path>,
-        excludedPids: Set<Long>,
+        preLaunchProcesses: Map<Long, ProcessSnapshot>,
     ): PidMarker? {
         val markerDir = PidMarker.markerDirectory(ideUserHome)
         if (!Files.isDirectory(markerDir)) return null
@@ -739,10 +758,10 @@ class BackendManager(
                         return@mapNotNull null
                     }
                     if (marker.pid != markerPid) return@mapNotNull null
-                    if (marker.pid in excludedPids) return@mapNotNull null
                     if (!processInspector.isAlive(marker.pid)) return@mapNotNull null
-                    val processStartInstant = processInspector.snapshot(marker.pid)?.startInstant
-                        ?: return@mapNotNull null
+                    val processSnapshot = processInspector.snapshot(marker.pid) ?: return@mapNotNull null
+                    val processStartInstant = processSnapshot.startInstant ?: return@mapNotNull null
+                    if (wasPresentBeforeLaunch(processSnapshot, preLaunchProcesses)) return@mapNotNull null
                     if (!markerWasCreatedForProcess(marker, processStartInstant, markerPath, warnedMarkers)) {
                         return@mapNotNull null
                     }
@@ -816,7 +835,7 @@ class BackendManager(
         launcherPid: Long?,
         knownBackendPid: Long?,
         pidFile: Path,
-        excludedPids: Set<Long>,
+        preLaunchProcesses: Map<Long, ProcessSnapshot>,
     ) {
         val candidatePids = linkedSetOf<Long>()
         launcherPid?.let(candidatePids::add)
@@ -831,11 +850,13 @@ class BackendManager(
                 expectedIdeHome,
                 expectedPluginHome,
                 warnedMarkers,
-                excludedPids,
+                preLaunchProcesses,
             )?.pid?.let(candidatePids::add)
             val currentProcesses = processInspector.allProcesses()
             for (process in currentProcesses) {
-                if (process.pid !in excludedPids && processSnapshotMatchesManagedLauncher(process, descriptor)) {
+                if (!wasPresentBeforeLaunch(process, preLaunchProcesses) &&
+                    processSnapshotMatchesManagedLauncher(process, descriptor)
+                ) {
                     candidatePids += process.pid
                 }
             }
@@ -883,6 +904,15 @@ class BackendManager(
         deleteRecursively(pidFile)
     }
 
+    private fun wasPresentBeforeLaunch(
+        current: ProcessSnapshot,
+        preLaunchProcesses: Map<Long, ProcessSnapshot>,
+    ): Boolean {
+        val previousStart = preLaunchProcesses[current.pid]?.startInstant ?: return false
+        val currentStart = current.startInstant ?: return false
+        return previousStart == currentStart
+    }
+
     private fun writePidFile(pidFile: Path, pid: Long, startInstant: Instant) {
         Files.createDirectories(pidFile.parent)
         val state = ManagedBackendProcessState(pid = pid, startInstant = startInstant.toString())
@@ -908,12 +938,18 @@ class BackendManager(
     }
 
     override suspend fun stop(id: BackendId): StopResult = withContext(Dispatchers.IO) {
-        val resolved = resolveConcreteId(id)
+        homePaths.mkdirsAll()
+        withGlobalBackendOperationLock {
+            stopLocked(resolveConcreteId(id))
+        }
+    }
+
+    private fun stopLocked(resolved: ResolvedBackendId): StopResult {
         val pidFile = homePaths.pidFile(resolved.id)
         val processState = readManagedBackendProcessState(pidFile)
         if (processState == null) {
             Files.deleteIfExists(pidFile)
-            return@withContext StopResult(resolved.id, pid = null, outcome = "not running")
+            return StopResult(resolved.id, pid = null, outcome = "not running")
         }
         val pid = processState.pid
         val descriptor = loadDescriptor(resolved)
@@ -922,11 +958,11 @@ class BackendManager(
         if (handle == null || !handle.isAlive) {
             deleteMcpMarker(pid)
             Files.deleteIfExists(pidFile)
-            return@withContext StopResult(resolved.id, pid = pid, outcome = "already stopped")
+            return StopResult(resolved.id, pid = pid, outcome = "already stopped")
         }
         if (!isManagedBackendProcess(handle, descriptor, processState)) {
             Files.deleteIfExists(pidFile)
-            return@withContext StopResult(
+            return StopResult(
                 id = resolved.id,
                 pid = null,
                 outcome = "stale",
@@ -950,7 +986,7 @@ class BackendManager(
         }
         deleteMcpMarker(pid)
         Files.deleteIfExists(pidFile)
-        StopResult(resolved.id, pid = pid, outcome = outcome)
+        return StopResult(resolved.id, pid = pid, outcome = outcome)
     }
 
     private fun isManagedBackendProcess(
@@ -1168,6 +1204,7 @@ class BackendManager(
                                 pid = processState.pid,
                                 startInstant = processState.parsedStartInstant(),
                                 untracked = false,
+                                ready = true,
                             )
                         } else {
                             Files.deleteIfExists(pidFile)
@@ -1184,11 +1221,13 @@ class BackendManager(
                 val launcherMatches = processSnapshotMatchesManagedLauncher(process, descriptor)
                 val markerMatches = pidMarkerMatchesDescriptor(process.pid, descriptor, process.startInstant)
                 if (!launcherMatches && !markerMatches) continue
+                val ready = markerMatches || !backendLauncherResolver.usesRemoteDevelopment(descriptor)
                 byId += RunningManagedProcess(
                     backendId = backendId,
                     pid = process.pid,
                     startInstant = process.startInstant,
                     untracked = true,
+                    ready = ready,
                 )
                 break
             }
@@ -1253,6 +1292,7 @@ private data class RunningManagedProcess(
     val pid: Long,
     val startInstant: Instant?,
     val untracked: Boolean,
+    val ready: Boolean,
 )
 
 fun writeBackendVmOptions(homePaths: HomePaths, id: String, bundleDirName: String): Path {

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/ManagedBackend.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/ManagedBackend.kt
@@ -793,7 +793,12 @@ class BackendManager(
         if (marker.devrigEndpoint == null) return false
         val expectedBuild = descriptor.buildNumber ?: return false
         // Marker builds carry the product-code prefix (`IC-262.8665.258`) that product-info.json
-        // omits, and a descriptor written from a baseline-only resolution holds just `262`.
+        // omits, and a descriptor written from a baseline-only resolution holds just `262`. The
+        // numeric comparison ignores prefixes on both sides, so when the marker DOES carry one it
+        // must name this backend's installed product — `IU-253.1` never matches an IC install
+        // that happens to share the same number.
+        val markerProductCode = marker.ide.build.substringBefore('-', missingDelimiterValue = "")
+        if (markerProductCode.isNotEmpty() && markerProductCode != descriptor.productCode) return false
         if (!ideBuildMatches(
                 actual = marker.ide.build,
                 expected = expectedBuild,

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/ManagedBackend.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/ManagedBackend.kt
@@ -25,11 +25,18 @@ import kotlin.io.path.exists
 import kotlin.io.path.isDirectory
 import kotlin.jvm.optionals.getOrNull
 import kotlin.streams.asSequence
+import kotlin.time.Duration.Companion.milliseconds
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import org.apache.commons.compress.archivers.zip.ZipFile
+
+private const val FAILED_START_CLEANUP_MAX_SCANS = 20
+private const val FAILED_START_CLEANUP_QUIET_SCANS = 3
+private const val FAILED_START_CLEANUP_SCAN_DELAY_MILLIS = 100L
 
 @Serializable
 data class BackendDescriptor(
@@ -124,11 +131,30 @@ interface BundledPluginResolver {
 data class ProcessSnapshot(
     val pid: Long,
     val command: String?,
+    val arguments: List<String> = emptyList(),
+    val startInstant: Instant? = null,
+)
+
+enum class ManagedProcessTerminationOutcome {
+    TERMINATED,
+    NOT_RUNNING,
+    IDENTITY_CHANGED,
+    FAILED,
+}
+
+@Serializable
+data class ManagedBackendProcessState(
+    val schemaVersion: Int = 1,
+    val pid: Long,
+    val startInstant: String? = null,
 )
 
 interface ManagedProcessInspector {
     fun isAlive(pid: Long): Boolean
     fun allProcesses(): List<ProcessSnapshot>
+    fun snapshot(pid: Long): ProcessSnapshot? = allProcesses().firstOrNull { it.pid == pid }
+    fun terminateIfMatches(expected: ProcessSnapshot): ManagedProcessTerminationOutcome =
+        terminateProcessIfMatches(expected)
 }
 
 object DefaultManagedProcessInspector : ManagedProcessInspector {
@@ -138,9 +164,28 @@ object DefaultManagedProcessInspector : ManagedProcessInspector {
     override fun allProcesses(): List<ProcessSnapshot> =
         ProcessHandle.allProcesses().use { stream ->
             stream.asSequence()
-                .map { handle -> ProcessSnapshot(handle.pid(), handle.info().command().orElse(null)) }
+                .map { handle ->
+                    val info = handle.info()
+                    ProcessSnapshot(
+                        pid = handle.pid(),
+                        command = info.command().orElse(null),
+                        arguments = info.arguments().orElse(emptyArray()).toList(),
+                        startInstant = info.startInstant().orElse(null),
+                    )
+                }
                 .toList()
         }
+
+    override fun snapshot(pid: Long): ProcessSnapshot? {
+        val handle = ProcessHandle.of(pid).getOrNull() ?: return null
+        val info = handle.info()
+        return ProcessSnapshot(
+            pid = pid,
+            command = info.command().orElse(null),
+            arguments = info.arguments().orElse(emptyArray()).toList(),
+            startInstant = info.startInstant().orElse(null),
+        )
+    }
 }
 
 class ManagedBackendLockException(message: String) : RuntimeException(message)
@@ -274,6 +319,7 @@ class BackendManager(
         archiveDownloadDir = homePaths.downloadsDir,
     ),
     private val launcherResolver: LauncherResolver = LauncherResolver(),
+    private val backendLauncherResolver: ManagedBackendLauncherResolver = ManagedBackendLauncherResolver(),
     private val bundledPluginResolver: BundledPluginResolver = ClasspathBundledPluginResolver(),
     private val processInspector: ManagedProcessInspector = DefaultManagedProcessInspector,
     /**
@@ -284,13 +330,14 @@ class BackendManager(
     private val pluginBuildRange: PluginBuildRange? = null,
     private val ideUserHome: Path = Path.of(System.getProperty("user.home")).toAbsolutePath().normalize(),
     private val stopGracePeriodMillis: Long = 5_000L,
+    private val remoteDevelopmentStartupTimeoutMillis: Long = 180_000L,
 ) : ManagedBackendService {
     init {
         homePaths.mkdirsAll()
         migrateLegacyArchives(homePaths)
     }
 
-    override suspend fun download(id: BackendId): DownloadResult {
+    override suspend fun download(id: BackendId): DownloadResult = withContext(Dispatchers.IO) {
         homePaths.mkdirsAll()
         val resolution = downloader.resolve(id)
         requirePluginCompatibleBuild(resolution.product, resolution.version, resolution.build)
@@ -299,35 +346,53 @@ class BackendManager(
         val descriptorPath = descriptorPath(backendDir)
         val existingDescriptor = readDescriptorOrNull(descriptorPath)
 
-        val prepared = if (isReusableBackendInstall(backendDir, existingDescriptor)) {
-            val bundleDir = resolveBundleDir(backendDir)
-            val launcher = launcherResolver.resolve(bundleDir)
-            val artifact = BackendDownloadArtifact(sourceArchiveSha256 = existingDescriptor?.sourceArchiveSha256)
-            validateInstalledProductCode(
-                product = resolution.product,
-                actualProductCode = launcher.productCode,
-                downloadedUrl = resolution.url,
-                archivePath = artifact.archivePath,
-                bundleDir = bundleDir,
-                descriptorPath = descriptorPath,
-            )
-            validateInstalledBuildNumber(
-                product = resolution.product,
-                expectedBuild = resolution.build,
-                expectedBuildIsBaseline = resolution.buildIsBaseline,
-                actualBuildNumber = launcher.buildNumber,
-                downloadedUrl = resolution.url,
-                archivePath = artifact.archivePath,
-                bundleDir = bundleDir,
-                descriptorPath = descriptorPath,
-            )
-            PreparedBackendInstall(
-                bundleDirName = bundleDir.fileName.toString(),
-                launcher = launcher,
-                downloadArtifact = artifact,
-                downloadedAt = existingDescriptor?.downloadedAt,
-            )
+        val reusablePrepared = if (isReusableBackendInstall(backendDir, existingDescriptor)) {
+            try {
+                validateReusableDescriptor(existingDescriptor, resolved, resolution)
+                val bundleDir = resolveBundleDir(backendDir)
+                val launcher = launcherResolver.resolve(bundleDir)
+                val artifact = BackendDownloadArtifact(sourceArchiveSha256 = existingDescriptor?.sourceArchiveSha256)
+                validateInstalledProductCode(
+                    product = resolution.product,
+                    actualProductCode = launcher.productCode,
+                    downloadedUrl = resolution.url,
+                    archivePath = artifact.archivePath,
+                    bundleDir = bundleDir,
+                    descriptorPath = descriptorPath,
+                )
+                validateInstalledBuildNumber(
+                    product = resolution.product,
+                    expectedBuild = resolution.build,
+                    expectedBuildIsBaseline = resolution.buildIsBaseline,
+                    actualBuildNumber = launcher.buildNumber,
+                    downloadedUrl = resolution.url,
+                    archivePath = artifact.archivePath,
+                    bundleDir = bundleDir,
+                    descriptorPath = descriptorPath,
+                )
+                backendLauncherResolver.validateRequiredAssets(
+                    resolution.product.id,
+                    launcher.buildNumber,
+                    bundleDir,
+                )
+                PreparedBackendInstall(
+                    bundleDirName = bundleDir.fileName.toString(),
+                    launcher = launcher,
+                    downloadArtifact = artifact,
+                    downloadedAt = existingDescriptor?.downloadedAt,
+                )
+            } catch (e: Exception) {
+                System.err.println(
+                    "WARN: managed backend install at $backendDir is not reusable and will be replaced: ${e.message}",
+                )
+                deleteRecursively(backendDir)
+                null
+            }
         } else {
+            null
+        }
+
+        val prepared = reusablePrepared ?: run {
             val partialDir = homePaths.backendsDir.resolve("${resolved.id}.partial")
             deleteRecursively(backendDir)
             deleteRecursively(partialDir)
@@ -354,12 +419,17 @@ class BackendManager(
                     bundleDir = partialBundleDir,
                     descriptorPath = descriptorPath(partialDir),
                 )
+                backendLauncherResolver.validateRequiredAssets(
+                    resolution.product.id,
+                    launcher.buildNumber,
+                    partialBundleDir,
+                )
                 Files.move(partialDir, backendDir, StandardCopyOption.ATOMIC_MOVE)
                 PreparedBackendInstall(
                     bundleDirName = partialBundleDir.fileName.toString(),
                     launcher = launcher,
                     downloadArtifact = artifact,
-                    downloadedAt = existingDescriptor?.downloadedAt,
+                    downloadedAt = null,
                 )
             } catch (e: Exception) {
                 deleteRecursively(partialDir)
@@ -367,13 +437,14 @@ class BackendManager(
             }
         }
 
+        val effectiveBuildNumber = prepared.launcher.buildNumber ?: resolution.build
         val vmOptionsPath = writeBackendVmOptions(homePaths, resolved.id, prepared.bundleDirName)
         val descriptor = BackendDescriptor(
             id = resolved.id,
             productKey = resolution.product.id,
             productCode = prepared.launcher.productCode ?: resolution.product.code,
             version = resolution.version,
-            buildNumber = prepared.launcher.buildNumber ?: resolution.build,
+            buildNumber = effectiveBuildNumber,
             bundleDirName = prepared.bundleDirName,
             launcherPath = prepared.launcher.launcherPath,
             downloadedAt = prepared.downloadedAt ?: Instant.now().toString(),
@@ -381,7 +452,7 @@ class BackendManager(
         )
         writeDescriptor(descriptorPath, descriptor)
         deployMcpSteroidPlugin(resolved.id)
-        return DownloadResult(resolved.id, descriptor, backendDir, vmOptionsPath)
+        DownloadResult(resolved.id, descriptor, backendDir, vmOptionsPath)
     }
 
     /**
@@ -412,6 +483,34 @@ class BackendManager(
         }
     }
 
+    private fun validateReusableDescriptor(
+        descriptor: BackendDescriptor?,
+        resolved: ResolvedBackendId,
+        resolution: BackendDownloadResolution,
+    ) {
+        descriptor ?: return
+        val expectedProductCode = resolution.product.installedProductCode
+        val mismatches = buildList {
+            if (descriptor.id != resolved.id) add("id=${descriptor.id}")
+            if (descriptor.productKey != resolution.product.id) add("productKey=${descriptor.productKey}")
+            if (descriptor.productCode != expectedProductCode) add("productCode=${descriptor.productCode}")
+            if (descriptor.version != resolution.version) add("version=${descriptor.version}")
+            if (descriptor.buildNumber != null && !ideBuildMatches(
+                    actual = descriptor.buildNumber,
+                    expected = resolution.build,
+                    expectedIsBaseline = resolution.buildIsBaseline,
+                )
+            ) {
+                add("buildNumber=${descriptor.buildNumber}")
+            }
+        }
+        if (mismatches.isNotEmpty()) {
+            throw ManagedBackendValidationException(
+                "backend descriptor does not match resolved ${resolved.id} (${resolution.build}): ${mismatches.joinToString()}",
+            )
+        }
+    }
+
     fun deployMcpSteroidPlugin(id: String): Path {
         val source = bundledPluginResolver.resolveBundledPluginZip()
         require(Files.isRegularFile(source)) { "Bundled ij-plugin.zip is missing: $source" }
@@ -432,9 +531,9 @@ class BackendManager(
         return target
     }
 
-    override suspend fun start(id: BackendId): StartResult {
+    override suspend fun start(id: BackendId): StartResult = withContext(Dispatchers.IO) {
         homePaths.mkdirsAll()
-        return withGlobalBackendOperationLock {
+        withGlobalBackendOperationLock {
             startLocked(id)
         }
     }
@@ -442,6 +541,7 @@ class BackendManager(
     private suspend fun startLocked(id: BackendId): StartResult {
         val resolved = resolveConcreteId(id)
         val descriptor = loadDescriptor(resolved)
+        val pidFile = homePaths.pidFile(resolved.id)
         descriptor.buildNumber?.let { build -> requirePluginCompatibleBuild(resolved.product, descriptor.version, build) }
         val running = scanRunningManagedProcesses()
         val other = running.firstOrNull { it.backendId != resolved.id }
@@ -450,6 +550,10 @@ class BackendManager(
         }
         val existing = running.firstOrNull { it.backendId == resolved.id }
         if (existing != null) {
+            if (existing.untracked) {
+                val startInstant = existing.startInstant ?: throw ManagedBackendLockException(lockConflictMessage(existing))
+                writePidFile(pidFile, existing.pid, startInstant)
+            }
             return StartResult(
                 id = resolved.id,
                 pid = existing.pid,
@@ -459,10 +563,11 @@ class BackendManager(
             )
         }
 
-        val pidFile = homePaths.pidFile(resolved.id)
         val bundleDir = homePaths.backendDir(resolved.id).resolve(descriptor.bundleDirName)
-        val launcher = bundleDir.resolve(descriptor.launcherPath)
-        require(Files.isExecutable(launcher)) { "Launcher is not executable: $launcher" }
+        val launchSpec = backendLauncherResolver.resolve(descriptor, bundleDir)
+        require(Files.isExecutable(launchSpec.executable)) {
+            "Launcher is not executable: ${launchSpec.executable}"
+        }
 
         writeBackendVmOptions(homePaths, resolved.id, descriptor.bundleDirName)
         // Re-provision the current bundled plugin before launch so a backend downloaded by an older
@@ -477,25 +582,314 @@ class BackendManager(
         writeIdeUserStartupConfigFiles(ideUserHome)
 
         val managedLog = logDir.resolve("managed.log")
-        val pid = spawnIdeProcess(
-            launcher = launcher,
-            workDir = bundleDir,
-            stdoutLog = managedLog.toFile(),
-            stderrLog = managedLog.toFile(),
-            environment = emptyMap(),
-        )
-
-        Files.createDirectories(pidFile.parent)
-        Files.writeString(pidFile, "$pid\n")
+        val expectedPluginHome = cacheDir.resolve("plugins/mcp-steroid")
+        val preLaunchPids = processInspector.allProcesses().mapTo(mutableSetOf()) { it.pid }
+        var launcherPid: Long? = null
+        var backendPid: Long? = null
+        try {
+            val spawnedPid = spawnIdeProcess(
+                launcher = launchSpec.executable,
+                arguments = launchSpec.arguments,
+                workDir = launchSpec.workingDirectory,
+                stdoutLog = managedLog.toFile(),
+                stderrLog = managedLog.toFile(),
+                environment = launchSpec.environment,
+            )
+            launcherPid = spawnedPid
+            val launcherSnapshot = processInspector.snapshot(spawnedPid)
+            val readyPid = if (backendLauncherResolver.usesRemoteDevelopment(descriptor)) {
+                awaitRemoteDevelopmentBackendMarker(
+                    backendId = resolved.id,
+                    descriptor = descriptor,
+                    expectedIdeHome = launchSpec.workingDirectory,
+                    expectedPluginHome = expectedPluginHome,
+                    launcherPid = spawnedPid,
+                    excludedPids = preLaunchPids,
+                ).pid
+            } else {
+                spawnedPid
+            }
+            backendPid = readyPid
+            val readyStartInstant = processInspector.snapshot(readyPid)?.startInstant
+                ?: throw ManagedBackendValidationException(
+                    "Managed backend '${resolved.id}' pid $readyPid has no process start instant; " +
+                        "refusing to persist PID-only state that could later target a reused PID.",
+                )
+            retireHandedOffLauncher(
+                backendId = resolved.id,
+                launcherPid = spawnedPid,
+                launcherSnapshot = launcherSnapshot,
+                backendPid = readyPid,
+            )
+            writePidFile(pidFile, readyPid, readyStartInstant)
+        } catch (e: Throwable) {
+            withContext(NonCancellable + Dispatchers.IO) {
+                try {
+                    terminateFailedBackendStart(
+                        descriptor = descriptor,
+                        expectedIdeHome = launchSpec.workingDirectory,
+                        expectedPluginHome = expectedPluginHome,
+                        launcherPid = launcherPid,
+                        knownBackendPid = backendPid,
+                        pidFile = pidFile,
+                        excludedPids = preLaunchPids,
+                    )
+                } catch (cleanupError: Exception) {
+                    System.err.println(
+                        "WARN: failed to clean up unsuccessful managed backend '${resolved.id}' start: ${cleanupError.message}",
+                    )
+                    e.addSuppressed(cleanupError)
+                }
+            }
+            throw e
+        }
         return StartResult(
             id = resolved.id,
-            pid = pid,
+            pid = backendPid,
             ideaLogPath = managedLog,
             configPath = cacheDir.resolve("config"),
         )
     }
 
-    private suspend fun <T> withGlobalBackendOperationLock(block: suspend () -> T): T {
+    private fun retireHandedOffLauncher(
+        backendId: String,
+        launcherPid: Long,
+        launcherSnapshot: ProcessSnapshot?,
+        backendPid: Long,
+    ) {
+        if (launcherPid == backendPid || !processInspector.isAlive(launcherPid)) return
+        val expectedLauncher = launcherSnapshot
+            ?: throw ManagedBackendValidationException(
+                "Managed backend '$backendId' handed off from launcher pid $launcherPid to backend pid $backendPid, " +
+                    "but the still-live launcher has no process identity; refusing to leave it untracked.",
+            )
+        when (processInspector.terminateIfMatches(expectedLauncher)) {
+            ManagedProcessTerminationOutcome.TERMINATED,
+            ManagedProcessTerminationOutcome.NOT_RUNNING,
+            ManagedProcessTerminationOutcome.IDENTITY_CHANGED,
+            -> Unit
+
+            ManagedProcessTerminationOutcome.FAILED -> throw ManagedBackendValidationException(
+                "Managed backend '$backendId' handed off to pid $backendPid, but launcher pid $launcherPid " +
+                    "could not be terminated; refusing to leave it untracked.",
+            )
+        }
+    }
+
+    private suspend fun awaitRemoteDevelopmentBackendMarker(
+        backendId: String,
+        descriptor: BackendDescriptor,
+        expectedIdeHome: Path,
+        expectedPluginHome: Path,
+        launcherPid: Long,
+        excludedPids: Set<Long>,
+    ): PidMarker {
+        val deadlineNanos = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(remoteDevelopmentStartupTimeoutMillis)
+        val warnedMarkers = mutableSetOf<Path>()
+        while (System.nanoTime() < deadlineNanos) {
+            findReadyRemoteDevelopmentMarker(
+                descriptor,
+                expectedIdeHome,
+                expectedPluginHome,
+                warnedMarkers,
+                excludedPids,
+            )?.let { return it }
+            delay(100.milliseconds)
+        }
+
+        // Do one final scan at the deadline boundary before tearing down the unready launch.
+        findReadyRemoteDevelopmentMarker(
+            descriptor,
+            expectedIdeHome,
+            expectedPluginHome,
+            warnedMarkers,
+            excludedPids,
+        )?.let { return it }
+        val launcherAlive = processInspector.isAlive(launcherPid)
+        throw ManagedBackendValidationException(
+            "Timed out waiting for the MCP Steroid readiness marker for '$backendId' after " +
+                "${remoteDevelopmentStartupTimeoutMillis}ms (launcher pid $launcherPid, alive=$launcherAlive). " +
+                "The IDE was not recorded as running; inspect ${homePaths.cacheDir(backendId).resolve("logs/managed.log")} " +
+                "and ${homePaths.cacheDir(backendId).resolve("logs")}.",
+        )
+    }
+
+    private fun findReadyRemoteDevelopmentMarker(
+        descriptor: BackendDescriptor,
+        expectedIdeHome: Path,
+        expectedPluginHome: Path,
+        warnedMarkers: MutableSet<Path>,
+        excludedPids: Set<Long>,
+    ): PidMarker? {
+        val markerDir = PidMarker.markerDirectory(ideUserHome)
+        if (!Files.isDirectory(markerDir)) return null
+        return Files.list(markerDir).use { stream ->
+            stream.asSequence()
+                .filter { Files.isRegularFile(it) }
+                .mapNotNull { markerPath ->
+                    val markerPid = PidMarker.pidFromFileName(markerPath.fileName.toString()) ?: return@mapNotNull null
+                    val marker = try {
+                        PidMarkerJson.decode(Files.readString(markerPath))
+                    } catch (e: Exception) {
+                        if (warnedMarkers.add(markerPath)) {
+                            System.err.println(
+                                "WARN: failed to decode MCP Steroid readiness marker $markerPath: ${e.javaClass.simpleName}",
+                            )
+                        }
+                        return@mapNotNull null
+                    }
+                    if (marker.pid != markerPid) return@mapNotNull null
+                    if (marker.pid in excludedPids) return@mapNotNull null
+                    if (!processInspector.isAlive(marker.pid)) return@mapNotNull null
+                    val processStartInstant = processInspector.snapshot(marker.pid)?.startInstant
+                        ?: return@mapNotNull null
+                    if (!markerWasCreatedForProcess(marker, processStartInstant, markerPath, warnedMarkers)) {
+                        return@mapNotNull null
+                    }
+                    val matchesBackend = markerMatchesManagedBackend(
+                        marker,
+                        descriptor,
+                        expectedIdeHome,
+                        expectedPluginHome,
+                        markerPath,
+                        warnedMarkers,
+                    )
+                    if (!matchesBackend) return@mapNotNull null
+                    marker
+                }
+                .firstOrNull()
+        }
+    }
+
+    private fun markerMatchesManagedBackend(
+        marker: PidMarker,
+        descriptor: BackendDescriptor,
+        expectedIdeHome: Path,
+        expectedPluginHome: Path,
+        markerPath: Path,
+        warnedMarkers: MutableSet<Path>,
+    ): Boolean {
+        if (marker.schema != PidMarker.SCHEMA_VERSION) return false
+        if (marker.plugin.id != MCP_STEROID_PLUGIN_ID) return false
+        if (marker.devrigEndpoint == null) return false
+        val expectedBuild = descriptor.buildNumber ?: return false
+        // Marker builds carry the product-code prefix (`IC-262.8665.258`) that product-info.json
+        // omits, and a descriptor written from a baseline-only resolution holds just `262`.
+        if (!ideBuildMatches(
+                actual = marker.ide.build,
+                expected = expectedBuild,
+                expectedIsBaseline = isPlatformBaselineOnly(expectedBuild),
+            )
+        ) {
+            return false
+        }
+        val markerIdeHome = marker.ideHome ?: return false
+        val parsedMarkerHome = try {
+            Path.of(markerIdeHome).toAbsolutePath().normalize()
+        } catch (e: Exception) {
+            if (warnedMarkers.add(markerPath)) {
+                System.err.println(
+                    "WARN: invalid ideHome in MCP Steroid readiness marker $markerPath: ${e.javaClass.simpleName}",
+                )
+            }
+            return false
+        }
+        if (parsedMarkerHome != expectedIdeHome.toAbsolutePath().normalize()) return false
+        val markerPluginHome = marker.mcpSteroidServer?.pluginPath ?: return false
+        val parsedPluginHome = try {
+            Path.of(markerPluginHome).toAbsolutePath().normalize()
+        } catch (e: Exception) {
+            if (warnedMarkers.add(markerPath)) {
+                System.err.println(
+                    "WARN: invalid pluginPath in MCP Steroid readiness marker $markerPath: ${e.javaClass.simpleName}",
+                )
+            }
+            return false
+        }
+        return parsedPluginHome == expectedPluginHome.toAbsolutePath().normalize()
+    }
+
+    private suspend fun terminateFailedBackendStart(
+        descriptor: BackendDescriptor,
+        expectedIdeHome: Path,
+        expectedPluginHome: Path,
+        launcherPid: Long?,
+        knownBackendPid: Long?,
+        pidFile: Path,
+        excludedPids: Set<Long>,
+    ) {
+        val candidatePids = linkedSetOf<Long>()
+        launcherPid?.let(candidatePids::add)
+        knownBackendPid?.let(candidatePids::add)
+        val warnedMarkers = mutableSetOf<Path>()
+        var scanCount = 0
+        var quietScanCount = 0
+        while (scanCount < FAILED_START_CLEANUP_MAX_SCANS && quietScanCount < FAILED_START_CLEANUP_QUIET_SCANS) {
+            scanCount++
+            findReadyRemoteDevelopmentMarker(
+                descriptor,
+                expectedIdeHome,
+                expectedPluginHome,
+                warnedMarkers,
+                excludedPids,
+            )?.pid?.let(candidatePids::add)
+            val currentProcesses = processInspector.allProcesses()
+            for (process in currentProcesses) {
+                if (process.pid !in excludedPids && processSnapshotMatchesManagedLauncher(process, descriptor)) {
+                    candidatePids += process.pid
+                }
+            }
+            val snapshotsByPid = currentProcesses.associateBy { it.pid }
+            val ownedProcesses = candidatePids.mapNotNull { pid ->
+                if (!processInspector.isAlive(pid)) return@mapNotNull null
+                val snapshot = snapshotsByPid[pid] ?: return@mapNotNull null
+                val ownedByCommand = processSnapshotMatchesManagedLauncher(snapshot, descriptor)
+                snapshot.takeIf {
+                    ownedByCommand || pidMarkerMatchesDescriptor(pid, descriptor, snapshot.startInstant)
+                }
+            }
+            var terminationFailed = false
+            for (process in ownedProcesses.sortedByDescending { it.pid }) {
+                when (processInspector.terminateIfMatches(process)) {
+                    ManagedProcessTerminationOutcome.TERMINATED,
+                    ManagedProcessTerminationOutcome.NOT_RUNNING,
+                    -> {
+                        candidatePids.remove(process.pid)
+                        deleteMcpMarker(process.pid)
+                    }
+
+                    ManagedProcessTerminationOutcome.IDENTITY_CHANGED -> {
+                        candidatePids.remove(process.pid)
+                    }
+
+                    ManagedProcessTerminationOutcome.FAILED -> terminationFailed = true
+                }
+            }
+
+            val liveCandidateRemains = candidatePids.any(processInspector::isAlive)
+            quietScanCount = if (!terminationFailed && !liveCandidateRemains) quietScanCount + 1 else 0
+            if (scanCount < FAILED_START_CLEANUP_MAX_SCANS && quietScanCount < FAILED_START_CLEANUP_QUIET_SCANS) {
+                delay(FAILED_START_CLEANUP_SCAN_DELAY_MILLIS.milliseconds)
+            }
+        }
+
+        val survivingPids = candidatePids.filter(processInspector::isAlive)
+        if (survivingPids.isNotEmpty()) {
+            throw ManagedBackendValidationException(
+                "Failed to clean up unsuccessful managed backend '${descriptor.id}'; " +
+                    "candidate processes still alive: ${survivingPids.sorted().joinToString()}.",
+            )
+        }
+        deleteRecursively(pidFile)
+    }
+
+    private fun writePidFile(pidFile: Path, pid: Long, startInstant: Instant) {
+        Files.createDirectories(pidFile.parent)
+        val state = ManagedBackendProcessState(pid = pid, startInstant = startInstant.toString())
+        Files.writeString(pidFile, backendJson.encodeToString(state) + "\n")
+    }
+
+    private suspend fun <T> withGlobalBackendOperationLock(block: suspend () -> T): T = withContext(Dispatchers.IO) {
         Files.createDirectories(homePaths.stateDir)
         val lockPath = homePaths.stateDir.resolve("global.lock")
         FileChannel.open(lockPath, StandardOpenOption.CREATE, StandardOpenOption.WRITE).use { channel ->
@@ -508,30 +902,31 @@ class BackendManager(
                 throw ManagedBackendLockException("another devrig backend operation is in progress; retry shortly")
             }
             lock.use {
-                return block()
+                block()
             }
         }
     }
 
-    override suspend fun stop(id: BackendId): StopResult {
+    override suspend fun stop(id: BackendId): StopResult = withContext(Dispatchers.IO) {
         val resolved = resolveConcreteId(id)
         val pidFile = homePaths.pidFile(resolved.id)
-        val pid = readPid(pidFile)
-        if (pid == null) {
+        val processState = readManagedBackendProcessState(pidFile)
+        if (processState == null) {
             Files.deleteIfExists(pidFile)
-            return StopResult(resolved.id, pid = null, outcome = "not running")
+            return@withContext StopResult(resolved.id, pid = null, outcome = "not running")
         }
+        val pid = processState.pid
         val descriptor = loadDescriptor(resolved)
 
         val handle = ProcessHandle.of(pid).getOrNull()
         if (handle == null || !handle.isAlive) {
             deleteMcpMarker(pid)
             Files.deleteIfExists(pidFile)
-            return StopResult(resolved.id, pid = pid, outcome = "already stopped")
+            return@withContext StopResult(resolved.id, pid = pid, outcome = "already stopped")
         }
-        if (!isManagedBackendProcess(handle, descriptor, pid)) {
+        if (!isManagedBackendProcess(handle, descriptor, processState)) {
             Files.deleteIfExists(pidFile)
-            return StopResult(
+            return@withContext StopResult(
                 id = resolved.id,
                 pid = null,
                 outcome = "stale",
@@ -545,57 +940,121 @@ class BackendManager(
             "stopped"
         } else {
             handle.destroyForcibly()
-            waitForExit(handle, timeoutMillis = 5_000L)
+            if (!waitForExit(handle, timeoutMillis = 5_000L)) {
+                throw ManagedBackendValidationException(
+                    "Managed backend '${resolved.id}' pid $pid is still alive after forced termination; " +
+                        "its pid file and marker were retained for a retry.",
+                )
+            }
             "killed"
         }
         deleteMcpMarker(pid)
         Files.deleteIfExists(pidFile)
-        return StopResult(resolved.id, pid = pid, outcome = outcome)
+        StopResult(resolved.id, pid = pid, outcome = outcome)
     }
 
     private fun isManagedBackendProcess(
         handle: ProcessHandle,
         descriptor: BackendDescriptor,
-        pid: Long,
+        processState: ManagedBackendProcessState,
     ): Boolean {
-        return processCommandIsUnderBackendsDir(handle) || pidMarkerMatchesDescriptor(pid, descriptor)
-    }
-
-    private fun processCommandIsUnderBackendsDir(handle: ProcessHandle): Boolean {
+        val pid = processState.pid
         val info = handle.info()
-        val command = info.command().orElse(null)
-        if (command != null && processPathIsUnderBackendsDir(command)) return true
-        return info.arguments().orElse(emptyArray()).any { processPathIsUnderBackendsDir(it) }
+        val snapshot = ProcessSnapshot(
+            pid = pid,
+            command = info.command().orElse(null),
+            arguments = info.arguments().orElse(emptyArray()).toList(),
+            startInstant = info.startInstant().orElse(null),
+        )
+        if (processState.startInstant != null) return processState.matchesProcessSnapshot(snapshot)
+        return pidMarkerMatchesDescriptor(pid, descriptor, snapshot.startInstant)
     }
 
-    private fun processPathIsUnderBackendsDir(rawPath: String): Boolean {
-        val commandPath = try {
-            Path.of(rawPath)
+    private fun processSnapshotMatchesManagedLauncher(
+        process: ProcessSnapshot,
+        descriptor: BackendDescriptor,
+    ): Boolean {
+        val expectedBundle = homePaths.backendDir(descriptor.id)
+            .resolve(descriptor.bundleDirName)
+            .toAbsolutePath()
+            .normalize()
+        val commandPath = process.command?.let(::parseAbsoluteProcessPath)
+
+        val expectedLauncher = try {
+            backendLauncherResolver.resolve(descriptor, expectedBundle).executable.toAbsolutePath().normalize()
         } catch (e: Exception) {
-            System.err.println("WARN: failed to parse process path '$rawPath': ${e.message}")
+            System.err.println(
+                "WARN: failed to resolve managed backend '${descriptor.id}' while scanning processes: " +
+                    e.javaClass.simpleName,
+            )
             return false
         }
-        if (!commandPath.isAbsolute) return false
-        val backendsDir = homePaths.backendsDir.toAbsolutePath().normalize()
-        return commandPath.toAbsolutePath().normalize().startsWith(backendsDir)
+        return commandPath == expectedLauncher ||
+            (commandPath != null && recognizedInterpreterLaunches(commandPath, process.arguments, expectedLauncher))
     }
 
-    private fun pidMarkerMatchesDescriptor(pid: Long, descriptor: BackendDescriptor): Boolean {
+    private fun recognizedInterpreterLaunches(commandPath: Path, arguments: List<String>, expectedLauncher: Path): Boolean {
+        val executableName = commandPath.fileName.toString().lowercase()
+        val unixShells = setOf("sh", "bash", "dash", "zsh", "ksh")
+        if (executableName in unixShells) {
+            return arguments.firstOrNull()?.let(::parseAbsoluteProcessPath) == expectedLauncher
+        }
+        val windowsShells = setOf("cmd", "cmd.exe")
+        if (executableName in windowsShells && arguments.size >= 2 && arguments.first().equals("/c", ignoreCase = true)) {
+            return parseAbsoluteProcessPath(arguments[1]) == expectedLauncher
+        }
+        return false
+    }
+
+    private fun pidMarkerMatchesDescriptor(
+        pid: Long,
+        descriptor: BackendDescriptor,
+        processStartInstant: Instant?,
+    ): Boolean {
+        processStartInstant ?: return false
         val markerPath = markerPathsForPid(pid).firstOrNull { Files.isRegularFile(it) } ?: return false
         val marker = try {
             PidMarkerJson.decode(Files.readString(markerPath))
         } catch (e: Exception) {
-            System.err.println("WARN: failed to decode MCP Steroid marker file $markerPath: ${e.message}")
+            System.err.println("WARN: failed to decode MCP Steroid marker file $markerPath: ${e.javaClass.simpleName}")
             return false
         }
-        val expectedBuild = descriptor.buildNumber ?: return false
-        // Marker builds carry the product-code prefix (`IC-262.8665.258`) that product-info.json
-        // omits, and a descriptor written from a baseline-only resolution holds just `262`.
-        return marker.pid == pid && ideBuildMatches(
-            actual = marker.ide.build,
-            expected = expectedBuild,
-            expectedIsBaseline = isPlatformBaselineOnly(expectedBuild),
+        if (marker.pid != pid) return false
+        if (!markerWasCreatedForProcess(marker, processStartInstant, markerPath, mutableSetOf())) return false
+        val bundleDir = homePaths.backendDir(descriptor.id).resolve(descriptor.bundleDirName)
+        val expectedIdeHome = try {
+            backendLauncherResolver.resolve(descriptor, bundleDir).workingDirectory
+        } catch (e: Exception) {
+            System.err.println("WARN: failed to resolve managed backend '${descriptor.id}' while validating pid $pid: ${e.message}")
+            return false
+        }
+        return markerMatchesManagedBackend(
+            marker = marker,
+            descriptor = descriptor,
+            expectedIdeHome = expectedIdeHome,
+            expectedPluginHome = homePaths.cacheDir(descriptor.id).resolve("plugins/mcp-steroid"),
+            markerPath = markerPath,
+            warnedMarkers = mutableSetOf(),
         )
+    }
+
+    private fun markerWasCreatedForProcess(
+        marker: PidMarker,
+        processStartInstant: Instant,
+        markerPath: Path,
+        warnedMarkers: MutableSet<Path>,
+    ): Boolean {
+        val markerCreatedAt = try {
+            Instant.parse(marker.createdAt)
+        } catch (e: Exception) {
+            if (warnedMarkers.add(markerPath)) {
+                System.err.println(
+                    "WARN: invalid createdAt in MCP Steroid marker file $markerPath: ${e.javaClass.simpleName}",
+                )
+            }
+            return false
+        }
+        return !markerCreatedAt.isBefore(processStartInstant)
     }
 
     private fun deleteMcpMarker(pid: Long) {
@@ -614,17 +1073,20 @@ class BackendManager(
 
     fun list(): List<ManagedBackendInfo> {
         if (!Files.isDirectory(homePaths.backendsDir)) return emptyList()
+        val snapshotsByPid = processInspector.allProcesses().associateBy { it.pid }
         return Files.list(homePaths.backendsDir).use { stream ->
             stream.asSequence()
                 .filter { it.isDirectory() }
                 .mapNotNull { dir ->
                     try {
                         val descriptor = readDescriptorOrNull(descriptorPath(dir)) ?: return@mapNotNull null
-                        val pid = readPid(homePaths.pidFile(descriptor.id))
-                        val alivePid = pid?.takeIf { processInspector.isAlive(it) }
+                        val processState = readManagedBackendProcessState(homePaths.pidFile(descriptor.id))
+                        val alivePid = processState
+                            ?.takeIf { isOwnedManagedBackendProcess(it, descriptor, snapshotsByPid) }
+                            ?.pid
                         val state = when {
                             alivePid != null -> ManagedBackendState.RUNNING
-                            pid != null -> ManagedBackendState.UNREACHABLE
+                            processState != null -> ManagedBackendState.UNREACHABLE
                             else -> ManagedBackendState.INSTALLED
                         }
                         ManagedBackendInfo(
@@ -686,17 +1148,27 @@ class BackendManager(
         val byId = mutableListOf<RunningManagedProcess>()
         val trackedPids = mutableSetOf<Long>()
         val trackedIds = mutableSetOf<String>()
+        val processSnapshots = processInspector.allProcesses()
+        val snapshotsByPid = processSnapshots.associateBy { it.pid }
         if (Files.isDirectory(homePaths.stateDir)) {
             Files.list(homePaths.stateDir).use { stream ->
                 stream.asSequence()
                     .filter { it.fileName.toString().endsWith(".pid") }
                     .forEach { pidFile ->
                         val backendId = pidFile.fileName.toString().removeSuffix(".pid")
-                        val pid = readPid(pidFile)
-                        if (pid != null && processInspector.isAlive(pid)) {
-                            trackedPids += pid
+                        val processState = readManagedBackendProcessState(pidFile)
+                        val descriptor = readDescriptorOrNull(descriptorPath(homePaths.backendDir(backendId)))
+                        if (processState != null && descriptor != null &&
+                            isOwnedManagedBackendProcess(processState, descriptor, snapshotsByPid)
+                        ) {
+                            trackedPids += processState.pid
                             trackedIds += backendId
-                            byId += RunningManagedProcess(backendId, pid, untracked = false)
+                            byId += RunningManagedProcess(
+                                backendId = backendId,
+                                pid = processState.pid,
+                                startInstant = processState.parsedStartInstant(),
+                                untracked = false,
+                            )
                         } else {
                             Files.deleteIfExists(pidFile)
                         }
@@ -704,24 +1176,66 @@ class BackendManager(
             }
         }
 
-        for (process in processInspector.allProcesses()) {
+        for (process in processSnapshots) {
             if (process.pid in trackedPids) continue
-            val backendId = backendIdFromCommand(process.command) ?: continue
-            if (backendId in trackedIds) continue
-            byId += RunningManagedProcess(backendId, process.pid, untracked = true)
+            for (backendId in backendIdsFromProcess(process)) {
+                if (backendId in trackedIds) continue
+                val descriptor = readDescriptorOrNull(descriptorPath(homePaths.backendDir(backendId))) ?: continue
+                val launcherMatches = processSnapshotMatchesManagedLauncher(process, descriptor)
+                val markerMatches = pidMarkerMatchesDescriptor(process.pid, descriptor, process.startInstant)
+                if (!launcherMatches && !markerMatches) continue
+                byId += RunningManagedProcess(
+                    backendId = backendId,
+                    pid = process.pid,
+                    startInstant = process.startInstant,
+                    untracked = true,
+                )
+                break
+            }
         }
 
         return byId.sortedWith(compareBy({ it.backendId }, { it.pid }))
     }
 
+    private fun isOwnedManagedBackendProcess(
+        processState: ManagedBackendProcessState,
+        descriptor: BackendDescriptor,
+        snapshotsByPid: Map<Long, ProcessSnapshot>,
+    ): Boolean {
+        val pid = processState.pid
+        if (!processInspector.isAlive(pid)) return false
+        val snapshot = snapshotsByPid[pid] ?: processInspector.snapshot(pid) ?: return false
+        if (processState.startInstant != null) return processState.matchesProcessSnapshot(snapshot)
+        return pidMarkerMatchesDescriptor(pid, descriptor, snapshot.startInstant)
+    }
+
+    private fun backendIdsFromProcess(process: ProcessSnapshot): List<String> =
+        (listOfNotNull(process.command).asSequence() + process.arguments.asSequence())
+            .mapNotNull(::backendIdFromCommand)
+            .distinct()
+            .toList()
+
     private fun backendIdFromCommand(command: String?): String? {
         if (command.isNullOrBlank()) return null
-        val backendsRoot = homePaths.backendsDir.toAbsolutePath().normalize().toString().pathKey() + "/"
-        val commandPath = Path.of(command).toAbsolutePath().normalize().toString().pathKey()
-        val index = commandPath.indexOf(backendsRoot)
-        if (index < 0) return null
-        val rest = commandPath.substring(index + backendsRoot.length)
-        return rest.substringBefore('/').takeIf { it.isNotBlank() }
+        val backendsRoot = homePaths.backendsDir.toAbsolutePath().normalize()
+        val commandPath = parseAbsoluteProcessPath(command) ?: return null
+        if (!commandPath.startsWith(backendsRoot)) return null
+        val relative = backendsRoot.relativize(commandPath)
+        if (relative.nameCount < 2) return null
+        return relative.getName(0).toString().takeIf { it.isNotBlank() }
+    }
+
+    private fun parseAbsoluteProcessPath(rawPath: String): Path? {
+        val path = try {
+            Path.of(rawPath)
+        } catch (e: Exception) {
+            System.err.println(
+                "WARN: ignored an invalid process path while scanning managed backends: ${e.javaClass.simpleName}",
+            )
+            return null
+        }
+        if (!path.isAbsolute) return null
+        return path.toAbsolutePath().normalize()
     }
 
     private fun lockConflictMessage(process: RunningManagedProcess): String = buildString {
@@ -737,11 +1251,9 @@ class BackendManager(
 private data class RunningManagedProcess(
     val backendId: String,
     val pid: Long,
+    val startInstant: Instant?,
     val untracked: Boolean,
 )
-
-private fun String.pathKey(): String =
-    replace('\\', '/').trimEnd('/').lowercase()
 
 fun writeBackendVmOptions(homePaths: HomePaths, id: String, bundleDirName: String): Path {
     val cacheDir = homePaths.cacheDir(id).toAbsolutePath().normalize()
@@ -884,11 +1396,56 @@ private fun hasProductInfoCandidate(dir: Path): Boolean {
     ).any { it.exists() }
 }
 
-private fun readPid(path: Path): Long? {
+fun readManagedBackendProcessState(path: Path): ManagedBackendProcessState? {
     if (!path.exists()) return null
     val text = Files.readString(path).trim()
     if (text.isBlank()) return null
-    return text.toLongOrNull()
+    text.toLongOrNull()?.let { legacyPid ->
+        return ManagedBackendProcessState(pid = legacyPid, startInstant = null)
+    }
+    return try {
+        backendJson.decodeFromString<ManagedBackendProcessState>(text)
+    } catch (e: Exception) {
+        System.err.println("WARN: failed to decode managed backend process state $path: ${e.javaClass.simpleName}")
+        null
+    }
+}
+
+private fun ManagedBackendProcessState.parsedStartInstant(): Instant? {
+    val raw = startInstant ?: return null
+    return try {
+        Instant.parse(raw)
+    } catch (e: Exception) {
+        System.err.println("WARN: invalid managed backend process start instant: ${e.javaClass.simpleName}")
+        null
+    }
+}
+
+fun ManagedBackendProcessState.matchesProcessSnapshot(snapshot: ProcessSnapshot?): Boolean {
+    val recordedStartInstant = parsedStartInstant() ?: return false
+    return recordedStartInstant == snapshot?.startInstant
+}
+
+private fun terminateProcessIfMatches(expected: ProcessSnapshot): ManagedProcessTerminationOutcome {
+    val expectedStartInstant = expected.startInstant
+        ?: return ManagedProcessTerminationOutcome.IDENTITY_CHANGED
+    val handle = ProcessHandle.of(expected.pid).getOrNull()
+        ?: return ManagedProcessTerminationOutcome.NOT_RUNNING
+    if (!handle.isAlive) return ManagedProcessTerminationOutcome.NOT_RUNNING
+    val currentStartInstant = handle.info().startInstant().orElse(null)
+    if (currentStartInstant != expectedStartInstant) {
+        return ManagedProcessTerminationOutcome.IDENTITY_CHANGED
+    }
+    handle.destroy()
+    if (waitForExit(handle, timeoutMillis = 2_000L)) {
+        return ManagedProcessTerminationOutcome.TERMINATED
+    }
+    handle.destroyForcibly()
+    if (waitForExit(handle, timeoutMillis = 5_000L)) {
+        return ManagedProcessTerminationOutcome.TERMINATED
+    }
+    System.err.println("WARN: failed to terminate managed backend process pid ${expected.pid}")
+    return ManagedProcessTerminationOutcome.FAILED
 }
 
 private fun waitForExit(handle: ProcessHandle, timeoutMillis: Long): Boolean {
@@ -932,25 +1489,52 @@ private fun nullDevice(): File {
  * Spawn the IDE launcher detached from the current process's lifetime, so it
  * survives devrig termination (and, on Windows, the surrounding shell's).
  *
- * Linux / macOS — [ProcessBuilder] is sufficient: the child gets its own session
- * and outlives the parent without special flags.
+ * Linux uses `setsid`; macOS uses a short job-control helper plus `nohup`. Both
+ * detach the launcher from the invoking agent tool's process group before returning.
  *
  * Windows — see [spawnDetachedOnWindows].
  */
 private fun spawnIdeProcess(
     launcher: Path,
+    arguments: List<String>,
     workDir: Path,
     stdoutLog: File,
     stderrLog: File,
     environment: Map<String, String>,
-): Long = if (resolveHostOs() == HostOs.WINDOWS) {
-    // stdoutLog/stderrLog are not propagated on Windows; the WMI-spawned child
-    // is created by the winmgmt service and has no caller-attached stdio.
-    // idea64.exe is GUI-subsystem and writes idea.log itself anyway.
-    spawnDetachedOnWindows(launcher, workDir, environment)
-} else {
-    ProcessBuilder(launcher.toString())
-        .also { builder -> builder.environment().putAll(environment) }
+): Long {
+    val hostOs = resolveHostOs()
+    if (hostOs == HostOs.WINDOWS) {
+        // stdoutLog/stderrLog are not propagated on Windows; the WMI-spawned child
+        // is created by the winmgmt service and has no caller-attached stdio.
+        // idea64.exe is GUI-subsystem and writes idea.log itself anyway.
+        return spawnDetachedOnWindows(launcher, arguments, workDir, environment)
+    }
+    if (hostOs == HostOs.MAC) {
+        return spawnDetachedOnMacOs(
+            launcher = launcher,
+            arguments = arguments,
+            workDir = workDir,
+            stdoutLog = stdoutLog,
+            stderrLog = stderrLog,
+            environment = environment,
+        )
+    }
+
+    // Agent shell tools terminate their whole process group after a command completes. The native
+    // Remote Development launcher stays in the foreground, so it must lead a new session or it is
+    // killed immediately after `devrig backend start` returns. `setsid` execs the launcher in that
+    // session while preserving its PID for the normal marker handoff.
+    val command = listOf(resolveSetsidExecutable().toString(), launcher.toString()) + arguments
+    return ProcessBuilder(command)
+        .also { builder ->
+            if (environment.isNotEmpty()) {
+                // Agent CLIs carry API keys in their environment. A Remote Development backend needs
+                // normal OS/session variables plus its explicit REMOTE_DEV_* flags, never those secrets.
+                val childEnvironment = managedProcessEnvironment(System.getenv(), environment, hostOs)
+                builder.environment().clear()
+                builder.environment().putAll(childEnvironment)
+            }
+        }
         .directory(workDir.toFile())
         .redirectInput(ProcessBuilder.Redirect.from(nullDevice()))
         .redirectOutput(ProcessBuilder.Redirect.appendTo(stdoutLog))
@@ -959,8 +1543,85 @@ private fun spawnIdeProcess(
         .pid()
 }
 
+private fun spawnDetachedOnMacOs(
+    launcher: Path,
+    arguments: List<String>,
+    workDir: Path,
+    stdoutLog: File,
+    stderrLog: File,
+    environment: Map<String, String>,
+): Long {
+    val pidFile = Files.createTempFile("devrig-spawn-", ".pid")
+    val errFile = Files.createTempFile("devrig-spawn-", ".err")
+    try {
+        val command = buildMacOsDetachedProcessCommand(
+            launcher = launcher,
+            arguments = arguments,
+            stdoutLog = stdoutLog.toPath(),
+            stderrLog = stderrLog.toPath(),
+        )
+        val helper = ProcessBuilder(command)
+            .also { builder ->
+                if (environment.isNotEmpty()) {
+                    val childEnvironment = managedProcessEnvironment(System.getenv(), environment, HostOs.MAC)
+                    builder.environment().clear()
+                    builder.environment().putAll(childEnvironment)
+                }
+            }
+            .directory(workDir.toFile())
+            .redirectInput(ProcessBuilder.Redirect.from(nullDevice()))
+            .redirectOutput(pidFile.toFile())
+            .redirectError(errFile.toFile())
+            .start()
+
+        val finished = helper.waitFor(10, TimeUnit.SECONDS)
+        if (!finished) {
+            helper.destroyForcibly()
+            error("macOS detach helper timed out launching $launcher")
+        }
+        if (helper.exitValue() != 0) {
+            val errOutput = Files.readString(errFile).trim()
+            error("macOS detach helper exited ${helper.exitValue()} launching $launcher; stderr: $errOutput")
+        }
+        val pidText = Files.readString(pidFile).trim()
+        return pidText.toLongOrNull()
+            ?: error("Could not parse pid from macOS detach helper output: '$pidText'")
+    } finally {
+        deleteTempQuietly(pidFile)
+        deleteTempQuietly(errFile)
+    }
+}
+
+private const val MAC_OS_DETACH_SCRIPT =
+    $$"set -m; out=$1; err=$2; shift 2; /usr/bin/nohup \"$@\" </dev/null >>\"$out\" 2>>\"$err\" & printf '%s\\n' \"$!\""
+
+fun buildMacOsDetachedProcessCommand(
+    launcher: Path,
+    arguments: List<String>,
+    stdoutLog: Path,
+    stderrLog: Path,
+): List<String> = listOf(
+    "/bin/sh",
+    "-c",
+    MAC_OS_DETACH_SCRIPT,
+    "devrig-detach",
+    stdoutLog.toString(),
+    stderrLog.toString(),
+    launcher.toString(),
+) + arguments
+
+private fun resolveSetsidExecutable(): Path {
+    val candidates = listOf(Path.of("/usr/bin/setsid"), Path.of("/bin/setsid"))
+    return candidates.firstOrNull { Files.isExecutable(it) }
+        ?: throw ManagedBackendValidationException(
+            "Cannot detach the managed IDE: setsid is required on Linux but was not found at " +
+                candidates.joinToString(),
+        )
+}
+
 private fun spawnDetachedOnWindows(
     launcher: Path,
+    arguments: List<String>,
     workDir: Path,
     environment: Map<String, String>,
 ): Long {
@@ -977,30 +1638,22 @@ private fun spawnDetachedOnWindows(
     val pidFile = Files.createTempFile("devrig-spawn-", ".pid")
     val errFile = Files.createTempFile("devrig-spawn-", ".err")
     try {
-        val launcherExt = launcher.fileName.toString().substringAfterLast('.', "").lowercase()
-        val isBatchScript = launcherExt == "bat" || launcherExt == "cmd"
+        val processCommand = buildWindowsProcessCommand(launcher, arguments)
         val script = buildString {
-            // Win32_Process.Create (which wraps CreateProcess) cannot execute .bat/.cmd scripts
-            // directly — they require the cmd.exe interpreter. Wrap with cmd.exe /c so the batch
-            // file path is still visible in the process's command-line arguments, which lets
-            // processCommandIsUnderBackendsDir() recognise the process for stop/list tracking.
-            if (isBatchScript) {
-                append("\$cmd = 'cmd.exe /c \"' + '").append(psQuote(launcher.toString())).append("' + '\"'; ")
-            } else {
-                append("\$cmd = '\"' + '").append(psQuote(launcher.toString())).append("' + '\"'; ")
-            }
+            append($$"$cmd = '").append(psQuote(processCommand)).append("'; ")
             if (environment.isEmpty()) {
-                append("\$startup = \$null; ")
+                append($$"$startup = $null; ")
             } else {
-                append("\$startup = ([wmiclass]'\\\\.\\root\\cimv2:Win32_ProcessStartup').CreateInstance(); ")
-                append("\$startup.EnvironmentVariables = @(")
-                append(environment.entries.joinToString(", ") { "'${psQuote("${it.key}=${it.value}")}'" })
+                val mergedEnvironment = windowsProcessEnvironment(System.getenv(), environment)
+                append($$"$startup = ([wmiclass]'\\\\.\\root\\cimv2:Win32_ProcessStartup').CreateInstance(); ")
+                append($$"$startup.EnvironmentVariables = @(")
+                append(mergedEnvironment.entries.joinToString(", ") { "'${psQuote("${it.key}=${it.value}")}'" })
                 append("); ")
             }
-            append("\$r = ([wmiclass]'\\\\.\\root\\cimv2:Win32_Process').Create(\$cmd, '")
-            append(psQuote(workDir.toString())).append("', \$startup); ")
-            append("if (\$r.ReturnValue -ne 0) { Write-Error (\"Win32_Process.Create returned \" + \$r.ReturnValue); exit \$r.ReturnValue }; ")
-            append("\$r.ProcessId | Out-File -FilePath '").append(psQuote(pidFile.toAbsolutePath().toString())).append("' -Encoding ASCII")
+            append($$"$r = ([wmiclass]'\\\\.\\root\\cimv2:Win32_Process').Create($cmd, '")
+            append(psQuote(workDir.toString())).append($$"', $startup); ")
+            append($$"if ($r.ReturnValue -ne 0) { Write-Error (\"Win32_Process.Create returned \" + $r.ReturnValue); exit $r.ReturnValue }; ")
+            append($$"$r.ProcessId | Out-File -FilePath '").append(psQuote(pidFile.toAbsolutePath().toString())).append("' -Encoding ASCII")
         }
 
         val helper = ProcessBuilder("powershell.exe", "-NoProfile", "-NonInteractive", "-Command", script)
@@ -1037,6 +1690,122 @@ private fun deleteTempQuietly(path: Path) {
 
 /** Doubles single quotes for embedding inside a PowerShell single-quoted string literal. */
 private fun psQuote(s: String): String = s.replace("'", "''")
+
+/** Builds the command line passed to Win32_Process.Create. */
+fun buildWindowsProcessCommand(launcher: Path, arguments: List<String>): String {
+    val launcherExt = launcher.fileName.toString().substringAfterLast('.', "").lowercase()
+    val executable = quoteWindowsProcessArgument(launcher.toString(), alwaysQuote = true)
+    val command = (listOf(executable) + arguments.map { quoteWindowsProcessArgument(it) }).joinToString(" ")
+    return if (launcherExt == "bat" || launcherExt == "cmd") {
+        // Win32_Process.Create cannot execute batch scripts directly. Keep the script path in
+        // the command line so processCommandIsUnderBackendsDir() can still recognise the process.
+        "cmd.exe /c $command"
+    } else {
+        command
+    }
+}
+
+fun windowsProcessEnvironment(
+    inherited: Map<String, String>,
+    overrides: Map<String, String>,
+): Map<String, String> = managedProcessEnvironment(inherited, overrides, HostOs.WINDOWS)
+
+fun managedProcessEnvironment(
+    inherited: Map<String, String>,
+    overrides: Map<String, String>,
+    hostOs: HostOs,
+): Map<String, String> {
+    val requiredKeys = if (hostOs == HostOs.WINDOWS) WINDOWS_PROCESS_ENVIRONMENT_KEYS else UNIX_PROCESS_ENVIRONMENT_KEYS
+    val caseInsensitive = hostOs == HostOs.WINDOWS
+
+    fun allowed(key: String): Boolean = if (caseInsensitive) {
+        key.uppercase() in requiredKeys
+    } else {
+        key in requiredKeys || key.startsWith("LC_")
+    }
+
+    fun overridden(key: String): Boolean = if (caseInsensitive) {
+        overrides.keys.any { it.equals(key, ignoreCase = true) }
+    } else {
+        key in overrides
+    }
+
+    val result = linkedMapOf<String, String>()
+    inherited.entries
+        .filter { allowed(it.key) }
+        .filterNot { overridden(it.key) }
+        .sortedBy { if (caseInsensitive) it.key.uppercase() else it.key }
+        .forEach { result[it.key] = it.value }
+    overrides.entries.sortedBy { it.key }.forEach { result[it.key] = it.value }
+    return result
+}
+
+private val WINDOWS_PROCESS_ENVIRONMENT_KEYS = setOf(
+    "APPDATA",
+    "COMSPEC",
+    "HOMEDRIVE",
+    "HOMEPATH",
+    "JAVA_HOME",
+    "LOCALAPPDATA",
+    "PATH",
+    "PATHEXT",
+    "PROGRAMDATA",
+    "PROGRAMFILES",
+    "PROGRAMFILES(X86)",
+    "SYSTEMDRIVE",
+    "SYSTEMROOT",
+    "TEMP",
+    "TMP",
+    "USERNAME",
+    "USERPROFILE",
+)
+
+private val UNIX_PROCESS_ENVIRONMENT_KEYS = setOf(
+    "DISPLAY",
+    "HOME",
+    "JAVA_HOME",
+    "JDK_HOME",
+    "LANG",
+    "LC_ALL",
+    "LC_CTYPE",
+    "LOGNAME",
+    "PATH",
+    "SHELL",
+    "TEMP",
+    "TMP",
+    "TMPDIR",
+    "USER",
+    "WAYLAND_DISPLAY",
+    "XAUTHORITY",
+    "XDG_CACHE_HOME",
+    "XDG_CONFIG_HOME",
+    "XDG_DATA_HOME",
+    "XDG_RUNTIME_DIR",
+)
+
+private fun quoteWindowsProcessArgument(value: String, alwaysQuote: Boolean = false): String {
+    if (!alwaysQuote && value.isNotEmpty() && value.none { it.isWhitespace() || it == '"' }) return value
+
+    val result = StringBuilder().append('"')
+    var backslashes = 0
+    for (character in value) {
+        when (character) {
+            '\\' -> backslashes++
+            '"' -> {
+                repeat(backslashes * 2 + 1) { result.append('\\') }
+                result.append('"')
+                backslashes = 0
+            }
+            else -> {
+                repeat(backslashes) { result.append('\\') }
+                result.append(character)
+                backslashes = 0
+            }
+        }
+    }
+    repeat(backslashes * 2) { result.append('\\') }
+    return result.append('"').toString()
+}
 
 private fun sha256(path: Path): String {
     val digest = MessageDigest.getInstance("SHA-256")

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/RemoteDevelopmentLauncherResolver.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/RemoteDevelopmentLauncherResolver.kt
@@ -1,0 +1,127 @@
+/* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
+package com.jonnyzzz.mcpSteroid.devrig
+
+import com.jonnyzzz.mcpSteroid.ideDownloader.HostOs
+import com.jonnyzzz.mcpSteroid.ideDownloader.resolveHostOs
+import java.nio.file.Files
+import java.nio.file.Path
+
+data class RemoteDevelopmentLaunchSpec(
+    val ideHome: Path,
+    val executable: Path,
+    val arguments: List<String>,
+)
+
+data class ManagedBackendLaunchSpec(
+    val executable: Path,
+    val arguments: List<String>,
+    val workingDirectory: Path,
+    val environment: Map<String, String>,
+)
+
+class ManagedBackendLauncherResolver(
+    private val hostOs: HostOs = resolveHostOs(),
+) {
+    fun resolve(descriptor: BackendDescriptor, bundleDir: Path): ManagedBackendLaunchSpec {
+        if (usesRemoteDevelopment(descriptor.productKey, descriptor.buildNumber)) {
+            val remote = RemoteDevelopmentLauncherResolver(hostOs).resolve(bundleDir)
+            return ManagedBackendLaunchSpec(
+                executable = remote.executable,
+                arguments = remote.arguments,
+                workingDirectory = remote.ideHome,
+                environment = mapOf(
+                    // The native Remote Development launcher otherwise enables
+                    // `jdk.configure.existing`. IU 262 then tries to create an SDK from inside a
+                    // background write action and logs a deadlock SEVERE on a clean profile.
+                    // The backend image/project already supplies its JDK; do not run the broken
+                    // workstation-style auto-detection path in this unattended process.
+                    "REMOTE_DEV_JDK_DETECTION" to "false",
+                    "REMOTE_DEV_NON_INTERACTIVE" to "1",
+                    "REMOTE_DEV_TRUST_PROJECTS" to "1",
+                ),
+            )
+        }
+
+        val executable = bundleDir.resolve(descriptor.launcherPath)
+        if (!Files.isRegularFile(executable)) {
+            throw ManagedBackendValidationException("The product launcher is missing: $executable")
+        }
+        return ManagedBackendLaunchSpec(
+            executable = executable,
+            arguments = emptyList(),
+            workingDirectory = bundleDir,
+            environment = emptyMap(),
+        )
+    }
+
+    fun validateRequiredAssets(productKey: String, buildNumber: String?, bundleDir: Path) {
+        if (usesRemoteDevelopment(productKey, buildNumber)) {
+            RemoteDevelopmentLauncherResolver(hostOs).resolve(bundleDir)
+        }
+    }
+
+    fun usesRemoteDevelopment(descriptor: BackendDescriptor): Boolean =
+        usesRemoteDevelopment(descriptor.productKey, descriptor.buildNumber)
+
+    fun usesRemoteDevelopment(productKey: String, buildNumber: String?): Boolean {
+        if (productKey != "idea-ultimate") return false
+        val baseline = buildNumber
+            ?.substringAfterLast('-')
+            ?.substringBefore('.')
+            ?.toIntOrNull()
+        return baseline == 262
+    }
+}
+
+class RemoteDevelopmentLauncherResolver(
+    private val hostOs: HostOs = resolveHostOs(),
+) {
+    fun resolve(bundleDir: Path): RemoteDevelopmentLaunchSpec {
+        val ideHome = resolveIdeHome(bundleDir).normalize()
+        val launcherName = if (hostOs == HostOs.WINDOWS) {
+            "remote-dev-server.exe"
+        } else {
+            "remote-dev-server"
+        }
+        val executable = ideHome.resolve("bin").resolve(launcherName)
+        if (!Files.isRegularFile(executable)) {
+            throw ManagedBackendValidationException(
+                "The native Remote Development launcher is missing: $executable",
+            )
+        }
+        if (Files.size(executable) == 0L) {
+            throw ManagedBackendValidationException(
+                "The native Remote Development launcher is empty: $executable",
+            )
+        }
+        if (hostOs != HostOs.WINDOWS && !Files.isExecutable(executable)) {
+            throw ManagedBackendValidationException(
+                "The native Remote Development launcher is not executable: $executable",
+            )
+        }
+
+        val remoteDevelopmentPlugin = ideHome.resolve("plugins/remote-dev-server")
+        if (!Files.isDirectory(remoteDevelopmentPlugin)) {
+            throw ManagedBackendValidationException(
+                "The Remote Development plugin is missing: $remoteDevelopmentPlugin",
+            )
+        }
+        val remoteDevelopmentPluginJar = remoteDevelopmentPlugin.resolve("lib/remote-dev-server.jar")
+        if (!Files.isRegularFile(remoteDevelopmentPluginJar)) {
+            throw ManagedBackendValidationException(
+                "The Remote Development plugin jar is missing: $remoteDevelopmentPluginJar",
+            )
+        }
+        if (Files.size(remoteDevelopmentPluginJar) == 0L) {
+            throw ManagedBackendValidationException(
+                "The Remote Development plugin jar is empty: $remoteDevelopmentPluginJar",
+            )
+        }
+
+        return RemoteDevelopmentLaunchSpec(
+            ideHome = ideHome,
+            executable = executable,
+            arguments = listOf("run"),
+        )
+    }
+}

--- a/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/AllIdeProductsDownloadTest.kt
+++ b/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/AllIdeProductsDownloadTest.kt
@@ -292,6 +292,17 @@ class AllIdeProductsDownloadTest {
             )
             Files.writeString(bundleDir.resolve("bin/$launcherExecutable.sh"), "#!/usr/bin/env sh\n")
             Files.writeString(bundleDir.resolve("bin/$launcherExecutable.bat"), "@echo off\r\n")
+            // A real IU 262 artifact ships the native Remote Development launcher and plugin, and
+            // download() refuses an idea-ultimate 262 install without them — mirror the artifact.
+            if (ManagedBackendLauncherResolver().usesRemoteDevelopment(resolution.product.id, installedBuild)) {
+                Files.writeString(bundleDir.resolve("bin/remote-dev-server"), "#!/usr/bin/env sh\n")
+                    .toFile()
+                    .setExecutable(true)
+                Files.writeString(bundleDir.resolve("bin/remote-dev-server.exe"), "remote development launcher")
+                val pluginJar = bundleDir.resolve("plugins/remote-dev-server/lib/remote-dev-server.jar")
+                Files.createDirectories(pluginJar.parent)
+                Files.writeString(pluginJar, "remote development plugin")
+            }
             return BackendDownloadArtifact(sourceArchiveSha256 = "sha-$installedProductCode")
         }
     }

--- a/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/BackendCommandDownloadOutputTest.kt
+++ b/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/BackendCommandDownloadOutputTest.kt
@@ -1,0 +1,78 @@
+/* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
+package com.jonnyzzz.mcpSteroid.devrig
+
+import com.jonnyzzz.mcpSteroid.ideDownloader.HostOs
+import com.jonnyzzz.mcpSteroid.ideDownloader.resolveHostOs
+import java.io.ByteArrayOutputStream
+import java.io.PrintStream
+import java.nio.file.Files
+import java.nio.file.Path
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class BackendCommandDownloadOutputTest {
+    @Test
+    fun `IU 262 download reports effective native remote development launcher`(
+        @TempDir tempDir: Path,
+    ) {
+        val homePaths = HomePaths(tempDir.resolve("home"))
+        val id = "idea-ultimate-2026.2.0.1"
+        val hostOs = resolveHostOs()
+        val bundleDirName = if (hostOs == HostOs.MAC) "IntelliJ IDEA.app" else "idea-IU-262"
+        val bundleDir = homePaths.backendDir(id).resolve(bundleDirName)
+        val ideHome = if (hostOs == HostOs.MAC) bundleDir.resolve("Contents") else bundleDir
+        val remoteLauncherName = if (hostOs == HostOs.WINDOWS) "remote-dev-server.exe" else "remote-dev-server"
+        val remoteLauncher = ideHome.resolve("bin").resolve(remoteLauncherName)
+        Files.createDirectories(remoteLauncher.parent)
+        Files.writeString(remoteLauncher, "remote development launcher")
+        if (hostOs != HostOs.WINDOWS) {
+            assertTrue(remoteLauncher.toFile().setExecutable(true), "Failed to mark $remoteLauncher executable")
+        }
+        val remoteDevelopmentPlugin = ideHome.resolve("plugins/remote-dev-server")
+        Files.createDirectories(remoteDevelopmentPlugin.resolve("lib"))
+        Files.writeString(remoteDevelopmentPlugin.resolve("lib/remote-dev-server.jar"), "plugin jar")
+
+        val productLauncherPath = if (hostOs == HostOs.WINDOWS) "bin/idea64.exe" else "bin/idea.sh"
+        val result = DownloadResult(
+            id = id,
+            descriptor = BackendDescriptor(
+                id = id,
+                productKey = "idea-ultimate",
+                productCode = "IU",
+                version = "2026.2.0.1",
+                buildNumber = "IU-262.8665.337",
+                bundleDirName = bundleDirName,
+                launcherPath = productLauncherPath,
+                downloadedAt = "2026-07-31T00:00:00Z",
+            ),
+            backendDir = homePaths.backendDir(id),
+            vmOptionsPath = homePaths.backendDir(id).resolve("$bundleDirName.vmoptions"),
+        )
+        val output = ByteArrayOutputStream()
+
+        val exitCode = runBackendDownloadCommand(
+            out = PrintStream(output, true, Charsets.UTF_8),
+            homePaths = homePaths,
+            command = DevrigCommand.DevrigCommandBackendDownload(id = "idea-ultimate"),
+            backendService = DownloadOnlyBackendService(result),
+        )
+
+        val stdout = output.toString(Charsets.UTF_8).replace("\r\n", "\n")
+        assertEquals(0, exitCode)
+        assertTrue(stdout.contains("launcher: $remoteLauncher\n"), stdout)
+        assertFalse(stdout.contains(bundleDir.resolve(productLauncherPath).toString()), stdout)
+    }
+
+    private class DownloadOnlyBackendService(
+        private val result: DownloadResult,
+    ) : ManagedBackendService {
+        override suspend fun download(id: BackendId): DownloadResult = result
+
+        override suspend fun start(id: BackendId): StartResult = error("start is not expected")
+
+        override suspend fun stop(id: BackendId): StopResult = error("stop is not expected")
+    }
+}

--- a/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/BackendCommandStartListTest.kt
+++ b/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/BackendCommandStartListTest.kt
@@ -31,7 +31,7 @@ class BackendCommandStartListTest {
         Files.writeString(homePaths.pidFile("idea-community-2025.3.3"), "12345\n")
         Files.writeString(homePaths.pidFile("pycharm-community-2025.3.3"), "54321\n")
 
-        val rows = collectInstalledBackendListRows(homePaths, FakeProcessInspector(alivePids = setOf(12345L)))
+        val rows = collectInstalledBackendListRows(homePaths, ownedLegacyProcessInspector(homePaths, "idea-community-2025.3.3"))
         val text = renderStartText(rows)
 
         assertTrue(text.startsWith("Installed backends:"), text)
@@ -80,7 +80,9 @@ class BackendCommandStartListTest {
         Files.writeString(homePaths.pidFile("idea-community-2025.3.3"), "12345\n")
         Files.writeString(homePaths.pidFile("pycharm-community-2025.3.3"), "54321\n")
 
-        val root = renderStartJson(collectInstalledBackendListRows(homePaths, FakeProcessInspector(alivePids = setOf(12345L))))
+        val root = renderStartJson(
+            collectInstalledBackendListRows(homePaths, ownedLegacyProcessInspector(homePaths, "idea-community-2025.3.3")),
+        )
 
         assertEquals(setOf("tool", "installed"), root.keys)
         val installed = root["installed"]!!.jsonArray.map { it.jsonObject }
@@ -119,6 +121,31 @@ class BackendCommandStartListTest {
                     pid = 12345L,
                     command = "/usr/bin/java",
                     startInstant = Instant.parse("2026-07-31T09:00:00Z"),
+                ),
+            ),
+        )
+
+        val row = collectInstalledBackendListRows(homePaths, processInspector).single()
+
+        assertEquals(LocalBackendState.INSTALLED, row.state)
+        assertNull(row.pid)
+    }
+
+    @Test
+    fun `legacy pid-only state rejects a launcher in a non-executable shell argument`(@TempDir tempDir: Path) {
+        val homePaths = HomePaths(tempDir)
+        homePaths.mkdirsAll()
+        val id = "idea-community-2025.3.3"
+        backendFixture(homePaths, id, productKey = "idea-community", productCode = "IC", version = "2025.3.3")
+        Files.writeString(homePaths.pidFile(id), "12345\n")
+        val launcher = homePaths.backendDir(id).resolve("bundle-$id/bin/idea.sh").toString()
+        val processInspector = FakeProcessInspector(
+            alivePids = setOf(12345L),
+            snapshots = mapOf(
+                12345L to ProcessSnapshot(
+                    pid = 12345L,
+                    command = "/bin/bash",
+                    arguments = listOf("/tmp/unrelated-script", launcher),
                 ),
             ),
         )
@@ -206,4 +233,15 @@ class BackendCommandStartListTest {
             releaseDate = "2026-04-23",
         ),
     )
+
+    private fun ownedLegacyProcessInspector(homePaths: HomePaths, id: String): FakeProcessInspector =
+        FakeProcessInspector(
+            alivePids = setOf(12345L),
+            snapshots = mapOf(
+                12345L to ProcessSnapshot(
+                    pid = 12345L,
+                    command = homePaths.backendDir(id).resolve("bundle-$id/bin/idea.sh").toString(),
+                ),
+            ),
+        )
 }

--- a/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/BackendCommandStartListTest.kt
+++ b/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/BackendCommandStartListTest.kt
@@ -17,6 +17,7 @@ import java.io.ByteArrayOutputStream
 import java.io.PrintStream
 import java.nio.file.Files
 import java.nio.file.Path
+import java.time.Instant
 
 class BackendCommandStartListTest {
 
@@ -97,6 +98,35 @@ class BackendCommandStartListTest {
         assertEquals(setOf("id", "productKey", "version", "displayName", "state", "pid", "installPath", "cachePath"), stopped.keys)
         assertEquals("installed", stopped["state"]!!.jsonPrimitive.content)
         assertNull(stopped["pid"]!!.jsonPrimitive.contentOrNull)
+    }
+
+    @Test
+    fun `reused pid with a different process start time is not listed as running`(@TempDir tempDir: Path) {
+        val homePaths = HomePaths(tempDir)
+        homePaths.mkdirsAll()
+        val id = "idea-community-2025.3.3"
+        backendFixture(homePaths, id, productKey = "idea-community", productCode = "IC", version = "2025.3.3")
+        Files.writeString(
+            homePaths.pidFile(id),
+            Json.encodeToString(
+                ManagedBackendProcessState(pid = 12345L, startInstant = "2026-07-31T08:00:00Z"),
+            ),
+        )
+        val processInspector = FakeProcessInspector(
+            alivePids = setOf(12345L),
+            snapshots = mapOf(
+                12345L to ProcessSnapshot(
+                    pid = 12345L,
+                    command = "/usr/bin/java",
+                    startInstant = Instant.parse("2026-07-31T09:00:00Z"),
+                ),
+            ),
+        )
+
+        val row = collectInstalledBackendListRows(homePaths, processInspector).single()
+
+        assertEquals(LocalBackendState.INSTALLED, row.state)
+        assertNull(row.pid)
     }
 
     @Test

--- a/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/BackendCommandStopListTest.kt
+++ b/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/BackendCommandStopListTest.kt
@@ -22,10 +22,12 @@ class BackendCommandStopListTest {
     fun `text lists only currently running managed backends`(@TempDir tempDir: Path) {
         val homePaths = HomePaths(tempDir)
         homePaths.mkdirsAll()
+        backendFixture(homePaths, "idea-community-2025.3.3", "idea-community", "IC", "2025.3.3")
+        backendFixture(homePaths, "pycharm-community-2025.3.3", "pycharm-community", "PC", "2025.3.3")
         Files.writeString(homePaths.pidFile("idea-community-2025.3.3"), "12345\n")
         Files.writeString(homePaths.pidFile("pycharm-community-2025.3.3"), "54321\n")
 
-        val rows = collectRunningBackendListRows(homePaths, FakeProcessInspector(alivePids = setOf(12345L)))
+        val rows = collectRunningBackendListRows(homePaths, ownedLegacyProcessInspector(homePaths))
         val text = renderStopText(rows)
 
         assertTrue(text.startsWith("Running backends:"), text)
@@ -40,6 +42,7 @@ class BackendCommandStopListTest {
     fun `empty text says nothing is running`(@TempDir tempDir: Path) {
         val homePaths = HomePaths(tempDir)
         homePaths.mkdirsAll()
+        backendFixture(homePaths, "idea-community-2025.3.3", "idea-community", "IC", "2025.3.3")
         Files.writeString(homePaths.pidFile("idea-community-2025.3.3"), "12345\n")
 
         val text = renderStopText(collectRunningBackendListRows(homePaths, FakeProcessInspector()))
@@ -51,9 +54,10 @@ class BackendCommandStopListTest {
     fun `json lists running schema`(@TempDir tempDir: Path) {
         val homePaths = HomePaths(tempDir)
         homePaths.mkdirsAll()
+        backendFixture(homePaths, "idea-community-2025.3.3", "idea-community", "IC", "2025.3.3")
         Files.writeString(homePaths.pidFile("idea-community-2025.3.3"), "12345\n")
 
-        val root = renderStopJson(collectRunningBackendListRows(homePaths, FakeProcessInspector(alivePids = setOf(12345L))))
+        val root = renderStopJson(collectRunningBackendListRows(homePaths, ownedLegacyProcessInspector(homePaths)))
 
         assertEquals(setOf("tool", "running"), root.keys)
         val running = root["running"]!!.jsonArray.single().jsonObject
@@ -69,6 +73,7 @@ class BackendCommandStopListTest {
         val homePaths = HomePaths(tempDir)
         homePaths.mkdirsAll()
         val id = "idea-community-2025.3.3"
+        backendFixture(homePaths, id, "idea-community", "IC", "2025.3.3")
         Files.writeString(
             homePaths.pidFile(id),
             Json.encodeToString(
@@ -89,6 +94,28 @@ class BackendCommandStopListTest {
         assertTrue(collectRunningBackendListRows(homePaths, processInspector).isEmpty())
     }
 
+    @Test
+    fun `legacy pid-only state omits a launcher in a non-executable shell argument`(@TempDir tempDir: Path) {
+        val homePaths = HomePaths(tempDir)
+        homePaths.mkdirsAll()
+        val id = "idea-community-2025.3.3"
+        backendFixture(homePaths, id, "idea-community", "IC", "2025.3.3")
+        Files.writeString(homePaths.pidFile(id), "12345\n")
+        val launcher = homePaths.backendDir(id).resolve("bundle-$id/bin/idea.sh").toString()
+        val processInspector = FakeProcessInspector(
+            alivePids = setOf(12345L),
+            snapshots = mapOf(
+                12345L to ProcessSnapshot(
+                    pid = 12345L,
+                    command = "/bin/bash",
+                    arguments = listOf("/tmp/unrelated-script", launcher),
+                ),
+            ),
+        )
+
+        assertTrue(collectRunningBackendListRows(homePaths, processInspector).isEmpty())
+    }
+
     private fun renderStopText(rows: List<RunningBackendListRow>): String {
         val buf = ByteArrayOutputStream()
         renderBackendStopListText(rows, PrintStream(buf, true, Charsets.UTF_8))
@@ -100,4 +127,17 @@ class BackendCommandStopListTest {
             renderBackendStopListJson(rows, PrintStream(buf, true, Charsets.UTF_8))
         }.toString(Charsets.UTF_8),
     ).jsonObject
+
+    private fun ownedLegacyProcessInspector(homePaths: HomePaths): FakeProcessInspector {
+        val id = "idea-community-2025.3.3"
+        return FakeProcessInspector(
+            alivePids = setOf(12345L),
+            snapshots = mapOf(
+                12345L to ProcessSnapshot(
+                    pid = 12345L,
+                    command = homePaths.backendDir(id).resolve("bundle-$id/bin/idea.sh").toString(),
+                ),
+            ),
+        )
+    }
 }

--- a/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/BackendCommandStopListTest.kt
+++ b/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/BackendCommandStopListTest.kt
@@ -14,6 +14,7 @@ import java.io.ByteArrayOutputStream
 import java.io.PrintStream
 import java.nio.file.Files
 import java.nio.file.Path
+import java.time.Instant
 
 class BackendCommandStopListTest {
 
@@ -61,6 +62,31 @@ class BackendCommandStopListTest {
         assertEquals(12345L, running["pid"]!!.jsonPrimitive.long)
         assertEquals("IntelliJ IDEA Community 2025.3.3", running["displayName"]!!.jsonPrimitive.content)
         assertEquals(homePaths.cacheDir("idea-community-2025.3.3").resolve("logs/managed.log").toString(), running["logPath"]!!.jsonPrimitive.content)
+    }
+
+    @Test
+    fun `reused pid with a different process start time is omitted`(@TempDir tempDir: Path) {
+        val homePaths = HomePaths(tempDir)
+        homePaths.mkdirsAll()
+        val id = "idea-community-2025.3.3"
+        Files.writeString(
+            homePaths.pidFile(id),
+            Json.encodeToString(
+                ManagedBackendProcessState(pid = 12345L, startInstant = "2026-07-31T08:00:00Z"),
+            ),
+        )
+        val processInspector = FakeProcessInspector(
+            alivePids = setOf(12345L),
+            snapshots = mapOf(
+                12345L to ProcessSnapshot(
+                    pid = 12345L,
+                    command = "/usr/bin/java",
+                    startInstant = Instant.parse("2026-07-31T09:00:00Z"),
+                ),
+            ),
+        )
+
+        assertTrue(collectRunningBackendListRows(homePaths, processInspector).isEmpty())
     }
 
     private fun renderStopText(rows: List<RunningBackendListRow>): String {

--- a/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/BackendListFixtures.kt
+++ b/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/BackendListFixtures.kt
@@ -29,8 +29,11 @@ fun backendFixture(
 
 class FakeProcessInspector(
     private val alivePids: Set<Long> = emptySet(),
+    private val snapshots: Map<Long, ProcessSnapshot> = emptyMap(),
 ) : ManagedProcessInspector {
     override fun isAlive(pid: Long): Boolean = pid in alivePids
 
-    override fun allProcesses(): List<ProcessSnapshot> = emptyList()
+    override fun allProcesses(): List<ProcessSnapshot> = snapshots.values.toList()
+
+    override fun snapshot(pid: Long): ProcessSnapshot? = snapshots[pid]
 }

--- a/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/BackendManagerDownloadValidationTest.kt
+++ b/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/BackendManagerDownloadValidationTest.kt
@@ -2,7 +2,9 @@
 package com.jonnyzzz.mcpSteroid.devrig
 
 import com.jonnyzzz.mcpSteroid.ideDownloader.IdeProduct
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withContext
 import org.apache.commons.compress.archivers.zip.ZipArchiveEntry
 import org.apache.commons.compress.archivers.zip.ZipArchiveOutputStream
 import org.junit.jupiter.api.Test
@@ -36,7 +38,171 @@ class BackendManagerDownloadValidationTest {
         assertEquals("IC", result.descriptor.productCode)
         assertEquals("sha-IC", result.descriptor.sourceArchiveSha256)
         assertTrue(descriptorPath(result.backendDir).exists())
-        assertTrue(result.backendDir.resolve(result.descriptor.bundleDirName).resolve("product-info.json").exists())
+        val bundleDir = result.backendDir.resolve(result.descriptor.bundleDirName)
+        assertTrue(bundleDir.resolve("product-info.json").exists())
+        assertFalse(bundleDir.resolve("bin/remote-dev-server").exists())
+    }
+
+    @Test
+    fun `download accepts matching unqualified resolver and product-info build numbers`(
+        @TempDir tempDir: Path,
+    ) = runBlocking {
+        val homePaths = HomePaths(tempDir.resolve("home"))
+        val manager = BackendManager(
+            homePaths = homePaths,
+            downloader = InstallingDownloader(
+                productCode = "IC",
+                buildNumber = "253.1",
+                resolvedBuildNumber = "253.1",
+                archivePath = fakeArchive(tempDir, "ideaIC-2025.3.3-aarch64.dmg"),
+            ),
+            bundledPluginResolver = FixedPluginResolver(pluginZipFixture(tempDir.resolve("dist/ij-plugin.zip"))),
+        )
+
+        val result = manager.download(parseBackendId("idea-community-2025.3.3"))
+
+        assertEquals("253.1", result.descriptor.buildNumber)
+        assertTrue(result.backendDir.resolve(result.descriptor.bundleDirName).exists())
+    }
+
+    @Test
+    fun `download rejects bundle without remote development assets and cleans partial install`(
+        @TempDir tempDir: Path,
+    ) = runBlocking {
+        val homePaths = HomePaths(tempDir.resolve("home"))
+        val backendId = "idea-ultimate-2026.2.0.1"
+        val manager = BackendManager(
+            homePaths = homePaths,
+            downloader = InstallingDownloader(
+                product = IdeProduct.IntelliJIdea,
+                productCode = "IU",
+                buildNumber = "IU-262.8665.337",
+                archivePath = fakeArchive(tempDir, "ideaIU-2026.2.0.1-aarch64.dmg"),
+                includeRemoteDevelopmentAssets = false,
+            ),
+            bundledPluginResolver = FixedPluginResolver(pluginZipFixture(tempDir.resolve("dist/ij-plugin.zip"))),
+        )
+
+        val error = assertFailsWith<ManagedBackendValidationException> {
+            manager.download(parseBackendId(backendId))
+        }
+
+        assertTrue(error.message!!.contains("native Remote Development launcher is missing"), error.message)
+        assertFalse(homePaths.backendDir(backendId).exists(), "invalid install must not be published")
+        assertFalse(homePaths.backendsDir.resolve("$backendId.partial").exists(), "invalid partial install must be removed")
+    }
+
+    @Test
+    fun `download replaces a corrupt reusable remote development install`(
+        @TempDir tempDir: Path,
+    ) = runBlocking {
+        val homePaths = HomePaths(tempDir.resolve("home"))
+        val backendId = "idea-ultimate-2026.2.0.1"
+        val downloader = InstallingDownloader(
+            product = IdeProduct.IntelliJIdea,
+            productCode = "IU",
+            buildNumber = "IU-262.8665.337",
+            archivePath = fakeArchive(tempDir, "ideaIU-2026.2.0.1-aarch64.dmg"),
+            includeRemoteDevelopmentAssets = true,
+        )
+        val manager = BackendManager(
+            homePaths = homePaths,
+            downloader = downloader,
+            bundledPluginResolver = FixedPluginResolver(pluginZipFixture(tempDir.resolve("dist/ij-plugin.zip"))),
+        )
+
+        val first = manager.download(parseBackendId(backendId))
+        val remoteLauncher = first.backendDir.resolve(first.descriptor.bundleDirName).resolve("bin/remote-dev-server")
+        assertTrue(remoteLauncher.exists())
+        Files.delete(remoteLauncher)
+
+        var repaired = manager.download(parseBackendId(backendId))
+
+        assertEquals(2, downloader.downloadCount, "the corrupt published install must be downloaded again")
+        assertTrue(
+            repaired.backendDir.resolve(repaired.descriptor.bundleDirName).resolve("bin/remote-dev-server").exists(),
+            "the replacement install must restore the required native launcher",
+        )
+
+        val repairedLauncher = repaired.backendDir.resolve(repaired.descriptor.bundleDirName).resolve("bin/remote-dev-server")
+        Files.writeString(repairedLauncher, "")
+        repaired = manager.download(parseBackendId(backendId))
+        assertEquals(3, downloader.downloadCount, "a zero-byte native launcher must not be reused")
+
+        val nonExecutableLauncher = repaired.backendDir.resolve(repaired.descriptor.bundleDirName).resolve("bin/remote-dev-server")
+        nonExecutableLauncher.toFile().setExecutable(false)
+        repaired = manager.download(parseBackendId(backendId))
+        assertEquals(4, downloader.downloadCount, "a non-executable Unix native launcher must not be reused")
+
+        val pluginJar = repaired.backendDir.resolve(repaired.descriptor.bundleDirName)
+            .resolve("plugins/remote-dev-server/lib/remote-dev-server.jar")
+        Files.writeString(pluginJar, "")
+        repaired = manager.download(parseBackendId(backendId))
+        assertEquals(5, downloader.downloadCount, "a zero-byte Remote Development plugin jar must not be reused")
+        assertTrue(Files.size(
+            repaired.backendDir.resolve(repaired.descriptor.bundleDirName)
+                .resolve("plugins/remote-dev-server/lib/remote-dev-server.jar"),
+        ) > 0L)
+        assertFalse(homePaths.backendsDir.resolve("$backendId.partial").exists())
+    }
+
+    @Test
+    fun `download replaces a reusable install whose product-info build differs from the resolved build`(
+        @TempDir tempDir: Path,
+    ) = runBlocking {
+        val homePaths = HomePaths(tempDir.resolve("home"))
+        val backendId = "idea-ultimate-2026.2.0.1"
+        val expectedBuild = "IU-262.8665.337"
+        val downloader = InstallingDownloader(
+            product = IdeProduct.IntelliJIdea,
+            productCode = "IU",
+            buildNumber = expectedBuild,
+            archivePath = fakeArchive(tempDir, "ideaIU-2026.2.0.1-aarch64.dmg"),
+            includeRemoteDevelopmentAssets = true,
+        )
+        val manager = BackendManager(
+            homePaths = homePaths,
+            downloader = downloader,
+            bundledPluginResolver = FixedPluginResolver(pluginZipFixture(tempDir.resolve("dist/ij-plugin.zip"))),
+        )
+
+        val first = manager.download(parseBackendId(backendId))
+        val productInfo = first.backendDir.resolve(first.descriptor.bundleDirName).resolve("product-info.json")
+        Files.writeString(productInfo, Files.readString(productInfo).replace(expectedBuild, "IU-263.1"))
+
+        val repaired = manager.download(parseBackendId(backendId))
+
+        assertEquals(2, downloader.downloadCount)
+        assertEquals(expectedBuild, repaired.descriptor.buildNumber)
+        assertTrue(Files.readString(productInfo).contains(expectedBuild))
+    }
+
+    @Test
+    fun `download rejects a freshly unpacked IDE whose build differs from the resolved artifact`(
+        @TempDir tempDir: Path,
+    ) = runBlocking {
+        val homePaths = HomePaths(tempDir.resolve("home"))
+        val backendId = "idea-ultimate-2026.2.0.1"
+        val manager = BackendManager(
+            homePaths = homePaths,
+            downloader = InstallingDownloader(
+                product = IdeProduct.IntelliJIdea,
+                productCode = "IU",
+                buildNumber = "IU-263.1",
+                resolvedBuildNumber = "IU-262.8665.337",
+                archivePath = fakeArchive(tempDir, "ideaIU-2026.2.0.1-aarch64.dmg"),
+            ),
+            bundledPluginResolver = FixedPluginResolver(pluginZipFixture(tempDir.resolve("dist/ij-plugin.zip"))),
+        )
+
+        val error = assertFailsWith<ManagedBackendValidationException> {
+            manager.download(parseBackendId(backendId))
+        }
+
+        assertTrue(error.message!!.contains("IU-263.1"), error.message)
+        assertTrue(error.message!!.contains("IU-262.8665.337"), error.message)
+        assertFalse(homePaths.backendDir(backendId).exists())
+        assertFalse(homePaths.backendsDir.resolve("$backendId.partial").exists())
     }
 
     @Test
@@ -96,10 +262,10 @@ class BackendManagerDownloadValidationTest {
             homePaths = homePaths,
             downloader = InstallingDownloader(
                 productCode = "IC",
-                archivePath = archivePath,
-                resolvedBuild = "262",
+                buildNumber = "262.8665.258",
+                resolvedBuildNumber = "262",
                 buildIsBaseline = true,
-                installedBuild = "262.8665.258",
+                archivePath = archivePath,
             ),
             bundledPluginResolver = FixedPluginResolver(pluginZipFixture(tempDir.resolve("dist/ij-plugin.zip"))),
         )
@@ -121,10 +287,10 @@ class BackendManagerDownloadValidationTest {
             homePaths = homePaths,
             downloader = InstallingDownloader(
                 productCode = "IC",
-                archivePath = archivePath,
-                resolvedBuild = "262",
+                buildNumber = "261.24374.151",
+                resolvedBuildNumber = "262",
                 buildIsBaseline = true,
-                installedBuild = "261.24374.151",
+                archivePath = archivePath,
             ),
             bundledPluginResolver = FixedPluginResolver(pluginZipFixture(tempDir.resolve("dist/ij-plugin.zip"))),
         )
@@ -149,9 +315,9 @@ class BackendManagerDownloadValidationTest {
             homePaths = homePaths,
             downloader = InstallingDownloader(
                 productCode = "IC",
+                buildNumber = "253.28294.999",
+                resolvedBuildNumber = "253.28294.334",
                 archivePath = archivePath,
-                resolvedBuild = "253.28294.334",
-                installedBuild = "253.28294.999",
             ),
             bundledPluginResolver = FixedPluginResolver(pluginZipFixture(tempDir.resolve("dist/ij-plugin.zip"))),
         )
@@ -294,7 +460,7 @@ class BackendManagerDownloadValidationTest {
         override suspend fun downloadAndUnpack(
             resolution: BackendDownloadResolution,
             targetDir: Path,
-        ): BackendDownloadArtifact {
+        ): BackendDownloadArtifact = withContext(Dispatchers.IO) {
             targetDirs.add(targetDir)
             attempts++
             val bundleDir = targetDir.resolve("idea-IC-253.1")
@@ -307,7 +473,7 @@ class BackendManagerDownloadValidationTest {
             Files.writeString(bundleDir.resolve("product-info.json"), productInfo())
             Files.writeString(bundleDir.resolve("bin/idea.sh"), "#!/usr/bin/env sh\n")
             Files.writeString(bundleDir.resolve("bin/idea.bat"), "@echo off\r\n")
-            return BackendDownloadArtifact(
+            BackendDownloadArtifact(
                 sourceArchiveSha256 = "sha-retry",
                 archivePath = archivePath,
             )
@@ -328,19 +494,24 @@ class BackendManagerDownloadValidationTest {
     }
 
     private class InstallingDownloader(
+        private val product: IdeProduct = IdeProduct.IntelliJIdeaCommunity,
         private val productCode: String,
-        private val archivePath: Path,
+        /** What the unpacked `product-info.json` reports (also names the bundle dir). */
+        private val buildNumber: String = "$productCode-253.1",
         /** What the release feed resolved to — a full build, or a baseline when [buildIsBaseline]. */
-        private val resolvedBuild: String = "$productCode-253.1",
+        private val resolvedBuildNumber: String = buildNumber,
         private val buildIsBaseline: Boolean = false,
-        /** What the unpacked `product-info.json` reports. */
-        private val installedBuild: String = "$productCode-253.1",
+        private val archivePath: Path,
+        private val includeRemoteDevelopmentAssets: Boolean = false,
     ) : ManagedBackendDownloader {
+        var downloadCount: Int = 0
+            private set
+
         override suspend fun resolve(id: BackendId): BackendDownloadResolution =
             BackendDownloadResolution(
-                product = IdeProduct.IntelliJIdeaCommunity,
+                product = product,
                 version = id.version ?: "2025.3.3",
-                build = resolvedBuild,
+                build = resolvedBuildNumber,
                 buildIsBaseline = buildIsBaseline,
                 url = "https://download.jetbrains.com/idea/${archivePath.fileName}",
             )
@@ -348,26 +519,28 @@ class BackendManagerDownloadValidationTest {
         override suspend fun downloadAndUnpack(
             resolution: BackendDownloadResolution,
             targetDir: Path,
-        ): BackendDownloadArtifact {
-            val bundleDir = targetDir.resolve("idea-$productCode-253.1")
+        ): BackendDownloadArtifact = withContext(Dispatchers.IO) {
+            downloadCount++
+            val bundleDir = targetDir.resolve("idea-$buildNumber")
             Files.createDirectories(bundleDir.resolve("bin"))
             Files.writeString(
                 bundleDir.resolve("product-info.json"),
-                productInfo(productCode),
+                productInfo(productCode, buildNumber),
             )
             Files.writeString(bundleDir.resolve("bin/idea.sh"), "#!/usr/bin/env sh\n")
             Files.writeString(bundleDir.resolve("bin/idea.bat"), "@echo off\r\n")
-            return BackendDownloadArtifact(
+            if (includeRemoteDevelopmentAssets) writeRemoteDevelopmentAssets(bundleDir)
+            BackendDownloadArtifact(
                 sourceArchiveSha256 = "sha-$productCode",
                 archivePath = archivePath,
             )
         }
 
-        private fun productInfo(productCode: String): String =
+        private fun productInfo(productCode: String, buildNumber: String): String =
             """
             {
               "productCode": "$productCode",
-              "buildNumber": "$installedBuild",
+              "buildNumber": "$buildNumber",
               "launch": [
                 { "os": "Linux", "launcherPath": "bin/idea.sh" },
                 { "os": "macOS", "launcherPath": "bin/idea.sh" },
@@ -375,5 +548,17 @@ class BackendManagerDownloadValidationTest {
               ]
             }
             """.trimIndent()
+    }
+
+    companion object {
+        private fun writeRemoteDevelopmentAssets(bundleDir: Path) {
+            Files.writeString(bundleDir.resolve("bin/remote-dev-server"), "#!/usr/bin/env sh\n")
+                .toFile()
+                .setExecutable(true)
+            Files.writeString(bundleDir.resolve("bin/remote-dev-server.exe"), "remote development launcher")
+            val pluginJar = bundleDir.resolve("plugins/remote-dev-server/lib/remote-dev-server.jar")
+            Files.createDirectories(pluginJar.parent)
+            Files.writeString(pluginJar, "remote development plugin")
+        }
     }
 }

--- a/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/BackendManagerStartStopTest.kt
+++ b/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/BackendManagerStartStopTest.kt
@@ -430,6 +430,105 @@ class BackendManagerStartStopTest {
     }
 
     @Test
+    fun `remote development start accepts a ready process that reused a pre-launch pid`(
+        @TempDir tempDir: Path,
+    ) = kotlinx.coroutines.runBlocking {
+        val id = "idea-ultimate-2026.2.0.1"
+        val build = "IU-262.8665.337"
+        val reusedPid = 4242L
+        val oldStart = Instant.parse("2026-07-31T08:00:00Z")
+        val newStart = Instant.parse("2026-07-31T09:00:00Z")
+        val homePaths = HomePaths(tempDir.resolve("home"))
+        val userHome = tempDir.resolve("user-home")
+        val markerDirectory = PidMarker.markerDirectory(userHome)
+        val bundleDir = homePaths.backendDir(id).resolve("idea-$build")
+        val pluginHome = homePaths.cacheDir(id).resolve("plugins/mcp-steroid")
+        installStubBackend(
+            homePaths = homePaths,
+            id = id,
+            productKey = "idea-ultimate",
+            productCode = "IU",
+            buildNumber = build,
+            launcherBody = gracefulLauncher(),
+            remoteDevelopmentLauncherBody = fixedPidMarkerLauncher(
+                markerPid = reusedPid,
+                markerDirectory = markerDirectory,
+                ideHome = bundleDir,
+                pluginHome = pluginHome,
+            ),
+        )
+        val manager = BackendManager(
+            homePaths = homePaths,
+            downloader = StaticDownloader,
+            bundledPluginResolver = FixedBundledPluginResolver(
+                bundledPluginZipFixture(tempDir.resolve("dist/ij-plugin.zip"), "test"),
+            ),
+            processInspector = ReusedPreLaunchPidInspector(reusedPid, oldStart, newStart),
+            ideUserHome = userHome,
+            remoteDevelopmentStartupTimeoutMillis = 1_000,
+        )
+
+        try {
+            val started = manager.start(parseBackendId(id))
+
+            assertEquals(reusedPid, started.pid)
+            assertEquals(
+                newStart.toString(),
+                requireNotNull(readManagedBackendProcessState(homePaths.pidFile(id))).startInstant,
+            )
+        } finally {
+            Files.deleteIfExists(homePaths.pidFile(id))
+            Files.deleteIfExists(markerDirectory.resolve(PidMarker.markerFileNameFor(reusedPid)))
+        }
+    }
+
+    @Test
+    fun `remote development start refuses to adopt an untracked launcher without a ready marker`(
+        @TempDir tempDir: Path,
+    ) = kotlinx.coroutines.runBlocking {
+        val id = "idea-ultimate-2026.2.0.1"
+        val build = "IU-262.8665.337"
+        val homePaths = HomePaths(tempDir.resolve("home"))
+        installStubBackend(
+            homePaths = homePaths,
+            id = id,
+            productKey = "idea-ultimate",
+            productCode = "IU",
+            buildNumber = build,
+            launcherBody = gracefulLauncher(),
+            remoteDevelopmentLauncherBody = gracefulLauncher(),
+        )
+        val remoteLauncher = homePaths.backendDir(id).resolve("idea-$build/bin/remote-dev-server")
+        val processStartedAt = Instant.parse("2026-07-31T10:00:00Z")
+        val manager = BackendManager(
+            homePaths = homePaths,
+            downloader = StaticDownloader,
+            bundledPluginResolver = FixedBundledPluginResolver(
+                bundledPluginZipFixture(tempDir.resolve("dist/ij-plugin.zip"), "test"),
+            ),
+            processInspector = FakeProcessInspector(
+                alivePids = setOf(4242L),
+                snapshots = mapOf(
+                    4242L to ProcessSnapshot(
+                        pid = 4242L,
+                        command = remoteLauncher.toString(),
+                        startInstant = processStartedAt,
+                    ),
+                ),
+            ),
+            ideUserHome = tempDir.resolve("user-home"),
+        )
+
+        val error = assertFailsWith<ManagedBackendLockException> {
+            manager.start(parseBackendId(id))
+        }
+
+        assertTrue(error.message!!.contains("not ready"), error.message)
+        assertTrue(error.message!!.contains("pid 4242"), error.message)
+        assertFalse(homePaths.pidFile(id).exists(), "an unready untracked launcher must not become durable state")
+    }
+
+    @Test
     fun `remote development start rejects a stale marker written for the current launcher pid`(
         @TempDir tempDir: Path,
     ) = kotlinx.coroutines.runBlocking {
@@ -1326,6 +1425,35 @@ class BackendManagerStartStopTest {
     }
 
     @Test
+    fun `download refuses to rewrite the plugin of a running backend`(
+        @TempDir tempDir: Path,
+    ) = kotlinx.coroutines.runBlocking {
+        val id = "idea-community-2025.3.3"
+        val homePaths = HomePaths(tempDir.resolve("home"))
+        installStubBackend(homePaths, launcherBody = gracefulLauncher())
+        val manager = BackendManager(
+            homePaths = homePaths,
+            downloader = StaticDownloader,
+            bundledPluginResolver = FixedBundledPluginResolver(
+                bundledPluginZipFixture(tempDir.resolve("dist/ij-plugin.zip"), "test"),
+            ),
+            ideUserHome = tempDir.resolve("user-home"),
+        )
+
+        val started = manager.start(parseBackendId(id))
+        try {
+            val error = assertFailsWith<ManagedBackendLockException> {
+                manager.download(parseBackendId(id))
+            }
+
+            assertTrue(error.message!!.contains("$id is running"), error.message)
+            assertTrue(ProcessHandle.of(started.pid).orElseThrow().isAlive)
+        } finally {
+            manager.stop(parseBackendId(id))
+        }
+    }
+
+    @Test
     fun `durable pid identity does not decode an unrelated marker`(
         @TempDir tempDir: Path,
     ) = kotlinx.coroutines.runBlocking {
@@ -1468,7 +1596,7 @@ class BackendManagerStartStopTest {
         markerDirectory: Path,
         ideHome: Path,
         pluginHome: Path,
-        markerCreatedAt: String = Instant.now().plusSeconds(1).toString(),
+        markerCreatedAt: String = FUTURE_MARKER_CREATED_AT,
     ): String {
         val shellPid = '$' + "pid"
         val markerJson = readyMarkerJson(0, ideHome, pluginHome, markerCreatedAt)
@@ -1480,6 +1608,24 @@ class BackendManagerStartStopTest {
         printf '%s\n' "$#" "$@" "$REMOTE_DEV_JDK_DETECTION" "$REMOTE_DEV_NON_INTERACTIVE" "$REMOTE_DEV_TRUST_PROJECTS" > '$$argumentsFile'
         mkdir -p '$$markerDirectory'
         cat > '$$markerDirectory/'"$pid"'.mcp-steroid' <<EOF
+        $$markerJson
+        EOF
+        trap 'exit 0' TERM
+        while true; do sleep 1; done
+        """.trimIndent() + "\n"
+    }
+
+    private fun fixedPidMarkerLauncher(
+        markerPid: Long,
+        markerDirectory: Path,
+        ideHome: Path,
+        pluginHome: Path,
+    ): String {
+        val markerJson = readyMarkerJson(markerPid, ideHome, pluginHome).replace("\n", "")
+        return $$"""
+        #!/usr/bin/env sh
+        mkdir -p '$$markerDirectory'
+        cat > '$$markerDirectory/$$markerPid.mcp-steroid' <<EOF
         $$markerJson
         EOF
         trap 'exit 0' TERM
@@ -1586,7 +1732,7 @@ class BackendManagerStartStopTest {
         ideHome: Path,
         pluginHome: Path,
         build: String = "IC-253.1",
-        createdAt: String = Instant.now().plusSeconds(1).toString(),
+        createdAt: String = FUTURE_MARKER_CREATED_AT,
     ): String =
         PidMarkerJson.encode(
             PidMarker(
@@ -1611,7 +1757,7 @@ class BackendManagerStartStopTest {
         pid: Long,
         ideHome: Path,
         pluginHome: Path? = null,
-        createdAt: String = Instant.now().plusSeconds(1).toString(),
+        createdAt: String = FUTURE_MARKER_CREATED_AT,
     ): String =
         PidMarkerJson.encode(
             PidMarker(
@@ -1762,5 +1908,37 @@ class BackendManagerStartStopTest {
             targetWasHidden = true
             return snapshots.filterNot { it.pid == targetPid }
         }
+    }
+
+    private class ReusedPreLaunchPidInspector(
+        private val reusedPid: Long,
+        private val oldStart: Instant,
+        private val newStart: Instant,
+    ) : ManagedProcessInspector {
+        private var processListingCount = 0
+
+        override fun isAlive(pid: Long): Boolean =
+            pid == reusedPid || DefaultManagedProcessInspector.isAlive(pid)
+
+        override fun snapshot(pid: Long): ProcessSnapshot? =
+            if (pid == reusedPid) {
+                ProcessSnapshot(pid = reusedPid, command = "/managed/backend", startInstant = newStart)
+            } else {
+                DefaultManagedProcessInspector.snapshot(pid)
+            }
+
+        override fun allProcesses(): List<ProcessSnapshot> {
+            processListingCount++
+            return when (processListingCount) {
+                1 -> emptyList()
+                2 -> listOf(ProcessSnapshot(pid = reusedPid, command = "/old/process", startInstant = oldStart))
+                else -> DefaultManagedProcessInspector.allProcesses().filterNot { it.pid == reusedPid } +
+                    requireNotNull(snapshot(reusedPid))
+            }
+        }
+    }
+
+    private companion object {
+        const val FUTURE_MARKER_CREATED_AT = "9999-12-31T23:59:59Z"
     }
 }

--- a/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/BackendManagerStartStopTest.kt
+++ b/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/BackendManagerStartStopTest.kt
@@ -6,24 +6,626 @@ import com.jonnyzzz.mcpSteroid.McpSteroidServerInfo
 import com.jonnyzzz.mcpSteroid.PidMarker
 import com.jonnyzzz.mcpSteroid.PidMarkerJson
 import com.jonnyzzz.mcpSteroid.PluginInfo
+import com.jonnyzzz.mcpSteroid.ideDownloader.HostOs
 import com.jonnyzzz.mcpSteroid.ideDownloader.IdeProduct
+import kotlinx.coroutines.async
+import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.withTimeout
+import kotlinx.serialization.json.Json
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.condition.DisabledOnOs
 import org.junit.jupiter.api.condition.OS
 import org.junit.jupiter.api.io.TempDir
+import java.io.ByteArrayOutputStream
+import java.io.PrintStream
 import java.nio.file.Files
 import java.nio.file.Path
+import java.time.Instant
 import java.util.concurrent.TimeUnit
 import kotlin.io.path.exists
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNotEquals
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
 
 @DisabledOnOs(OS.WINDOWS)
 class BackendManagerStartStopTest {
+
+    @Test
+    fun `start launches native remote development server with run argument`(
+        @TempDir tempDir: Path,
+    ) = kotlinx.coroutines.runBlocking {
+        val homePaths = HomePaths(tempDir.resolve("home"))
+        val argumentsFile = tempDir.resolve("remote-dev-arguments.txt")
+        val userHome = tempDir.resolve("user-home")
+        val bundleDir = homePaths.backendDir("idea-ultimate-2026.2.0.1").resolve("idea-IU-262.8665.337")
+        installStubBackend(
+            homePaths = homePaths,
+            id = "idea-ultimate-2026.2.0.1",
+            productKey = "idea-ultimate",
+            productCode = "IU",
+            buildNumber = "IU-262.8665.337",
+            launcherBody = gracefulLauncher(),
+            remoteDevelopmentLauncherBody = remoteArgumentRecordingLauncher(
+                argumentsFile = argumentsFile,
+                markerDirectory = PidMarker.markerDirectory(userHome),
+                ideHome = bundleDir,
+                pluginHome = homePaths.cacheDir("idea-ultimate-2026.2.0.1").resolve("plugins/mcp-steroid"),
+            ),
+        )
+        val manager = BackendManager(
+            homePaths = homePaths,
+            downloader = StaticDownloader,
+            bundledPluginResolver = FixedBundledPluginResolver(bundledPluginZipFixture(tempDir.resolve("dist/ij-plugin.zip"), "test")),
+            ideUserHome = userHome,
+        )
+
+        val started = manager.start(parseBackendId("idea-ultimate-2026.2.0.1"))
+        try {
+            withTimeout(5.seconds) {
+                while (!argumentsFile.exists()) delay(50.milliseconds)
+            }
+            assertEquals("1\nrun\nfalse\n1\n1\n", Files.readString(argumentsFile))
+        } finally {
+            manager.stop(parseBackendId("idea-ultimate-2026.2.0.1"))
+        }
+        assertFalse(ProcessHandle.of(started.pid).map { it.isAlive }.orElse(false))
+    }
+
+    @Test
+    fun `remote development start waits for marker and persists handed-off backend pid`(
+        @TempDir tempDir: Path,
+    ) = kotlinx.coroutines.runBlocking {
+        val id = "idea-ultimate-2026.2.0.1"
+        val build = "IU-262.8665.337"
+        val homePaths = HomePaths(tempDir.resolve("home"))
+        val userHome = tempDir.resolve("user-home")
+        val bundleDir = homePaths.backendDir(id).resolve("idea-$build")
+        val launcherPidFile = tempDir.resolve("launcher.pid")
+        installStubBackend(
+            homePaths = homePaths,
+            id = id,
+            productKey = "idea-ultimate",
+            productCode = "IU",
+            buildNumber = build,
+            launcherBody = gracefulLauncher(),
+            remoteDevelopmentLauncherBody = handoffRemoteDevelopmentLauncher(
+                launcherPidFile = launcherPidFile,
+                markerDirectory = PidMarker.markerDirectory(userHome),
+                ideHome = bundleDir,
+                pluginHome = homePaths.cacheDir(id).resolve("plugins/mcp-steroid"),
+            ),
+        )
+        val manager = BackendManager(
+            homePaths = homePaths,
+            downloader = StaticDownloader,
+            bundledPluginResolver = FixedBundledPluginResolver(bundledPluginZipFixture(tempDir.resolve("dist/ij-plugin.zip"), "test")),
+            ideUserHome = userHome,
+            remoteDevelopmentStartupTimeoutMillis = 5_000,
+        )
+
+        val started = manager.start(parseBackendId(id))
+        try {
+            val launcherPid = Files.readString(launcherPidFile).trim().toLong()
+            assertNotEquals(launcherPid, started.pid, "start must return the marker/backend pid, not the exited launcher pid")
+            val processState = requireNotNull(readManagedBackendProcessState(homePaths.pidFile(id)))
+            assertEquals(started.pid, processState.pid)
+            assertTrue(processState.startInstant != null)
+            assertTrue(ProcessHandle.of(started.pid).orElseThrow().isAlive)
+            val markerPath = PidMarker.markerDirectory(userHome).resolve(PidMarker.markerFileNameFor(started.pid))
+            assertEquals(started.pid, PidMarkerJson.decode(Files.readString(markerPath)).pid)
+        } finally {
+            manager.stop(parseBackendId(id))
+        }
+        assertFalse(ProcessHandle.of(started.pid).map { it.isAlive }.orElse(false))
+    }
+
+    @Test
+    fun `remote development handoff terminates a surviving launcher`(
+        @TempDir tempDir: Path,
+    ) = kotlinx.coroutines.runBlocking {
+        val id = "idea-ultimate-2026.2.0.1"
+        val build = "IU-262.8665.337"
+        val homePaths = HomePaths(tempDir.resolve("home"))
+        val userHome = tempDir.resolve("user-home")
+        val bundleDir = homePaths.backendDir(id).resolve("idea-$build")
+        val launcherPidFile = tempDir.resolve("launcher.pid")
+        installStubBackend(
+            homePaths = homePaths,
+            id = id,
+            productKey = "idea-ultimate",
+            productCode = "IU",
+            buildNumber = build,
+            launcherBody = gracefulLauncher(),
+            remoteDevelopmentLauncherBody = persistentHandoffRemoteDevelopmentLauncher(
+                launcherPidFile = launcherPidFile,
+                markerDirectory = PidMarker.markerDirectory(userHome),
+                ideHome = bundleDir,
+                pluginHome = homePaths.cacheDir(id).resolve("plugins/mcp-steroid"),
+            ),
+        )
+        val manager = BackendManager(
+            homePaths = homePaths,
+            downloader = StaticDownloader,
+            bundledPluginResolver = FixedBundledPluginResolver(
+                bundledPluginZipFixture(tempDir.resolve("dist/ij-plugin.zip"), "test"),
+            ),
+            ideUserHome = userHome,
+            remoteDevelopmentStartupTimeoutMillis = 5_000,
+        )
+
+        val started = manager.start(parseBackendId(id))
+        val launcherPid = Files.readString(launcherPidFile).trim().toLong()
+        val launcher = ProcessHandle.of(launcherPid)
+        try {
+            assertNotEquals(launcherPid, started.pid)
+            assertFalse(
+                launcher.map { it.isAlive }.orElse(false),
+                "the launcher must not survive after readiness hands ownership to a different backend pid",
+            )
+            assertTrue(ProcessHandle.of(started.pid).orElseThrow().isAlive)
+        } finally {
+            manager.stop(parseBackendId(id))
+            launcher.filter { it.isAlive }.ifPresent { handle ->
+                handle.destroyForcibly()
+                handle.onExit().get(5, TimeUnit.SECONDS)
+            }
+        }
+    }
+
+    @Test
+    fun `remote development start fails clearly when no ready marker appears`(
+        @TempDir tempDir: Path,
+    ) = kotlinx.coroutines.runBlocking {
+        val id = "idea-ultimate-2026.2.0.1"
+        val homePaths = HomePaths(tempDir.resolve("home"))
+        installStubBackend(
+            homePaths = homePaths,
+            id = id,
+            productKey = "idea-ultimate",
+            productCode = "IU",
+            buildNumber = "IU-262.8665.337",
+            launcherBody = gracefulLauncher(),
+            remoteDevelopmentLauncherBody = gracefulLauncher(),
+        )
+        val manager = BackendManager(
+            homePaths = homePaths,
+            downloader = StaticDownloader,
+            bundledPluginResolver = FixedBundledPluginResolver(bundledPluginZipFixture(tempDir.resolve("dist/ij-plugin.zip"), "test")),
+            ideUserHome = tempDir.resolve("user-home"),
+            remoteDevelopmentStartupTimeoutMillis = 300,
+        )
+
+        val error = assertFailsWith<ManagedBackendValidationException> {
+            manager.start(parseBackendId(id))
+        }
+
+        assertTrue(error.message!!.contains("Timed out waiting for the MCP Steroid readiness marker"), error.message)
+        assertTrue(error.message!!.contains(id), error.message)
+        assertFalse(homePaths.pidFile(id).exists(), "an unready launcher pid must never be persisted")
+    }
+
+    @Test
+    fun `failed remote development start retries process discovery before leaving cleanup`(
+        @TempDir tempDir: Path,
+    ) = kotlinx.coroutines.runBlocking {
+        val id = "idea-ultimate-2026.2.0.1"
+        val homePaths = HomePaths(tempDir.resolve("home"))
+        val launcherPidFile = tempDir.resolve("launcher.pid")
+        installStubBackend(
+            homePaths = homePaths,
+            id = id,
+            productKey = "idea-ultimate",
+            productCode = "IU",
+            buildNumber = "IU-262.8665.337",
+            launcherBody = gracefulLauncher(),
+            remoteDevelopmentLauncherBody = pidRecordingLauncher(launcherPidFile),
+        )
+        val manager = BackendManager(
+            homePaths = homePaths,
+            downloader = StaticDownloader,
+            bundledPluginResolver = FixedBundledPluginResolver(
+                bundledPluginZipFixture(tempDir.resolve("dist/ij-plugin.zip"), "test"),
+            ),
+            processInspector = HideFirstVisibleLauncherInspector(launcherPidFile),
+            ideUserHome = tempDir.resolve("user-home"),
+            remoteDevelopmentStartupTimeoutMillis = 100,
+        )
+
+        assertFailsWith<ManagedBackendValidationException> {
+            manager.start(parseBackendId(id))
+        }
+        val launcherPid = Files.readString(launcherPidFile).trim().toLong()
+        val launcher = ProcessHandle.of(launcherPid)
+        try {
+            assertFalse(
+                launcher.map { it.isAlive }.orElse(false),
+                "cleanup must rescan when the first process snapshot misses the launcher",
+            )
+        } finally {
+            launcher.filter { it.isAlive }.ifPresent { handle ->
+                handle.destroyForcibly()
+                handle.onExit().get(5, TimeUnit.SECONDS)
+            }
+        }
+    }
+
+    @Test
+    fun `failed remote development cleanup refuses a pid whose start identity changed after discovery`(
+        @TempDir tempDir: Path,
+    ) = kotlinx.coroutines.runBlocking {
+        val id = "idea-ultimate-2026.2.0.1"
+        val homePaths = HomePaths(tempDir.resolve("home"))
+        val launcherPidFile = tempDir.resolve("launcher.pid")
+        installStubBackend(
+            homePaths = homePaths,
+            id = id,
+            productKey = "idea-ultimate",
+            productCode = "IU",
+            buildNumber = "IU-262.8665.337",
+            launcherBody = gracefulLauncher(),
+            remoteDevelopmentLauncherBody = pidRecordingLauncher(launcherPidFile),
+        )
+        val manager = BackendManager(
+            homePaths = homePaths,
+            downloader = StaticDownloader,
+            bundledPluginResolver = FixedBundledPluginResolver(
+                bundledPluginZipFixture(tempDir.resolve("dist/ij-plugin.zip"), "test"),
+            ),
+            processInspector = ChangedStartIdentityInspector(launcherPidFile),
+            ideUserHome = tempDir.resolve("user-home"),
+            remoteDevelopmentStartupTimeoutMillis = 100,
+        )
+
+        assertFailsWith<ManagedBackendValidationException> {
+            manager.start(parseBackendId(id))
+        }
+        val launcherPid = Files.readString(launcherPidFile).trim().toLong()
+        val launcher = ProcessHandle.of(launcherPid)
+        try {
+            assertTrue(
+                launcher.map { it.isAlive }.orElse(false),
+                "cleanup must revalidate process start identity immediately before signalling a discovered pid",
+            )
+        } finally {
+            launcher.filter { it.isAlive }.ifPresent { handle ->
+                handle.destroyForcibly()
+                handle.onExit().get(5, TimeUnit.SECONDS)
+            }
+        }
+    }
+
+    @Test
+    fun `remote development marker decode warning never logs marker contents`(
+        @TempDir tempDir: Path,
+    ) = kotlinx.coroutines.runBlocking {
+        val id = "idea-ultimate-2026.2.0.1"
+        val secretSentinel = "SECRET_SENTINEL"
+        val homePaths = HomePaths(tempDir.resolve("home"))
+        val userHome = tempDir.resolve("user-home")
+        installStubBackend(
+            homePaths = homePaths,
+            id = id,
+            productKey = "idea-ultimate",
+            productCode = "IU",
+            buildNumber = "IU-262.8665.337",
+            launcherBody = gracefulLauncher(),
+            remoteDevelopmentLauncherBody = gracefulLauncher(),
+        )
+        val markerDirectory = PidMarker.markerDirectory(userHome)
+        Files.createDirectories(markerDirectory)
+        val markerPath = markerDirectory.resolve(PidMarker.markerFileNameFor(999_999L))
+        Files.writeString(markerPath, "{\"authorization\":\"Bearer $secretSentinel\",")
+        val manager = BackendManager(
+            homePaths = homePaths,
+            downloader = StaticDownloader,
+            bundledPluginResolver = FixedBundledPluginResolver(bundledPluginZipFixture(tempDir.resolve("dist/ij-plugin.zip"), "test")),
+            ideUserHome = userHome,
+            remoteDevelopmentStartupTimeoutMillis = 100,
+        )
+
+        val stderr = captureStderr {
+            assertFailsWith<ManagedBackendValidationException> {
+                manager.start(parseBackendId(id))
+            }
+        }
+
+        assertTrue(stderr.contains(markerPath.toString()), stderr)
+        assertTrue(stderr.contains("JsonDecodingException"), stderr)
+        assertFalse(stderr.contains(secretSentinel), stderr)
+    }
+
+    @Test
+    fun `remote development start rejects marker from an unmanaged plugin path`(
+        @TempDir tempDir: Path,
+    ) = kotlinx.coroutines.runBlocking {
+        val id = "idea-ultimate-2026.2.0.1"
+        val homePaths = HomePaths(tempDir.resolve("home"))
+        val userHome = tempDir.resolve("user-home")
+        val bundleDir = homePaths.backendDir(id).resolve("idea-IU-262.8665.337")
+        installStubBackend(
+            homePaths = homePaths,
+            id = id,
+            productKey = "idea-ultimate",
+            productCode = "IU",
+            buildNumber = "IU-262.8665.337",
+            launcherBody = gracefulLauncher(),
+            remoteDevelopmentLauncherBody = remoteArgumentRecordingLauncher(
+                argumentsFile = tempDir.resolve("remote-dev-arguments.txt"),
+                markerDirectory = PidMarker.markerDirectory(userHome),
+                ideHome = bundleDir,
+                pluginHome = tempDir.resolve("unmanaged-plugin"),
+            ),
+        )
+        val manager = BackendManager(
+            homePaths = homePaths,
+            downloader = StaticDownloader,
+            bundledPluginResolver = FixedBundledPluginResolver(
+                bundledPluginZipFixture(tempDir.resolve("dist/ij-plugin.zip"), "test"),
+            ),
+            ideUserHome = userHome,
+            remoteDevelopmentStartupTimeoutMillis = 300,
+        )
+
+        val error = assertFailsWith<ManagedBackendValidationException> {
+            manager.start(parseBackendId(id))
+        }
+
+        assertTrue(error.message!!.contains("Timed out waiting for the MCP Steroid readiness marker"), error.message)
+        assertFalse(homePaths.pidFile(id).exists(), "a marker for a different plugin install must not be persisted")
+    }
+
+    @Test
+    fun `remote development start ignores a live matching marker that predates the launch`(
+        @TempDir tempDir: Path,
+    ): Unit = kotlinx.coroutines.runBlocking {
+        val id = "idea-ultimate-2026.2.0.1"
+        val build = "IU-262.8665.337"
+        val homePaths = HomePaths(tempDir.resolve("home"))
+        val userHome = tempDir.resolve("user-home")
+        val markerDirectory = PidMarker.markerDirectory(userHome)
+        val bundleDir = homePaths.backendDir(id).resolve("idea-$build")
+        val pluginHome = homePaths.cacheDir(id).resolve("plugins/mcp-steroid")
+        val argumentsFile = tempDir.resolve("remote-args.txt")
+        installStubBackend(
+            homePaths = homePaths,
+            id = id,
+            productKey = "idea-ultimate",
+            productCode = "IU",
+            buildNumber = build,
+            launcherBody = gracefulLauncher(),
+            remoteDevelopmentLauncherBody = remoteArgumentRecordingLauncher(
+                argumentsFile = argumentsFile,
+                markerDirectory = markerDirectory,
+                ideHome = bundleDir,
+                pluginHome = pluginHome,
+            ),
+        )
+        val unrelated = startUnrelatedSleeper()
+        Files.createDirectories(markerDirectory)
+        val oldMarker = markerDirectory.resolve(PidMarker.markerFileNameFor(unrelated.pid()))
+        Files.writeString(oldMarker, readyMarkerJson(unrelated.pid(), bundleDir, pluginHome))
+        val manager = BackendManager(
+            homePaths = homePaths,
+            downloader = StaticDownloader,
+            bundledPluginResolver = FixedBundledPluginResolver(bundledPluginZipFixture(tempDir.resolve("dist/ij-plugin.zip"), "test")),
+            ideUserHome = userHome,
+            remoteDevelopmentStartupTimeoutMillis = 5_000,
+        )
+
+        try {
+            val started = manager.start(parseBackendId(id))
+            assertNotEquals(unrelated.pid(), started.pid, "a pre-launch marker must not capture this start")
+            assertTrue(unrelated.isAlive, "the pre-existing process must remain untouched")
+            manager.stop(parseBackendId(id))
+        } finally {
+            Files.deleteIfExists(oldMarker)
+            stopProcess(unrelated)
+        }
+    }
+
+    @Test
+    fun `remote development start rejects a stale marker written for the current launcher pid`(
+        @TempDir tempDir: Path,
+    ) = kotlinx.coroutines.runBlocking {
+        val id = "idea-ultimate-2026.2.0.1"
+        val build = "IU-262.8665.337"
+        val homePaths = HomePaths(tempDir.resolve("home"))
+        val userHome = tempDir.resolve("user-home")
+        val markerDirectory = PidMarker.markerDirectory(userHome)
+        val bundleDir = homePaths.backendDir(id).resolve("idea-$build")
+        val pluginHome = homePaths.cacheDir(id).resolve("plugins/mcp-steroid")
+        installStubBackend(
+            homePaths = homePaths,
+            id = id,
+            productKey = "idea-ultimate",
+            productCode = "IU",
+            buildNumber = build,
+            launcherBody = gracefulLauncher(),
+            remoteDevelopmentLauncherBody = remoteArgumentRecordingLauncher(
+                argumentsFile = tempDir.resolve("remote-args.txt"),
+                markerDirectory = markerDirectory,
+                ideHome = bundleDir,
+                pluginHome = pluginHome,
+                markerCreatedAt = "2000-01-01T00:00:00Z",
+            ),
+        )
+        val manager = BackendManager(
+            homePaths = homePaths,
+            downloader = StaticDownloader,
+            bundledPluginResolver = FixedBundledPluginResolver(bundledPluginZipFixture(tempDir.resolve("dist/ij-plugin.zip"), "test")),
+            ideUserHome = userHome,
+            remoteDevelopmentStartupTimeoutMillis = 300,
+        )
+
+        val error = assertFailsWith<ManagedBackendValidationException> {
+            manager.start(parseBackendId(id))
+        }
+
+        assertTrue(error.message!!.contains("Timed out waiting for the MCP Steroid readiness marker"), error.message)
+        assertFalse(homePaths.pidFile(id).exists())
+    }
+
+    @Test
+    fun `remote development timeout terminates an unmarked handed-off backend process`(
+        @TempDir tempDir: Path,
+    ) = kotlinx.coroutines.runBlocking {
+        val id = "idea-ultimate-2026.2.0.1"
+        val homePaths = HomePaths(tempDir.resolve("home"))
+        val handedOffPidFile = tempDir.resolve("handed-off.pid")
+        installStubBackend(
+            homePaths = homePaths,
+            id = id,
+            productKey = "idea-ultimate",
+            productCode = "IU",
+            buildNumber = "IU-262.8665.337",
+            launcherBody = gracefulLauncher(),
+            remoteDevelopmentLauncherBody = unmarkedHandoffRemoteDevelopmentLauncher(handedOffPidFile),
+        )
+        val manager = BackendManager(
+            homePaths = homePaths,
+            downloader = StaticDownloader,
+            bundledPluginResolver = FixedBundledPluginResolver(bundledPluginZipFixture(tempDir.resolve("dist/ij-plugin.zip"), "test")),
+            ideUserHome = tempDir.resolve("user-home"),
+            remoteDevelopmentStartupTimeoutMillis = 300,
+        )
+
+        assertFailsWith<ManagedBackendValidationException> {
+            manager.start(parseBackendId(id))
+        }
+        val handedOffPid = Files.readString(handedOffPidFile).trim().toLong()
+        try {
+            withTimeout(5.seconds) {
+                while (ProcessHandle.of(handedOffPid).map { it.isAlive }.orElse(false)) delay(50.milliseconds)
+            }
+            assertFalse(homePaths.pidFile(id).exists())
+        } finally {
+            ProcessHandle.of(handedOffPid).ifPresent { it.destroyForcibly() }
+        }
+    }
+
+    @Test
+    fun `cancelling remote development start terminates an unmarked handed-off backend process`(
+        @TempDir tempDir: Path,
+    ) = kotlinx.coroutines.runBlocking {
+        val id = "idea-ultimate-2026.2.0.1"
+        val homePaths = HomePaths(tempDir.resolve("home"))
+        val handedOffPidFile = tempDir.resolve("handed-off.pid")
+        installStubBackend(
+            homePaths = homePaths,
+            id = id,
+            productKey = "idea-ultimate",
+            productCode = "IU",
+            buildNumber = "IU-262.8665.337",
+            launcherBody = gracefulLauncher(),
+            remoteDevelopmentLauncherBody = unmarkedHandoffRemoteDevelopmentLauncher(handedOffPidFile),
+        )
+        val manager = BackendManager(
+            homePaths = homePaths,
+            downloader = StaticDownloader,
+            bundledPluginResolver = FixedBundledPluginResolver(bundledPluginZipFixture(tempDir.resolve("dist/ij-plugin.zip"), "test")),
+            ideUserHome = tempDir.resolve("user-home"),
+            remoteDevelopmentStartupTimeoutMillis = 30_000,
+        )
+
+        val starting = async { manager.start(parseBackendId(id)) }
+        withTimeout(5.seconds) {
+            while (!handedOffPidFile.exists()) delay(50.milliseconds)
+        }
+        val handedOffPid = Files.readString(handedOffPidFile).trim().toLong()
+        try {
+            assertTrue(ProcessHandle.of(handedOffPid).orElseThrow().isAlive)
+            starting.cancelAndJoin()
+            withTimeout(5.seconds) {
+                while (ProcessHandle.of(handedOffPid).map { it.isAlive }.orElse(false)) delay(50.milliseconds)
+            }
+            assertFalse(homePaths.pidFile(id).exists())
+        } finally {
+            starting.cancel()
+            ProcessHandle.of(handedOffPid).ifPresent { it.destroyForcibly() }
+        }
+    }
+
+    @Test
+    fun `pid persistence failure terminates a ready handed-off backend process`(
+        @TempDir tempDir: Path,
+    ) = kotlinx.coroutines.runBlocking {
+        val id = "idea-ultimate-2026.2.0.1"
+        val build = "IU-262.8665.337"
+        val homePaths = HomePaths(tempDir.resolve("home"))
+        val userHome = tempDir.resolve("user-home")
+        val bundleDir = homePaths.backendDir(id).resolve("idea-$build")
+        val handedOffPidFile = tempDir.resolve("handed-off.pid")
+        installStubBackend(
+            homePaths = homePaths,
+            id = id,
+            productKey = "idea-ultimate",
+            productCode = "IU",
+            buildNumber = build,
+            launcherBody = gracefulLauncher(),
+            remoteDevelopmentLauncherBody = handoffWithPidPersistenceFailureLauncher(
+                handedOffPidFile = handedOffPidFile,
+                markerDirectory = PidMarker.markerDirectory(userHome),
+                ideHome = bundleDir,
+                pluginHome = homePaths.cacheDir(id).resolve("plugins/mcp-steroid"),
+                pidFile = homePaths.pidFile(id),
+            ),
+        )
+        val manager = BackendManager(
+            homePaths = homePaths,
+            downloader = StaticDownloader,
+            bundledPluginResolver = FixedBundledPluginResolver(bundledPluginZipFixture(tempDir.resolve("dist/ij-plugin.zip"), "test")),
+            ideUserHome = userHome,
+            remoteDevelopmentStartupTimeoutMillis = 5_000,
+        )
+
+        assertFailsWith<Exception> {
+            manager.start(parseBackendId(id))
+        }
+        val handedOffPid = Files.readString(handedOffPidFile).trim().toLong()
+        try {
+            withTimeout(5.seconds) {
+                while (ProcessHandle.of(handedOffPid).map { it.isAlive }.orElse(false)) delay(50.milliseconds)
+            }
+            assertFalse(homePaths.pidFile(id).exists(), "failed PID persistence must leave no state entry")
+            assertFalse(
+                PidMarker.markerDirectory(userHome).resolve(PidMarker.markerFileNameFor(handedOffPid)).exists(),
+                "failed PID persistence must remove the handed-off backend marker",
+            )
+        } finally {
+            ProcessHandle.of(handedOffPid).ifPresent { it.destroyForcibly() }
+        }
+    }
+
+    @Test
+    fun `start preserves standard launcher for Community`(
+        @TempDir tempDir: Path,
+    ) = kotlinx.coroutines.runBlocking {
+        val homePaths = HomePaths(tempDir.resolve("home"))
+        val argumentsFile = tempDir.resolve("standard-arguments.txt")
+        installStubBackend(homePaths, launcherBody = argumentRecordingLauncher(argumentsFile))
+        val manager = BackendManager(
+            homePaths = homePaths,
+            downloader = StaticDownloader,
+            bundledPluginResolver = FixedBundledPluginResolver(bundledPluginZipFixture(tempDir.resolve("dist/ij-plugin.zip"), "test")),
+            ideUserHome = tempDir.resolve("user-home"),
+        )
+
+        manager.start(parseBackendId("idea-community-2025.3.3"))
+        try {
+            withTimeout(5.seconds) {
+                while (!argumentsFile.exists()) delay(50.milliseconds)
+            }
+            assertEquals("0\n", Files.readString(argumentsFile))
+        } finally {
+            manager.stop(parseBackendId("idea-community-2025.3.3"))
+        }
+    }
 
     @Test
     fun `start writes pid file and stop terminates gracefully`(
@@ -41,8 +643,25 @@ class BackendManagerStartStopTest {
         val started = manager.start(parseBackendId("idea-community-2025.3.3"))
 
         assertTrue(started.pid > 0)
-        assertEquals("${started.pid}\n", Files.readString(homePaths.pidFile("idea-community-2025.3.3")))
-        assertTrue(ProcessHandle.of(started.pid).orElseThrow().isAlive)
+        val processState = requireNotNull(
+            readManagedBackendProcessState(homePaths.pidFile("idea-community-2025.3.3")),
+        )
+        assertEquals(started.pid, processState.pid)
+        assertTrue(processState.startInstant != null)
+        val liveHandle = ProcessHandle.of(started.pid).orElseThrow()
+        assertTrue(liveHandle.isAlive)
+        assertEquals(
+            Instant.parse(processState.startInstant).toEpochMilli(),
+            liveHandle.info().startInstant().orElseThrow().toEpochMilli(),
+        )
+        assertEquals(
+            homePaths.backendDir("idea-community-2025.3.3")
+                .resolve("idea-IC-253.1/bin/idea.sh")
+                .toAbsolutePath()
+                .normalize()
+                .toString(),
+            liveHandle.info().arguments().orElseThrow().first(),
+        )
         val marker = PidMarker.markerDirectory(tempDir.resolve("user-home"))
             .resolve(PidMarker.markerFileNameFor(started.pid))
         Files.createDirectories(marker.parent)
@@ -54,6 +673,55 @@ class BackendManagerStartStopTest {
         assertFalse(homePaths.pidFile("idea-community-2025.3.3").exists())
         assertFalse(marker.exists())
         assertFalse(ProcessHandle.of(started.pid).map { it.isAlive }.orElse(false))
+    }
+
+    @Test
+    fun `start ignores unrelated executable inside another managed IDE bundle`(
+        @TempDir tempDir: Path,
+    ) = kotlinx.coroutines.runBlocking {
+        val homePaths = HomePaths(tempDir.resolve("home"))
+        val unrelatedId = "idea-community-2025.3.2"
+        val requestedId = "idea-community-2025.3.3"
+        installStubBackend(homePaths, launcherBody = gracefulLauncher(), id = unrelatedId)
+        installStubBackend(homePaths, launcherBody = gracefulLauncher(), id = requestedId)
+        val fakePid = 987_654L
+        val unrelatedJava = homePaths.backendDir(unrelatedId)
+            .resolve("idea-IC-253.1/jbr/bin/java")
+            .toAbsolutePath()
+            .normalize()
+        val fakeSnapshot = ProcessSnapshot(
+            pid = fakePid,
+            command = unrelatedJava.toString(),
+            arguments = listOf("-version"),
+            startInstant = Instant.parse("2026-07-31T08:00:00Z"),
+        )
+        val processInspector = object : ManagedProcessInspector {
+            override fun isAlive(pid: Long): Boolean =
+                if (pid == fakePid) true else DefaultManagedProcessInspector.isAlive(pid)
+
+            override fun allProcesses(): List<ProcessSnapshot> =
+                DefaultManagedProcessInspector.allProcesses() + fakeSnapshot
+
+            override fun snapshot(pid: Long): ProcessSnapshot? =
+                if (pid == fakePid) fakeSnapshot else DefaultManagedProcessInspector.snapshot(pid)
+        }
+        val manager = BackendManager(
+            homePaths = homePaths,
+            downloader = StaticDownloader,
+            bundledPluginResolver = FixedBundledPluginResolver(
+                bundledPluginZipFixture(tempDir.resolve("dist/ij-plugin.zip"), "test"),
+            ),
+            processInspector = processInspector,
+            ideUserHome = tempDir.resolve("user-home"),
+        )
+
+        val started = manager.start(parseBackendId(requestedId))
+        try {
+            assertFalse(started.alreadyRunning)
+            assertNotEquals(fakePid, started.pid)
+        } finally {
+            manager.stop(parseBackendId(requestedId))
+        }
     }
 
     @Test
@@ -124,6 +792,73 @@ class BackendManagerStartStopTest {
     }
 
     @Test
+    fun `stop marker decode warning never logs marker contents`(
+        @TempDir tempDir: Path,
+    ) = kotlinx.coroutines.runBlocking {
+        val id = "idea-community-2025.3.3"
+        val secretSentinel = "SECRET_SENTINEL"
+        val homePaths = HomePaths(tempDir.resolve("home"))
+        installStubBackend(homePaths, launcherBody = gracefulLauncher())
+        val unrelated = startUnrelatedSleeper()
+        val userHome = tempDir.resolve("user-home")
+        try {
+            Files.createDirectories(homePaths.stateDir)
+            Files.writeString(homePaths.pidFile(id), "${unrelated.pid()}\n")
+            val markerDirectory = PidMarker.markerDirectory(userHome)
+            Files.createDirectories(markerDirectory)
+            val markerPath = markerDirectory.resolve(PidMarker.markerFileNameFor(unrelated.pid()))
+            Files.writeString(markerPath, "{\"authorization\":\"Bearer $secretSentinel\",")
+            val manager = BackendManager(
+                homePaths = homePaths,
+                downloader = StaticDownloader,
+                bundledPluginResolver = FixedBundledPluginResolver(bundledPluginZipFixture(tempDir.resolve("dist/ij-plugin.zip"), "test")),
+                ideUserHome = userHome,
+            )
+
+            val stderr = captureStderr {
+                val stopped = manager.stop(parseBackendId(id))
+                assertEquals("stale", stopped.outcome)
+            }
+
+            assertTrue(stderr.contains(markerPath.toString()), stderr)
+            assertTrue(stderr.contains("JsonDecodingException"), stderr)
+            assertFalse(stderr.contains(secretSentinel), stderr)
+            assertTrue(unrelated.isAlive)
+        } finally {
+            stopProcess(unrelated)
+        }
+    }
+
+    @Test
+    fun `stop does not signal unrelated process with exact file argument under managed bundle`(
+        @TempDir tempDir: Path,
+    ) = kotlinx.coroutines.runBlocking {
+        val id = "idea-community-2025.3.3"
+        val homePaths = HomePaths(tempDir.resolve("home"))
+        installStubBackend(homePaths, launcherBody = gracefulLauncher())
+        val unrelatedFile = homePaths.backendDir(id).resolve("idea-IC-253.1/product-info.json")
+        Files.writeString(unrelatedFile, "{}")
+        val unrelated = ProcessBuilder("tail", "-f", unrelatedFile.toString()).start()
+        try {
+            Files.createDirectories(homePaths.stateDir)
+            Files.writeString(homePaths.pidFile(id), "${unrelated.pid()}\n")
+            val manager = BackendManager(
+                homePaths = homePaths,
+                downloader = StaticDownloader,
+                bundledPluginResolver = FixedBundledPluginResolver(bundledPluginZipFixture(tempDir.resolve("dist/ij-plugin.zip"), "test")),
+                ideUserHome = tempDir.resolve("user-home"),
+            )
+
+            val stopped = manager.stop(parseBackendId(id))
+
+            assertEquals("stale", stopped.outcome)
+            assertTrue(unrelated.isAlive, "an unrelated process must not be signalled")
+        } finally {
+            stopProcess(unrelated)
+        }
+    }
+
+    @Test
     fun `stop accepts matching pid marker for process outside backend directory`(
         @TempDir tempDir: Path,
     ) = kotlinx.coroutines.runBlocking {
@@ -138,21 +873,10 @@ class BackendManagerStartStopTest {
             Files.writeString(homePaths.pidFile("idea-community-2025.3.3"), "${process.pid()}\n")
             Files.writeString(
                 markersDir.resolve(PidMarker.markerFileNameFor(process.pid())),
-                PidMarkerJson.encode(
-                    PidMarker(
-                        schema = PidMarker.SCHEMA_VERSION,
-                        pid = process.pid(),
-                        mcpSteroidServer = McpSteroidServerInfo(
-                            mcpUrl = "http://localhost:63342/mcp",
-                            headers = emptyMap(),
-                        ),
-                        devrigEndpoint = testDevrigEndpoint("http://localhost:63342/mcp"),
-                        ide = IdeInfo(name = "IntelliJ IDEA Community", version = "2025.3.3", build = "IC-253.1"),
-                        plugin = PluginInfo(id = "com.jonnyzzz.mcpSteroid", name = "MCP Steroid", version = "1.0.0"),
-                        createdAt = "2026-05-14T21:00:00Z",
-                        intellijWebServer = null,
-                        intellijMcpServer = null,
-                    ),
+                communityMarkerJson(
+                    pid = process.pid(),
+                    ideHome = homePaths.backendDir("idea-community-2025.3.3").resolve("idea-IC-253.1"),
+                    pluginHome = homePaths.cacheDir("idea-community-2025.3.3").resolve("plugins/mcp-steroid"),
                 ),
             )
             val manager = BackendManager(
@@ -169,6 +893,247 @@ class BackendManagerStartStopTest {
             assertFalse(ProcessHandle.of(process.pid()).map { it.isAlive }.orElse(false))
         } finally {
             stopProcess(process)
+        }
+    }
+
+    @Test
+    fun `stop rejects a matching stale marker when its pid was reused by a newer process`(
+        @TempDir tempDir: Path,
+    ) = kotlinx.coroutines.runBlocking {
+        val id = "idea-community-2025.3.3"
+        val homePaths = HomePaths(tempDir.resolve("home"))
+        installStubBackend(homePaths, launcherBody = gracefulLauncher())
+        val process = startUnrelatedSleeper()
+        val userHome = tempDir.resolve("user-home")
+        try {
+            Files.createDirectories(homePaths.stateDir)
+            val markerDirectory = PidMarker.markerDirectory(userHome)
+            Files.createDirectories(markerDirectory)
+            Files.writeString(homePaths.pidFile(id), "${process.pid()}\n")
+            val processStartedAt = process.toHandle().info().startInstant().orElseThrow()
+            Files.writeString(
+                markerDirectory.resolve(PidMarker.markerFileNameFor(process.pid())),
+                communityMarkerJson(
+                    pid = process.pid(),
+                    ideHome = homePaths.backendDir(id).resolve("idea-IC-253.1"),
+                    pluginHome = homePaths.cacheDir(id).resolve("plugins/mcp-steroid"),
+                    createdAt = processStartedAt.minusSeconds(1).toString(),
+                ),
+            )
+            val manager = BackendManager(
+                homePaths = homePaths,
+                downloader = StaticDownloader,
+                bundledPluginResolver = FixedBundledPluginResolver(bundledPluginZipFixture(tempDir.resolve("dist/ij-plugin.zip"), "test")),
+                ideUserHome = userHome,
+            )
+
+            val stopped = manager.stop(parseBackendId(id))
+
+            assertEquals("stale", stopped.outcome)
+            assertTrue(process.isAlive, "a newer process that reused the marker pid must not be signalled")
+        } finally {
+            stopProcess(process)
+        }
+    }
+
+    @Test
+    fun `stop rejects a matching launcher when persisted process start instant differs`(
+        @TempDir tempDir: Path,
+    ) = kotlinx.coroutines.runBlocking {
+        val id = "idea-community-2025.3.3"
+        val homePaths = HomePaths(tempDir.resolve("home"))
+        installStubBackend(homePaths, launcherBody = gracefulLauncher())
+        val manager = BackendManager(
+            homePaths = homePaths,
+            downloader = StaticDownloader,
+            bundledPluginResolver = FixedBundledPluginResolver(bundledPluginZipFixture(tempDir.resolve("dist/ij-plugin.zip"), "test")),
+            ideUserHome = tempDir.resolve("user-home"),
+        )
+        val started = manager.start(parseBackendId(id))
+        val handle = ProcessHandle.of(started.pid).orElseThrow()
+        try {
+            val statePath = homePaths.pidFile(id)
+            val state = requireNotNull(readManagedBackendProcessState(statePath))
+            Files.writeString(
+                statePath,
+                Json.encodeToString(state.copy(startInstant = "2000-01-01T00:00:00Z")) + "\n",
+            )
+
+            val stopped = manager.stop(parseBackendId(id))
+
+            assertEquals("stale", stopped.outcome)
+            assertTrue(handle.isAlive, "a process whose start instant differs from persisted state must not be signalled")
+        } finally {
+            handle.destroy()
+            runCatching { handle.onExit().get(5, TimeUnit.SECONDS) }.getOrNull()
+            if (handle.isAlive) {
+                handle.destroyForcibly()
+                handle.onExit().get(5, TimeUnit.SECONDS)
+            }
+        }
+    }
+
+    @Test
+    fun `stop rejects a matching build marker from a different IDE home`(
+        @TempDir tempDir: Path,
+    ) = kotlinx.coroutines.runBlocking {
+        val id = "idea-community-2025.3.3"
+        val homePaths = HomePaths(tempDir.resolve("home"))
+        installStubBackend(homePaths, launcherBody = gracefulLauncher())
+        val process = startUnrelatedSleeper()
+        val userHome = tempDir.resolve("user-home")
+        try {
+            Files.createDirectories(homePaths.stateDir)
+            Files.createDirectories(PidMarker.markerDirectory(userHome))
+            Files.writeString(homePaths.pidFile(id), "${process.pid()}\n")
+            Files.writeString(
+                PidMarker.markerDirectory(userHome).resolve(PidMarker.markerFileNameFor(process.pid())),
+                communityMarkerJson(
+                    pid = process.pid(),
+                    ideHome = tempDir.resolve("different-ide-home"),
+                    pluginHome = homePaths.cacheDir(id).resolve("plugins/mcp-steroid"),
+                ),
+            )
+            val manager = BackendManager(
+                homePaths = homePaths,
+                downloader = StaticDownloader,
+                bundledPluginResolver = FixedBundledPluginResolver(bundledPluginZipFixture(tempDir.resolve("dist/ij-plugin.zip"), "test")),
+                ideUserHome = userHome,
+            )
+
+            val stopped = manager.stop(parseBackendId(id))
+
+            assertEquals("stale", stopped.outcome)
+            assertTrue(process.isAlive, "a process belonging to another IDE home must not be signalled")
+        } finally {
+            stopProcess(process)
+        }
+    }
+
+    @Test
+    fun `stop rejects a marker with another product prefix and the same numeric build`(
+        @TempDir tempDir: Path,
+    ) = kotlinx.coroutines.runBlocking {
+        val id = "idea-community-2025.3.3"
+        val homePaths = HomePaths(tempDir.resolve("home"))
+        installStubBackend(homePaths, launcherBody = gracefulLauncher())
+        val process = startUnrelatedSleeper()
+        val userHome = tempDir.resolve("user-home")
+        try {
+            Files.createDirectories(homePaths.stateDir)
+            Files.createDirectories(PidMarker.markerDirectory(userHome))
+            Files.writeString(homePaths.pidFile(id), "${process.pid()}\n")
+            Files.writeString(
+                PidMarker.markerDirectory(userHome).resolve(PidMarker.markerFileNameFor(process.pid())),
+                communityMarkerJson(
+                    pid = process.pid(),
+                    ideHome = homePaths.backendDir(id).resolve("idea-IC-253.1"),
+                    pluginHome = homePaths.cacheDir(id).resolve("plugins/mcp-steroid"),
+                    build = "IU-253.1",
+                ),
+            )
+            val manager = BackendManager(
+                homePaths = homePaths,
+                downloader = StaticDownloader,
+                bundledPluginResolver = FixedBundledPluginResolver(bundledPluginZipFixture(tempDir.resolve("dist/ij-plugin.zip"), "test")),
+                ideUserHome = userHome,
+            )
+
+            val stopped = manager.stop(parseBackendId(id))
+
+            assertEquals("stale", stopped.outcome)
+            assertTrue(process.isAlive, "a same-number build from another IDE product must not be signalled")
+        } finally {
+            stopProcess(process)
+        }
+    }
+
+    @Test
+    fun `stop accepts a matching macOS marker whose IDE home is the app Contents directory`(
+        @TempDir tempDir: Path,
+    ) = kotlinx.coroutines.runBlocking {
+        val id = "idea-ultimate-2026.2.0.1"
+        val build = "IU-262.8665.337"
+        val homePaths = HomePaths(tempDir.resolve("home"))
+        val userHome = tempDir.resolve("user-home")
+        val backendDir = homePaths.backendDir(id)
+        val bundleDir = backendDir.resolve("IntelliJ IDEA.app")
+        val ideHome = bundleDir.resolve("Contents")
+        val remoteLauncher = ideHome.resolve("bin/remote-dev-server")
+        Files.createDirectories(remoteLauncher.parent)
+        Files.writeString(remoteLauncher, gracefulLauncher())
+        remoteLauncher.toFile().setExecutable(true)
+        val remoteDevelopmentPluginJar = ideHome.resolve("plugins/remote-dev-server/lib/remote-dev-server.jar")
+        Files.createDirectories(remoteDevelopmentPluginJar.parent)
+        Files.writeString(remoteDevelopmentPluginJar, "remote development plugin")
+        writeDescriptor(
+            descriptorPath(backendDir),
+            BackendDescriptor(
+                id = id,
+                productKey = "idea-ultimate",
+                productCode = "IU",
+                version = "2026.2.0.1",
+                buildNumber = build,
+                bundleDirName = bundleDir.fileName.toString(),
+                launcherPath = "Contents/bin/idea.sh",
+                downloadedAt = "2026-07-31T00:00:00Z",
+            ),
+        )
+        val pluginHome = homePaths.cacheDir(id).resolve("plugins/mcp-steroid")
+        val unrelated = startUnrelatedSleeper()
+        Files.createDirectories(homePaths.stateDir)
+        Files.writeString(homePaths.pidFile(id), "${unrelated.pid()}\n")
+        val markerDirectory = PidMarker.markerDirectory(userHome)
+        Files.createDirectories(markerDirectory)
+        Files.writeString(
+            markerDirectory.resolve(PidMarker.markerFileNameFor(unrelated.pid())),
+            readyMarkerJson(unrelated.pid(), ideHome, pluginHome),
+        )
+        val manager = BackendManager(
+            homePaths = homePaths,
+            downloader = StaticDownloader,
+            bundledPluginResolver = FixedBundledPluginResolver(bundledPluginZipFixture(tempDir.resolve("dist/ij-plugin.zip"), "test")),
+            backendLauncherResolver = ManagedBackendLauncherResolver(HostOs.MAC),
+            ideUserHome = userHome,
+        )
+
+        try {
+            val stopped = manager.stop(parseBackendId(id))
+            assertEquals("stopped", stopped.outcome)
+            assertEquals(unrelated.pid(), stopped.pid)
+        } finally {
+            stopProcess(unrelated)
+        }
+    }
+
+    @Test
+    fun `stale pid for one backend does not stop another managed backend`(
+        @TempDir tempDir: Path,
+    ) = kotlinx.coroutines.runBlocking {
+        val firstId = "idea-community-2025.3.2"
+        val secondId = "idea-community-2025.3.3"
+        val homePaths = HomePaths(tempDir.resolve("home"))
+        installStubBackend(homePaths, launcherBody = gracefulLauncher(), id = firstId)
+        installStubBackend(homePaths, launcherBody = gracefulLauncher(), id = secondId)
+        val manager = BackendManager(
+            homePaths = homePaths,
+            downloader = StaticDownloader,
+            bundledPluginResolver = FixedBundledPluginResolver(bundledPluginZipFixture(tempDir.resolve("dist/ij-plugin.zip"), "test")),
+            ideUserHome = tempDir.resolve("user-home"),
+        )
+        val second = manager.start(parseBackendId(secondId))
+        try {
+            Files.writeString(homePaths.pidFile(firstId), "${second.pid}\n")
+
+            val stopped = manager.stop(parseBackendId(firstId))
+
+            assertEquals("stale", stopped.outcome)
+            assertTrue(
+                ProcessHandle.of(second.pid).map { it.isAlive }.orElse(false),
+                "a stale PID for backend A must not signal backend B",
+            )
+        } finally {
+            manager.stop(parseBackendId(secondId))
         }
     }
 
@@ -234,13 +1199,13 @@ class BackendManagerStartStopTest {
         val started = manager.start(parseBackendId("idea-community-2025.3.3"))
         try {
             assertEquals(homePaths.cacheDir("idea-community-2025.3.3").resolve("logs/managed.log"), started.ideaLogPath)
-            withTimeout(5_000) {
+            withTimeout(5.seconds) {
                 while (true) {
                     if (started.ideaLogPath.exists()) {
                         val text = Files.readString(started.ideaLogPath)
                         if ("managed stdout" in text && "managed stderr" in text) break
                     }
-                    delay(100)
+                    delay(100.milliseconds)
                 }
             }
         } finally {
@@ -360,25 +1325,114 @@ class BackendManagerStartStopTest {
         }
     }
 
+    @Test
+    fun `durable pid identity does not decode an unrelated marker`(
+        @TempDir tempDir: Path,
+    ) = kotlinx.coroutines.runBlocking {
+        val homePaths = HomePaths(tempDir.resolve("home"))
+        val userHome = tempDir.resolve("user-home")
+        installStubBackend(homePaths, launcherBody = gracefulLauncher())
+        val firstManager = BackendManager(
+            homePaths = homePaths,
+            downloader = StaticDownloader,
+            bundledPluginResolver = FixedBundledPluginResolver(bundledPluginZipFixture(tempDir.resolve("dist/ij-plugin.zip"), "v1")),
+            ideUserHome = userHome,
+        )
+
+        val firstStart = firstManager.start(parseBackendId("idea-community-2025.3.3"))
+        try {
+            val markerDirectory = PidMarker.markerDirectory(userHome)
+            Files.createDirectories(markerDirectory)
+            Files.writeString(
+                markerDirectory.resolve(PidMarker.markerFileNameFor(firstStart.pid)),
+                "not-json Bearer SECRET_SENTINEL",
+            )
+            val secondManager = BackendManager(
+                homePaths = homePaths,
+                downloader = StaticDownloader,
+                bundledPluginResolver = ThrowingBundledPluginResolver,
+                ideUserHome = userHome,
+            )
+
+            val stderr = captureStderr {
+                val secondStart = secondManager.start(parseBackendId("idea-community-2025.3.3"))
+                assertTrue(secondStart.alreadyRunning)
+                assertEquals(firstStart.pid, secondStart.pid)
+                firstManager.stop(parseBackendId("idea-community-2025.3.3"))
+            }
+
+            assertFalse(stderr.contains("failed to decode MCP Steroid marker"), stderr)
+        } finally {
+            if (DefaultManagedProcessInspector.isAlive(firstStart.pid)) {
+                firstManager.stop(parseBackendId("idea-community-2025.3.3"))
+            }
+        }
+    }
+
+    @Test
+    fun `start retains tracked backend when one process listing omits its pid`(
+        @TempDir tempDir: Path,
+    ) = kotlinx.coroutines.runBlocking {
+        val homePaths = HomePaths(tempDir.resolve("home"))
+        installStubBackend(homePaths, launcherBody = gracefulLauncher())
+        val firstManager = BackendManager(
+            homePaths = homePaths,
+            downloader = StaticDownloader,
+            bundledPluginResolver = FixedBundledPluginResolver(bundledPluginZipFixture(tempDir.resolve("dist/ij-plugin.zip"), "v1")),
+            ideUserHome = tempDir.resolve("user-home"),
+        )
+
+        val firstStart = firstManager.start(parseBackendId("idea-community-2025.3.3"))
+        try {
+            val secondManager = BackendManager(
+                homePaths = homePaths,
+                downloader = StaticDownloader,
+                bundledPluginResolver = ThrowingBundledPluginResolver,
+                processInspector = HideTargetFromFirstProcessListingInspector(firstStart.pid),
+                ideUserHome = tempDir.resolve("user-home"),
+            )
+
+            val secondStart = secondManager.start(parseBackendId("idea-community-2025.3.3"))
+
+            assertTrue(secondStart.alreadyRunning)
+            assertEquals(firstStart.pid, secondStart.pid)
+            assertTrue(homePaths.pidFile("idea-community-2025.3.3").exists())
+        } finally {
+            firstManager.stop(parseBackendId("idea-community-2025.3.3"))
+        }
+    }
+
     private fun installStubBackend(
         homePaths: HomePaths,
         launcherBody: String,
         id: String = "idea-community-2025.3.3",
+        productKey: String = "idea-community",
+        productCode: String = "IC",
+        buildNumber: String = "IC-253.1",
+        remoteDevelopmentLauncherBody: String? = null,
     ) {
         val backendDir = homePaths.backendDir(id)
-        val bundleDir = backendDir.resolve("idea-IC-253.1")
-        val launcher = bundleDir.resolve("bin/idea.sh")
-        Files.createDirectories(launcher.parent)
-        Files.writeString(launcher, launcherBody)
-        launcher.toFile().setExecutable(true)
+        val bundleDir = backendDir.resolve("idea-$buildNumber")
+        val productLauncher = bundleDir.resolve("bin/idea.sh")
+        Files.createDirectories(productLauncher.parent)
+        Files.writeString(productLauncher, launcherBody)
+        productLauncher.toFile().setExecutable(true)
+        if (remoteDevelopmentLauncherBody != null) {
+            val remoteDevelopmentLauncher = bundleDir.resolve("bin/remote-dev-server")
+            Files.writeString(remoteDevelopmentLauncher, remoteDevelopmentLauncherBody)
+            remoteDevelopmentLauncher.toFile().setExecutable(true)
+            val remoteDevelopmentPluginJar = bundleDir.resolve("plugins/remote-dev-server/lib/remote-dev-server.jar")
+            Files.createDirectories(remoteDevelopmentPluginJar.parent)
+            Files.writeString(remoteDevelopmentPluginJar, "remote development plugin")
+        }
         writeDescriptor(
             descriptorPath(backendDir),
             BackendDescriptor(
                 id = id,
-                productKey = "idea-community",
-                productCode = "IC",
-                version = id.removePrefix("idea-community-"),
-                buildNumber = "IC-253.1",
+                productKey = productKey,
+                productCode = productCode,
+                version = id.removePrefix("$productKey-"),
+                buildNumber = buildNumber,
                 bundleDirName = bundleDir.fileName.toString(),
                 launcherPath = "bin/idea.sh",
                 downloadedAt = "2026-05-14T21:00:00Z",
@@ -392,6 +1446,191 @@ class BackendManagerStartStopTest {
         trap 'exit 0' TERM
         while true; do sleep 1; done
         """.trimIndent() + "\n"
+
+    private fun pidRecordingLauncher(launcherPidFile: Path): String =
+        $$"""
+        #!/usr/bin/env sh
+        printf '%s\n' "$$" > '$$launcherPidFile'
+        trap 'exit 0' TERM
+        while true; do sleep 1; done
+        """.trimIndent() + "\n"
+
+    private fun argumentRecordingLauncher(argumentsFile: Path): String =
+        $$"""
+        #!/usr/bin/env sh
+        printf '%s\n' "$#" "$@" > '$$argumentsFile'
+        trap 'exit 0' TERM
+        while true; do sleep 1; done
+        """.trimIndent() + "\n"
+
+    private fun remoteArgumentRecordingLauncher(
+        argumentsFile: Path,
+        markerDirectory: Path,
+        ideHome: Path,
+        pluginHome: Path,
+        markerCreatedAt: String = Instant.now().plusSeconds(1).toString(),
+    ): String {
+        val shellPid = '$' + "pid"
+        val markerJson = readyMarkerJson(0, ideHome, pluginHome, markerCreatedAt)
+            .replace("\"pid\": 0", "\"pid\": $shellPid")
+            .replace("\n", "")
+        return $$"""
+        #!/usr/bin/env sh
+        pid=$$
+        printf '%s\n' "$#" "$@" "$REMOTE_DEV_JDK_DETECTION" "$REMOTE_DEV_NON_INTERACTIVE" "$REMOTE_DEV_TRUST_PROJECTS" > '$$argumentsFile'
+        mkdir -p '$$markerDirectory'
+        cat > '$$markerDirectory/'"$pid"'.mcp-steroid' <<EOF
+        $$markerJson
+        EOF
+        trap 'exit 0' TERM
+        while true; do sleep 1; done
+        """.trimIndent() + "\n"
+    }
+
+    private fun handoffRemoteDevelopmentLauncher(
+        launcherPidFile: Path,
+        markerDirectory: Path,
+        ideHome: Path,
+        pluginHome: Path,
+    ): String {
+        val shellBackendPid = '$' + "backend_pid"
+        val markerJson = readyMarkerJson(0, ideHome, pluginHome)
+            .replace("\"pid\": 0", "\"pid\": $shellBackendPid")
+            .replace("\n", "")
+        return $$"""
+            #!/usr/bin/env sh
+            printf '%s\n' "$$" > '$$launcherPidFile'
+            (
+              trap 'exit 0' TERM
+              while true; do sleep 1; done
+            ) &
+            backend_pid=$!
+            mkdir -p '$$markerDirectory'
+            cat > '$$markerDirectory/'"$backend_pid"'.mcp-steroid' <<EOF
+            $$markerJson
+            EOF
+            exit 0
+        """.trimIndent() + "\n"
+    }
+
+    private fun persistentHandoffRemoteDevelopmentLauncher(
+        launcherPidFile: Path,
+        markerDirectory: Path,
+        ideHome: Path,
+        pluginHome: Path,
+    ): String {
+        val shellBackendPid = '$' + "backend_pid"
+        val markerJson = readyMarkerJson(0, ideHome, pluginHome)
+            .replace("\"pid\": 0", "\"pid\": $shellBackendPid")
+            .replace("\n", "")
+        return $$"""
+            #!/usr/bin/env sh
+            printf '%s\n' "$$" > '$$launcherPidFile'
+            (
+              trap 'exit 0' TERM
+              while true; do sleep 1; done
+            ) &
+            backend_pid=$!
+            mkdir -p '$$markerDirectory'
+            cat > '$$markerDirectory/'"$backend_pid"'.mcp-steroid' <<EOF
+            $$markerJson
+            EOF
+            trap 'exit 0' TERM
+            while true; do sleep 1; done
+        """.trimIndent() + "\n"
+    }
+
+    private fun unmarkedHandoffRemoteDevelopmentLauncher(handedOffPidFile: Path): String =
+        $$"""
+        #!/usr/bin/env sh
+        if [ "${1:-}" = "devrig-test-child" ]; then
+          printf '%s\n' "$$" > '$$handedOffPidFile'
+          trap 'exit 0' TERM
+          while true; do sleep 1; done
+        fi
+        "$0" devrig-test-child &
+        while [ ! -s '$$handedOffPidFile' ]; do sleep 0.01; done
+        exit 0
+        """.trimIndent() + "\n"
+
+    private fun handoffWithPidPersistenceFailureLauncher(
+        handedOffPidFile: Path,
+        markerDirectory: Path,
+        ideHome: Path,
+        pluginHome: Path,
+        pidFile: Path,
+    ): String {
+        val shellBackendPid = '$' + "backend_pid"
+        val markerJson = readyMarkerJson(0, ideHome, pluginHome)
+            .replace("\"pid\": 0", "\"pid\": $shellBackendPid")
+            .replace("\n", "")
+        return $$"""
+            #!/usr/bin/env sh
+            (
+              trap 'exit 0' TERM
+              while true; do sleep 1; done
+            ) &
+            backend_pid=$!
+            printf '%s\n' "$backend_pid" > '$$handedOffPidFile'
+            mkdir -p '$$markerDirectory'
+            cat > '$$markerDirectory/'"$backend_pid"'.mcp-steroid' <<EOF
+            $$markerJson
+            EOF
+            mkdir '$$pidFile'
+            exit 0
+        """.trimIndent() + "\n"
+    }
+
+    private fun communityMarkerJson(
+        pid: Long,
+        ideHome: Path,
+        pluginHome: Path,
+        build: String = "IC-253.1",
+        createdAt: String = Instant.now().plusSeconds(1).toString(),
+    ): String =
+        PidMarkerJson.encode(
+            PidMarker(
+                schema = PidMarker.SCHEMA_VERSION,
+                pid = pid,
+                mcpSteroidServer = McpSteroidServerInfo(
+                    mcpUrl = "http://localhost:63342/mcp",
+                    headers = emptyMap(),
+                    pluginPath = pluginHome.toAbsolutePath().normalize().toString(),
+                ),
+                devrigEndpoint = testDevrigEndpoint("http://localhost:63342/mcp"),
+                ide = IdeInfo(name = "IntelliJ IDEA Community", version = "2025.3.3", build = build),
+                plugin = PluginInfo(id = MCP_STEROID_PLUGIN_ID, name = "MCP Steroid", version = "1.0.0"),
+                createdAt = createdAt,
+                ideHome = ideHome.toAbsolutePath().normalize().toString(),
+                intellijWebServer = null,
+                intellijMcpServer = null,
+            ),
+        )
+
+    private fun readyMarkerJson(
+        pid: Long,
+        ideHome: Path,
+        pluginHome: Path? = null,
+        createdAt: String = Instant.now().plusSeconds(1).toString(),
+    ): String =
+        PidMarkerJson.encode(
+            PidMarker(
+                schema = PidMarker.SCHEMA_VERSION,
+                pid = pid,
+                mcpSteroidServer = McpSteroidServerInfo(
+                    mcpUrl = "http://localhost:63342/mcp",
+                    headers = emptyMap(),
+                    pluginPath = pluginHome?.toAbsolutePath()?.normalize()?.toString(),
+                ),
+                devrigEndpoint = testDevrigEndpoint("http://localhost:63342/mcp"),
+                ide = IdeInfo(name = "IntelliJ IDEA Ultimate", version = "2026.2.0.1", build = "IU-262.8665.337"),
+                plugin = PluginInfo(id = "com.jonnyzzz.mcp-steroid", name = "MCP Steroid", version = "1.0.0"),
+                createdAt = createdAt,
+                ideHome = ideHome.toAbsolutePath().normalize().toString(),
+                intellijWebServer = null,
+                intellijMcpServer = null,
+            ),
+        )
 
     private fun sleepyLauncher(): String =
         // A process that deliberately does NOT exit on SIGTERM, so `stop` with a 0ms grace
@@ -427,6 +1666,18 @@ class BackendManagerStartStopTest {
         }
     }
 
+    private suspend fun <T> captureStderr(block: suspend () -> T): String {
+        val original = System.err
+        val buffer = ByteArrayOutputStream()
+        System.setErr(PrintStream(buffer, true, Charsets.UTF_8))
+        try {
+            block()
+        } finally {
+            System.setErr(original)
+        }
+        return buffer.toString(Charsets.UTF_8)
+    }
+
     private object StaticDownloader : ManagedBackendDownloader {
         override suspend fun resolve(id: BackendId): BackendDownloadResolution =
             BackendDownloadResolution(
@@ -455,5 +1706,61 @@ class BackendManagerStartStopTest {
     private object ThrowingBundledPluginResolver : BundledPluginResolver {
         override fun resolveBundledPluginZip(): Path =
             error("re-provision must not run for an already-running backend")
+    }
+
+    private class HideFirstVisibleLauncherInspector(
+        private val launcherPidFile: Path,
+    ) : ManagedProcessInspector {
+        private var launcherWasHidden = false
+
+        override fun isAlive(pid: Long): Boolean = DefaultManagedProcessInspector.isAlive(pid)
+
+        override fun snapshot(pid: Long): ProcessSnapshot? = DefaultManagedProcessInspector.snapshot(pid)
+
+        override fun allProcesses(): List<ProcessSnapshot> {
+            val snapshots = DefaultManagedProcessInspector.allProcesses()
+            if (!launcherPidFile.exists() || launcherWasHidden) return snapshots
+            launcherWasHidden = true
+            val launcherPid = Files.readString(launcherPidFile).trim().toLong()
+            return snapshots.filterNot { it.pid == launcherPid }
+        }
+    }
+
+    private class ChangedStartIdentityInspector(
+        private val launcherPidFile: Path,
+    ) : ManagedProcessInspector {
+        override fun isAlive(pid: Long): Boolean = DefaultManagedProcessInspector.isAlive(pid)
+
+        override fun snapshot(pid: Long): ProcessSnapshot? = DefaultManagedProcessInspector.snapshot(pid)
+
+        override fun allProcesses(): List<ProcessSnapshot> {
+            val snapshots = DefaultManagedProcessInspector.allProcesses()
+            if (!launcherPidFile.exists()) return snapshots
+            val launcherPid = Files.readString(launcherPidFile).trim().toLong()
+            return snapshots.map { snapshot ->
+                if (snapshot.pid != launcherPid || snapshot.startInstant == null) {
+                    snapshot
+                } else {
+                    snapshot.copy(startInstant = snapshot.startInstant.minusSeconds(1))
+                }
+            }
+        }
+    }
+
+    private class HideTargetFromFirstProcessListingInspector(
+        private val targetPid: Long,
+    ) : ManagedProcessInspector {
+        private var targetWasHidden = false
+
+        override fun isAlive(pid: Long): Boolean = DefaultManagedProcessInspector.isAlive(pid)
+
+        override fun snapshot(pid: Long): ProcessSnapshot? = DefaultManagedProcessInspector.snapshot(pid)
+
+        override fun allProcesses(): List<ProcessSnapshot> {
+            val snapshots = DefaultManagedProcessInspector.allProcesses()
+            if (targetWasHidden) return snapshots
+            targetWasHidden = true
+            return snapshots.filterNot { it.pid == targetPid }
+        }
     }
 }

--- a/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/InstalledBackendsTest.kt
+++ b/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/InstalledBackendsTest.kt
@@ -112,7 +112,6 @@ class InstalledBackendsTest {
         val bundleDirName = "idea-IU-261.1.app"
         val backendDir = tempDir.resolve("backends").resolve(id)
         val bundleDir = backendDir.resolve(bundleDirName)
-        val launcherPath = "../bin/idea"  // product-info.json on macOS: launcherPath is relative from Contents/Resources
         // Contents/bin must exist for resolveIdeHome to detect macOS layout
         val contentsBin = bundleDir.resolve("Contents/bin")
         Files.createDirectories(contentsBin)
@@ -226,6 +225,81 @@ class InstalledBackendsTest {
 
         assertEquals(0, backends.size, "incomplete install (missing launcher) must be skipped")
     }
+
+    @Test
+    fun `installedBackends accepts IU 262 with remote development assets`(@TempDir tempDir: Path) {
+        val id = "idea-ultimate-2026.2.0.1"
+        val bundleDirName = "idea-ultimate"
+        val backendDir = tempDir.resolve("backends").resolve(id)
+        val bundleDir = backendDir.resolve(bundleDirName)
+        Files.createDirectories(bundleDir.resolve("bin"))
+        Files.createFile(bundleDir.resolve("bin/idea.sh"))
+        installRemoteDevelopmentAssets(bundleDir)
+        writeDescriptor(
+            descriptorPath(backendDir),
+            BackendDescriptor(
+                id = id,
+                productKey = "idea-ultimate",
+                productCode = "IU",
+                version = "2026.2.0.1",
+                buildNumber = "IU-262.8665.337",
+                bundleDirName = bundleDirName,
+                launcherPath = "bin/idea.sh",
+                downloadedAt = "2026-01-01T00:00:00Z",
+            ),
+        )
+
+        val services = DevrigServices(
+            com.jonnyzzz.mcpSteroid.testHelper.CloseableStackHost(),
+            homePaths = HomePaths(tempDir),
+            mcpStdin = System.`in`,
+            mcpStdout = System.out,
+        )
+
+        val backend = services.installedBackends().single()
+
+        assertEquals(id, backend.id)
+        assertTrue(
+            backend.launcher.fileName.toString() in setOf("remote-dev-server", "remote-dev-server.exe"),
+            "IU 262 must use the native Remote Development launcher, actual: ${backend.launcher}",
+        )
+    }
+
+    @Test
+    fun `installedBackends skips IU 262 with missing remote development launcher`(@TempDir tempDir: Path) {
+        val id = "idea-ultimate-2026.2.0.1"
+        val bundleDirName = "idea-ultimate"
+        val backendDir = tempDir.resolve("backends").resolve(id)
+        val bundleDir = backendDir.resolve(bundleDirName)
+        Files.createDirectories(bundleDir.resolve("bin"))
+        Files.createFile(bundleDir.resolve("bin/idea.sh"))
+        Files.createDirectories(bundleDir.resolve("plugins/remote-dev-server"))
+        writeDescriptor(
+            descriptorPath(backendDir),
+            BackendDescriptor(
+                id = id,
+                productKey = "idea-ultimate",
+                productCode = "IU",
+                version = "2026.2.0.1",
+                buildNumber = "IU-262.8665.337",
+                bundleDirName = bundleDirName,
+                launcherPath = "bin/idea.sh",
+                downloadedAt = "2026-01-01T00:00:00Z",
+            ),
+        )
+
+        val services = DevrigServices(
+            com.jonnyzzz.mcpSteroid.testHelper.CloseableStackHost(),
+            homePaths = HomePaths(tempDir),
+            mcpStdin = System.`in`,
+            mcpStdout = System.out,
+        )
+
+        val backends = services.installedBackends()
+
+        assertTrue(backends.isEmpty(), "IU 262 without a native Remote Development launcher must be skipped")
+    }
+
     @Test
     fun `startable excludes installed backend with a running managed pid`() {
         val a = installed(id = "idea-community-2026.1", home = "/b/idea")
@@ -244,6 +318,18 @@ class InstalledBackendsTest {
         val runningIdea = discoveredIde(ideHome = "/b/idea")
         val startable = startableBackends(listOf(a, b), listOf(runningIdea), runningManagedIds = setOf("goland-2026.1"))
         assertTrue(startable.isEmpty(), "both exclusion paths must work together")
+    }
+
+    private fun installRemoteDevelopmentAssets(bundleDir: Path) {
+        val ideHome = resolveIdeHome(bundleDir)
+        Files.createDirectories(ideHome.resolve("bin"))
+        Files.writeString(ideHome.resolve("bin/remote-dev-server"), "remote development launcher")
+            .toFile()
+            .setExecutable(true)
+        Files.writeString(ideHome.resolve("bin/remote-dev-server.exe"), "remote development launcher")
+        val pluginJar = ideHome.resolve("plugins/remote-dev-server/lib/remote-dev-server.jar")
+        Files.createDirectories(pluginJar.parent)
+        Files.writeString(pluginJar, "remote development plugin")
     }
 
 

--- a/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/RemoteDevelopmentLauncherResolverTest.kt
+++ b/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/RemoteDevelopmentLauncherResolverTest.kt
@@ -1,0 +1,266 @@
+/* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
+package com.jonnyzzz.mcpSteroid.devrig
+
+import com.jonnyzzz.mcpSteroid.ideDownloader.HostOs
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+class RemoteDevelopmentLauncherResolverTest {
+
+    @Test
+    fun `IU 262 selects trusted non-interactive remote development launch`(
+        @TempDir tempDir: Path,
+    ) {
+        val bundle = tempDir.resolve("iu-262-launch")
+        writeProductLauncher(bundle)
+        writeRemoteDevelopmentBundle(bundle, HostOs.LINUX)
+        val descriptor = descriptor(
+            productKey = "idea-ultimate",
+            productCode = "IU",
+            version = "2026.2.0.1",
+            buildNumber = "IU-262.8665.337",
+        )
+
+        val resolved = ManagedBackendLauncherResolver(HostOs.LINUX).resolve(descriptor, bundle)
+
+        assertEquals(bundle.resolve("bin/remote-dev-server"), resolved.executable)
+        assertEquals(listOf("run"), resolved.arguments)
+        assertEquals(bundle, resolved.workingDirectory)
+        assertEquals(
+            mapOf(
+                "REMOTE_DEV_JDK_DETECTION" to "false",
+                "REMOTE_DEV_NON_INTERACTIVE" to "1",
+                "REMOTE_DEV_TRUST_PROJECTS" to "1",
+            ),
+            resolved.environment,
+        )
+    }
+
+    @Test
+    fun `Community 262 retains standard product launcher`(
+        @TempDir tempDir: Path,
+    ) {
+        val bundle = tempDir.resolve("ic-262-launch")
+        writeProductLauncher(bundle)
+        writeRemoteDevelopmentBundle(bundle, HostOs.LINUX)
+        val descriptor = descriptor(
+            productKey = "idea-community",
+            productCode = "IC",
+            version = "2026.2.0.1",
+            buildNumber = "IC-262.8665.337",
+        )
+
+        val resolved = ManagedBackendLauncherResolver(HostOs.LINUX).resolve(descriptor, bundle)
+
+        assertEquals(bundle.resolve("bin/idea.sh"), resolved.executable)
+        assertEquals(emptyList(), resolved.arguments)
+        assertEquals(emptyMap(), resolved.environment)
+    }
+
+    @Test
+    fun `Ultimate before 262 retains standard product launcher`(
+        @TempDir tempDir: Path,
+    ) {
+        val bundle = tempDir.resolve("iu-261-launch")
+        writeProductLauncher(bundle)
+        val descriptor = descriptor(
+            productKey = "idea-ultimate",
+            productCode = "IU",
+            version = "2026.1.4",
+            buildNumber = "IU-261.26222.65",
+        )
+
+        val resolved = ManagedBackendLauncherResolver(HostOs.LINUX).resolve(descriptor, bundle)
+
+        assertEquals(bundle.resolve("bin/idea.sh"), resolved.executable)
+        assertEquals(emptyList(), resolved.arguments)
+        assertEquals(emptyMap(), resolved.environment)
+    }
+
+    @Test
+    fun `Ultimate after 262 retains standard product launcher`(
+        @TempDir tempDir: Path,
+    ) {
+        val bundle = tempDir.resolve("iu-263-launch")
+        writeProductLauncher(bundle)
+        val descriptor = descriptor(
+            productKey = "idea-ultimate",
+            productCode = "IU",
+            version = "2026.3",
+            buildNumber = "IU-263.1",
+        )
+
+        val resolved = ManagedBackendLauncherResolver(HostOs.LINUX).resolve(descriptor, bundle)
+
+        assertEquals(bundle.resolve("bin/idea.sh"), resolved.executable)
+        assertEquals(emptyList(), resolved.arguments)
+        assertEquals(emptyMap(), resolved.environment)
+    }
+
+    @Test
+    fun `resolves linux native remote development launcher`(
+        @TempDir tempDir: Path,
+    ) {
+        val bundle = writeRemoteDevelopmentBundle(tempDir.resolve("idea"), HostOs.LINUX)
+
+        val resolved = RemoteDevelopmentLauncherResolver(HostOs.LINUX).resolve(bundle)
+
+        assertEquals(bundle, resolved.ideHome)
+        assertEquals(bundle.resolve("bin/remote-dev-server"), resolved.executable)
+        assertEquals(listOf("run"), resolved.arguments)
+    }
+
+    @Test
+    fun `resolves macOS native launcher inside app Contents`(
+        @TempDir tempDir: Path,
+    ) {
+        val bundle = writeRemoteDevelopmentBundle(tempDir.resolve("IntelliJ IDEA.app"), HostOs.MAC)
+
+        val resolved = RemoteDevelopmentLauncherResolver(HostOs.MAC).resolve(bundle)
+
+        assertEquals(bundle.resolve("Contents"), resolved.ideHome)
+        assertEquals(bundle.resolve("Contents/bin/remote-dev-server"), resolved.executable)
+        assertEquals(listOf("run"), resolved.arguments)
+    }
+
+    @Test
+    fun `resolves windows native remote development launcher`(
+        @TempDir tempDir: Path,
+    ) {
+        val bundle = writeRemoteDevelopmentBundle(tempDir.resolve("idea"), HostOs.WINDOWS)
+
+        val resolved = RemoteDevelopmentLauncherResolver(HostOs.WINDOWS).resolve(bundle)
+
+        assertEquals(bundle.resolve("bin/remote-dev-server.exe"), resolved.executable)
+        assertEquals(listOf("run"), resolved.arguments)
+    }
+
+    @Test
+    fun `missing native launcher fails clearly`(
+        @TempDir tempDir: Path,
+    ) {
+        val bundle = tempDir.resolve("idea")
+        Files.createDirectories(bundle.resolve("plugins/remote-dev-server"))
+
+        val error = assertFailsWith<ManagedBackendValidationException> {
+            RemoteDevelopmentLauncherResolver(HostOs.LINUX).resolve(bundle)
+        }
+
+        assertTrue(error.message!!.contains("native Remote Development launcher is missing"), error.message)
+        assertTrue(error.message!!.contains("bin/remote-dev-server"), error.message)
+    }
+
+    @Test
+    fun `empty native launcher fails clearly`(
+        @TempDir tempDir: Path,
+    ) {
+        val bundle = writeRemoteDevelopmentBundle(tempDir.resolve("idea"), HostOs.LINUX)
+        Files.writeString(bundle.resolve("bin/remote-dev-server"), "")
+
+        val error = assertFailsWith<ManagedBackendValidationException> {
+            RemoteDevelopmentLauncherResolver(HostOs.LINUX).resolve(bundle)
+        }
+
+        assertTrue(error.message!!.contains("native Remote Development launcher is empty"), error.message)
+    }
+
+    @Test
+    fun `non executable Unix native launcher fails clearly`(
+        @TempDir tempDir: Path,
+    ) {
+        val bundle = writeRemoteDevelopmentBundle(tempDir.resolve("idea"), HostOs.LINUX)
+        bundle.resolve("bin/remote-dev-server").toFile().setExecutable(false)
+
+        val error = assertFailsWith<ManagedBackendValidationException> {
+            RemoteDevelopmentLauncherResolver(HostOs.LINUX).resolve(bundle)
+        }
+
+        assertTrue(error.message!!.contains("native Remote Development launcher is not executable"), error.message)
+    }
+
+    @Test
+    fun `missing remote development plugin fails clearly`(
+        @TempDir tempDir: Path,
+    ) {
+        val bundle = tempDir.resolve("idea")
+        val launcher = bundle.resolve("bin/remote-dev-server")
+        Files.createDirectories(launcher.parent)
+        Files.writeString(launcher, "#!/usr/bin/env sh\n")
+        launcher.toFile().setExecutable(true)
+
+        val error = assertFailsWith<ManagedBackendValidationException> {
+            RemoteDevelopmentLauncherResolver(HostOs.LINUX).resolve(bundle)
+        }
+
+        assertTrue(error.message!!.contains("Remote Development plugin is missing"), error.message)
+        assertTrue(error.message!!.contains("plugins/remote-dev-server"), error.message)
+    }
+
+    @Test
+    fun `missing remote development plugin jar fails clearly`(
+        @TempDir tempDir: Path,
+    ) {
+        val bundle = writeRemoteDevelopmentBundle(tempDir.resolve("idea"), HostOs.LINUX)
+        Files.delete(bundle.resolve("plugins/remote-dev-server/lib/remote-dev-server.jar"))
+
+        val error = assertFailsWith<ManagedBackendValidationException> {
+            RemoteDevelopmentLauncherResolver(HostOs.LINUX).resolve(bundle)
+        }
+
+        assertTrue(error.message!!.contains("Remote Development plugin jar is missing"), error.message)
+    }
+
+    @Test
+    fun `empty remote development plugin jar fails clearly`(
+        @TempDir tempDir: Path,
+    ) {
+        val bundle = writeRemoteDevelopmentBundle(tempDir.resolve("idea"), HostOs.LINUX)
+        Files.writeString(bundle.resolve("plugins/remote-dev-server/lib/remote-dev-server.jar"), "")
+
+        val error = assertFailsWith<ManagedBackendValidationException> {
+            RemoteDevelopmentLauncherResolver(HostOs.LINUX).resolve(bundle)
+        }
+
+        assertTrue(error.message!!.contains("Remote Development plugin jar is empty"), error.message)
+    }
+
+    private fun writeRemoteDevelopmentBundle(bundle: Path, hostOs: HostOs): Path {
+        val ideHome = if (hostOs == HostOs.MAC) bundle.resolve("Contents") else bundle
+        val launcherName = if (hostOs == HostOs.WINDOWS) "remote-dev-server.exe" else "remote-dev-server"
+        val launcher = ideHome.resolve("bin").resolve(launcherName)
+        Files.createDirectories(launcher.parent)
+        Files.writeString(launcher, "remote development launcher")
+        if (hostOs != HostOs.WINDOWS) launcher.toFile().setExecutable(true)
+        val pluginJar = ideHome.resolve("plugins/remote-dev-server/lib/remote-dev-server.jar")
+        Files.createDirectories(pluginJar.parent)
+        Files.writeString(pluginJar, "remote development plugin")
+        return bundle
+    }
+
+    private fun writeProductLauncher(bundle: Path) {
+        val launcher = bundle.resolve("bin/idea.sh")
+        Files.createDirectories(launcher.parent)
+        Files.writeString(launcher, "#!/usr/bin/env sh\n")
+    }
+
+    private fun descriptor(
+        productKey: String,
+        productCode: String,
+        version: String,
+        buildNumber: String,
+    ): BackendDescriptor = BackendDescriptor(
+        id = "$productKey-$version",
+        productKey = productKey,
+        productCode = productCode,
+        version = version,
+        buildNumber = buildNumber,
+        bundleDirName = "idea",
+        launcherPath = "bin/idea.sh",
+        downloadedAt = "2026-07-31T00:00:00Z",
+    )
+}

--- a/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/SingleInstanceLockTest.kt
+++ b/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/SingleInstanceLockTest.kt
@@ -8,6 +8,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeout
+import kotlinx.serialization.json.Json
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
 import java.io.ByteArrayInputStream
@@ -15,6 +16,7 @@ import java.io.ByteArrayOutputStream
 import java.io.PrintStream
 import java.nio.file.Files
 import java.nio.file.Path
+import java.time.Instant
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
 import kotlin.io.path.exists
@@ -22,6 +24,7 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 import kotlin.test.fail
+import kotlin.time.Duration.Companion.seconds
 import org.junit.jupiter.api.condition.DisabledOnOs
 import org.junit.jupiter.api.condition.OS
 
@@ -34,12 +37,13 @@ class SingleInstanceLockTest {
     ) {
         val homePaths = HomePaths(tempDir.resolve("home"))
         installStubBackend(homePaths, id = "idea-community-2025.3.3")
-        val requestedProcess = startSleeper()
-        val otherProcess = startSleeper()
+        installStubBackend(homePaths, id = "idea-community-2025.3.2")
+        val requestedProcess = startManagedStub(homePaths, "idea-community-2025.3.3")
+        val otherProcess = startManagedStub(homePaths, "idea-community-2025.3.2")
         try {
             Files.createDirectories(homePaths.stateDir)
-            Files.writeString(homePaths.pidFile("idea-community-2025.3.3"), "${requestedProcess.pid()}\n")
-            Files.writeString(homePaths.pidFile("idea-community-2025.3.2"), "${otherProcess.pid()}\n")
+            writeProcessState(homePaths.pidFile("idea-community-2025.3.3"), requestedProcess)
+            writeProcessState(homePaths.pidFile("idea-community-2025.3.2"), otherProcess)
 
             val (exit, stdout, stderr) = captureCli { stdoutStream ->
                 runStartCli(homePaths, "idea-community-2025.3.3", stdoutStream)
@@ -63,25 +67,33 @@ class SingleInstanceLockTest {
     }
 
     @Test
-    fun `start reports already running for requested backend and prints normal paths`(
+    fun `start rejects a live unrelated pid file and launches the requested backend`(
         @TempDir tempDir: Path,
-    ) {
+    ) = runBlocking {
         val homePaths = HomePaths(tempDir.resolve("home"))
-        installStubBackend(homePaths, id = "idea-community-2025.3.3")
+        val id = "idea-community-2025.3.3"
+        installStubBackend(homePaths, id = id)
         val pid = ProcessHandle.current().pid()
         Files.createDirectories(homePaths.stateDir)
-        Files.writeString(homePaths.pidFile("idea-community-2025.3.3"), "$pid\n")
+        Files.writeString(homePaths.pidFile(id), "$pid\n")
+        val manager = BackendManager(
+            homePaths = homePaths,
+            downloader = StaticDownloader,
+            bundledPluginResolver = FixedBundledPluginResolver(bundledPluginZipFixture(tempDir.resolve("dist/ij-plugin.zip"), "test")),
+            ideUserHome = tempDir.resolve("user-home"),
+        )
 
-        val (exit, stdout, stderr) = captureCli { stdoutStream ->
-            runStartCli(homePaths, "idea-community-2025.3.3", stdoutStream)
+        val started = manager.start(parseBackendId(id))
+        try {
+            assertFalse(started.alreadyRunning)
+            assertTrue(started.pid > 0)
+            assertTrue(started.pid != pid, "the unrelated current JVM pid must not be trusted as the backend")
+            val processState = requireNotNull(readManagedBackendProcessState(homePaths.pidFile(id)))
+            assertEquals(started.pid, processState.pid)
+            assertTrue(processState.startInstant != null)
+        } finally {
+            manager.stop(parseBackendId(id))
         }
-
-        assertEquals(0, exit)
-        assertEquals("", stderr)
-        assertTrue(stdout.contains("already running: idea-community-2025.3.3 (pid $pid)"), stdout)
-        assertTrue(stdout.contains("pid: $pid"), stdout)
-        assertTrue(stdout.contains("log: ${homePaths.cacheDir("idea-community-2025.3.3").resolve("logs/managed.log")}"), stdout)
-        assertTrue(stdout.contains("config: ${homePaths.cacheDir("idea-community-2025.3.3").resolve("config")}"), stdout)
     }
 
     @Test
@@ -119,6 +131,7 @@ class SingleInstanceLockTest {
     ) = runBlocking {
         val homePaths = HomePaths(tempDir.resolve("home"))
         installStubBackend(homePaths, id = "idea-community-2025.3.3")
+        installStubBackend(homePaths, id = "idea-community-2025.3.2")
         val orphanCommand = homePaths.backendsDir
             .resolve("idea-community-2025.3.2/idea-IC-253.1/bin/idea.sh")
             .toString()
@@ -142,6 +155,105 @@ class SingleInstanceLockTest {
         assertTrue(error.contains("error: another managed backend is already running: idea-community-2025.3.2 (pid 4242)"), error)
         assertTrue(error.contains("stop it first:  devrig backend stop idea-community-2025.3.2"), error)
         assertTrue(error.contains("cleanup stale state under ${homePaths.stateDir}"), error)
+    }
+
+    @Test
+    fun `process list fallback repairs pid state for an untracked matching backend`(
+        @TempDir tempDir: Path,
+    ) = runBlocking {
+        val id = "idea-community-2025.3.3"
+        val homePaths = HomePaths(tempDir.resolve("home"))
+        installStubBackend(homePaths, id = id)
+        val managedCommand = homePaths.backendsDir
+            .resolve("$id/idea-IC-253.1/bin/idea.sh")
+            .toString()
+        val processStartedAt = Instant.parse("2026-07-31T12:00:00Z")
+        val manager = BackendManager(
+            homePaths = homePaths,
+            downloader = StaticDownloader,
+            bundledPluginResolver = FixedBundledPluginResolver(bundledPluginZipFixture(tempDir.resolve("dist/ij-plugin.zip"), "test")),
+            ideUserHome = tempDir.resolve("user-home"),
+            processInspector = FakeProcessInspector(
+                snapshots = listOf(
+                    ProcessSnapshot(pid = 4242L, command = managedCommand, startInstant = processStartedAt),
+                ),
+            ),
+        )
+
+        val started = manager.start(parseBackendId(id))
+
+        assertTrue(started.alreadyRunning)
+        assertEquals(4242L, started.pid)
+        val processState = requireNotNull(readManagedBackendProcessState(homePaths.pidFile(id)))
+        assertEquals(4242L, processState.pid)
+        assertEquals(processStartedAt.toString(), processState.startInstant)
+    }
+
+    @Test
+    fun `process list ignores an unrelated argument that merely contains a backend path`(
+        @TempDir tempDir: Path,
+    ) = runBlocking {
+        val id = "idea-community-2025.3.3"
+        val homePaths = HomePaths(tempDir.resolve("home"))
+        installStubBackend(homePaths, id = id)
+        val mentionedPath = homePaths.backendDir(id).resolve("idea-IC-253.1/bin/idea.sh")
+        val manager = BackendManager(
+            homePaths = homePaths,
+            downloader = StaticDownloader,
+            bundledPluginResolver = FixedBundledPluginResolver(bundledPluginZipFixture(tempDir.resolve("dist/ij-plugin.zip"), "test")),
+            ideUserHome = tempDir.resolve("user-home"),
+            processInspector = FakeProcessInspector(
+                snapshots = listOf(
+                    ProcessSnapshot(
+                        pid = 4242L,
+                        command = "/bin/echo",
+                        arguments = listOf("--message=$mentionedPath", "${0.toChar()}"),
+                    ),
+                ),
+            ),
+        )
+
+        val started = manager.start(parseBackendId(id))
+        try {
+            assertFalse(started.alreadyRunning)
+            assertTrue(started.pid > 0)
+        } finally {
+            manager.stop(parseBackendId(id))
+        }
+    }
+
+    @Test
+    fun `process list ignores an unrelated exact file argument under a managed bundle`(
+        @TempDir tempDir: Path,
+    ) = runBlocking {
+        val id = "idea-community-2025.3.3"
+        val homePaths = HomePaths(tempDir.resolve("home"))
+        installStubBackend(homePaths, id = id)
+        val unrelatedFile = homePaths.backendDir(id).resolve("idea-IC-253.1/product-info.json")
+        Files.writeString(unrelatedFile, "{}")
+        val manager = BackendManager(
+            homePaths = homePaths,
+            downloader = StaticDownloader,
+            bundledPluginResolver = FixedBundledPluginResolver(bundledPluginZipFixture(tempDir.resolve("dist/ij-plugin.zip"), "test")),
+            ideUserHome = tempDir.resolve("user-home"),
+            processInspector = FakeProcessInspector(
+                snapshots = listOf(
+                    ProcessSnapshot(
+                        pid = 4242L,
+                        command = "/usr/bin/tail",
+                        arguments = listOf("-f", unrelatedFile.toString()),
+                    ),
+                ),
+            ),
+        )
+
+        val started = manager.start(parseBackendId(id))
+        try {
+            assertFalse(started.alreadyRunning)
+            assertTrue(started.pid > 0)
+        } finally {
+            manager.stop(parseBackendId(id))
+        }
     }
 
     @Test
@@ -171,7 +283,7 @@ class SingleInstanceLockTest {
         val first = async(Dispatchers.Default) {
             firstManager.start(parseBackendId("idea-community-2025.3.3"))
         }
-        withTimeout(5_000) { firstScanEntered.await() }
+        withTimeout(5.seconds) { firstScanEntered.await() }
 
         val second = async(Dispatchers.Default) {
             try {
@@ -182,9 +294,9 @@ class SingleInstanceLockTest {
             }
         }
 
-        assertEquals("another devrig backend operation is in progress; retry shortly", withTimeout(5_000) { second.await() })
+        assertEquals("another devrig backend operation is in progress; retry shortly", withTimeout(5.seconds) { second.await() })
         releaseFirstScan.complete(Unit)
-        val started = withTimeout(5_000) { first.await() }
+        val started = withTimeout(5.seconds) { first.await() }
         try {
             assertTrue(ProcessHandle.of(started.pid).orElseThrow().isAlive)
         } finally {
@@ -263,8 +375,18 @@ class SingleInstanceLockTest {
         while true; do sleep 1; done
         """.trimIndent() + "\n"
 
-    private fun startSleeper(): Process =
-        ProcessBuilder("sh", "-c", "trap 'exit 0' TERM; while true; do sleep 1; done").start()
+    private fun startManagedStub(homePaths: HomePaths, id: String): Process =
+        ProcessBuilder(
+            homePaths.backendDir(id).resolve("idea-IC-253.1/bin/idea.sh").toString(),
+        ).start()
+
+    private fun writeProcessState(path: Path, process: Process) {
+        val state = ManagedBackendProcessState(
+            pid = process.pid(),
+            startInstant = process.toHandle().info().startInstant().orElseThrow().toString(),
+        )
+        Files.writeString(path, Json.encodeToString(state) + "\n")
+    }
 
     private fun stopProcess(process: Process) {
         process.destroy()
@@ -277,8 +399,13 @@ class SingleInstanceLockTest {
     private class FakeProcessInspector(
         private val snapshots: List<ProcessSnapshot>,
     ) : ManagedProcessInspector {
-        override fun isAlive(pid: Long): Boolean = snapshots.any { it.pid == pid }
+        override fun isAlive(pid: Long): Boolean =
+            snapshots.any { it.pid == pid } || DefaultManagedProcessInspector.isAlive(pid)
+
         override fun allProcesses(): List<ProcessSnapshot> = snapshots
+
+        override fun snapshot(pid: Long): ProcessSnapshot? =
+            snapshots.firstOrNull { it.pid == pid } ?: DefaultManagedProcessInspector.snapshot(pid)
     }
 
     private class BlockingFirstScanInspector(
@@ -294,11 +421,13 @@ class SingleInstanceLockTest {
             if (firstScan.compareAndSet(true, false)) {
                 firstScanEntered.complete(Unit)
                 runBlocking {
-                    withTimeout(5_000) { releaseFirstScan.await() }
+                    withTimeout(5.seconds) { releaseFirstScan.await() }
                 }
             }
             return emptyList()
         }
+
+        override fun snapshot(pid: Long): ProcessSnapshot? = DefaultManagedProcessInspector.snapshot(pid)
     }
 
     private object StaticDownloader : ManagedBackendDownloader {

--- a/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/SingleInstanceLockTest.kt
+++ b/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/SingleInstanceLockTest.kt
@@ -304,6 +304,54 @@ class SingleInstanceLockTest {
         }
     }
 
+    @Test
+    fun `download and stop refuse while start holds the global operation lock`(
+        @TempDir tempDir: Path,
+    ) = runBlocking {
+        val id = "idea-community-2025.3.3"
+        val homePaths = HomePaths(tempDir.resolve("home"))
+        installStubBackend(homePaths, id = id)
+        val firstScanEntered = CompletableDeferred<Unit>()
+        val releaseFirstScan = CompletableDeferred<Unit>()
+        val firstManager = BackendManager(
+            homePaths = homePaths,
+            downloader = StaticDownloader,
+            bundledPluginResolver = FixedBundledPluginResolver(
+                bundledPluginZipFixture(tempDir.resolve("dist/ij-plugin.zip"), "test"),
+            ),
+            ideUserHome = tempDir.resolve("user-home"),
+            processInspector = BlockingFirstScanInspector(firstScanEntered, releaseFirstScan),
+        )
+        val secondManager = BackendManager(
+            homePaths = homePaths,
+            downloader = StaticDownloader,
+            bundledPluginResolver = FixedBundledPluginResolver(
+                bundledPluginZipFixture(tempDir.resolve("dist/ij-plugin.zip"), "test"),
+            ),
+            ideUserHome = tempDir.resolve("user-home"),
+        )
+
+        val starting = async(Dispatchers.Default) { firstManager.start(parseBackendId(id)) }
+        withTimeout(5.seconds) { firstScanEntered.await() }
+        val downloadAttempt = runCatching { secondManager.download(parseBackendId(id)) }
+        val stopAttempt = runCatching { secondManager.stop(parseBackendId(id)) }
+        releaseFirstScan.complete(Unit)
+        val started = withTimeout(5.seconds) { starting.await() }
+        try {
+            assertEquals(
+                "another devrig backend operation is in progress; retry shortly",
+                (downloadAttempt.exceptionOrNull() as? ManagedBackendLockException)?.message,
+            )
+            assertEquals(
+                "another devrig backend operation is in progress; retry shortly",
+                (stopAttempt.exceptionOrNull() as? ManagedBackendLockException)?.message,
+            )
+        } finally {
+            firstManager.stop(parseBackendId(id))
+        }
+        assertFalse(ProcessHandle.of(started.pid).map { it.isAlive }.orElse(false))
+    }
+
     private fun captureCli(block: (PrintStream) -> Int): CliCapture {
         val originalOut = System.out
         val originalErr = System.err

--- a/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/WindowsProcessCommandTest.kt
+++ b/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/WindowsProcessCommandTest.kt
@@ -1,0 +1,125 @@
+/* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
+package com.jonnyzzz.mcpSteroid.devrig
+
+import com.jonnyzzz.mcpSteroid.ideDownloader.HostOs
+import org.junit.jupiter.api.Test
+import java.nio.file.Path
+import kotlin.test.assertContains
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+
+class WindowsProcessCommandTest {
+
+    @Test
+    fun `remote overrides retain required Windows launcher environment without secrets`() {
+        val merged = windowsProcessEnvironment(
+            inherited = mapOf(
+                "Path" to "C:\\Windows\\System32",
+                "USERPROFILE" to "C:\\Users\\agent",
+                "ANTHROPIC_API_KEY" to "must-not-leak",
+                "remote_dev_non_interactive" to "old",
+            ),
+            overrides = mapOf(
+                "REMOTE_DEV_NON_INTERACTIVE" to "1",
+                "REMOTE_DEV_TRUST_PROJECTS" to "1",
+            ),
+        )
+
+        assertEquals("C:\\Windows\\System32", merged["Path"])
+        assertEquals("C:\\Users\\agent", merged["USERPROFILE"])
+        assertEquals("1", merged["REMOTE_DEV_NON_INTERACTIVE"])
+        assertEquals("1", merged["REMOTE_DEV_TRUST_PROJECTS"])
+        assertEquals(false, merged.containsKey("remote_dev_non_interactive"))
+        assertEquals(false, merged.containsKey("ANTHROPIC_API_KEY"))
+    }
+
+    @Test
+    fun `remote overrides retain required Unix session environment without agent secrets`() {
+        val merged = managedProcessEnvironment(
+            inherited = mapOf(
+                "HOME" to "/home/agent",
+                "PATH" to "/usr/local/bin:/usr/bin",
+                "DISPLAY" to ":99",
+                "LC_MESSAGES" to "en_US.UTF-8",
+                "OPENAI_API_KEY" to "must-not-leak",
+                "CODEX_API_KEY" to "must-not-leak",
+            ),
+            overrides = mapOf(
+                "REMOTE_DEV_NON_INTERACTIVE" to "1",
+                "REMOTE_DEV_TRUST_PROJECTS" to "1",
+            ),
+            hostOs = HostOs.LINUX,
+        )
+
+        assertEquals("/home/agent", merged["HOME"])
+        assertEquals("/usr/local/bin:/usr/bin", merged["PATH"])
+        assertEquals(":99", merged["DISPLAY"])
+        assertEquals("en_US.UTF-8", merged["LC_MESSAGES"])
+        assertEquals("1", merged["REMOTE_DEV_NON_INTERACTIVE"])
+        assertEquals("1", merged["REMOTE_DEV_TRUST_PROJECTS"])
+        assertEquals(false, merged.containsKey("OPENAI_API_KEY"))
+        assertEquals(false, merged.containsKey("CODEX_API_KEY"))
+    }
+
+    @Test
+    fun `quotes executable path and appends remote development run argument`() {
+        val command = buildWindowsProcessCommand(
+            launcher = Path.of("C:\\Program Files\\JetBrains\\IntelliJ IDEA\\bin\\remote-dev-server.exe"),
+            arguments = listOf("run"),
+        )
+
+        assertEquals(
+            "\"C:\\Program Files\\JetBrains\\IntelliJ IDEA\\bin\\remote-dev-server.exe\" run",
+            command,
+        )
+    }
+
+    @Test
+    fun `quotes arguments with whitespace quotes and trailing backslashes`() {
+        val command = buildWindowsProcessCommand(
+            launcher = Path.of("C:\\idea\\bin\\remote-dev-server.exe"),
+            arguments = listOf("run", "two words", "quoted\"value", "C:\\project path\\"),
+        )
+
+        assertEquals(
+            "\"C:\\idea\\bin\\remote-dev-server.exe\" run \"two words\" \"quoted\\\"value\" \"C:\\project path\\\\\"",
+            command,
+        )
+    }
+
+    @Test
+    fun `macOS detachment keeps every dynamic path out of the shell program`() {
+        val launcher = Path.of("/Applications/IntelliJ IDEA.app/Contents/bin/remote-dev-server")
+        val stdout = Path.of("/tmp/devrig logs/managed out.log")
+        val stderr = Path.of("/tmp/devrig logs/managed err.log")
+
+        val command = buildMacOsDetachedProcessCommand(
+            launcher = launcher,
+            arguments = listOf("run", "/tmp/project with spaces"),
+            stdoutLog = stdout,
+            stderrLog = stderr,
+        )
+
+        assertEquals("/bin/sh", command[0])
+        assertEquals("-c", command[1])
+        val shellProgram = command[2]
+        assertContains(shellProgram, "set -m")
+        assertContains(shellProgram, "/usr/bin/nohup")
+        assertContains(shellProgram, "\"$@\"")
+        assertContains(shellProgram, "$!")
+        assertFalse(shellProgram.contains(launcher.toString()))
+        assertFalse(shellProgram.contains(stdout.toString()))
+        assertFalse(shellProgram.contains(stderr.toString()))
+        assertEquals(
+            listOf(
+                "devrig-detach",
+                stdout.toString(),
+                stderr.toString(),
+                launcher.toString(),
+                "run",
+                "/tmp/project with spaces",
+            ),
+            command.drop(3),
+        )
+    }
+}

--- a/test-experiments/src/test/kotlin/com/jonnyzzz/mcpSteroid/integration/arena/ArenaAgentToolCallParserTest.kt
+++ b/test-experiments/src/test/kotlin/com/jonnyzzz/mcpSteroid/integration/arena/ArenaAgentToolCallParserTest.kt
@@ -1,0 +1,370 @@
+/* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
+package com.jonnyzzz.mcpSteroid.integration.arena
+
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.addJsonObject
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.put
+import kotlinx.serialization.json.putJsonArray
+import kotlinx.serialization.json.putJsonObject
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class ArenaAgentToolCallParserTest {
+
+    @Test
+    fun `claude calls retain shell commands and normalized MCP arguments and results`() {
+        val transcript = decodeAgentToolCalls(
+            listOf(
+                claudeCall(
+                    id = "download",
+                    name = "Bash",
+                    input = buildJsonObject {
+                        put("command", "devrig backend download idea-ultimate --version 2026.2.0.1")
+                    },
+                ),
+                claudeResult("download", "downloaded IU 262", isError = false),
+                claudeCall(
+                    id = "start",
+                    name = "Bash",
+                    input = buildJsonObject {
+                        put("command", "devrig backend start idea-ultimate --version 2026.2.0.1")
+                    },
+                ),
+                claudeResult("start", "backend started", isError = false),
+                claudeCall(
+                    id = "open",
+                    name = "mcp__mcp-steroid__steroid_open_project",
+                    input = buildJsonObject { put("project_path", "/workspace/keycloak") },
+                ),
+                claudeResult("open", "opened /workspace/keycloak", isError = false, contentAsArray = true),
+                claudeCall(
+                    id = "execute",
+                    name = "mcp__mcp-steroid__steroid_execute_code",
+                    input = buildJsonObject {
+                        put("code", "ClassInheritorsSearch.search(authenticator, scope, true).findAll()")
+                    },
+                ),
+                claudeResult("execute", "UsernamePasswordForm\nOTPFormAuthenticator", isError = false),
+            ).joinToString("\n"),
+        )
+
+        assertEquals(listOf("Bash", "Bash", "steroid_open_project", "steroid_execute_code"), transcript.map { it.toolName })
+        assertEquals(
+            "devrig backend download idea-ultimate --version 2026.2.0.1",
+            transcript[0].arguments["command"]?.jsonPrimitive?.content,
+        )
+        assertEquals(
+            "devrig backend start idea-ultimate --version 2026.2.0.1",
+            transcript[1].arguments["command"]?.jsonPrimitive?.content,
+        )
+        assertEquals("/workspace/keycloak", transcript[2].arguments["project_path"]?.jsonPrimitive?.content)
+        assertEquals("opened /workspace/keycloak", transcript[2].result?.text)
+        assertEquals(
+            "ClassInheritorsSearch.search(authenticator, scope, true).findAll()",
+            transcript[3].arguments["code"]?.jsonPrimitive?.content,
+        )
+        assertEquals("UsernamePasswordForm\nOTPFormAuthenticator", transcript[3].result?.text)
+        assertFalse(transcript.any { it.result?.isError == true })
+    }
+
+    @Test
+    fun `codex de-duplicates lifecycle events and retains command and MCP results`() {
+        val transcript = decodeAgentToolCalls(
+            listOf(
+                codexCommandStarted(
+                    id = "download",
+                    command = "devrig backend download idea-ultimate --version 2026.2.0.1",
+                ),
+                codexCommandCompleted(
+                    id = "download",
+                    command = "devrig backend download idea-ultimate --version 2026.2.0.1",
+                    output = "downloaded IU 262",
+                ),
+                codexCommandCompleted(
+                    id = "start",
+                    command = "devrig backend start idea-ultimate --version 2026.2.0.1",
+                    output = "backend started",
+                ),
+                codexMcpStarted(
+                    id = "open",
+                    tool = "steroid_open_project",
+                    arguments = buildJsonObject { put("project_path", "/workspace/keycloak") },
+                ),
+                codexMcpCompleted(
+                    id = "open",
+                    tool = "steroid_open_project",
+                    arguments = buildJsonObject { put("project_path", "/workspace/keycloak") },
+                    resultText = "opened /workspace/keycloak",
+                ),
+                codexMcpCompletedWithStringArguments(
+                    id = "execute",
+                    tool = "mcp__mcp-steroid__steroid_execute_code",
+                    arguments = buildJsonObject {
+                        put("code", "ClassInheritorsSearch.search(authenticator, scope, true).findAll()")
+                    },
+                    resultText = "OTPFormAuthenticator\nIdpConfirmLinkAuthenticator",
+                ),
+            ).joinToString("\n"),
+        )
+
+        assertEquals(
+            listOf("command_execution", "command_execution", "steroid_open_project", "steroid_execute_code"),
+            transcript.map { it.toolName },
+        )
+        assertEquals(4, transcript.size)
+        assertTrue(transcript[0].arguments["command"]?.jsonPrimitive?.content?.contains("backend download") == true)
+        assertEquals("downloaded IU 262", transcript[0].result?.text)
+        assertTrue(transcript[1].arguments["command"]?.jsonPrimitive?.content?.contains("backend start") == true)
+        assertEquals("backend started", transcript[1].result?.text)
+        assertEquals("/workspace/keycloak", transcript[2].arguments["project_path"]?.jsonPrimitive?.content)
+        assertEquals("opened /workspace/keycloak", transcript[2].result?.text)
+        assertTrue(transcript[3].arguments["code"]?.jsonPrimitive?.content?.contains("ClassInheritorsSearch") == true)
+        assertEquals("OTPFormAuthenticator\nIdpConfirmLinkAuthenticator", transcript[3].result?.text)
+    }
+
+    @Test
+    fun `claude final response comes from the successful result event`() {
+        val raw = listOf(
+            claudeResult("execute", "tool output must not become the final answer", isError = false),
+            buildJsonObject {
+                put("type", "assistant")
+                putJsonObject("message") {
+                    putJsonArray("content") {
+                        addJsonObject {
+                            put("type", "text")
+                            put("text", "intermediate assistant text")
+                        }
+                    }
+                }
+            }.toString(),
+            buildJsonObject {
+                put("type", "result")
+                put("subtype", "success")
+                put("result", "SUBTYPES_FOUND: 72\nSUBTYPE: org.example.FinalClaudeAnswer")
+            }.toString(),
+        ).joinToString("\n")
+
+        assertEquals(
+            "SUBTYPES_FOUND: 72\nSUBTYPE: org.example.FinalClaudeAnswer",
+            decodeAgentFinalResponse(raw),
+        )
+    }
+
+    @Test
+    fun `claude final response falls back to the last assistant text when result is empty`() {
+        val raw = listOf(
+            buildJsonObject {
+                put("type", "assistant")
+                putJsonObject("message") {
+                    putJsonArray("content") {
+                        addJsonObject {
+                            put("type", "text")
+                            put("text", "intermediate assistant text")
+                        }
+                    }
+                }
+            }.toString(),
+            buildJsonObject {
+                put("type", "assistant")
+                putJsonObject("message") {
+                    putJsonArray("content") {
+                        addJsonObject {
+                            put("type", "text")
+                            put("text", "SUBTYPES_FOUND: 72\nSUBTYPE: org.example.FinalClaudeAnswer")
+                        }
+                    }
+                }
+            }.toString(),
+            buildJsonObject {
+                put("type", "result")
+                put("subtype", "success")
+                put("result", "")
+            }.toString(),
+        ).joinToString("\n")
+
+        assertEquals(
+            "SUBTYPES_FOUND: 72\nSUBTYPE: org.example.FinalClaudeAnswer",
+            decodeAgentFinalResponse(raw),
+        )
+    }
+
+    @Test
+    fun `codex final response is the last completed agent message`() {
+        val raw = listOf(
+            buildJsonObject {
+                put("type", "item.completed")
+                putJsonObject("item") {
+                    put("id", "progress")
+                    put("type", "agent_message")
+                    put("text", "Still indexing")
+                }
+            }.toString(),
+            codexMcpCompleted(
+                id = "execute",
+                tool = "steroid_execute_code",
+                arguments = buildJsonObject { put("code", "ClassInheritorsSearch") },
+                resultText = "tool output must not become the final answer",
+            ),
+            buildJsonObject {
+                put("type", "item.completed")
+                putJsonObject("item") {
+                    put("id", "final")
+                    put("type", "agent_message")
+                    put("text", "SUBTYPES_FOUND: 70\nSUBTYPE: org.example.FinalCodexAnswer")
+                }
+            }.toString(),
+            buildJsonObject { put("type", "turn.completed") }.toString(),
+        ).joinToString("\n")
+
+        assertEquals(
+            "SUBTYPES_FOUND: 70\nSUBTYPE: org.example.FinalCodexAnswer",
+            decodeAgentFinalResponse(raw),
+        )
+    }
+
+    @Test
+    fun `failed calls and missing results remain distinguishable`() {
+        val transcript = decodeAgentToolCalls(
+            listOf(
+                "not json",
+                claudeCall("pending", "custom__tool", buildJsonObject { put("value", 1) }),
+                codexMcpCompleted(
+                    id = "failed",
+                    tool = "steroid_open_project",
+                    arguments = buildJsonObject { put("project_path", "/workspace/missing") },
+                    resultText = "Project not found",
+                    status = "failed",
+                ),
+            ).joinToString("\n"),
+        )
+
+        assertEquals("custom__tool", transcript[0].toolName)
+        assertNull(transcript[0].result)
+        assertEquals("steroid_open_project", transcript[1].toolName)
+        assertTrue(transcript[1].result?.isError == true)
+        assertEquals("Project not found", transcript[1].result?.text)
+    }
+
+    private fun claudeCall(id: String, name: String, input: JsonObject): String = buildJsonObject {
+        put("type", "assistant")
+        putJsonObject("message") {
+            putJsonArray("content") {
+                addJsonObject {
+                    put("type", "tool_use")
+                    put("id", id)
+                    put("name", name)
+                    put("input", input)
+                }
+            }
+        }
+    }.toString()
+
+    private fun claudeResult(id: String, text: String, isError: Boolean, contentAsArray: Boolean = false): String =
+        buildJsonObject {
+            put("type", "user")
+            putJsonObject("message") {
+                putJsonArray("content") {
+                    addJsonObject {
+                        put("type", "tool_result")
+                        put("tool_use_id", id)
+                        put("is_error", isError)
+                        if (contentAsArray) {
+                            putJsonArray("content") {
+                                addJsonObject {
+                                    put("type", "text")
+                                    put("text", text)
+                                }
+                            }
+                        } else {
+                            put("content", text)
+                        }
+                    }
+                }
+            }
+        }.toString()
+
+    private fun codexCommandStarted(id: String, command: String): String = buildJsonObject {
+        put("type", "item.started")
+        putJsonObject("item") {
+            put("id", id)
+            put("type", "command_execution")
+            put("command", command)
+        }
+    }.toString()
+
+    private fun codexCommandCompleted(id: String, command: String, output: String): String = buildJsonObject {
+        put("type", "item.completed")
+        putJsonObject("item") {
+            put("id", id)
+            put("type", "command_execution")
+            put("command", command)
+            put("status", "completed")
+            put("exit_code", 0)
+            put("aggregated_output", output)
+        }
+    }.toString()
+
+    private fun codexMcpStarted(id: String, tool: String, arguments: JsonObject): String = buildJsonObject {
+        put("type", "item.started")
+        putJsonObject("item") {
+            put("id", id)
+            put("type", "mcp_tool_call")
+            put("tool", tool)
+            put("arguments", arguments)
+        }
+    }.toString()
+
+    private fun codexMcpCompleted(
+        id: String,
+        tool: String,
+        arguments: JsonObject,
+        resultText: String,
+        status: String = "completed",
+    ): String = buildJsonObject {
+        put("type", "item.completed")
+        putJsonObject("item") {
+            put("id", id)
+            put("type", "mcp_tool_call")
+            put("tool", tool)
+            put("arguments", arguments)
+            put("status", status)
+            putJsonObject("result") {
+                putJsonArray("content") {
+                    addJsonObject {
+                        put("type", "text")
+                        put("text", resultText)
+                    }
+                }
+            }
+        }
+    }.toString()
+
+    private fun codexMcpCompletedWithStringArguments(
+        id: String,
+        tool: String,
+        arguments: JsonObject,
+        resultText: String,
+    ): String = buildJsonObject {
+        put("type", "item.completed")
+        putJsonObject("item") {
+            put("id", id)
+            put("type", "mcp_tool_call")
+            put("tool", tool)
+            put("arguments", arguments.toString())
+            put("status", "completed")
+            putJsonObject("result") {
+                putJsonArray("content") {
+                    addJsonObject {
+                        put("type", "text")
+                        put("text", resultText)
+                    }
+                }
+            }
+        }
+    }.toString()
+}

--- a/test-experiments/src/test/kotlin/com/jonnyzzz/mcpSteroid/integration/arena/ArenaOutputParsing.kt
+++ b/test-experiments/src/test/kotlin/com/jonnyzzz/mcpSteroid/integration/arena/ArenaOutputParsing.kt
@@ -32,6 +32,30 @@ data class ExecuteCodeCall(
     val result: ExecuteCodeResult?,
 )
 
+/** Result content retained from one Claude or Codex raw tool event. */
+data class AgentToolResult(
+    val isError: Boolean?,
+    val content: JsonElement?,
+) {
+    val text: String
+        get() = textOf(content)
+}
+
+/**
+ * One Claude or Codex tool call normalized across their NDJSON schemas.
+ *
+ * MCP-qualified Claude names such as `mcp__mcp-steroid__steroid_open_project` are reduced to the
+ * bare tool name. Native names such as `Bash`, `command_execution`, and names that merely contain
+ * double underscores are preserved. [arguments] and [result] retain their JSON structure so E2E
+ * assertions can prove what an agent actually submitted and received without inspecting decoded prose.
+ */
+data class AgentToolCall(
+    val callId: String,
+    val toolName: String,
+    val arguments: JsonObject,
+    val result: AgentToolResult?,
+)
+
 /** Structural MCP facts extracted from an agent's raw NDJSON transcript. */
 data class AgentTranscript(
     val executeCodeCalls: List<ExecuteCodeCall>,
@@ -79,6 +103,147 @@ private data class ResultCandidate(
     val isError: Boolean,
     val text: String,
 )
+
+private data class AgentToolCallBuilder(
+    val callId: String,
+    var toolName: String? = null,
+    var arguments: JsonObject? = null,
+    var result: AgentToolResult? = null,
+)
+
+/**
+ * Decode raw Claude Code and Codex NDJSON into ordered, ID-correlated tool calls.
+ *
+ * Claude's structured `message.content` events and its older root `tool_use` / `tool_result` events
+ * are accepted. Codex `item.started` / `item.completed` lifecycle pairs are de-duplicated by item id;
+ * MCP/function/tool calls retain their submitted JSON arguments, while native shell executions are
+ * represented as `command_execution` with a `command` argument. Malformed and unrelated lines are
+ * ignored because real agent log files may also contain non-NDJSON diagnostic text.
+ */
+fun decodeAgentToolCalls(rawNdjson: String): List<AgentToolCall> {
+    val callsById = LinkedHashMap<String, AgentToolCallBuilder>()
+
+    fun recordCall(callId: String?, rawToolName: String?, arguments: JsonObject?) {
+        if (callId == null || rawToolName == null) return
+        val call = callsById.getOrPut(callId) { AgentToolCallBuilder(callId) }
+        call.toolName = normalizeAgentToolName(rawToolName)
+        if (arguments != null && (call.arguments == null || arguments.isNotEmpty())) {
+            call.arguments = arguments
+        }
+    }
+
+    fun recordResult(callId: String?, result: AgentToolResult) {
+        if (callId == null) return
+        callsById.getOrPut(callId) { AgentToolCallBuilder(callId) }.result = result
+    }
+
+    fun parseClaudeItem(item: JsonObject) {
+        when (item["type"].stringOrNull()) {
+            "tool_use" -> recordCall(
+                callId = item["id"].stringOrNull(),
+                rawToolName = item["name"].stringOrNull(),
+                arguments = inputObject(item["input"]),
+            )
+
+            "tool_result" -> recordResult(
+                callId = item["tool_use_id"].stringOrNull(),
+                result = AgentToolResult(
+                    // Claude omits is_error on successful results.
+                    isError = item["is_error"].boolOrNull() ?: false,
+                    content = item["content"],
+                ),
+            )
+        }
+    }
+
+    rawNdjson.lineSequence().forEach lines@{ raw ->
+        if ('{' !in raw) return@lines
+        val obj = runCatching { Json.parseToJsonElement(raw) }.getOrNull() as? JsonObject
+            ?: return@lines
+
+        ((obj["message"] as? JsonObject)?.get("content") as? JsonArray)
+            ?.forEach { entry -> (entry as? JsonObject)?.let(::parseClaudeItem) }
+
+        // Older Claude stream-json events put tool_use / tool_result directly at the root.
+        if (obj["type"].stringOrNull() == "tool_use" || obj["type"].stringOrNull() == "tool_result") {
+            parseClaudeItem(obj)
+        }
+
+        val eventType = obj["type"].stringOrNull()
+        val item = obj["item"] as? JsonObject ?: return@lines
+        val itemType = item["type"].stringOrNull()
+        val callId = item["id"].stringOrNull()
+
+        if (itemType == "command_execution") {
+            val command = item["command"]
+            val arguments = if (command == null) null else JsonObject(mapOf("command" to command))
+            recordCall(callId, "command_execution", arguments)
+            if (eventType == "item.completed") {
+                val content = item["output"] ?: item["aggregated_output"] ?: item["result"] ?: item["error"]
+                recordResult(callId, AgentToolResult(codexResultIsError(item, content), content))
+            }
+            return@lines
+        }
+
+        if (itemType !in setOf("mcp_tool_call", "tool_call", "function_call")) return@lines
+        val rawToolName = item["name"].stringOrNull()
+            ?: (item["function"] as? JsonObject)?.get("name").stringOrNull()
+            ?: item["tool"].stringOrNull()
+        recordCall(callId, rawToolName, codexArguments(item))
+
+        if (eventType == "item.completed") {
+            val rawResult = item["result"] ?: item["output"] ?: item["error"]
+            val content = (rawResult as? JsonObject)?.get("content") ?: rawResult
+            recordResult(callId, AgentToolResult(codexResultIsError(item, rawResult), content))
+        }
+    }
+
+    return callsById.values.mapNotNull { call ->
+        val toolName = call.toolName ?: return@mapNotNull null
+        AgentToolCall(
+            callId = call.callId,
+            toolName = toolName,
+            arguments = call.arguments ?: JsonObject(emptyMap()),
+            result = call.result,
+        )
+    }
+}
+
+/** Extract the user-visible final response without mistaking tool output or progress prose for it. */
+fun decodeAgentFinalResponse(rawNdjson: String): String? {
+    var claudeResult: String? = null
+    var claudeAssistantText: String? = null
+    var codexAgentMessage: String? = null
+
+    rawNdjson.lineSequence().forEach { raw ->
+        if ('{' !in raw) return@forEach
+        val obj = runCatching { Json.parseToJsonElement(raw) }.getOrNull() as? JsonObject
+            ?: return@forEach
+
+        if (obj["type"].stringOrNull() == "result" && obj["subtype"].stringOrNull() == "success") {
+            obj["result"].stringOrNull()?.takeIf { it.isNotBlank() }?.let { claudeResult = it }
+        }
+
+        if (obj["type"].stringOrNull() == "assistant") {
+            val message = obj["message"] as? JsonObject
+            val text = (message?.get("content") as? JsonArray)
+                ?.mapNotNull { entry ->
+                    val item = entry as? JsonObject ?: return@mapNotNull null
+                    if (item["type"].stringOrNull() == "text") item["text"].stringOrNull() else null
+                }
+                ?.filter { it.isNotBlank() }
+                ?.joinToString("\n")
+            text?.takeIf { it.isNotBlank() }?.let { claudeAssistantText = it }
+        }
+
+        val item = obj["item"] as? JsonObject
+        if (obj["type"].stringOrNull() == "item.completed" && item?.get("type").stringOrNull() == "agent_message") {
+            item?.get("text").stringOrNull()?.takeIf { it.isNotBlank() }?.let { codexAgentMessage = it }
+        }
+    }
+
+    return claudeResult ?: claudeAssistantText ?: codexAgentMessage
+}
 
 /**
  * Normalize Claude Code, Codex, and Gemini raw NDJSON into execute-code calls/results.
@@ -212,6 +377,37 @@ private fun ExecuteCodeResult.isProjectResolutionFailure(): Boolean =
 private fun JsonElement?.stringOrNull(): String? = (this as? JsonPrimitive)?.contentOrNull
 
 private fun JsonElement?.boolOrNull(): Boolean? = (this as? JsonPrimitive)?.booleanOrNull
+
+private fun inputObject(element: JsonElement?): JsonObject? = when (element) {
+    is JsonObject -> element
+    is JsonPrimitive -> element.contentOrNull?.let { encoded ->
+        runCatching { Json.parseToJsonElement(encoded) as? JsonObject }.getOrNull()
+    }
+
+    else -> null
+}
+
+private fun codexArguments(item: JsonObject): JsonObject? {
+    val function = item["function"] as? JsonObject
+    return inputObject(item["input"])
+        ?: inputObject(item["arguments"])
+        ?: inputObject(function?.get("arguments"))
+}
+
+private fun codexResultIsError(item: JsonObject, result: JsonElement?): Boolean? {
+    val status = item["status"].stringOrNull()?.lowercase()
+    val error = item["error"]
+    val hasError = error != null && error !is JsonNull
+    val exitCode = (item["exit_code"] as? JsonPrimitive)?.contentOrNull?.toIntOrNull()
+    return when {
+        hasError || status == "failed" || status == "error" || (exitCode != null && exitCode != 0) -> true
+        status == "completed" || status == "success" || exitCode == 0 || result != null -> false
+        else -> null
+    }
+}
+
+private fun normalizeAgentToolName(rawToolName: String): String =
+    if (rawToolName.startsWith("mcp__")) rawToolName.substringAfterLast("__") else rawToolName
 
 private fun textOf(element: JsonElement?): String = when (element) {
     is JsonPrimitive -> element.contentOrNull.orEmpty()

--- a/test-experiments/src/test/kotlin/com/jonnyzzz/mcpSteroid/integration/tests/DevrigRemoteDevelopmentKeycloakTypeHierarchyTest.kt
+++ b/test-experiments/src/test/kotlin/com/jonnyzzz/mcpSteroid/integration/tests/DevrigRemoteDevelopmentKeycloakTypeHierarchyTest.kt
@@ -1,0 +1,465 @@
+/* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
+package com.jonnyzzz.mcpSteroid.integration.tests
+
+import com.jonnyzzz.mcpSteroid.integration.arena.AgentToolCall
+import com.jonnyzzz.mcpSteroid.integration.arena.decodeAgentFinalResponse
+import com.jonnyzzz.mcpSteroid.integration.arena.decodeAgentToolCalls
+import com.jonnyzzz.mcpSteroid.integration.infra.ConsoleAwareAgentSession
+import com.jonnyzzz.mcpSteroid.integration.infra.DevrigContainer
+import com.jonnyzzz.mcpSteroid.integration.infra.DevrigContainerOpts
+import com.jonnyzzz.mcpSteroid.integration.infra.IdeTestFolders
+import com.jonnyzzz.mcpSteroid.integration.infra.create
+import com.jonnyzzz.mcpSteroid.integration.infra.streamDevrigLogsToConsole
+import com.jonnyzzz.mcpSteroid.testHelper.AiAgentSession
+import com.jonnyzzz.mcpSteroid.testHelper.DockerClaudeSession
+import com.jonnyzzz.mcpSteroid.testHelper.DockerCodexSession
+import com.jonnyzzz.mcpSteroid.testHelper.docker.startProcessInContainer
+import com.jonnyzzz.mcpSteroid.testHelper.git.BareRepoCache
+import com.jonnyzzz.mcpSteroid.testHelper.git.GitDriver
+import com.jonnyzzz.mcpSteroid.testHelper.process.assertExitCode
+import com.jonnyzzz.mcpSteroid.testHelper.runWithCloseableStack
+import java.io.File
+import java.util.concurrent.TimeUnit
+import kotlinx.serialization.json.JsonPrimitive
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Timeout
+import org.junit.jupiter.api.parallel.Execution
+import org.junit.jupiter.api.parallel.ExecutionMode
+
+/** Clean-machine user journeys for devrig's IU-262 headless Remote Development backend. */
+@Execution(ExecutionMode.SAME_THREAD)
+class DevrigRemoteDevelopmentKeycloakTypeHierarchyTest {
+
+    @Test
+    @Timeout(value = 75, unit = TimeUnit.MINUTES)
+    fun `claude installs devrig and uses a remote development backend for keycloak hierarchy`() =
+        runScenario("claude")
+
+    @Test
+    @Timeout(value = 75, unit = TimeUnit.MINUTES)
+    fun `codex installs devrig and uses a remote development backend for keycloak hierarchy`() =
+        runScenario("codex")
+
+    private fun runScenario(agentName: String) = runWithCloseableStack { lifetime ->
+        BareRepoCache.ensureRepo(KEYCLOAK_REPO_URL, IdeTestFolders.repoCacheDir)
+
+        val container = DevrigContainer.create(
+            lifetime,
+            DevrigContainerOpts(
+                consoleTitle = "devrig-remote-backend-keycloak-$agentName",
+                mountRepoCache = true,
+                mountDependencyCaches = true,
+            ),
+        )
+        val console = container.console
+        console.writeHeader(
+            "test-experiments — ${this::class.simpleName} — $agentName installs devrig, " +
+                "starts IU 262 Remote Development, and queries Keycloak",
+        )
+
+        prepareKeycloak(container)
+        installDevrigForAgent(container, agentName)
+        streamDevrigLogsToConsole(lifetime, File(container.runDir, "devrig-logs"), console)
+
+        var backendMayBeRunning = false
+        try {
+            val agent = ConsoleAwareAgentSession(
+                delegate = createAgentSession(agentName, container),
+                console = console,
+                agentName = agentName,
+                logDir = container.runDir,
+            )
+            val result = agent.runPrompt(
+                buildPrompt(),
+                timeoutSeconds = 50 * 60L,
+            ).awaitForProcessFinish()
+            backendMayBeRunning = true
+
+            val toolScore = assertAgentWorkflow(result.rawStdout)
+            val finalAnswerScore = assertFinalAnswer(result.rawStdout)
+
+            assertRemoteBackendState(container)
+            if (agentName == "codex" && result.exitCode == 137) {
+                console.writeInfo("Codex exited with 137 after all workflow, semantic, and backend evidence passed")
+            } else {
+                result.assertExitCode(0, "$agentName Remote Development Keycloak hierarchy")
+            }
+            console.writeSuccess(
+                "$agentName completed the hierarchy through the IU 262 Remote Development backend " +
+                    "(${toolScore.reportedCount} tool-result subtypes, " +
+                    "${finalAnswerScore.reportedCount} final-answer subtypes)",
+            )
+        } finally {
+            try {
+                if (backendMayBeRunning || hasUltimateBackend(container)) {
+                    stopAndAssertNoBackendSurvives(container)
+                }
+            } finally {
+                sanitizePreservedBackendLog(container.runDir)
+            }
+        }
+    }
+
+    private fun prepareKeycloak(container: DevrigContainer) {
+        container.console.writeStep("Clone and pin Keycloak $KEYCLOAK_VERSION from the host bare-repository cache")
+        val cloned = GitDriver(container.scope).cloneFromCachedBare("keycloak/keycloak", PROJECT_DIR)
+        assertTrue(cloned) { "Keycloak must be available from the mounted /repo-cache bare repository." }
+        GitDriver(container.scope).checkout(PROJECT_DIR, KEYCLOAK_COMMIT)
+
+        container.execAndAssertWithConsoleStream(
+            description = "warm and verify the pinned Keycloak Maven build cache",
+            timeoutSeconds = 20 * 60L,
+            script = $$"""
+                set -euo pipefail
+                cd "$$PROJECT_DIR"
+                test "$(git rev-parse HEAD)" = "$$KEYCLOAK_COMMIT"
+                export JAVA_HOME="/usr/lib/jvm/temurin-21-jdk-$(dpkg --print-architecture)"
+                export PATH="$JAVA_HOME/bin:$PATH"
+                test -x "$JAVA_HOME/bin/java"
+                java -version
+                extension_file=.mvn/extensions.xml
+                test "$(grep -c '<version>1.2.0</version>' "$extension_file")" -eq 1
+                sed -i 's#<version>1\.2\.0</version>#<version>1.2.1</version>#' "$extension_file"
+                grep -F '<version>1.2.1</version>' "$extension_file"
+                ./mvnw -q -DskipTests -pl server-spi-private,services -am compile
+                ./mvnw -q -o -DskipTests -pl server-spi-private,services -am compile
+            """.trimIndent(),
+        )
+    }
+
+    private fun installDevrigForAgent(container: DevrigContainer, agentName: String) {
+        val listCommand = when (agentName) {
+            "claude" -> "claude mcp list"
+            "codex" -> "codex mcp list"
+            else -> error("Unknown agent: $agentName")
+        }
+        container.execAndAssertWithConsoleStream(
+            description = "user installs devrig for $agentName",
+            timeoutSeconds = 120,
+            script = $$"""
+                set -euo pipefail
+                "$${container.devrig}" install $$agentName
+                test -x "$$INSTALLED_DEVRIG"
+                registration_check_dir=/tmp/devrig-registration-check
+                mkdir -p "$registration_check_dir"
+                cd "$registration_check_dir"
+                $$listCommand > /tmp/devrig-mcp-list.txt
+                grep -F 'mcp-steroid' /tmp/devrig-mcp-list.txt >/dev/null
+            """.trimIndent(),
+        )
+    }
+
+    private fun createAgentSession(agentName: String, container: DevrigContainer): AiAgentSession =
+        when (agentName) {
+            "claude" -> DockerClaudeSession.create(container.scope)
+            "codex" -> DockerCodexSession.create(container.scope)
+            else -> error("Unknown agent: $agentName")
+        }
+
+    private fun buildPrompt(): String = buildString {
+        appendLine("# Open Keycloak in a devrig-managed IDE and report its complete Authenticator hierarchy")
+        appendLine()
+        appendLine("This is a clean machine. devrig is installed and registered as your `mcp-steroid` server,")
+        appendLine("but no IDE is installed or running. You must provision and start the IDE yourself.")
+        appendLine()
+        appendLine("1. Use your shell tool to run this exact download command:")
+        appendLine("   \"$INSTALLED_DEVRIG\" backend download idea-ultimate --version $IDE_VERSION")
+        appendLine("2. Use your shell tool to run this exact start command:")
+        appendLine("   \"$INSTALLED_DEVRIG\" backend start idea-ultimate --version $IDE_VERSION")
+        appendLine("3. Call `steroid_open_project` with `project_path=$PROJECT_DIR`. The IDE is a headless Remote")
+        appendLine("   Development backend, so no frontend window is expected. Its first boot and project import can")
+        appendLine("   take several minutes; if it is not reachable yet, wait and retry the MCP call.")
+        appendLine("4. After open_project succeeds, call `steroid_list_projects`. Its successful result must contain")
+        appendLine("   the Keycloak path `$PROJECT_DIR`. If it does not yet, retry open_project/list_projects until it does.")
+        appendLine("5. Only after Keycloak appears in list_projects, complete this semantic task in that managed IDE:")
+        appendLine()
+        append(KeycloakTypeHierarchyScenario.mcpTaskInstructions())
+    }
+
+    private fun assertAgentWorkflow(rawNdjson: String): TypeHierarchyScore {
+        val calls = decodeAgentToolCalls(rawNdjson)
+        assertTrue(calls.isNotEmpty()) { "No Claude/Codex tool calls were decoded from raw NDJSON." }
+
+        assertSuccessfulCommand(calls, INSTALLED_DEVRIG, "backend download idea-ultimate", "--version $IDE_VERSION")
+        assertSuccessfulCommand(calls, INSTALLED_DEVRIG, "backend start idea-ultimate", "--version $IDE_VERSION")
+
+        val openedProject = calls.any { call ->
+            call.toolName == "steroid_open_project" &&
+                call.argumentText("project_path") == PROJECT_DIR &&
+                call.hasSuccessfulResult()
+        }
+        assertTrue(openedProject) {
+            "Raw agent events do not contain a successful steroid_open_project for $PROJECT_DIR. " +
+                summarizeCalls(calls)
+        }
+
+        val listedKeycloak = calls.any { call ->
+            call.toolName == "steroid_list_projects" &&
+                call.hasSuccessfulResult() &&
+                call.result?.text?.contains(PROJECT_DIR) == true
+        }
+        assertTrue(listedKeycloak) {
+            "Raw agent events do not contain a successful steroid_list_projects result with $PROJECT_DIR. " +
+                summarizeCalls(calls)
+        }
+
+        val hierarchyExecutions = calls.filter { call ->
+            if (call.toolName != "steroid_execute_code" || !call.hasSuccessfulResult()) return@filter false
+            val code = call.argumentText("code")
+            code.contains("ClassInheritorsSearch") &&
+                code.contains("findAll") &&
+                DEEP_SEARCH_ARGUMENT.containsMatchIn(code)
+        }
+        assertTrue(hierarchyExecutions.isNotEmpty()) {
+            "Raw agent events do not contain a successful deep ClassInheritorsSearch execution. " +
+                summarizeCalls(calls)
+        }
+        val scores = hierarchyExecutions.map { call ->
+            scoreTypeHierarchy(
+                call.result?.text.orEmpty(),
+                KeycloakTypeHierarchyScenario.requiredTransitive,
+                KeycloakTypeHierarchyScenario.MIN_TOTAL,
+            )
+        }
+        val bestScore = scores.maxBy { it.reportedCount }
+        assertTrue(scores.any { it.complete }) {
+            "No successful deep ClassInheritorsSearch tool result contained the complete hierarchy: " +
+                "best reported=${bestScore.reportedCount}, missing=${bestScore.missingRequired}. " +
+                summarizeCalls(calls)
+        }
+        return scores.first { it.complete }
+    }
+
+    private fun assertFinalAnswer(rawNdjson: String): TypeHierarchyScore {
+        val finalResponse = decodeAgentFinalResponse(rawNdjson)
+        assertTrue(finalResponse != null) { "Raw agent events do not contain a final user-visible response." }
+        val score = scoreTypeHierarchy(
+            finalResponse.orEmpty(),
+            KeycloakTypeHierarchyScenario.requiredTransitive,
+            KeycloakTypeHierarchyScenario.MIN_TOTAL,
+        )
+        assertTrue(score.complete) {
+            "The agent final response does not contain the complete hierarchy: " +
+                "reported=${score.reportedCount}, missing=${score.missingRequired}."
+        }
+        return score
+    }
+
+    private fun assertSuccessfulCommand(calls: List<AgentToolCall>, vararg fragments: String) {
+        val succeeded = calls.any { candidate ->
+            (candidate.toolName.equals("Bash", ignoreCase = true) || candidate.toolName == "command_execution") &&
+                fragments.all { it in candidate.argumentText("command") } &&
+                candidate.hasSuccessfulResult()
+        }
+        assertTrue(succeeded) {
+            "Raw agent events do not contain a successful shell command with ${fragments.toList()}. " +
+                summarizeCalls(calls)
+        }
+    }
+
+    private fun assertRemoteBackendState(container: DevrigContainer) {
+        container.execAndAssertWithConsoleStream(
+            description = "verify IU 262 Remote Development backend, marker, plugin, log, and Keycloak route",
+            timeoutSeconds = 180,
+            script = $$"""
+                set -eEuo pipefail
+                failed_invariant="initialize Remote Development backend verification"
+                preserve_sanitized_backend_log() {
+                  local source_log="$1"
+                  sed -E 's|Bearer[[:space:]]+[$$BEARER_TOKEN_CHARACTERS]+|<redacted>|g' \
+                    "$source_log" > /mcp-run-dir/managed-backend-idea.log
+                }
+                preserve_backend_log_after_failure() {
+                  if [ -z "${cache:-}" ] || [ ! -d "$cache/logs" ]; then
+                    return 0
+                  fi
+                  local failed_idea_log
+                  failed_idea_log="$(find "$cache/logs" -type f -name 'idea.log' -print -quit)"
+                  if [ -z "$failed_idea_log" ]; then
+                    printf 'MANAGED_BACKEND_LOG_PRESERVE_SKIPPED: no idea.log under %s\n' "$cache/logs" >&2
+                    return 0
+                  fi
+                  if ! preserve_sanitized_backend_log "$failed_idea_log"; then
+                    printf 'MANAGED_BACKEND_LOG_PRESERVE_FAILED: %s\n' "$failed_idea_log" >&2
+                  fi
+                }
+                report_failed_invariant() {
+                  local status=$?
+                  local failed_line="$1"
+                  local failed_command="$2"
+                  trap - ERR
+                  set +e
+                  preserve_backend_log_after_failure
+                  printf 'REMOTE_BACKEND_INVARIANT_FAILED: %s (line=%s command=%s status=%s)\n' \
+                    "$failed_invariant" "$failed_line" "$failed_command" "$status" >&2
+                  exit "$status"
+                }
+                trap 'report_failed_invariant "$LINENO" "$BASH_COMMAND"' ERR
+
+                failed_invariant="IU 262 backend directory exists"
+                backend_dir="$(find /home/agent/.mcp-steroid/backends -mindepth 1 -maxdepth 1 -type d -name 'idea-ultimate-*' | sort | head -1)"
+                test -n "$backend_dir"
+                failed_invariant="backend descriptor exists"
+                descriptor="$backend_dir/backend.json"
+                test -f "$descriptor"
+                failed_invariant="backend descriptor is preserved in run artifacts"
+                cp "$descriptor" /mcp-run-dir/managed-backend-descriptor.json
+                failed_invariant="backend descriptor identifies the exact IU 262 build"
+                jq -e '.productKey == "idea-ultimate" and .productCode == "IU" and .version == "$$IDE_VERSION" and .buildNumber == "$$IDE_DESCRIPTOR_BUILD"' "$descriptor" >/dev/null
+                id="$(jq -r '.id' "$descriptor")"
+                bundle="$backend_dir/$(jq -r '.bundleDirName' "$descriptor")"
+                cache="/home/agent/.mcp-steroid/caches/$id"
+                failed_invariant="backend PID state exists"
+                pid="$(jq -r '.pid' "/home/agent/.mcp-steroid/state/$id.pid")"
+                marker="/home/agent/.mcp-steroid/markers/$pid.mcp-steroid"
+
+                failed_invariant="native Remote Development launcher is executable"
+                test -x "$bundle/bin/remote-dev-server"
+                failed_invariant="Remote Development plugin is installed"
+                test -d "$bundle/plugins/remote-dev-server"
+                failed_invariant="MCP Steroid plugin and EULA are installed in the backend cache"
+                test -d "$cache/plugins/mcp-steroid/lib"
+                test -f "$cache/plugins/mcp-steroid/EULA"
+                failed_invariant="backend PID is alive"
+                kill -0 "$pid"
+                failed_invariant="backend process has unattended Remote Development environment"
+                tr '\0' '\n' < "/proc/$pid/environ" > /tmp/managed-backend-environment.txt
+                grep -Fx 'REMOTE_DEV_JDK_DETECTION=false' /tmp/managed-backend-environment.txt >/dev/null
+                grep -Fx 'REMOTE_DEV_NON_INTERACTIVE=1' /tmp/managed-backend-environment.txt >/dev/null
+                grep -Fx 'REMOTE_DEV_TRUST_PROJECTS=1' /tmp/managed-backend-environment.txt >/dev/null
+                failed_invariant="backend process environment contains no agent API credentials"
+                if grep -Eq '^(ANTHROPIC_API_KEY|OPENAI_API_KEY|CODEX_API_KEY)=' /tmp/managed-backend-environment.txt; then
+                  printf 'managed backend inherited an agent API credential variable\n' >&2
+                  false
+                fi
+                failed_invariant="MCP marker matches backend PID, home, build, and managed plugin path"
+                jq -e --argjson pid "$pid" --arg home "$(readlink -f "$bundle")" --arg build "$$IDE_BUILD" \
+                  --arg plugin "$(readlink -f "$cache/plugins/mcp-steroid")" \
+                  '.pid == $pid and .ideHome == $home and .ide.build == $build and
+                   .plugin.id == "com.jonnyzzz.mcp-steroid" and .mcpSteroidServer.pluginPath == $plugin' "$marker" >/dev/null
+                failed_invariant="IDE log confirms Remote Development backend mode"
+                grep -R -F -- "IDE run mode: remote development (backend)" "$cache/logs" >/dev/null
+
+                failed_invariant="managed backend idea.log exists"
+                idea_log="$(find "$cache/logs" -type f -name 'idea.log' -print -quit)"
+                test -n "$idea_log"
+                failed_invariant="managed backend idea.log is preserved in run artifacts"
+                preserve_sanitized_backend_log "$idea_log"
+                failed_invariant="preserved managed backend idea.log contains no Bearer credential"
+                if grep -Eq 'Bearer[[:space:]]+[$$BEARER_TOKEN_CHARACTERS]+' /mcp-run-dir/managed-backend-idea.log; then
+                  printf 'preserved managed backend idea.log contains an unredacted Bearer credential\n' >&2
+                  false
+                fi
+                failed_invariant="managed backend launcher log is preserved in run artifacts"
+                cp "$cache/logs/managed.log" /mcp-run-dir/managed-backend-launcher.log
+                failed_invariant="backend JVM uses the managed plugin cache"
+                grep -F -- "-Didea.plugins.path=$cache/plugins" "$idea_log" >/dev/null
+
+                failed_invariant="managed backend idea.log has no SEVERE diagnostics"
+                if grep -n -F ' SEVERE - ' "$idea_log" > /tmp/unexpected-ide-diagnostics.txt; then
+                  cat /tmp/unexpected-ide-diagnostics.txt >&2
+                  false
+                fi
+                failed_invariant="Maven core extensions initialize without a ProvisionException"
+                if grep -n -E 'ProvisionException|ErrorInCustomProvider|MavenCoreInitializationFailure' "$idea_log" > /tmp/unexpected-ide-diagnostics.txt; then
+                  cat /tmp/unexpected-ide-diagnostics.txt >&2
+                  false
+                fi
+                failed_invariant="MCP Steroid logs no unexpected warning or error"
+                grep -n -E ' (WARN|ERROR|SEVERE) - #com\.jonnyzzz\.mcpSteroid\.' "$idea_log" | \
+                  grep -v -F '#com.jonnyzzz.mcpSteroid.execution.VcsConfirmationSilencer - [mcp-vcs-silencer]' \
+                  > /tmp/unexpected-ide-diagnostics.txt || true
+                if test -s /tmp/unexpected-ide-diagnostics.txt; then
+                  cat /tmp/unexpected-ide-diagnostics.txt >&2
+                  false
+                fi
+
+                failed_invariant="devrig project route eventually reports Keycloak"
+                project_deadline=$((SECONDS + 60))
+                while true; do
+                  if "$$INSTALLED_DEVRIG" project --json > /tmp/devrig-projects.json && \
+                    jq -e --arg path "$$PROJECT_DIR" '.projects[] | select(.path == $path)' /tmp/devrig-projects.json >/dev/null; then
+                    break
+                  fi
+                  if [ "$SECONDS" -ge "$project_deadline" ]; then
+                    false
+                  fi
+                  sleep 2
+                done
+                failed_invariant="backend remains alive after the agent disconnects"
+                kill -0 "$pid"
+                printf 'id=%s\npid=%s\n' "$id" "$pid"
+            """.trimIndent(),
+        )
+    }
+
+    private fun hasUltimateBackend(container: DevrigContainer): Boolean =
+        container.scope.startProcessInContainer {
+            args("bash", "-lc", "compgen -G '/home/agent/.mcp-steroid/backends/idea-ultimate-*' >/dev/null")
+                .timeoutSeconds(10)
+                .description("detect IU backend for cleanup")
+                .quietly()
+        }.awaitForProcessFinish().exitCode == 0
+
+    private fun sanitizePreservedBackendLog(runDir: File) {
+        val artifact = runDir.resolve("managed-backend-idea.log")
+        if (!artifact.isFile) return
+        artifact.writeText(redactBearerCredentials(artifact.readText()))
+    }
+
+    private fun stopAndAssertNoBackendSurvives(container: DevrigContainer) {
+        container.execAndAssertWithConsoleStream(
+            description = "stop IU 262 and prove no managed backend process survives",
+            timeoutSeconds = 180,
+            script = $$"""
+                set -euo pipefail
+                mapfile -t managed_pids < <(find /home/agent/.mcp-steroid/state -maxdepth 1 -type f -name 'idea-ultimate-*.pid' -exec jq -r '.pid' {} \; 2>/dev/null || true)
+                "$$INSTALLED_DEVRIG" backend stop idea-ultimate --version "$$IDE_VERSION"
+                deadline=$((SECONDS + 60))
+                for pid in "${managed_pids[@]}"; do
+                  while kill -0 "$pid" 2>/dev/null && [ "$SECONDS" -lt "$deadline" ]; do sleep 1; done
+                  if kill -0 "$pid" 2>/dev/null; then
+                    ps -fp "$pid" >&2 || true
+                    exit 1
+                  fi
+                done
+                test -z "$(find /home/agent/.mcp-steroid/state -maxdepth 1 -type f -name 'idea-ultimate-*.pid' -print -quit)"
+            """.trimIndent(),
+        )
+    }
+
+    private fun AgentToolCall.argumentText(name: String): String =
+        when (val value = arguments[name]) {
+            is JsonPrimitive -> value.content
+            null -> ""
+            else -> value.toString()
+        }
+
+    private fun AgentToolCall.hasSuccessfulResult(): Boolean = result?.isError == false
+
+    private fun summarizeCalls(calls: List<AgentToolCall>): String = calls.joinToString(
+        prefix = "Calls: ",
+        limit = 20,
+    ) { call -> "${call.toolName}(${call.arguments}) result=${call.result?.isError}" }
+
+    companion object {
+        private const val PROJECT_DIR = "/home/agent/keycloak"
+        private const val INSTALLED_DEVRIG = "/home/agent/.mcp-steroid/bin/devrig"
+        private const val KEYCLOAK_REPO_URL = "https://github.com/keycloak/keycloak.git"
+        private const val KEYCLOAK_VERSION = "26.6.4"
+        private const val KEYCLOAK_COMMIT = "dc1bfc54bf1462f7e79822adb4c59aba7e25d50f"
+        private const val IDE_VERSION = "2026.2.0.1"
+        // product-info.json / backend.json stores the numeric build; the runtime marker uses IU-<build>.
+        private const val IDE_DESCRIPTOR_BUILD = "262.8665.337"
+        private const val IDE_BUILD = "IU-262.8665.337"
+        const val BEARER_TOKEN_CHARACTERS = "A-Za-z0-9._~+/=-"
+        private val BEARER_CREDENTIAL = Regex("Bearer\\s+[$BEARER_TOKEN_CHARACTERS]+")
+        val DEEP_SEARCH_ARGUMENT = Regex(
+            "ClassInheritorsSearch\\s*\\.\\s*search\\s*\\(\\s*[^,]+,\\s*[^,]+," +
+                "\\s*(?:checkDeep\\s*=\\s*)?true\\s*\\)",
+        )
+
+        fun redactBearerCredentials(text: String): String = BEARER_CREDENTIAL.replace(text, "<redacted>")
+    }
+}

--- a/test-experiments/src/test/kotlin/com/jonnyzzz/mcpSteroid/integration/tests/DevrigRemoteDevelopmentKeycloakTypeHierarchyTest.kt
+++ b/test-experiments/src/test/kotlin/com/jonnyzzz/mcpSteroid/integration/tests/DevrigRemoteDevelopmentKeycloakTypeHierarchyTest.kt
@@ -96,7 +96,7 @@ class DevrigRemoteDevelopmentKeycloakTypeHierarchyTest {
                     stopAndAssertNoBackendSurvives(container)
                 }
             } finally {
-                sanitizePreservedBackendLog(container.runDir)
+                sanitizePreservedBackendLogs(container.runDir)
             }
         }
     }
@@ -267,8 +267,16 @@ class DevrigRemoteDevelopmentKeycloakTypeHierarchyTest {
                 failed_invariant="initialize Remote Development backend verification"
                 preserve_sanitized_backend_log() {
                   local source_log="$1"
-                  sed -E 's|Bearer[[:space:]]+[$$BEARER_TOKEN_CHARACTERS]+|<redacted>|g' \
-                    "$source_log" > /mcp-run-dir/managed-backend-idea.log
+                  local target_log="$2"
+                  sed -E \
+                    -e 's|Bearer[[:space:]]+[$$BEARER_TOKEN_CHARACTERS]+|<redacted>|g' \
+                    -e 's|([?&]_ijt=)[^&"[:space:]]+|\1<redacted>|g' \
+                    -e 's|("x-ijt"[[:space:]]*:[[:space:]]*")[^"]*(")|\1<redacted>\2|g' \
+                    "$source_log" > "$target_log"
+                }
+                backend_log_contains_credentials() {
+                  local artifact="$1"
+                  grep -Eq 'Bearer[[:space:]]+[$$BEARER_TOKEN_CHARACTERS]+|([?&]_ijt=|"x-ijt"[[:space:]]*:[[:space:]]*")[$$MARKER_CREDENTIAL_VALUE_CHARACTERS]+' "$artifact"
                 }
                 preserve_backend_log_after_failure() {
                   if [ -z "${cache:-}" ] || [ ! -d "$cache/logs" ]; then
@@ -278,10 +286,14 @@ class DevrigRemoteDevelopmentKeycloakTypeHierarchyTest {
                   failed_idea_log="$(find "$cache/logs" -type f -name 'idea.log' -print -quit)"
                   if [ -z "$failed_idea_log" ]; then
                     printf 'MANAGED_BACKEND_LOG_PRESERVE_SKIPPED: no idea.log under %s\n' "$cache/logs" >&2
-                    return 0
-                  fi
-                  if ! preserve_sanitized_backend_log "$failed_idea_log"; then
+                  elif ! preserve_sanitized_backend_log "$failed_idea_log" /mcp-run-dir/managed-backend-idea.log; then
                     printf 'MANAGED_BACKEND_LOG_PRESERVE_FAILED: %s\n' "$failed_idea_log" >&2
+                  fi
+                  local failed_launcher_log="$cache/logs/managed.log"
+                  if [ ! -f "$failed_launcher_log" ]; then
+                    printf 'MANAGED_BACKEND_LOG_PRESERVE_SKIPPED: no launcher log at %s\n' "$failed_launcher_log" >&2
+                  elif ! preserve_sanitized_backend_log "$failed_launcher_log" /mcp-run-dir/managed-backend-launcher.log; then
+                    printf 'MANAGED_BACKEND_LOG_PRESERVE_FAILED: %s\n' "$failed_launcher_log" >&2
                   fi
                 }
                 report_failed_invariant() {
@@ -345,14 +357,19 @@ class DevrigRemoteDevelopmentKeycloakTypeHierarchyTest {
                 idea_log="$(find "$cache/logs" -type f -name 'idea.log' -print -quit)"
                 test -n "$idea_log"
                 failed_invariant="managed backend idea.log is preserved in run artifacts"
-                preserve_sanitized_backend_log "$idea_log"
-                failed_invariant="preserved managed backend idea.log contains no Bearer credential"
-                if grep -Eq 'Bearer[[:space:]]+[$$BEARER_TOKEN_CHARACTERS]+' /mcp-run-dir/managed-backend-idea.log; then
-                  printf 'preserved managed backend idea.log contains an unredacted Bearer credential\n' >&2
+                preserve_sanitized_backend_log "$idea_log" /mcp-run-dir/managed-backend-idea.log
+                failed_invariant="preserved managed backend idea.log contains no marker credential"
+                if backend_log_contains_credentials /mcp-run-dir/managed-backend-idea.log; then
+                  printf 'preserved managed backend idea.log contains an unredacted marker credential\n' >&2
                   false
                 fi
                 failed_invariant="managed backend launcher log is preserved in run artifacts"
-                cp "$cache/logs/managed.log" /mcp-run-dir/managed-backend-launcher.log
+                preserve_sanitized_backend_log "$cache/logs/managed.log" /mcp-run-dir/managed-backend-launcher.log
+                failed_invariant="preserved managed backend launcher log contains no marker credential"
+                if backend_log_contains_credentials /mcp-run-dir/managed-backend-launcher.log; then
+                  printf 'preserved managed backend launcher log contains an unredacted marker credential\n' >&2
+                  false
+                fi
                 failed_invariant="backend JVM uses the managed plugin cache"
                 grep -F -- "-Didea.plugins.path=$cache/plugins" "$idea_log" >/dev/null
 
@@ -402,19 +419,34 @@ class DevrigRemoteDevelopmentKeycloakTypeHierarchyTest {
                 .quietly()
         }.awaitForProcessFinish().exitCode == 0
 
-    private fun sanitizePreservedBackendLog(runDir: File) {
-        val artifact = runDir.resolve("managed-backend-idea.log")
-        if (!artifact.isFile) return
-        artifact.writeText(redactBearerCredentials(artifact.readText()))
-    }
-
     private fun stopAndAssertNoBackendSurvives(container: DevrigContainer) {
         container.execAndAssertWithConsoleStream(
             description = "stop IU 262 and prove no managed backend process survives",
             timeoutSeconds = 180,
             script = $$"""
                 set -euo pipefail
-                mapfile -t managed_pids < <(find /home/agent/.mcp-steroid/state -maxdepth 1 -type f -name 'idea-ultimate-*.pid' -exec jq -r '.pid' {} \; 2>/dev/null || true)
+                backend_root="/home/agent/.mcp-steroid/backends/idea-ultimate-$$IDE_VERSION"
+                find_managed_backend_processes() {
+                  local proc_dir arg found
+                  for proc_dir in /proc/[0-9]*; do
+                    [ -r "$proc_dir/cmdline" ] || continue
+                    found=false
+                    while IFS= read -r -d '' arg; do
+                      case "$arg" in
+                        "$backend_root"/*) found=true ;;
+                      esac
+                    done < "$proc_dir/cmdline" 2>/dev/null || continue
+                    if $found; then
+                      printf '%s\n' "${proc_dir##*/}"
+                    fi
+                  done
+                }
+                mapfile -t managed_pids < <(
+                  {
+                    find /home/agent/.mcp-steroid/state -maxdepth 1 -type f -name 'idea-ultimate-*.pid' -exec jq -r '.pid' {} \; 2>/dev/null || true
+                    find_managed_backend_processes
+                  } | sort -nu
+                )
                 "$$INSTALLED_DEVRIG" backend stop idea-ultimate --version "$$IDE_VERSION"
                 deadline=$((SECONDS + 60))
                 for pid in "${managed_pids[@]}"; do
@@ -423,6 +455,19 @@ class DevrigRemoteDevelopmentKeycloakTypeHierarchyTest {
                     ps -fp "$pid" >&2 || true
                     exit 1
                   fi
+                done
+                while true; do
+                  mapfile -t surviving_managed_pids < <(find_managed_backend_processes | sort -nu)
+                  if [ "${#surviving_managed_pids[@]}" -eq 0 ]; then
+                    break
+                  fi
+                  if [ "$SECONDS" -ge "$deadline" ]; then
+                    printf 'managed launcher/backend processes survived teardown: %s\n' \
+                      "${surviving_managed_pids[*]}" >&2
+                    for pid in "${surviving_managed_pids[@]}"; do ps -fp "$pid" >&2 || true; done
+                    exit 1
+                  fi
+                  sleep 1
                 done
                 test -z "$(find /home/agent/.mcp-steroid/state -maxdepth 1 -type f -name 'idea-ultimate-*.pid' -print -quit)"
             """.trimIndent(),
@@ -454,12 +499,30 @@ class DevrigRemoteDevelopmentKeycloakTypeHierarchyTest {
         private const val IDE_DESCRIPTOR_BUILD = "262.8665.337"
         private const val IDE_BUILD = "IU-262.8665.337"
         const val BEARER_TOKEN_CHARACTERS = "A-Za-z0-9._~+/=-"
+        const val MARKER_CREDENTIAL_VALUE_CHARACTERS = "A-Za-z0-9._~+/%=-"
         private val BEARER_CREDENTIAL = Regex("Bearer\\s+[$BEARER_TOKEN_CHARACTERS]+")
+        private val IJT_QUERY_CREDENTIAL = Regex("([?&]_ijt=)[^&\"\\s]+")
+        private val IJT_HEADER_CREDENTIAL = Regex("(\"x-ijt\"\\s*:\\s*\")[^\"]*(\")")
         val DEEP_SEARCH_ARGUMENT = Regex(
             "ClassInheritorsSearch\\s*\\.\\s*search\\s*\\(\\s*[^,]+,\\s*[^,]+," +
                 "\\s*(?:checkDeep\\s*=\\s*)?true\\s*\\)",
         )
 
-        fun redactBearerCredentials(text: String): String = BEARER_CREDENTIAL.replace(text, "<redacted>")
+        fun redactMarkerCredentials(text: String): String {
+            val withoutBearer = BEARER_CREDENTIAL.replace(text, "<redacted>")
+            val withoutIjtQuery = IJT_QUERY_CREDENTIAL.replace(withoutBearer) { match ->
+                match.groupValues[1] + "<redacted>"
+            }
+            return IJT_HEADER_CREDENTIAL.replace(withoutIjtQuery) { match ->
+                match.groupValues[1] + "<redacted>" + match.groupValues[2]
+            }
+        }
+
+        fun sanitizePreservedBackendLogs(runDir: File) {
+            listOf("managed-backend-idea.log", "managed-backend-launcher.log").forEach { artifactName ->
+                val artifact = runDir.resolve(artifactName)
+                if (artifact.isFile) artifact.writeText(redactMarkerCredentials(artifact.readText()))
+            }
+        }
     }
 }

--- a/test-experiments/src/test/kotlin/com/jonnyzzz/mcpSteroid/integration/tests/DevrigRemoteDevelopmentWorkflowTest.kt
+++ b/test-experiments/src/test/kotlin/com/jonnyzzz/mcpSteroid/integration/tests/DevrigRemoteDevelopmentWorkflowTest.kt
@@ -1,0 +1,41 @@
+/* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
+package com.jonnyzzz.mcpSteroid.integration.tests
+
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class DevrigRemoteDevelopmentWorkflowTest {
+
+    @Test
+    fun `deep hierarchy verifier accepts multiline qualified search call`() {
+        val code = """
+            val inheritors = ClassInheritorsSearch
+                .search(baseClass, GlobalSearchScope.allScope(project), true)
+                .findAll()
+        """.trimIndent()
+
+        assertTrue(DevrigRemoteDevelopmentKeycloakTypeHierarchyTest.DEEP_SEARCH_ARGUMENT.containsMatchIn(code))
+    }
+
+    @Test
+    fun `deep hierarchy verifier rejects false followed by unrelated true`() {
+        val code = """
+            val inheritors = ClassInheritorsSearch.search(baseClass, scope, false).findAll()
+            val unrelated = true
+        """.trimIndent()
+
+        assertTrue(!DevrigRemoteDevelopmentKeycloakTypeHierarchyTest.DEEP_SEARCH_ARGUMENT.containsMatchIn(code))
+    }
+
+    @Test
+    fun `preserved backend log redacts Bearer credentials without dropping diagnostics`() {
+        val original =
+            "INFO marker headers={Authorization=Bearer secret_token-123+/=} diagnostics=remote-development-backend"
+
+        val redacted = DevrigRemoteDevelopmentKeycloakTypeHierarchyTest.redactBearerCredentials(original)
+
+        assertTrue("secret_token-123+/=" !in redacted)
+        assertTrue("<redacted>" in redacted)
+        assertTrue("diagnostics=remote-development-backend" in redacted)
+    }
+}

--- a/test-experiments/src/test/kotlin/com/jonnyzzz/mcpSteroid/integration/tests/DevrigRemoteDevelopmentWorkflowTest.kt
+++ b/test-experiments/src/test/kotlin/com/jonnyzzz/mcpSteroid/integration/tests/DevrigRemoteDevelopmentWorkflowTest.kt
@@ -1,8 +1,11 @@
 /* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
 package com.jonnyzzz.mcpSteroid.integration.tests
 
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Path
 
 class DevrigRemoteDevelopmentWorkflowTest {
 
@@ -28,14 +31,48 @@ class DevrigRemoteDevelopmentWorkflowTest {
     }
 
     @Test
-    fun `preserved backend log redacts Bearer credentials without dropping diagnostics`() {
+    fun `preserved backend log redacts every marker credential without dropping diagnostics`() {
         val original =
-            "INFO marker headers={Authorization=Bearer secret_token-123+/=} diagnostics=remote-development-backend"
+            "INFO marker Authorization=Bearer bearer_secret-123+/= " +
+                "aboutUrl=https://127.0.0.1/api/about?foo=1&_ijt=ijt_query_secret%2B&next=2 " +
+                "headers={\"x-ijt\": \"ijt_header_secret-123\"} diagnostics=remote-development-backend"
 
-        val redacted = DevrigRemoteDevelopmentKeycloakTypeHierarchyTest.redactBearerCredentials(original)
+        val redacted = DevrigRemoteDevelopmentKeycloakTypeHierarchyTest.redactMarkerCredentials(original)
 
-        assertTrue("secret_token-123+/=" !in redacted)
-        assertTrue("<redacted>" in redacted)
+        assertTrue("bearer_secret-123+/=" !in redacted)
+        assertTrue("ijt_query_secret%2B" !in redacted)
+        assertTrue("ijt_header_secret-123" !in redacted)
+        assertTrue("&_ijt=<redacted>&next=2" in redacted)
+        assertTrue("\"x-ijt\": \"<redacted>\"" in redacted)
         assertTrue("diagnostics=remote-development-backend" in redacted)
+    }
+
+    @Test
+    fun `final artifact sanitizer redacts both idea and launcher logs`(@TempDir tempDir: Path) {
+        val ideaLog = tempDir.resolve("managed-backend-idea.log").toFile()
+        val launcherLog = tempDir.resolve("managed-backend-launcher.log").toFile()
+        ideaLog.writeText(
+            "idea Authorization=Bearer idea_bearer " +
+                "aboutUrl=http://localhost/api/about?_ijt=idea_query " +
+                "headers={\"x-ijt\":\"idea_header\"} diagnostics=idea",
+        )
+        launcherLog.writeText(
+            "launcher Authorization=Bearer launcher_bearer " +
+                "aboutUrl=http://localhost/api/about?_ijt=launcher_query " +
+                "headers={\"x-ijt\":\"launcher_header\"} diagnostics=launcher",
+        )
+
+        DevrigRemoteDevelopmentKeycloakTypeHierarchyTest.sanitizePreservedBackendLogs(tempDir.toFile())
+
+        assertEquals(
+            "idea Authorization=<redacted> aboutUrl=http://localhost/api/about?_ijt=<redacted> " +
+                "headers={\"x-ijt\":\"<redacted>\"} diagnostics=idea",
+            ideaLog.readText(),
+        )
+        assertEquals(
+            "launcher Authorization=<redacted> aboutUrl=http://localhost/api/about?_ijt=<redacted> " +
+                "headers={\"x-ijt\":\"<redacted>\"} diagnostics=launcher",
+            launcherLog.readText(),
+        )
     }
 }

--- a/test-experiments/src/test/kotlin/com/jonnyzzz/mcpSteroid/integration/tests/KeycloakTypeHierarchyScenario.kt
+++ b/test-experiments/src/test/kotlin/com/jonnyzzz/mcpSteroid/integration/tests/KeycloakTypeHierarchyScenario.kt
@@ -1,0 +1,44 @@
+/* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
+package com.jonnyzzz.mcpSteroid.integration.tests
+
+/** Shared task contract for every Keycloak Authenticator hierarchy experiment. */
+object KeycloakTypeHierarchyScenario {
+    const val INTERFACE_FQN: String = "org.keycloak.authentication.Authenticator"
+    const val MIN_TOTAL: Int = 40
+
+    // Indirect implementors a text search for `implements Authenticator` misses.
+    val requiredTransitive: Set<String> = setOf(
+        "org.keycloak.authentication.authenticators.browser.UsernamePasswordForm",
+        "org.keycloak.authentication.authenticators.browser.OTPFormAuthenticator",
+        "org.keycloak.authentication.authenticators.broker.IdpConfirmLinkAuthenticator",
+    )
+
+    fun mcpTaskInstructions(): String = buildString {
+        appendLine("Task: list EVERY class that implements the interface `$INTERFACE_FQN`,")
+        appendLine("INCLUDING transitive/indirect implementors (a class that extends an abstract base which")
+        appendLine("implements the interface still counts). Be exhaustive.")
+        appendLine()
+        appendLine("Use IntelliJ's PSI inheritance search via `steroid_execute_code`. BEFORE executing code,")
+        appendLine("fetch `mcp-steroid://ide/type-hierarchy`, then adapt that recipe to use")
+        appendLine("`ClassInheritorsSearch.search(psiClass, GlobalSearchScope.allScope(project), true)`.")
+        appendLine("Print the FULL, untruncated transitive result (raise any recipe limit above 200).")
+        appendLine("Do not rely on text search.")
+        appendLine()
+        append(outputFormat(includeToolEvidence = true))
+    }
+
+    fun baselineTaskInstructions(): String = buildString {
+        appendLine("Task: list EVERY class that implements the interface `$INTERFACE_FQN`,")
+        appendLine("INCLUDING transitive/indirect implementors (a class that extends an abstract base which")
+        appendLine("implements the interface still counts). Be exhaustive.")
+        appendLine()
+        append(outputFormat(includeToolEvidence = false))
+    }
+
+    private fun outputFormat(includeToolEvidence: Boolean): String = buildString {
+        appendLine("Output (markers on their own lines):")
+        appendLine("SUBTYPES_FOUND: <total count>")
+        appendLine("SUBTYPE: <fully.qualified.ClassName>   ← one line per implementor, including transitive ones")
+        if (includeToolEvidence) appendLine("TOOL_EVIDENCE: <copy the line starting with execution_id: ...>")
+    }
+}

--- a/test-experiments/src/test/kotlin/com/jonnyzzz/mcpSteroid/integration/tests/KeycloakTypeHierarchyTest.kt
+++ b/test-experiments/src/test/kotlin/com/jonnyzzz/mcpSteroid/integration/tests/KeycloakTypeHierarchyTest.kt
@@ -69,7 +69,11 @@ class KeycloakTypeHierarchyTest {
             val agentDurationMs = System.currentTimeMillis() - startedAt
             val combined = result.stdout + "\n" + result.stderr
 
-            val score = scoreTypeHierarchy(combined, REQUIRED_TRANSITIVE, MIN_TOTAL)
+            val score = scoreTypeHierarchy(
+                combined,
+                KeycloakTypeHierarchyScenario.requiredTransitive,
+                KeycloakTypeHierarchyScenario.MIN_TOTAL,
+            )
             println("[TEST] keycloak type-hierarchy [$agentName+$modeLabel] complete=${score.complete} " +
                     "reported=${score.reportedCount} missing=${score.missingRequired}")
 
@@ -98,48 +102,17 @@ class KeycloakTypeHierarchyTest {
     private fun withMcpPrompt(): String = buildString {
         appendLine("The Keycloak project is open in IntelliJ IDEA — a large multi-module Java project.")
         appendLine()
-        appendLine("Task: list EVERY class that implements the interface `$INTERFACE_FQN`,")
-        appendLine("INCLUDING transitive/indirect implementors (a class that extends an abstract base which")
-        appendLine("implements the interface still counts). Be exhaustive.")
-        appendLine()
-        appendLine("Use IntelliJ's PSI inheritance search via `steroid_execute_code`. BEFORE your first attempt,")
-        appendLine("fetch `mcp-steroid://lsp/find-references` / the type-hierarchy recipe, then use")
-        appendLine("`ClassInheritorsSearch.search(psiClass, GlobalSearchScope.allScope(project), /*checkDeep=*/ true)`")
-        appendLine("to walk the FULL transitive hierarchy. Do not rely on text search.")
-        appendLine()
-        appendLine("Output (markers on their own lines):")
-        appendLine("SUBTYPES_FOUND: <total count>")
-        appendLine("SUBTYPE: <fully.qualified.ClassName>   ← one line per implementor, including transitive ones")
-        appendLine("TOOL_EVIDENCE: <copy the line starting with execution_id: ...>")
+        append(KeycloakTypeHierarchyScenario.mcpTaskInstructions())
     }
 
     private fun baselinePrompt(): String = buildString {
         appendLine("The Keycloak project is checked out (a large multi-module Java project).")
         appendLine("IntelliJ MCP tools are unavailable in this run — use shell commands only (grep/rg/find).")
         appendLine()
-        appendLine("Task: list EVERY class that implements the interface `$INTERFACE_FQN`,")
-        appendLine("INCLUDING transitive/indirect implementors (a class that extends an abstract base which")
-        appendLine("implements the interface still counts). Be exhaustive.")
-        appendLine()
-        appendLine("Output (markers on their own lines):")
-        appendLine("SUBTYPES_FOUND: <total count>")
-        appendLine("SUBTYPE: <fully.qualified.ClassName>   ← one line per implementor, including transitive ones")
+        append(KeycloakTypeHierarchyScenario.baselineTaskInstructions())
     }
 
     companion object {
         private const val SCENARIO = "keycloak__type_hierarchy"
-        private const val INTERFACE_FQN = "org.keycloak.authentication.Authenticator"
-
-        // Transitive (indirect) implementors a naive `grep "implements Authenticator"` MISSES — they
-        // extend an abstract base that implements the interface. Verified against the Keycloak source.
-        private val REQUIRED_TRANSITIVE = setOf(
-            "org.keycloak.authentication.authenticators.browser.UsernamePasswordForm",
-            "org.keycloak.authentication.authenticators.browser.OTPFormAuthenticator",
-            "org.keycloak.authentication.authenticators.broker.IdpConfirmLinkAuthenticator",
-        )
-
-        // Keycloak has ~60 Authenticator implementors; require a healthy fraction so a near-empty
-        // (or only-direct) answer scores incomplete.
-        private const val MIN_TOTAL = 40
     }
 }

--- a/test-integration/src/main/kotlin/com/jonnyzzz/mcpSteroid/integration/infra/devrig-container.kt
+++ b/test-integration/src/main/kotlin/com/jonnyzzz/mcpSteroid/integration/infra/devrig-container.kt
@@ -11,6 +11,12 @@ import com.jonnyzzz.mcpSteroid.testHelper.process.ProcessResult
 import com.jonnyzzz.mcpSteroid.testHelper.process.ProcessStreamType
 import com.jonnyzzz.mcpSteroid.testHelper.process.assertExitCode
 import java.io.File
+import java.nio.channels.Channels
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import java.nio.file.LinkOption
+import java.nio.file.Path
+import java.nio.file.StandardOpenOption
 import java.util.UUID
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.zip.ZipFile
@@ -39,6 +45,12 @@ data class DevrigContainerOpts(
      * [com.jonnyzzz.mcpSteroid.testHelper.git.GitDriver.cloneFromCachedBare] instead of a full network fetch.
      */
     val mountRepoCache: Boolean = false,
+    /**
+     * Persist Maven and Gradle dependency caches across containers. This mounts only `/home/agent/.m2` and
+     * `/home/agent/.gradle`; devrig's backend markers and configuration under [DEVRIG_GUEST_HOME] remain
+     * container-local so every scenario still starts with clean devrig state.
+     */
+    val mountDependencyCaches: Boolean = false,
 )
 
 class DevrigContainer(
@@ -149,14 +161,27 @@ class DevrigContainer(
  * (so interleaved output from multiple devrig processes stays attributable).
  */
 fun streamDevrigLogsToConsole(lifetime: CloseableStack, hostLogsDir: File, console: ConsoleDriver) {
+    val realLogsRoot = hostLogsDir.toPath().toRealPath()
+    require(Files.isDirectory(realLogsRoot, LinkOption.NOFOLLOW_LINKS)) {
+        "devrig log root is not a real directory: $realLogsRoot"
+    }
     val stopped = java.util.concurrent.atomic.AtomicBoolean(false)
     val followed = java.util.concurrent.ConcurrentHashMap.newKeySet<String>()
+    val followers = java.util.concurrent.ConcurrentHashMap.newKeySet<Thread>()
+    val warnedUnsafe = java.util.concurrent.ConcurrentHashMap.newKeySet<String>()
     val logName = Regex("""devrig-.*\.log""")
 
-    fun follow(file: File) {
-        thread(start = true, isDaemon = true, name = "devrig-log-tee-${file.name}") {
+    fun warnUnsafe(path: Path, reason: String) {
+        if (warnedUnsafe.add(path.toString())) {
+            System.err.println("devrig log scanner rejected $path: $reason")
+        }
+    }
+
+    fun follow(file: Path) {
+        val follower = thread(start = false, isDaemon = true, name = "devrig-log-tee-${file.fileName}") {
             try {
-                file.bufferedReader().use { reader ->
+                Files.newByteChannel(file, StandardOpenOption.READ, LinkOption.NOFOLLOW_LINKS).use { channel ->
+                    val reader = Channels.newReader(channel, StandardCharsets.UTF_8).buffered()
                     while (!stopped.get()) {
                         val line = reader.readLine()
                         if (line == null) {
@@ -168,28 +193,114 @@ fun streamDevrigLogsToConsole(lifetime: CloseableStack, hostLogsDir: File, conso
                         }
                     }
                 }
+            } catch (e: InterruptedException) {
+                Thread.currentThread().interrupt()
+                System.err.println("devrig log tee for ${file.fileName} was interrupted (teardown=${stopped.get()})")
             } catch (e: Exception) {
-                if (!stopped.get()) System.err.println("devrig log tee for ${file.name} stopped: ${e.message}")
+                System.err.println("devrig log tee for ${file.fileName} stopped (teardown=${stopped.get()}): ${e.message}")
             }
         }
+        followers += follower
+        follower.start()
     }
 
     val scanner = thread(start = true, isDaemon = true, name = "devrig-log-tee-scan") {
-        while (!stopped.get()) {
-            try {
-                hostLogsDir.listFiles { f -> f.isFile && logName.matches(f.name) }?.forEach { f ->
-                    if (followed.add(f.absolutePath)) follow(f)
+        try {
+            while (!stopped.get()) {
+                try {
+                    Files.list(realLogsRoot).use { paths ->
+                        paths.forEach { candidate ->
+                            if (!logName.matches(candidate.fileName.toString())) return@forEach
+                            try {
+                                val normalized = candidate.toAbsolutePath().normalize()
+                                if (normalized.parent != realLogsRoot) {
+                                    warnUnsafe(candidate, "path escapes the real log root")
+                                    return@forEach
+                                }
+                                if (!Files.isRegularFile(normalized, LinkOption.NOFOLLOW_LINKS)) {
+                                    warnUnsafe(candidate, "not a no-follow regular file")
+                                    return@forEach
+                                }
+                                val resolved = normalized.toRealPath(LinkOption.NOFOLLOW_LINKS)
+                                if (resolved.parent != realLogsRoot || !resolved.startsWith(realLogsRoot)) {
+                                    warnUnsafe(candidate, "resolved path escapes the real log root")
+                                    return@forEach
+                                }
+                                if (followed.add(resolved.toString())) follow(resolved)
+                            } catch (e: Exception) {
+                                System.err.println("devrig log scanner failed to inspect $candidate: ${e.message}")
+                            }
+                        }
+                    }
+                } catch (e: Exception) {
+                    System.err.println("devrig log scan iteration failed and will retry: ${e.message}")
                 }
-            } catch (e: Exception) {
-                System.err.println("devrig log scan error: ${e.message}")
+                Thread.sleep(1_000)
             }
-            Thread.sleep(1_000)
+        } catch (e: InterruptedException) {
+            Thread.currentThread().interrupt()
+            System.err.println("devrig log scan was interrupted (teardown=${stopped.get()})")
+        } catch (e: Exception) {
+            System.err.println("devrig log scan error: ${e.message}")
         }
     }
     lifetime.registerCleanupAction {
         stopped.set(true)
-        scanner.interrupt()
+        joinDevrigLogThread(scanner, 2_500)
+        followers.toList().forEach { follower -> joinDevrigLogThread(follower, 1_500) }
     }
+}
+
+private fun joinDevrigLogThread(thread: Thread, timeoutMillis: Long) {
+    try {
+        thread.join(timeoutMillis)
+    } catch (e: InterruptedException) {
+        Thread.currentThread().interrupt()
+        System.err.println("interrupted while joining ${thread.name} during devrig log teardown: ${e.message}")
+        throw IllegalStateException("interrupted while joining ${thread.name}", e)
+    }
+    check(!thread.isAlive) { "devrig log thread did not stop within ${timeoutMillis}ms: ${thread.name}" }
+}
+
+fun devrigContainerVolumes(runDir: File, opts: DevrigContainerOpts): List<ContainerVolume> = buildList {
+    add(ContainerVolume(runDir, "/mcp-run-dir", "rw"))
+    if (opts.mountRepoCache) {
+        // repoCacheDir mkdirs()-es itself and errors if `test.integration.repo.cache.dir` is unset,
+        // so the mount source always exists (no silent skip on a missing dir).
+        add(ContainerVolume(IdeTestFolders.repoCacheDir, "/repo-cache", "ro"))
+    }
+    if (opts.mountDependencyCaches) {
+        addAll(IdeTestFolders.dependencyCacheVolumes())
+    }
+
+    // ALWAYS bind-mount ONLY devrig's logs dir out to THIS RUN's folder (`<runDir>/devrig-logs`) — never
+    // to the host's real `~/.mcp-steroid` (would trigger a macOS trust prompt and pollute the user's
+    // home), and never the whole home (the multi-GB downloaded IDE + caches would make a bind mount far
+    // too slow). The JVM-side monitor ([streamDevrigLogsToConsole]) tails these files directly.
+    val hostLogs = File(runDir, "devrig-logs").also {
+        it.mkdirs()
+        // a+rwx so the in-container `agent` (uid 1000) can write log files through the bind mount
+        // on Linux CI (no UID remap); macOS virtiofs maps the uid transparently.
+        it.setReadable(true, false); it.setWritable(true, false); it.setExecutable(true, false)
+    }
+    add(ContainerVolume(hostLogs, DEVRIG_GUEST_LOGS_DIR, "rw"))
+
+    // Bind-mount the shared host IDE-archive cache ([IdeTestFolders.ideDownloadDir], the same dir the
+    // IDE-image download uses) RW at devrig's downloads dir. The first managed-backend run downloads the
+    // ~1.5GB IDE archive into it; subsequent runs (and the IDE-image build) reuse it via IdeDownloader's
+    // skip-if-exists. RW so the cache self-populates. IdeDownloader names archives `<hash>-<filename>`
+    // (hash of URL + checksum), so Community and Ultimate — which BOTH ship as `idea-<version>.tar.gz` —
+    // never collide in this shared dir.
+    val ideDownloadsCache = IdeTestFolders.ideDownloadDir.also {
+        it.mkdirs()
+        // a+rwx (same as devrig-logs above) so the in-container `agent` (uid 1000) can create the
+        // `.tmp` download file through the bind mount on Linux CI (no UID remap). Must run even when
+        // the dir pre-exists: the host-side IDE-image download creates it first with default 0755
+        // (intelliJ-download.kt), which leaves it read-only for uid 1000 -> devrig's backend download
+        // fails with FileNotFoundException (Permission denied) and exit code 64.
+        it.setReadable(true, false); it.setWritable(true, false); it.setExecutable(true, false)
+    }
+    add(ContainerVolume(ideDownloadsCache, DEVRIG_GUEST_DOWNLOADS_DIR, "rw"))
 }
 
 fun DevrigContainer.Companion.create(lifetime: CloseableStack, opts: DevrigContainerOpts) : DevrigContainer {
@@ -205,44 +316,9 @@ fun DevrigContainer.Companion.create(lifetime: CloseableStack, opts: DevrigConta
 
     val containerMountedPath = "/mcp-run-dir"
 
-    val volumes = buildList {
-        add(ContainerVolume(runDir, containerMountedPath, "rw"))
-        if (opts.mountRepoCache) {
-            // repoCacheDir mkdirs()-es itself and errors if `test.integration.repo.cache.dir` is unset,
-            // so the mount source always exists (no silent skip on a missing dir).
-            add(ContainerVolume(IdeTestFolders.repoCacheDir, "/repo-cache", "ro"))
-        }
-        // ALWAYS bind-mount ONLY devrig's logs dir out to THIS RUN's folder (`<runDir>/devrig-logs`) — never
-        // to the host's real `~/.mcp-steroid` (would trigger a macOS trust prompt and pollute the user's
-        // home), and never the whole home (the multi-GB downloaded IDE + caches would make a bind mount far
-        // too slow). The JVM-side monitor ([streamDevrigLogsToConsole]) tails these files directly.
-        val hostLogs = File(runDir, "devrig-logs").also {
-            it.mkdirs()
-            // a+rwx so the in-container `agent` (uid 1000) can write log files through the bind mount
-            // on Linux CI (no UID remap); macOS virtiofs maps the uid transparently.
-            it.setReadable(true, false); it.setWritable(true, false); it.setExecutable(true, false)
-        }
-        add(ContainerVolume(hostLogs, DEVRIG_GUEST_LOGS_DIR, "rw"))
+    val volumes = devrigContainerVolumes(runDir, opts)
 
-        // Bind-mount the shared host IDE-archive cache ([IdeTestFolders.ideDownloadDir], the same dir the
-        // IDE-image download uses) RW at devrig's downloads dir. The first managed-backend run downloads the
-        // ~1.5GB IDE archive into it; subsequent runs (and the IDE-image build) reuse it via IdeDownloader's
-        // skip-if-exists. RW so the cache self-populates. IdeDownloader names archives `<hash>-<filename>`
-        // (hash of URL + checksum), so Community and Ultimate — which BOTH ship as `idea-<version>.tar.gz` —
-        // never collide in this shared dir.
-        val ideDownloadsCache = IdeTestFolders.ideDownloadDir.also {
-            it.mkdirs()
-            // a+rwx (same as devrig-logs above) so the in-container `agent` (uid 1000) can create the
-            // `.tmp` download file through the bind mount on Linux CI (no UID remap). Must run even when
-            // the dir pre-exists: the host-side IDE-image download creates it first with default 0755
-            // (intelliJ-download.kt), which leaves it read-only for uid 1000 -> devrig's backend download
-            // fails with FileNotFoundException (Permission denied) and exit code 64.
-            it.setReadable(true, false); it.setWritable(true, false); it.setExecutable(true, false)
-        }
-        add(ContainerVolume(ideDownloadsCache, DEVRIG_GUEST_DOWNLOADS_DIR, "rw"))
-    }
-
-    val containerEnv = buildMap<String, String> {
+    val containerEnv = buildMap {
         // Every devrig process in this container is debuggable: DEVRIG_DEBUG makes the devrig start script
         // pick a FREE, PID-seeded JDWP port from the published 23900-23999 range, so the concurrent devrig
         // processes a managed-backend test spawns (mpc + backend download/start + the agent's CLI calls)

--- a/test-integration/src/test/kotlin/com/jonnyzzz/mcpSteroid/integration/infra/DevrigContainerVolumesTest.kt
+++ b/test-integration/src/test/kotlin/com/jonnyzzz/mcpSteroid/integration/infra/DevrigContainerVolumesTest.kt
@@ -1,0 +1,68 @@
+/* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
+package com.jonnyzzz.mcpSteroid.integration.infra
+
+import com.jonnyzzz.mcpSteroid.testHelper.docker.ContainerVolume
+import java.nio.file.Path
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+
+class DevrigContainerVolumesTest {
+    @TempDir
+    lateinit var tempDir: Path
+
+    @Test
+    fun `dependency caches are not mounted by default`() {
+        val volumes = devrigContainerVolumes(
+            runDir = tempDir.toFile(),
+            opts = DevrigContainerOpts(consoleTitle = "test"),
+        )
+
+        assertEquals(
+            setOf("/mcp-run-dir", DEVRIG_GUEST_LOGS_DIR, DEVRIG_GUEST_DOWNLOADS_DIR),
+            volumes.mapTo(mutableSetOf()) { it.guest },
+        )
+        assertNoDevrigHomeMount(volumes)
+    }
+
+    @Test
+    fun `dependency cache opt in adds only Maven and Gradle caches`() {
+        val defaultVolumes = devrigContainerVolumes(
+            runDir = tempDir.resolve("default").toFile(),
+            opts = DevrigContainerOpts(consoleTitle = "default"),
+        )
+        val cachedVolumes = devrigContainerVolumes(
+            runDir = tempDir.resolve("cached").toFile(),
+            opts = DevrigContainerOpts(
+                consoleTitle = "cached",
+                mountDependencyCaches = true,
+            ),
+        )
+
+        val defaultGuests = defaultVolumes.mapTo(mutableSetOf()) { it.guest }
+        val cachedByGuest = cachedVolumes.associateBy { it.guest }
+        assertEquals(
+            setOf("/home/agent/.m2", "/home/agent/.gradle"),
+            cachedByGuest.keys - defaultGuests,
+        )
+        assertEquals(
+            IdeTestFolders.dependencyCacheDir.resolve("m2").canonicalFile,
+            cachedByGuest.getValue("/home/agent/.m2").host.canonicalFile,
+        )
+        assertEquals(
+            IdeTestFolders.dependencyCacheDir.resolve("gradle").canonicalFile,
+            cachedByGuest.getValue("/home/agent/.gradle").host.canonicalFile,
+        )
+        assertEquals("rw", cachedByGuest.getValue("/home/agent/.m2").mode)
+        assertEquals("rw", cachedByGuest.getValue("/home/agent/.gradle").mode)
+        assertNoDevrigHomeMount(cachedVolumes)
+    }
+
+    private fun assertNoDevrigHomeMount(volumes: List<ContainerVolume>) {
+        assertFalse(
+            volumes.any { it.guest.trimEnd('/') == DEVRIG_GUEST_HOME },
+            "The whole devrig home must stay container-local so backend markers and configuration start clean",
+        )
+    }
+}

--- a/test-integration/src/test/kotlin/com/jonnyzzz/mcpSteroid/integration/infra/DevrigLogStreamingTest.kt
+++ b/test-integration/src/test/kotlin/com/jonnyzzz/mcpSteroid/integration/infra/DevrigLogStreamingTest.kt
@@ -1,0 +1,188 @@
+/* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
+package com.jonnyzzz.mcpSteroid.integration.infra
+
+import com.jonnyzzz.mcpSteroid.testHelper.CloseableStackHost
+import com.jonnyzzz.mcpSteroid.testHelper.docker.ContainerDriver
+import com.jonnyzzz.mcpSteroid.testHelper.docker.StartContainerRequest
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.concurrent.atomic.AtomicReference
+import kotlinx.coroutines.channels.Channel
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+
+class DevrigLogStreamingTest {
+
+    @Test
+    fun `cleanup stops log scanner naturally without interruption or an uncaught exception`(@TempDir logsDir: Path) {
+        val lifetime = CloseableStackHost("devrig-log-stream-test")
+        val lineChannel = Channel<ByteArray>(Channel.UNLIMITED)
+        val console = ConsoleDriver(
+            container = ContainerDriver(
+                logPrefix = "devrig-log-stream-test",
+                containerId = "not-used",
+                startRequest = StartContainerRequest(),
+            ),
+            consoleFile = "/not-used",
+            lineChannel = lineChannel,
+        )
+        Files.writeString(logsDir.resolve("devrig-cleanup.log"), "cleanup follower\n")
+        val threadsBefore = Thread.getAllStackTraces().keys.mapTo(mutableSetOf()) { it.threadId() }
+
+        try {
+            streamDevrigLogsToConsole(lifetime, logsDir.toFile(), console)
+            val scanner = awaitThread(threadsBefore, "devrig-log-tee-scan")
+            val follower = awaitThread(threadsBefore, "devrig-log-tee-devrig-cleanup.log")
+            val uncaught = AtomicReference<Throwable?>()
+            scanner.uncaughtExceptionHandler = Thread.UncaughtExceptionHandler { _, error -> uncaught.set(error) }
+            follower.uncaughtExceptionHandler = Thread.UncaughtExceptionHandler { _, error -> uncaught.set(error) }
+
+            awaitTimedWaiting(scanner)
+            awaitTimedWaiting(follower)
+            lifetime.closeAllStacks()
+
+            assertFalse(scanner.isAlive, "devrig log scanner must terminate during cleanup")
+            assertFalse(follower.isAlive, "devrig log follower must terminate during cleanup")
+            assertFalse(scanner.isInterrupted, "normal cleanup must let the polling loop observe stopped without interrupting it")
+            assertFalse(follower.isInterrupted, "normal cleanup must let the follower observe stopped without interruption")
+            assertNull(uncaught.get(), "normal cleanup must not escape the scanner thread")
+        } finally {
+            lifetime.closeAllStacks()
+            lineChannel.close()
+        }
+    }
+
+    @Test
+    fun `log streaming never follows symlinks outside the mounted log root`(@TempDir logsDir: Path) {
+        val lifetime = CloseableStackHost("devrig-log-security-test")
+        val lineChannel = Channel<ByteArray>(Channel.UNLIMITED)
+        val console = ConsoleDriver(
+            container = ContainerDriver(
+                logPrefix = "devrig-log-security-test",
+                containerId = "not-used",
+                startRequest = StartContainerRequest(),
+            ),
+            consoleFile = "/not-used",
+            lineChannel = lineChannel,
+        )
+        val safeText = "SAFE_DEVRIG_LOG_LINE"
+        val secretText = "HOST_SECRET_MUST_NOT_BE_STREAMED"
+        val outsideSecret = logsDir.parent.resolve("outside-secret.txt")
+        Files.writeString(outsideSecret, "$secretText\n")
+        Files.writeString(logsDir.resolve("devrig-safe.log"), "$safeText\n")
+        Files.createDirectory(logsDir.resolve("devrig-directory.log"))
+        Files.createSymbolicLink(logsDir.resolve("devrig-secret.log"), outsideSecret)
+        val threadsBefore = Thread.getAllStackTraces().keys.mapTo(mutableSetOf()) { it.threadId() }
+
+        try {
+            streamDevrigLogsToConsole(lifetime, logsDir.toFile(), console)
+            awaitThread(threadsBefore, "devrig-log-tee-devrig-safe.log")
+            val output = awaitConsoleOutput(lineChannel, safeText) + collectConsoleOutput(lineChannel, 1_200)
+
+            assertTrue(safeText in output, "a real regular devrig log must still be streamed")
+            assertFalse(secretText in output, "a symlinked host file must never be streamed")
+            val newThreads = Thread.getAllStackTraces().keys.filter { it.threadId() !in threadsBefore }
+            assertFalse(
+                newThreads.any { it.name == "devrig-log-tee-devrig-secret.log" },
+                "the scanner must reject a symlink before starting a follower",
+            )
+            assertFalse(
+                newThreads.any { it.name == "devrig-log-tee-devrig-directory.log" },
+                "the scanner must reject a directory even when its name matches",
+            )
+        } finally {
+            lifetime.closeAllStacks()
+            lineChannel.close()
+        }
+    }
+
+    @Test
+    fun `log scanner retries after the mounted log directory temporarily disappears`(@TempDir logsDir: Path) {
+        val lifetime = CloseableStackHost("devrig-log-retry-test")
+        val lineChannel = Channel<ByteArray>(Channel.UNLIMITED)
+        val console = ConsoleDriver(
+            container = ContainerDriver(
+                logPrefix = "devrig-log-retry-test",
+                containerId = "not-used",
+                startRequest = StartContainerRequest(),
+            ),
+            consoleFile = "/not-used",
+            lineChannel = lineChannel,
+        )
+        val recoveredText = "RECOVERED_DEVRIG_LOG_LINE"
+        val threadsBefore = Thread.getAllStackTraces().keys.mapTo(mutableSetOf()) { it.threadId() }
+
+        try {
+            streamDevrigLogsToConsole(lifetime, logsDir.toFile(), console)
+            val scanner = awaitThread(threadsBefore, "devrig-log-tee-scan")
+            awaitTimedWaiting(scanner)
+
+            Files.delete(logsDir)
+            Thread.sleep(1_200)
+            Files.createDirectory(logsDir)
+            Files.writeString(logsDir.resolve("devrig-recovered.log"), "$recoveredText\n")
+
+            awaitThread(threadsBefore, "devrig-log-tee-devrig-recovered.log")
+            val output = awaitConsoleOutput(lineChannel, recoveredText)
+            assertTrue(recoveredText in output, "the scanner must resume after a transient directory failure")
+            assertTrue(scanner.isAlive, "a transient directory failure must not terminate the scanner")
+        } finally {
+            lifetime.closeAllStacks()
+            lineChannel.close()
+        }
+    }
+
+    private fun awaitThread(threadsBefore: Set<Long>, name: String): Thread {
+        val deadline = System.nanoTime() + 2_000_000_000L
+        while (System.nanoTime() < deadline) {
+            val found = Thread.getAllStackTraces().keys.firstOrNull { thread ->
+                thread.threadId() !in threadsBefore && thread.name == name
+            }
+            if (found != null) return found
+            Thread.sleep(10)
+        }
+        error("thread did not start: $name")
+    }
+
+    private fun awaitTimedWaiting(scanner: Thread) {
+        val deadline = System.nanoTime() + 2_000_000_000L
+        while (System.nanoTime() < deadline) {
+            if (scanner.state == Thread.State.TIMED_WAITING) return
+            Thread.sleep(10)
+        }
+        error("devrig log scanner did not enter its polling sleep; state=${scanner.state}")
+    }
+
+    private fun awaitConsoleOutput(channel: Channel<ByteArray>, expected: String): String {
+        val deadline = System.nanoTime() + 3_000_000_000L
+        val output = StringBuilder()
+        while (System.nanoTime() < deadline) {
+            output.append(drainConsoleOutput(channel))
+            if (expected in output) return output.toString()
+            Thread.sleep(10)
+        }
+        return output.toString()
+    }
+
+    private fun collectConsoleOutput(channel: Channel<ByteArray>, durationMillis: Long): String {
+        val deadline = System.nanoTime() + durationMillis * 1_000_000L
+        val output = StringBuilder()
+        while (System.nanoTime() < deadline) {
+            output.append(drainConsoleOutput(channel))
+            Thread.sleep(10)
+        }
+        output.append(drainConsoleOutput(channel))
+        return output.toString()
+    }
+
+    private fun drainConsoleOutput(channel: Channel<ByteArray>): String = buildString {
+        while (true) {
+            val received = channel.tryReceive()
+            if (received.isFailure) break
+            append(received.getOrThrow().toString(Charsets.UTF_8))
+        }
+    }
+}

--- a/test-integration/src/test/kotlin/com/jonnyzzz/mcpSteroid/integration/tests/DevrigManagedBackendGuiIntegrationTest.kt
+++ b/test-integration/src/test/kotlin/com/jonnyzzz/mcpSteroid/integration/tests/DevrigManagedBackendGuiIntegrationTest.kt
@@ -36,7 +36,7 @@ class DevrigManagedBackendGuiIntegrationTest {
 
         val id = container.execAndAssert(
             description = "resolve managed backend id",
-            script = $$"""
+            script = """
                 set -euo pipefail
                 basename "$(find /home/agent/.mcp-steroid/backends -mindepth 1 -maxdepth 1 -type d -name 'idea-community-*' | sort | head -1)"
             """.trimIndent(),
@@ -112,7 +112,7 @@ class DevrigManagedBackendGuiIntegrationTest {
             script = $$"""
                 set -euo pipefail
                 test -f "/home/agent/.mcp-steroid/state/$$id.pid"
-                test "$(cat "/home/agent/.mcp-steroid/state/$$id.pid")" = "$$pid"
+                test "$(jq -r '.pid' "/home/agent/.mcp-steroid/state/$$id.pid")" = "$$pid"
                 kill -0 "$$pid"
                 grep -F -- "experimental.ui.onboarding.proposed.version" "/home/agent/.mcp-steroid/caches/$$id/config/options/other.xml"
                 grep -F -- "switched.from.classic.to.islands" "/home/agent/.mcp-steroid/caches/$$id/config/early-access-registry.txt"
@@ -131,12 +131,15 @@ class DevrigManagedBackendGuiIntegrationTest {
             timeoutSeconds = 180,
             script = $$"""
                 set -euo pipefail
+                print_safe_marker() {
+                  jq '{schema, pid, ideHome, ide, plugin, createdAt}' "$1"
+                }
                 marker="/home/agent/.mcp-steroid/markers/$$pid.mcp-steroid"
                 deadline=$((SECONDS + 180))
                 found=0
                 while [ "$SECONDS" -lt "$deadline" ]; do
-                  if [ -f "$marker" ] && jq -e --argjson pid "$$pid" '.pid == $pid and (.mcpSteroidServer.mcpUrl | startswith("http://")) and .ide.name and .plugin.id == "com.jonnyzzz.mcp-steroid"' "$marker" >/dev/null; then
-                    cat "$marker"
+                  if [ -f "$marker" ] && jq -e --argjson pid "$$pid" '.pid == $pid and (.mcpSteroidServer.mcpUrl | startswith("http" + "://")) and .ide.name and .plugin.id == "com.jonnyzzz.mcp-steroid"' "$marker" >/dev/null; then
+                    print_safe_marker "$marker"
                     found=1
                     break
                   fi
@@ -146,7 +149,10 @@ class DevrigManagedBackendGuiIntegrationTest {
                   :
                 else
                 echo "MCP Steroid marker did not appear at $marker" >&2
-                find /home/agent/.mcp-steroid/markers -maxdepth 1 -name '*.mcp-steroid' -print -exec cat {} \; >&2 || true
+                while IFS= read -r candidate_marker; do
+                  printf '%s\n' "$candidate_marker" >&2
+                  print_safe_marker "$candidate_marker" >&2 || true
+                done < <(find /home/agent/.mcp-steroid/markers -maxdepth 1 -name '*.mcp-steroid' -print)
                 exit 1
                 fi
             """.trimIndent(),


### PR DESCRIPTION
## Summary

- provision exact IntelliJ IDEA Ultimate 2026.2.0.1 / IU-262.8665.337 and launch native `remote-dev-server run` with MCP Steroid in the managed plugin cache
- wait for marker-backed readiness, preserve PID start identity, serialize lifecycle operations, and harden handoff/cleanup/list ownership
- add clean-machine Claude Code and Codex Docker scenarios that install devrig, start the headless backend, open pinned Keycloak, and independently score a deep `ClassInheritorsSearch` tool result and final answer
- sanitize preserved idea and launcher logs for Bearer, `_ijt`, and `x-ijt` credentials; track production full-marker logging in #405

## Verification

- `:npx-kt:test`: 1,445 total; 1,441 passed; 0 failed; 4 Windows-only ignored
- focused lifecycle/list regressions: 50/50 passed
- Remote Development workflow contracts: 4/4 passed
- parser/workflow contracts: 9/9 passed
- volume/log infrastructure contracts: 5/5 passed
- IntelliJ inspections: all 8 changed Kotlin files clean; 0 failed tools
- clean Docker Claude run: `run-20260731-173006-devrig-remote-backend-keycloak-claude`
- clean Docker Codex run: `run-20260731-173355-devrig-remote-backend-keycloak-codex`
- each Docker result reported 70 unique subtypes and all required transitive Keycloak classes

## Review and audit

- Claude Fable 5: PASS (`run_20260731-175744-47024`)
- Claude Opus 5: PASS (`run_20260731-180448-50119`)
- Codex: PASS (`run_20260731-175744-47025`)
- terminal `steroid_execute_code` audit: 1,108 unique calls; all problems consolidated into existing issues #20, #66, #91, #207, #215, #280, and #402-#405; no duplicate issue required

The detailed plan, evidence, run identifiers, deferred follow-ups, and issue mapping are in `docs/devrig-remote-development-backend-e2e.md`.