### PR TITLE
devrig mcp: advertise the steroid capability statement in `initialize`

### DIFF
--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/server/DevrigServerInstructions.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/server/DevrigServerInstructions.kt
@@ -1,0 +1,37 @@
+/* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
+package com.jonnyzzz.mcpSteroid.devrig.server
+
+/**
+ * The `instructions` devrig returns from `initialize` (jonnyzzz/mcp-steroid#417).
+ *
+ * Why this text exists at all: agent harnesses increasingly *defer* MCP tools. Claude Code
+ * indexes tool NAMES only and loads a schema on demand, so everything we say in a tool
+ * description — including how to provision an IDE, which lives in `steroid_open_project`'s
+ * `BACKEND_NAME_DESCRIPTION` — is unreachable until the agent has already guessed our tools
+ * exist. A task-only prompt therefore never touches the IDE: it falls back to `find` + `cat`.
+ * The `initialize` result is the one channel a deferring harness still puts in context
+ * verbatim, so the capability statement belongs here.
+ *
+ * Keep it SHORT and navigational: it costs context on every session. State what the backend is,
+ * name the tool prefix so the agent can search for it, and point at the two entry points
+ * (`steroid_list_projects` to see what is reachable, `devrig backend` to provision one). Depth
+ * stays in the tool descriptions and the `mcp-steroid://` article corpus.
+ */
+const val DEVRIG_MCP_SERVER_INSTRUCTIONS = """This server hands you a real JetBrains IDE (IntelliJ IDEA, PyCharm, WebStorm, Rider, ...) as a
+tool backend: the resolved project model, indexes, inspections, refactorings, run configurations,
+the debugger and the IDE UI. Prefer it over grep/find/sed for anything about code SEMANTICS —
+call hierarchies, subtypes, references, symbol resolution, rename/refactor, running or debugging.
+
+Its tools are all named steroid_* (steroid_list_projects, steroid_open_project,
+steroid_list_windows, steroid_execute_code, steroid_execute_feedback, steroid_take_screenshot,
+steroid_input, steroid_fetch_resource). If your harness loads MCP tool schemas on demand, load
+them before you decide the IDE is unavailable.
+
+Start here:
+- steroid_list_projects - which IDEs and projects are reachable right now.
+- No IDE reachable? Provision one from the shell with the `devrig` binary that serves this MCP
+  server — it is on your PATH: `devrig backend` lists them,
+  `devrig backend download <id>` installs one, `devrig backend start <id>` runs it.
+- steroid_open_project opens a project in a backend; steroid_execute_code runs Kotlin against
+  the live IntelliJ API for everything the narrow tool surface does not cover.
+- steroid_fetch_resource returns the mcp-steroid:// article corpus - the recipes for that API."""

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/server/StubStdioMcpServer.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/server/StubStdioMcpServer.kt
@@ -15,7 +15,8 @@ import kotlinx.serialization.json.JsonObject
  * Boot a real MCP stdio server inside the devrig CLI process.
  *
  * Wiring:
- *  - [McpServerCore] declares server identity and advertised capabilities.
+ *  - [McpServerCore] declares server identity, advertised capabilities, and the
+ *    [DEVRIG_MCP_SERVER_INSTRUCTIONS] capability statement the `initialize` result carries.
  *  - [StubMcpSteroidTools.devrigToolSpecs] is the canonical devrig tool list; every
  *    spec from it is registered onto the core. The handlers themselves are not yet
  *    implemented in devrig — see [StubMcpSteroidTools] — so calling a tool returns
@@ -39,6 +40,10 @@ suspend fun runStubStdioMcpServer(
             name = "devrig",
             version = DevrigVersionMetadata.getDevrigVersion(),
         ),
