### PR TITLE
devrig: accept a baseline-only resolved build for idea-community downloads

### DIFF
--- a/intellij-downloader/src/buildsrc-shared/kotlin/com/jonnyzzz/mcpSteroid/ideDownloader/IdeReleaseLookup.kt
+++ b/intellij-downloader/src/buildsrc-shared/kotlin/com/jonnyzzz/mcpSteroid/ideDownloader/IdeReleaseLookup.kt
@@ -20,6 +20,13 @@ data class IdeArchiveResolution(
     val channel: IdeChannel,
     val version: String,
     val build: String,
+    /**
+     * True when [build] is only the platform baseline (`262`) because the feed does not publish the
+     * full build number — GitHub Community releases and the Android Studio canary page both resolve
+     * that way, while the downloaded artifact reports `262.8665.258`. Consumers must compare such a
+     * build as a baseline instead of for exact equality.
+     */
+    val buildIsBaseline: Boolean = false,
     val url: String,
     val downloadKey: String,
     val releaseDate: String? = null,

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/AndroidStudioCanaryReleases.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/AndroidStudioCanaryReleases.kt
@@ -77,6 +77,9 @@ fun resolveAndroidStudioCanaryArchiveFromHtml(
         channel = IdeChannel.STABLE,
         version = resolvedVersion,
         build = baseline?.toString() ?: resolvedVersion,
+        // The preview page only exposes the marketing version, so the build is the platform baseline
+        // (`262`) while the installed artifact reports the full `262.8665.258.2621.14049965`.
+        buildIsBaseline = baseline != null,
         url = url,
         downloadKey = url.substringAfterLast('/'),
     )

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/BackendInfoMapping.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/BackendInfoMapping.kt
@@ -21,3 +21,30 @@ fun normaliseBuildForDedup(build: String?): String? {
     if (build.isNullOrBlank()) return null
     return build.replaceFirst(Regex("^[A-Z]+-"), "")
 }
+
+/**
+ * True when a bare platform baseline was given — `262`, `IC-262` — with no build/patch segments.
+ * Used where the resolved build is no longer at hand (a persisted descriptor); a live resolution
+ * carries [BackendDownloadResolution.buildIsBaseline] instead of guessing from the string shape.
+ */
+fun isPlatformBaselineOnly(build: String?): Boolean {
+    val baseline = normaliseBuildForDedup(build)?.toIntOrNull() ?: return false
+    return baseline in 1..999
+}
+
+/**
+ * True when the build [actual] reported by a real install (`product-info.json`, a marker file) is the
+ * build that was requested. Product-code prefixes are ignored on both sides, so `IC-262.8665.258`
+ * and `262.8665.258` are the same build.
+ *
+ * Some feeds only publish the platform baseline: GitHub Community releases and the Android Studio
+ * canary page resolve to `262` while the artifact reports `262.8665.258`. Those resolutions set
+ * [expectedIsBaseline], and then [expected] matches the FIRST dot-separated segment of [actual] —
+ * segment-wise, not a raw string prefix, so `26` never matches `262.8665.258`.
+ */
+fun ideBuildMatches(actual: String?, expected: String?, expectedIsBaseline: Boolean): Boolean {
+    val normalisedActual = normaliseBuildForDedup(actual) ?: return false
+    val normalisedExpected = normaliseBuildForDedup(expected) ?: return false
+    if (normalisedActual == normalisedExpected) return true
+    return expectedIsBaseline && normalisedActual.substringBefore('.') == normalisedExpected
+}

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/GithubCommunityReleases.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/GithubCommunityReleases.kt
@@ -113,6 +113,9 @@ fun resolveGithubCommunityArchiveFromReleasesJson(
         channel = IdeChannel.STABLE,
         version = chosen.version,
         build = baseline.toString(),
+        // GitHub releases carry no full build number, so this is the baseline only: the artifact
+        // itself reports `262.8665.258` for baseline `262`.
+        buildIsBaseline = true,
         url = url,
         downloadKey = name,
         releaseDate = chosen.publishedAt,

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/ManagedBackend.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/ManagedBackend.kt
@@ -98,6 +98,8 @@ data class BackendDownloadResolution(
     val product: IdeProduct,
     val version: String,
     val build: String,
+    /** @see com.jonnyzzz.mcpSteroid.ideDownloader.IdeArchiveResolution.buildIsBaseline */
+    val buildIsBaseline: Boolean = false,
     val url: String,
     val checksumUrl: String? = null,
     val expectedSha256: String? = null,
@@ -226,6 +228,7 @@ class DefaultManagedBackendDownloader(
             product = archive.product,
             version = archive.version,
             build = archive.build,
+            buildIsBaseline = archive.buildIsBaseline,
             url = archive.url,
             checksumUrl = archive.checksumUrl,
             expectedSha256 = archive.expectedSha256,
@@ -316,6 +319,16 @@ class BackendManager(
                 bundleDir = bundleDir,
                 descriptorPath = descriptorPath,
             )
+            validateInstalledBuildNumber(
+                product = resolution.product,
+                expectedBuild = resolution.build,
+                expectedBuildIsBaseline = resolution.buildIsBaseline,
+                actualBuildNumber = launcher.buildNumber,
+                downloadedUrl = resolution.url,
+                archivePath = artifact.archivePath,
+                bundleDir = bundleDir,
+                descriptorPath = descriptorPath,
+            )
             PreparedBackendInstall(
                 bundleDirName = bundleDir.fileName.toString(),
                 launcher = launcher,
@@ -334,6 +347,16 @@ class BackendManager(
                 validateInstalledProductCode(
                     product = resolution.product,
                     actualProductCode = launcher.productCode,
+                    downloadedUrl = resolution.url,
+                    archivePath = artifact.archivePath,
+                    bundleDir = partialBundleDir,
+                    descriptorPath = descriptorPath(partialDir),
+                )
+                validateInstalledBuildNumber(
+                    product = resolution.product,
+                    expectedBuild = resolution.build,
+                    expectedBuildIsBaseline = resolution.buildIsBaseline,
+                    actualBuildNumber = launcher.buildNumber,
                     downloadedUrl = resolution.url,
                     archivePath = artifact.archivePath,
                     bundleDir = partialBundleDir,
@@ -574,7 +597,13 @@ class BackendManager(
             return false
         }
         val expectedBuild = descriptor.buildNumber ?: return false
-        return marker.pid == pid && marker.ide.build == expectedBuild
+        // Marker builds carry the product-code prefix (`IC-262.8665.258`) that product-info.json
+        // omits, and a descriptor written from a baseline-only resolution holds just `262`.
+        return marker.pid == pid && ideBuildMatches(
+            actual = marker.ide.build,
+            expected = expectedBuild,
+            expectedIsBaseline = isPlatformBaselineOnly(expectedBuild),
+        )
     }
 
     private fun deleteMcpMarker(pid: Long) {
@@ -789,6 +818,50 @@ fun validateInstalledProductCode(
             append("Managed backend product validation failed for ${product.id} (${product.code}). ")
             append("Expected product-info.json productCode '$expectedProductCode', ")
             append("actual '${actualProductCode ?: "<missing>"}'. ")
+            append("Downloaded URL: $downloadedUrl. ")
+            append("Archive path: ${archivePath?.toString() ?: "<not downloaded in this invocation>"}. ")
+            append("Unpacked path: $bundleDir. ")
+            append("Removed unpacked bundle and descriptor: $descriptorPath")
+        }
+    )
+}
+
+/**
+ * Refuses an install whose `product-info.json` build is not the build that was resolved — a wrong or
+ * swapped artifact under the requested id.
+ *
+ * Feeds differ in what they can tell us: `data.services.jetbrains.com` returns the exact build
+ * (`262.8665.337`), while GitHub Community releases and the Android Studio canary page only give the
+ * platform baseline (`262`). A baseline resolution therefore matches any `262.*` install — comparing
+ * it for equality with the real `262.8665.258` would reject every Community download.
+ *
+ * A missing `buildNumber` is not a failure: there is nothing to compare, and
+ * [validateInstalledProductCode] already covers artifact identity.
+ */
+fun validateInstalledBuildNumber(
+    product: IdeProduct,
+    expectedBuild: String,
+    expectedBuildIsBaseline: Boolean,
+    actualBuildNumber: String?,
+    downloadedUrl: String,
+    archivePath: Path?,
+    bundleDir: Path,
+    descriptorPath: Path,
+) {
+    if (actualBuildNumber == null) return
+    if (ideBuildMatches(actualBuildNumber, expectedBuild, expectedBuildIsBaseline)) return
+
+    deleteRecursively(bundleDir)
+    Files.deleteIfExists(descriptorPath)
+    throw ManagedBackendValidationException(
+        buildString {
+            append("Managed backend build validation failed for ${product.id} (${product.code}). ")
+            if (expectedBuildIsBaseline) {
+                append("Expected a product-info.json build on platform baseline '$expectedBuild', ")
+            } else {
+                append("Expected product-info.json build '$expectedBuild', ")
+            }
+            append("actual '$actualBuildNumber'. ")
             append("Downloaded URL: $downloadedUrl. ")
             append("Archive path: ${archivePath?.toString() ?: "<not downloaded in this invocation>"}. ")
             append("Unpacked path: $bundleDir. ")

--- a/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/AndroidStudioCanaryReleasesTest.kt
+++ b/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/AndroidStudioCanaryReleasesTest.kt
@@ -33,6 +33,8 @@ class AndroidStudioCanaryReleasesTest {
         val archive = resolveAndroidStudioCanaryArchiveFromHtml(html, HostOs.MAC, HostArchitecture.ARM64)
         assertEquals("2026.1.2.3", archive.version)
         assertEquals("261", archive.build)
+        // The preview page gives no full build, so the install reports 261.x — baseline comparison only.
+        assertTrue(archive.buildIsBaseline)
         assertEquals(
             "https://edgedl.me.gvt1.com/android/studio/install/2026.1.2.3/android-studio-quail2-canary3-mac_arm.dmg",
             archive.url,

--- a/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/BackendManagerDownloadValidationTest.kt
+++ b/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/BackendManagerDownloadValidationTest.kt
@@ -85,6 +85,87 @@ class BackendManagerDownloadValidationTest {
     }
 
     @Test
+    fun `download accepts a full build under a baseline-only resolution`(
+        @TempDir tempDir: Path,
+    ) = runBlocking {
+        // #423: GitHub Community releases resolve to baseline "262" while the downloaded artifact
+        // reports "262.8665.258". Comparing those for equality failed every idea-community download.
+        val homePaths = HomePaths(tempDir.resolve("home"))
+        val archivePath = fakeArchive(tempDir, "idea-2026.2-aarch64.tar.gz")
+        val manager = BackendManager(
+            homePaths = homePaths,
+            downloader = InstallingDownloader(
+                productCode = "IC",
+                archivePath = archivePath,
+                resolvedBuild = "262",
+                buildIsBaseline = true,
+                installedBuild = "262.8665.258",
+            ),
+            bundledPluginResolver = FixedPluginResolver(pluginZipFixture(tempDir.resolve("dist/ij-plugin.zip"))),
+        )
+
+        val result = manager.download(parseBackendId("idea-community-2026.2"))
+
+        assertEquals("262.8665.258", result.descriptor.buildNumber)
+        assertTrue(result.backendDir.resolve(result.descriptor.bundleDirName).resolve("product-info.json").exists())
+    }
+
+    @Test
+    fun `download rejects a build from another baseline and cleans partial install`(
+        @TempDir tempDir: Path,
+    ) = runBlocking {
+        val homePaths = HomePaths(tempDir.resolve("home"))
+        val backendId = "idea-community-2026.2"
+        val archivePath = fakeArchive(tempDir, "idea-2026.2-aarch64.tar.gz")
+        val manager = BackendManager(
+            homePaths = homePaths,
+            downloader = InstallingDownloader(
+                productCode = "IC",
+                archivePath = archivePath,
+                resolvedBuild = "262",
+                buildIsBaseline = true,
+                installedBuild = "261.24374.151",
+            ),
+            bundledPluginResolver = FixedPluginResolver(pluginZipFixture(tempDir.resolve("dist/ij-plugin.zip"))),
+        )
+
+        val error = assertFailsWith<ManagedBackendValidationException> {
+            manager.download(parseBackendId(backendId))
+        }
+
+        assertFalse(homePaths.backendsDir.resolve("$backendId.partial").exists(), "partial dir must be removed")
+        assertTrue(error.message!!.contains("platform baseline '262'"), error.message)
+        assertTrue(error.message!!.contains("actual '261.24374.151'"), error.message)
+    }
+
+    @Test
+    fun `download rejects a product-info build that is not the resolved build`(
+        @TempDir tempDir: Path,
+    ) = runBlocking {
+        val homePaths = HomePaths(tempDir.resolve("home"))
+        val backendId = "idea-community-2025.3.3"
+        val archivePath = fakeArchive(tempDir, "ideaIC-2025.3.3.tar.gz")
+        val manager = BackendManager(
+            homePaths = homePaths,
+            downloader = InstallingDownloader(
+                productCode = "IC",
+                archivePath = archivePath,
+                resolvedBuild = "253.28294.334",
+                installedBuild = "253.28294.999",
+            ),
+            bundledPluginResolver = FixedPluginResolver(pluginZipFixture(tempDir.resolve("dist/ij-plugin.zip"))),
+        )
+
+        val error = assertFailsWith<ManagedBackendValidationException> {
+            manager.download(parseBackendId(backendId))
+        }
+
+        assertFalse(homePaths.backendsDir.resolve("$backendId.partial").exists(), "partial dir must be removed")
+        assertTrue(error.message!!.contains("Expected product-info.json build '253.28294.334'"), error.message)
+        assertTrue(error.message!!.contains("actual '253.28294.999'"), error.message)
+    }
+
+    @Test
     fun `failed partial extraction is cleaned before retry succeeds`(
         @TempDir tempDir: Path,
     ) = runBlocking {
@@ -242,12 +323,18 @@ class BackendManagerDownloadValidationTest {
     private class InstallingDownloader(
         private val productCode: String,
         private val archivePath: Path,
+        /** What the release feed resolved to — a full build, or a baseline when [buildIsBaseline]. */
+        private val resolvedBuild: String = "$productCode-253.1",
+        private val buildIsBaseline: Boolean = false,
+        /** What the unpacked `product-info.json` reports. */
+        private val installedBuild: String = "$productCode-253.1",
     ) : ManagedBackendDownloader {
         override suspend fun resolve(id: BackendId): BackendDownloadResolution =
             BackendDownloadResolution(
                 product = IdeProduct.IntelliJIdeaCommunity,
                 version = id.version ?: "2025.3.3",
-                build = "$productCode-253.1",
+                build = resolvedBuild,
+                buildIsBaseline = buildIsBaseline,
                 url = "https://download.jetbrains.com/idea/${archivePath.fileName}",
             )
 
@@ -273,7 +360,7 @@ class BackendManagerDownloadValidationTest {
             """
             {
               "productCode": "$productCode",
-              "buildNumber": "$productCode-253.1",
+              "buildNumber": "$installedBuild",
               "launch": [
                 { "os": "Linux", "launcherPath": "bin/idea.sh" },
                 { "os": "macOS", "launcherPath": "bin/idea.sh" },

--- a/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/GithubCommunityReleasesTest.kt
+++ b/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/GithubCommunityReleasesTest.kt
@@ -50,6 +50,9 @@ class GithubCommunityReleasesTest {
         // 2026.2 is a prerelease and 2025.3.5 is older, so 2026.1.2 wins.
         assertEquals("2026.1.2", archive.version)
         assertEquals("261", archive.build)
+        // GitHub releases publish no full build number, so the resolution must say so — the artifact
+        // reports 261.x and an exact comparison would reject every Community download.
+        assertTrue(archive.buildIsBaseline)
         assertEquals("2026-05-15", archive.releaseDate)
         assertEquals("https://gh/idea-2026.1.2-aarch64.dmg", archive.url)
     }

--- a/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/IdeBuildMatchesTest.kt
+++ b/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/IdeBuildMatchesTest.kt
@@ -1,0 +1,59 @@
+/* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
+package com.jonnyzzz.mcpSteroid.devrig
+
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import org.junit.jupiter.api.Test
+
+class IdeBuildMatchesTest {
+
+    @Test
+    fun `a full build matches itself, prefixed or not`() {
+        assertTrue(ideBuildMatches("262.8665.258", "262.8665.258", expectedIsBaseline = false))
+        assertTrue(ideBuildMatches("IC-262.8665.258", "262.8665.258", expectedIsBaseline = false))
+        assertTrue(ideBuildMatches("262.8665.258", "IU-262.8665.258", expectedIsBaseline = false))
+    }
+
+    @Test
+    fun `a full build does not match a different build`() {
+        assertFalse(ideBuildMatches("262.8665.258", "262.8665.337", expectedIsBaseline = false))
+        assertFalse(ideBuildMatches("263.1.1", "262.8665.258", expectedIsBaseline = false))
+    }
+
+    @Test
+    fun `a baseline expectation matches the full build on that baseline`() {
+        // #423: idea-community resolves to baseline 262 and the artifact reports 262.8665.258.
+        assertTrue(ideBuildMatches("262.8665.258", "262", expectedIsBaseline = true))
+        assertTrue(ideBuildMatches("IC-262.8665.258", "262", expectedIsBaseline = true))
+        assertTrue(ideBuildMatches("AI-262.8665.258.2621.14049965", "262", expectedIsBaseline = true))
+        assertTrue(ideBuildMatches("262", "262", expectedIsBaseline = true))
+    }
+
+    @Test
+    fun `a baseline expectation is not a raw string prefix`() {
+        assertFalse(ideBuildMatches("262.8665.258", "26", expectedIsBaseline = true))
+        assertFalse(ideBuildMatches("2620.1.1", "262", expectedIsBaseline = true))
+        assertFalse(ideBuildMatches("263.8665.258", "262", expectedIsBaseline = true))
+    }
+
+    @Test
+    fun `a baseline is only tolerated when the resolution says so`() {
+        assertFalse(ideBuildMatches("262.8665.258", "262", expectedIsBaseline = false))
+    }
+
+    @Test
+    fun `missing builds never match`() {
+        assertFalse(ideBuildMatches(null, "262", expectedIsBaseline = true))
+        assertFalse(ideBuildMatches("262.8665.258", null, expectedIsBaseline = true))
+        assertFalse(ideBuildMatches("  ", "262", expectedIsBaseline = true))
+    }
+
+    @Test
+    fun `isPlatformBaselineOnly recognises a bare baseline`() {
+        assertTrue(isPlatformBaselineOnly("262"))
+        assertTrue(isPlatformBaselineOnly("IC-262"))
+        assertFalse(isPlatformBaselineOnly("262.8665.258"))
+        assertFalse(isPlatformBaselineOnly("2026.1.2"))
+        assertFalse(isPlatformBaselineOnly(null))
+    }
+}


### PR DESCRIPTION
## Problem

`devrig backend download idea-community` fails on every current build, and only after the full ~850 MB download.

GitHub releases carry no full build number, so `GithubCommunityReleases` resolves `idea-community 2026.2` to `build = "262"` — the platform baseline. The unpacked install reports `262.8665.258` in `product-info.json`, and an exact-equality comparison rejects it as "not the requested IDE artifact". Deterministic: a retry downloads the archive again and fails identically.

The Android Studio canary resolver derives its build the same way (`build = baseline`), so `android-studio` carries the same exposure. IU is unaffected — `data.services.jetbrains.com` returns the exact build.

## Fix

- **`IdeArchiveResolution.buildIsBaseline` / `BackendDownloadResolution.buildIsBaseline`** — the resolution now states whether it knows the full build, instead of the comparison inferring it from the string shape. Set by the two baseline-only feeds (GitHub Community, Android Studio canary).
- **`ideBuildMatches(actual, expected, expectedIsBaseline)`** — one comparison, next to `normaliseBuildForDedup`. Drops the product-code prefix on both sides (`IC-262.8665.258` == `262.8665.258`) and, for a baseline expectation, matches the FIRST dot-separated segment. Segment-wise, not a raw string prefix: `26` does not match `262.8665.258`, and `2620.1.1` does not match `262`.
- **`BackendManager.download`** validates the installed `product-info.json` build against the resolution on both the fresh-download and the reuse path (`validateInstalledBuildNumber`, mirroring `validateInstalledProductCode`: removes the bundle and descriptor, reports URL / archive / unpacked paths). A `product-info.json` with no build number is not a failure — there is nothing to compare, and the product-code check already covers artifact identity.
- **`pidMarkerMatchesDescriptor`** uses the same matcher instead of raw `==`, which also stops marker builds from being rejected over their `IC-` prefix.

## Tests

`./gradlew :npx-kt:test :intellij-downloader:test` — green (1394 + 90 tests).

- `IdeBuildMatchesTest` — the comparison truth table, including the negatives that keep the baseline match from degrading into a loose prefix match.
- `BackendManagerDownloadValidationTest` — a baseline-only resolution (`262`) accepts an install reporting `262.8665.258` (the #423 case); a `261.24374.151` install under baseline `262` and a wrong full build are both rejected with the partial install cleaned up.
- `GithubCommunityReleasesTest` / `AndroidStudioCanaryReleasesTest` — both resolvers flag their build as a baseline.

## Note for #411

PR #411 carries its own `validateInstalledBuildNumber` / `ideBuildMatchesProduct` — the exact-equality version this issue reports. After rebasing on this, that copy can go in favour of `ideBuildMatches(..., expectedIsBaseline = resolution.buildIsBaseline)`.

Fixes #423