+        // The capability statement a deferring harness sees WITHOUT loading a tool schema
+        // (#417) — see DEVRIG_MCP_SERVER_INSTRUCTIONS for why this channel and not a tool
+        // description.
+        instructions = DEVRIG_MCP_SERVER_INSTRUCTIONS,
         capabilities = ServerCapabilities(
             tools = ToolsCapability(listChanged = true),
             // Advertise `logging` so clients accept our `notifications/message`

--- a/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/server/DevrigServerInstructionsTest.kt
+++ b/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/server/DevrigServerInstructionsTest.kt
@@ -1,0 +1,111 @@
+/* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
+package com.jonnyzzz.mcpSteroid.devrig.server
+
+import com.jonnyzzz.mcpSteroid.devrig.DevrigServices
+import com.jonnyzzz.mcpSteroid.devrig.HomePaths
+import com.jonnyzzz.mcpSteroid.mcp.FramingBuffer
+import com.jonnyzzz.mcpSteroid.mcp.MCP_PROTOCOL_VERSION
+import com.jonnyzzz.mcpSteroid.mcp.McpServerCore
+import com.jonnyzzz.mcpSteroid.mcp.Tool
+import com.jonnyzzz.mcpSteroid.mcp.encodeNdjsonMessage
+import com.jonnyzzz.mcpSteroid.testHelper.CloseableStackHost
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.io.PrintStream
+import java.nio.file.Path
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import org.junit.jupiter.api.io.TempDir
+
+/**
+ * jonnyzzz/mcp-steroid#417 — the `initialize` result must carry the steroid capability statement.
+ *
+ * A harness that defers MCP tools (Claude Code indexes tool NAMES only until a `ToolSearch`) never
+ * reads a tool description on its own, so `instructions` is the one place a task-only prompt can
+ * learn the IDE exists. This test drives the real `devrig mcp` server over the stdio transport and
+ * asserts the text actually reaches the wire.
+ */
+class DevrigServerInstructionsTest {
+
+    @Test
+    fun `initialize carries the steroid capability statement`(@TempDir tempDir: Path) {
+        val instructions = runDevrigMcp(tempDir).initializeResult["instructions"]?.jsonPrimitive?.contentOrNull
+        assertEquals(
+            DEVRIG_MCP_SERVER_INSTRUCTIONS,
+            instructions,
+            "devrig must advertise its capability statement in the initialize result",
+        )
+    }
+
+    @Test
+    fun `the capability statement names the tool prefix and the IDE provisioning commands`(
+        @TempDir tempDir: Path,
+    ) {
+        val instructions = runDevrigMcp(tempDir).initializeResult["instructions"]?.jsonPrimitive?.contentOrNull
+            ?: error("initialize result has no instructions")
+
+        // The two facts an agent cannot discover any other way before loading a schema: the tool
+        // name prefix to search for, and how to get an IDE when none is running.
+        for (fact in listOf("steroid_", "devrig backend download", "devrig backend start")) {
+            assertTrue(fact in instructions, "capability statement must mention '$fact': $instructions")
+        }
+    }
+
+    @Test
+    fun `the capability statement names only tools devrig actually advertises`(@TempDir tempDir: Path) {
+        val run = runDevrigMcp(tempDir)
+        val advertised = run.tools.map(Tool::name).toSet()
+        val mentioned = Regex("steroid_\\w+").findAll(DEVRIG_MCP_SERVER_INSTRUCTIONS).map { it.value }.toSet()
+
+        assertTrue(mentioned.isNotEmpty(), "capability statement must name the tools by name")
+        assertEquals(
+            emptySet(),
+            mentioned - advertised,
+            "capability statement names tools devrig does not advertise (advertised: $advertised)",
+        )
+    }
+
+    private class DevrigMcpRun(val initializeResult: kotlinx.serialization.json.JsonObject, val tools: List<Tool>)
+
+    /**
+     * Boots the production `devrig mcp` server ([runStubStdioMcpServer]) on in-memory streams, feeds
+     * it one NDJSON `initialize`, and returns the parsed result plus the tools it registered. The
+     * stdin buffer ends right after the request, so the reader loop sees EOF and `run()` returns.
+     */
+    private fun runDevrigMcp(tempDir: Path): DevrigMcpRun {
+        val initialize = encodeNdjsonMessage(
+            """{"jsonrpc":"2.0","id":"1","method":"initialize","params":{"protocolVersion":"$MCP_PROTOCOL_VERSION",""" +
+                """"capabilities":{},"clientInfo":{"name":"instructions-test","version":"1.0"}}}"""
+        )
+        val stdout = ByteArrayOutputStream()
+        val lifetime = CloseableStackHost()
+        var core: McpServerCore? = null
+        try {
+            runBlocking {
+                runStubStdioMcpServer(
+                    DevrigServices(
+                        lifetime = lifetime,
+                        homePaths = HomePaths(tempDir.resolve("devrig-home")).also { it.mkdirsAll() },
+                        mcpStdin = ByteArrayInputStream(initialize.toByteArray(Charsets.UTF_8)),
+                        mcpStdout = PrintStream(stdout, true, Charsets.UTF_8),
+                    ),
+                    onServerReady = { core = it },
+                )
+            }
+        } finally {
+            lifetime.closeAllStacks()
+        }
+
+        val buffer = FramingBuffer().also { it.append(stdout.toByteArray()) }
+        val frame = buffer.readNextFrame() ?: error("devrig wrote no response to initialize")
+        val response = Json.parseToJsonElement(frame.payloadText).jsonObject
+        val result = response["result"]?.jsonObject ?: error("initialize failed: $response")
+        return DevrigMcpRun(result, (core ?: error("onServerReady was never called")).toolRegistry.listTools())
+    }
+}


### PR DESCRIPTION
Fixes #417

## Problem

Claude Code *defers* MCP tools: the deferred index carries the tool **name** only, and a schema is loaded on demand via `ToolSearch`. Everything we say in a tool *description* — including how to provision an IDE, which lives in `steroid_open_project`'s `BACKEND_NAME_DESCRIPTION` — is unreachable until the agent has already guessed our tools exist. Per the issue's R2 probe, a task-only prompt answered with `find` + `cat` in 12.7 s and never touched `mcp-steroid`.

## Where the hint goes

The `instructions` field of the `initialize` result — the one channel a deferring harness still puts in the agent's context verbatim, before any tool schema is loaded. `SteroidsMcpServer` (in-IDE) already sets it; `runStubStdioMcpServer` — the devrig server agents actually connect to as `mcp-steroid` — did not, so nothing reached the agent.

## Change

- `DevrigServerInstructions.kt` (new): `DEVRIG_MCP_SERVER_INSTRUCTIONS` — a short, navigational capability statement. What the backend is (a real JetBrains IDE, prefer it over grep for code semantics), the `steroid_*` tool prefix to search for, an explicit "if your harness loads MCP tool schemas on demand, load them before you decide the IDE is unavailable", and the two entry points: `steroid_list_projects` to see what is reachable, `devrig backend download|start <id>` to provision one when nothing is. Depth stays in the tool descriptions and the `mcp-steroid://` corpus — this text costs context on every session.
- `StubStdioMcpServer.kt`: wire it into `McpServerCore(instructions = ...)`.
- `DevrigServerInstructionsTest.kt` (new): drives the production stdio server end to end (NDJSON `initialize` in, framed response out), asserts the text lands in the result, that it names the tool prefix and the provisioning commands, and — drift guard — that every `steroid_*` it names is a tool devrig actually advertises.

Deliberately out of scope (the issue's other two bullets): writing a memory line from `devrig install <agent>`, and the task-only-prompt E2E variant.

## Verification

`./gradlew :npx-kt:test :mcp-stdio:test :mcp-core:test :mcp-steroid-server:test` — green.