### PR TITLE
devrig: integration-test the IDE download path for every supported product (incl. Android Studio)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -229,6 +229,17 @@ Root `build.gradle.kts` defines `ci`-prefixed aggregator tasks for TeamCity and 
 `:test-integration:test` and `:test-experiments:test` have an `onlyIf` guard — plain root `./gradlew test`
 silently skips both. Direct `./gradlew :test-integration:test --tests '...'` still works.
 
+**Vendor-feed tests are opt-in**, so a Google/JetBrains/GitHub outage can never redden a normal build:
+
+| Task | Covers | Cost |
+|------|--------|------|
+| `:npx-kt:liveNetworkTest` | every supported IDE resolves off its live feed with a plugin-compatible build (`live-network` tag) | ~1 min, no archive download |
+| `:npx-kt:liveDownloadSmokeTest` | `idea-community` + `android-studio` really download, unpack and pass `product-info.json` validation (`live-download` tag) | multi-GB per case |
+| `:intellij-downloader:liveNetworkTest` | products-API filename tokens still match (JUnit4 `LiveNetwork` category) | seconds |
+
+The offline equivalent runs by default: `AllIdeProductsDownloadTest` walks all nine products through
+recorded payloads of all three feeds.
+
 **TeamCity DSL** lives in a separate repo (`~/Work/mcp-steroid-teamcity`). See its own `CLAUDE.md` for the
 generate→edit→regenerate→commit workflow. The TC VCS root pulls from `jb`, not `origin` — see "Git remotes" below.
 

--- a/intellij-downloader/src/buildsrc-shared/kotlin/com/jonnyzzz/mcpSteroid/ideDownloader/IdeReleaseLookup.kt
+++ b/intellij-downloader/src/buildsrc-shared/kotlin/com/jonnyzzz/mcpSteroid/ideDownloader/IdeReleaseLookup.kt
@@ -118,7 +118,12 @@ private fun resolveArchiveWithUrlReader(
     )
 }
 
-internal fun resolveArchiveFromProductsApiPayload(
+/**
+ * Resolves an archive from a raw `data.services.jetbrains.com/products` payload — pure, no I/O, so
+ * callers can exercise the products-API feed from a fixture. The sibling feeds expose the same seam
+ * (`resolveGithubCommunityArchiveFromReleasesJson`, `resolveAndroidStudioCanaryArchiveFromHtml`).
+ */
+fun resolveArchiveFromProductsApiPayload(
     product: IdeProduct,
     channel: IdeChannel,
     os: HostOs,

--- a/npx-kt/build.gradle.kts
+++ b/npx-kt/build.gradle.kts
@@ -3,6 +3,7 @@ import com.jonnyzzz.mcpSteroid.gradle.VerifyClassFileVersionTask
 import com.jonnyzzz.mcpSteroid.gradle.configurePathingJarClasspath
 import org.gradle.api.attributes.Usage
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+import java.time.Duration
 import java.util.SortedSet
 
 plugins {
@@ -262,13 +263,49 @@ distributions {
     }
 }
 
+// Tests that intentionally call public vendor feeds (data.services.jetbrains.com, the
+// intellij-community releases API, developer.android.com). `live-network` resolves only;
+// `live-download` additionally pulls whole IDE archives. Both are opt-in tasks below.
+val liveNetworkTag = "live-network"
+val liveDownloadTag = "live-download"
+
 tasks.test {
-    useJUnitPlatform()
+    useJUnitPlatform {
+        excludeTags(liveNetworkTag, liveDownloadTag)
+    }
     // Hand the build's project.version through to DevrigVersionMetadataTest so it can
     // end-to-end-assert the generated runtime value.
     systemProperty("devrig.expected.version", version.toString())
     // Unit tests must never reach PostHog over the network (DevrigBeacon).
     systemProperty("devrig.beacon.disabled", "true")
+}
+
+/** Shares the default `test` wiring with a different tag filter. */
+fun Test.configureLikeUnitTests(tag: String) {
+    useJUnitPlatform {
+        includeTags(tag)
+    }
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    systemProperty("devrig.expected.version", version.toString())
+    systemProperty("devrig.beacon.disabled", "true")
+    shouldRunAfter(tasks.test)
+    // A vendor feed changing under us is the very thing these assert; never serve a cached verdict.
+    outputs.upToDateWhen { false }
+}
+
+tasks.register<Test>("liveNetworkTest") {
+    description = "Resolves every supported IDE against the live vendor feeds (no archive download)."
+    group = "verification"
+    configureLikeUnitTests(liveNetworkTag)
+}
+
+tasks.register<Test>("liveDownloadSmokeTest") {
+    description = "Downloads and validates real IDE archives (idea-community, android-studio). Multi-GB."
+    group = "verification"
+    configureLikeUnitTests(liveDownloadTag)
+    // A single IDE archive plus its unpacked bundle needs far longer than a unit test.
+    timeout.set(Duration.ofMinutes(60))
 }
 
 kotlin {

--- a/npx-kt/build.gradle.kts
+++ b/npx-kt/build.gradle.kts
@@ -304,6 +304,12 @@ tasks.register<Test>("liveDownloadSmokeTest") {
     description = "Downloads and validates real IDE archives (idea-community, android-studio). Multi-GB."
     group = "verification"
     configureLikeUnitTests(liveDownloadTag)
+    // Windows ships the IDE as an NSIS .exe, whose unpack path needs the bundled 7z.exe from a real
+    // installDist tree — structurally incompatible with this classpath-driven smoke. Gated at the
+    // TASK level (the only skip the root CLAUDE.md allows); the test methods stay unconditional.
+    val isWindows = System.getProperty("os.name").lowercase().contains("windows")
+    enabled = !isWindows
+    onlyIf("the .exe unpack path needs an installDist 7z.exe (not available on Windows here)") { !isWindows }
     // A single IDE archive plus its unpacked bundle needs far longer than a unit test.
     timeout.set(Duration.ofMinutes(60))
 }

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/BackendDownloadFeeds.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/BackendDownloadFeeds.kt
@@ -1,0 +1,65 @@
+/* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
+package com.jonnyzzz.mcpSteroid.devrig
+
+import com.jonnyzzz.mcpSteroid.ideDownloader.HostArchitecture
+import com.jonnyzzz.mcpSteroid.ideDownloader.HostOs
+import com.jonnyzzz.mcpSteroid.ideDownloader.IdeArchiveResolution
+import com.jonnyzzz.mcpSteroid.ideDownloader.IdeChannel
+import com.jonnyzzz.mcpSteroid.ideDownloader.IdeProduct
+import com.jonnyzzz.mcpSteroid.ideDownloader.resolveArchive
+import com.jonnyzzz.mcpSteroid.ideDownloader.resolveHostArchitecture
+import com.jonnyzzz.mcpSteroid.ideDownloader.resolveHostOs
+
+/**
+ * The release feed a product's archive comes from. The three feeds differ in how much of the build
+ * number they publish, which is what [IdeArchiveResolution.buildIsBaseline] and [ideBuildMatches]
+ * exist for: only [JETBRAINS_PRODUCTS_API] states the full build.
+ */
+enum class BackendDownloadFeed {
+    /** `developer.android.com/studio/preview` — marketing version only, so the build is the baseline. */
+    ANDROID_STUDIO_PREVIEW,
+
+    /** `api.github.com/repos/JetBrains/intellij-community/releases` — no build number, baseline only. */
+    GITHUB_COMMUNITY,
+
+    /** `data.services.jetbrains.com/products` — publishes the exact build (`262.8665.337`). */
+    JETBRAINS_PRODUCTS_API,
+}
+
+/** True when [feed] publishes only the platform baseline instead of the full build number. */
+val BackendDownloadFeed.publishesBaselineOnly: Boolean
+    get() = this != BackendDownloadFeed.JETBRAINS_PRODUCTS_API
+
+/**
+ * The feed [product] resolves from — the single source of truth for the dispatch, so the download
+ * path and `devrig backend download` (the list) can never drift apart.
+ *
+ * Android Studio's stable channel lags the platform (253) and the products API stops at 253 for the
+ * Community editions, so both are served from elsewhere; see [ANDROID_STUDIO_PREVIEW_PAGE] and
+ * [INTELLIJ_COMMUNITY_RELEASES_API].
+ */
+fun backendDownloadFeed(product: IdeProduct): BackendDownloadFeed = when {
+    product === IdeProduct.AndroidStudio -> BackendDownloadFeed.ANDROID_STUDIO_PREVIEW
+    isGithubCommunityProduct(product) -> BackendDownloadFeed.GITHUB_COMMUNITY
+    else -> BackendDownloadFeed.JETBRAINS_PRODUCTS_API
+}
+
+/**
+ * Resolves the archive devrig downloads for [product] from whichever feed serves it.
+ * Blocking; call on [kotlinx.coroutines.Dispatchers.IO].
+ */
+fun resolveBackendArchive(
+    product: IdeProduct,
+    os: HostOs = resolveHostOs(),
+    architecture: HostArchitecture = resolveHostArchitecture(),
+    version: String? = null,
+): IdeArchiveResolution = when (backendDownloadFeed(product)) {
+    BackendDownloadFeed.ANDROID_STUDIO_PREVIEW ->
+        resolveAndroidStudioCanaryArchive(os = os, architecture = architecture, version = version)
+
+    BackendDownloadFeed.GITHUB_COMMUNITY ->
+        resolveGithubCommunityArchive(product = product, os = os, architecture = architecture, version = version)
+
+    BackendDownloadFeed.JETBRAINS_PRODUCTS_API ->
+        resolveArchive(product = product, channel = IdeChannel.STABLE, os = os, architecture = architecture, version = version)
+}

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/BackendDownloadListCommand.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/BackendDownloadListCommand.kt
@@ -2,10 +2,8 @@
 package com.jonnyzzz.mcpSteroid.devrig
 
 import com.jonnyzzz.mcpSteroid.ideDownloader.HostOs
-import com.jonnyzzz.mcpSteroid.ideDownloader.IdeChannel
 import com.jonnyzzz.mcpSteroid.ideDownloader.IdeProduct
 import com.jonnyzzz.mcpSteroid.ideDownloader.LicenseTier
-import com.jonnyzzz.mcpSteroid.ideDownloader.resolveArchive
 import com.jonnyzzz.mcpSteroid.ideDownloader.resolveHostOs
 import java.io.PrintStream
 import kotlin.time.Duration
@@ -49,12 +47,7 @@ class ReleaseServiceAvailableBackendVersionResolver(
     private val os: HostOs = resolveHostOs(),
 ) : AvailableBackendVersionResolver {
     override suspend fun resolveLatestStableRelease(product: IdeProduct): AvailableBackendRelease = withContext(Dispatchers.IO) {
-        // Android Studio from the canary channel (261); Community from GitHub (261); rest from products API.
-        val archive = when {
-            product === IdeProduct.AndroidStudio -> resolveAndroidStudioCanaryArchive(os = os, version = null)
-            isGithubCommunityProduct(product) -> resolveGithubCommunityArchive(product = product, os = os, version = null)
-            else -> resolveArchive(product = product, channel = IdeChannel.STABLE, os = os, version = null)
-        }
+        val archive = resolveBackendArchive(product = product, os = os, version = null)
         AvailableBackendRelease(
             version = archive.version,
             releaseDate = archive.releaseDate,

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/ManagedBackend.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/ManagedBackend.kt
@@ -4,11 +4,9 @@ package com.jonnyzzz.mcpSteroid.devrig
 import com.jonnyzzz.mcpSteroid.PidMarker
 import com.jonnyzzz.mcpSteroid.PidMarkerJson
 import com.jonnyzzz.mcpSteroid.ideDownloader.HostOs
-import com.jonnyzzz.mcpSteroid.ideDownloader.IdeChannel
 import com.jonnyzzz.mcpSteroid.ideDownloader.IdeDistribution
 import com.jonnyzzz.mcpSteroid.ideDownloader.IdeProduct
 import com.jonnyzzz.mcpSteroid.ideDownloader.resolveAndDownload
-import com.jonnyzzz.mcpSteroid.ideDownloader.resolveArchive
 import com.jonnyzzz.mcpSteroid.ideDownloader.resolveHostOs
 import com.jonnyzzz.mcpSteroid.ideDownloader.unpackIdeArchive
 import com.jonnyzzz.mcpSteroid.ideDownloader.writeIdeStartupConfigFiles
@@ -217,13 +215,7 @@ class DefaultManagedBackendDownloader(
     private val os: HostOs = resolveHostOs(),
 ) : ManagedBackendDownloader {
     override suspend fun resolve(id: BackendId): BackendDownloadResolution = withContext(Dispatchers.IO) {
-        // Android Studio's compatible (261) build is on the canary channel; true Community editions
-        // live on GitHub (the products API stops at 253); everything else from data.services.jetbrains.com.
-        val archive = when {
-            id.product === IdeProduct.AndroidStudio -> resolveAndroidStudioCanaryArchive(os = os, version = id.version)
-            isGithubCommunityProduct(id.product) -> resolveGithubCommunityArchive(product = id.product, os = os, version = id.version)
-            else -> resolveArchive(product = id.product, channel = IdeChannel.STABLE, os = os, version = id.version)
-        }
+        val archive = resolveBackendArchive(product = id.product, os = os, version = id.version)
         BackendDownloadResolution(
             product = archive.product,
             version = archive.version,

--- a/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/AllIdeProductsDownloadTest.kt
+++ b/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/AllIdeProductsDownloadTest.kt
@@ -1,0 +1,269 @@
+/* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
+package com.jonnyzzz.mcpSteroid.devrig
+
+import com.jonnyzzz.mcpSteroid.ideDownloader.HostArchitecture
+import com.jonnyzzz.mcpSteroid.ideDownloader.HostOs
+import com.jonnyzzz.mcpSteroid.ideDownloader.IdeArchiveResolution
+import com.jonnyzzz.mcpSteroid.ideDownloader.IdeChannel
+import com.jonnyzzz.mcpSteroid.ideDownloader.IdeProduct
+import com.jonnyzzz.mcpSteroid.ideDownloader.resolveArchiveFromProductsApiPayload
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.io.path.exists
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * `devrig backend download` for EVERY supported IDE, end to end over recorded feed payloads:
+ * feed dispatch -> resolution -> [BackendManager.download] -> unpack -> product-info validation ->
+ * descriptor.
+ *
+ * The regression it guards is #423/#429. devrig reads three feeds and only
+ * `data.services.jetbrains.com` publishes a full build number; the GitHub Community releases and
+ * the Android Studio preview page publish just the platform baseline (`262`) while the artifact
+ * itself reports `262.8665.258`. Comparing those for equality rejected the install AFTER the full
+ * multi-hundred-MB transfer. The fix landed with an idea-community test only, so this walks all
+ * nine products — Android Studio included, whose canary resolver derives the build the same way.
+ *
+ * Live-feed coverage of the same contract is [AllIdeProductsLiveFeedTest] (tag `live-network`) and
+ * real downloads are [BackendDownloadSmokeTest] (tag `live-download`).
+ */
+class AllIdeProductsDownloadTest {
+
+    /**
+     * One row per supported product, mirroring what its feed served in 2026-08. [installedBuild] is
+     * the `product-info.json` build of that very artifact — the value the resolution is validated
+     * against, and the whole point of the baseline comparison. `product-info.json` states the build
+     * without the product-code prefix that marker files carry.
+     *
+     * The two baseline-fed rows are transcribed from real downloads (see [BackendDownloadSmokeTest]).
+     */
+    private data class ProductFeedCase(
+        val product: IdeProduct,
+        val feed: BackendDownloadFeed,
+        val version: String,
+        val resolvedBuild: String,
+        val installedBuild: String,
+        val fileName: String,
+    ) {
+        val expectedBaseline: Boolean get() = feed.publishesBaselineOnly
+    }
+
+    private val cases = listOf(
+        ProductFeedCase(
+            IdeProduct.IntelliJIdeaCommunity, BackendDownloadFeed.GITHUB_COMMUNITY,
+            version = "2026.2", resolvedBuild = "262", installedBuild = "262.8665.258",
+            fileName = "idea-2026.2-aarch64.dmg",
+        ),
+        ProductFeedCase(
+            IdeProduct.PyCharmCommunity, BackendDownloadFeed.GITHUB_COMMUNITY,
+            version = "2026.2.0.1", resolvedBuild = "262", installedBuild = "262.8665.369",
+            fileName = "pycharm-2026.2.0.1-aarch64.dmg",
+        ),
+        ProductFeedCase(
+            IdeProduct.AndroidStudio, BackendDownloadFeed.ANDROID_STUDIO_PREVIEW,
+            version = "2026.1.4.3", resolvedBuild = "261",
+            // Android Studio appends its own two segments to the platform build.
+            installedBuild = "261.26222.65.2614.15978069",
+            fileName = "android-studio-quail4-canary3-mac_arm.dmg",
+        ),
+        ProductFeedCase(
+            IdeProduct.IntelliJIdea, BackendDownloadFeed.JETBRAINS_PRODUCTS_API,
+            version = "2026.2.0.1", resolvedBuild = "262.8665.337", installedBuild = "262.8665.337",
+            fileName = "idea-2026.2.0.1-aarch64.dmg",
+        ),
+        ProductFeedCase(
+            IdeProduct.PyCharm, BackendDownloadFeed.JETBRAINS_PRODUCTS_API,
+            version = "2026.2.0.1", resolvedBuild = "262.8665.369", installedBuild = "262.8665.369",
+            fileName = "pycharm-2026.2.0.1-aarch64.dmg",
+        ),
+        ProductFeedCase(
+            IdeProduct.GoLand, BackendDownloadFeed.JETBRAINS_PRODUCTS_API,
+            version = "2026.2.0.1", resolvedBuild = "262.8665.336", installedBuild = "262.8665.336",
+            fileName = "goland-2026.2.0.1-aarch64.dmg",
+        ),
+        ProductFeedCase(
+            IdeProduct.WebStorm, BackendDownloadFeed.JETBRAINS_PRODUCTS_API,
+            version = "2026.2.0.1", resolvedBuild = "262.8665.341", installedBuild = "262.8665.341",
+            fileName = "WebStorm-2026.2.0.1-aarch64.dmg",
+        ),
+        ProductFeedCase(
+            IdeProduct.Rider, BackendDownloadFeed.JETBRAINS_PRODUCTS_API,
+            version = "2026.2.0.1", resolvedBuild = "262.8665.385", installedBuild = "262.8665.385",
+            fileName = "JetBrains.Rider-2026.2.0.1-aarch64.dmg",
+        ),
+        ProductFeedCase(
+            IdeProduct.CLion, BackendDownloadFeed.JETBRAINS_PRODUCTS_API,
+            version = "2026.2.0.1", resolvedBuild = "262.8665.321", installedBuild = "262.8665.321",
+            fileName = "CLion-2026.2.0.1-aarch64.dmg",
+        ),
+    )
+
+    @Test
+    fun `every supported product is covered by a feed case`() {
+        assertEquals(
+            IdeProduct.knownProducts.toSet(),
+            cases.map { it.product }.toSet(),
+            "a new IdeProduct must get a download case here — that is how a new feed gets baseline coverage",
+        )
+        for (case in cases) {
+            assertEquals(case.feed, backendDownloadFeed(case.product), "feed dispatch for ${case.product.id}")
+        }
+    }
+
+    @Test
+    fun `every product resolves from its feed with the right build shape`() {
+        for (case in cases) {
+            val resolution = case.resolve()
+
+            assertEquals(case.product, resolution.product, case.product.id)
+            assertEquals(case.version, resolution.version, case.product.id)
+            assertEquals(case.resolvedBuild, resolution.build, case.product.id)
+            assertTrue(resolution.url.endsWith(case.fileName), "${case.product.id}: ${resolution.url}")
+            // The feed's build shape and the flag that describes it must agree — a feed that stops at
+            // the baseline MUST say so, or the download is rejected on arrival (#423).
+            assertEquals(case.expectedBaseline, resolution.buildIsBaseline, "buildIsBaseline for ${case.product.id}")
+            assertEquals(case.expectedBaseline, isPlatformBaselineOnly(resolution.build), "build shape for ${case.product.id}")
+            // Every product the CLI offers must be loadable by the bundled plugin (plugin.xml since-build 261).
+            assertTrue(
+                bundledPluginRange.accepts(resolution.build),
+                "${case.product.id} build ${resolution.build} is outside ${bundledPluginRange.describe()}",
+            )
+        }
+    }
+
+    @Test
+    fun `download accepts the build the real artifact reports, for every product`(
+        @TempDir tempDir: Path,
+    ) = runBlocking {
+        for (case in cases) {
+            val home = tempDir.resolve("ok/${case.product.id}")
+            val result = case.newManager(home).download(BackendId(case.product, case.version))
+
+            assertEquals("${case.product.id}-${case.version}", result.id)
+            assertEquals(case.product.installedProductCode, result.descriptor.productCode, case.product.id)
+            assertEquals(case.installedBuild, result.descriptor.buildNumber, case.product.id)
+            assertTrue(
+                result.backendDir.resolve(result.descriptor.bundleDirName).resolve("product-info.json").exists(),
+                "${case.product.id}: installed bundle must survive validation",
+            )
+        }
+    }
+
+    @Test
+    fun `download still rejects an artifact from another baseline, for every product`(
+        @TempDir tempDir: Path,
+    ) = runBlocking {
+        for (case in cases) {
+            // One baseline up: the shape a swapped or stale artifact has. A baseline resolution must
+            // not degrade into "any build will do".
+            val foreignBuild = case.installedBuild.replaceFirst(
+                Regex("""(\D*)(\d{3})"""),
+                "$1${ideBuildBaseline(case.resolvedBuild)!! + 1}",
+            )
+            val home = tempDir.resolve("reject/${case.product.id}")
+
+            val error = assertFailsWith<ManagedBackendValidationException>(case.product.id) {
+                case.newManager(home, installedBuild = foreignBuild).download(BackendId(case.product, case.version))
+            }
+
+            assertTrue(error.message!!.contains(foreignBuild), "${case.product.id}: ${error.message}")
+            assertFalse(
+                HomePaths(home).backendsDir.resolve("${case.product.id}-${case.version}.partial").exists(),
+                "${case.product.id}: partial install must be cleaned",
+            )
+        }
+    }
+
+    /** Mirrors `ij-plugin/build.gradle.kts` — `sinceBuild = "261"`, no upper bound. */
+    private val bundledPluginRange = PluginBuildRange(sinceBaseline = 261, untilBaseline = null)
+
+    /** Resolves through the production per-feed resolver, from a recorded payload of that feed. */
+    private fun ProductFeedCase.resolve(): IdeArchiveResolution = when (feed) {
+        BackendDownloadFeed.ANDROID_STUDIO_PREVIEW -> resolveAndroidStudioCanaryArchiveFromHtml(
+            androidStudioPreviewHtml(version, fileName), HostOs.MAC, HostArchitecture.ARM64,
+        )
+
+        BackendDownloadFeed.GITHUB_COMMUNITY -> resolveGithubCommunityArchiveFromReleasesJson(
+            githubCommunityReleasesJson(product, version, fileName), product, HostOs.MAC, HostArchitecture.ARM64,
+        )
+
+        BackendDownloadFeed.JETBRAINS_PRODUCTS_API -> resolveArchiveFromProductsApiPayload(
+            product = product,
+            channel = IdeChannel.STABLE,
+            os = HostOs.MAC,
+            architecture = HostArchitecture.ARM64,
+            productsApiUrl = "fixture://products?code=${product.code}",
+            payload = productsApiPayload(product, version, resolvedBuild, fileName),
+        )
+    }
+
+    private fun ProductFeedCase.newManager(
+        home: Path,
+        installedBuild: String = this.installedBuild,
+    ): BackendManager {
+        val resolution = resolve()
+        return BackendManager(
+            homePaths = HomePaths(home),
+            downloader = FeedResolutionDownloader(
+                resolution = resolution,
+                installedProductCode = product.installedProductCode,
+                installedBuild = installedBuild,
+                launcherExecutable = product.launcherExecutable,
+            ),
+            bundledPluginResolver = FixtureBundledPluginResolver(home.resolve("dist/ij-plugin.zip")),
+            pluginBuildRange = bundledPluginRange,
+        )
+    }
+
+    /**
+     * Installs what the resolved archive would unpack to: a bundle whose `product-info.json` carries
+     * the real artifact's product code and build. Everything before it — the feed dispatch and the
+     * resolution — is production code.
+     */
+    private class FeedResolutionDownloader(
+        private val resolution: IdeArchiveResolution,
+        private val installedProductCode: String,
+        private val installedBuild: String,
+        private val launcherExecutable: String,
+    ) : ManagedBackendDownloader {
+        override suspend fun resolve(id: BackendId) = BackendDownloadResolution(
+            product = resolution.product,
+            version = resolution.version,
+            build = resolution.build,
+            buildIsBaseline = resolution.buildIsBaseline,
+            url = resolution.url,
+            expectedSha256 = resolution.expectedSha256,
+        )
+
+        override suspend fun downloadAndUnpack(
+            resolution: BackendDownloadResolution,
+            targetDir: Path,
+        ): BackendDownloadArtifact {
+            val bundleDir = targetDir.resolve("${resolution.product.id}-${resolution.version}")
+            Files.createDirectories(bundleDir.resolve("bin"))
+            Files.writeString(
+                bundleDir.resolve("product-info.json"),
+                """
+                {
+                  "productCode": "$installedProductCode",
+                  "buildNumber": "$installedBuild",
+                  "launch": [
+                    { "os": "Linux", "launcherPath": "bin/$launcherExecutable.sh" },
+                    { "os": "macOS", "launcherPath": "bin/$launcherExecutable.sh" },
+                    { "os": "Windows", "launcherPath": "bin/$launcherExecutable.bat" }
+                  ]
+                }
+                """.trimIndent(),
+            )
+            Files.writeString(bundleDir.resolve("bin/$launcherExecutable.sh"), "#!/usr/bin/env sh\n")
+            Files.writeString(bundleDir.resolve("bin/$launcherExecutable.bat"), "@echo off\r\n")
+            return BackendDownloadArtifact(sourceArchiveSha256 = "sha-$installedProductCode")
+        }
+    }
+}

--- a/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/AllIdeProductsLiveFeedTest.kt
+++ b/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/AllIdeProductsLiveFeedTest.kt
@@ -1,0 +1,96 @@
+/* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
+package com.jonnyzzz.mcpSteroid.devrig
+
+import com.jonnyzzz.mcpSteroid.ideDownloader.HostArchitecture
+import com.jonnyzzz.mcpSteroid.ideDownloader.HostOs
+import com.jonnyzzz.mcpSteroid.ideDownloader.IdeProduct
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Path
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+/**
+ * The same contract as [AllIdeProductsDownloadTest], but against the LIVE vendor feeds: every
+ * supported IDE must still resolve, still be plugin-compatible, and still declare its build shape
+ * truthfully. Catches a feed changing what it publishes (the 2025.3 -> 262 Community move that
+ * produced #423) without waiting for a user to hit it after a 850 MB download.
+ *
+ * Opt-in — `./gradlew :npx-kt:liveNetworkTest`. Resolution only, so it costs three HTTP GETs
+ * per product, not a download.
+ */
+@Tag("live-network")
+class AllIdeProductsLiveFeedTest {
+
+    /** Mirrors `ij-plugin/build.gradle.kts` — `sinceBuild = "261"`, no upper bound. */
+    private val bundledPluginRange = PluginBuildRange(sinceBaseline = 261, untilBaseline = null)
+
+    // Feeds are host-independent; pinning the host keeps the assertions the same everywhere.
+    private val os = HostOs.MAC
+    private val architecture = HostArchitecture.ARM64
+
+    @Test
+    fun `every supported product resolves from its live feed`(@TempDir tempDir: Path) {
+        for (product in IdeProduct.knownProducts) {
+            val resolution = resolveBackendArchive(product = product, os = os, architecture = architecture)
+
+            assertEquals(product, resolution.product)
+            assertTrue(resolution.url.startsWith("https://"), "${product.id}: ${resolution.url}")
+            assertTrue(resolution.version.isNotBlank(), "${product.id}: blank version")
+            assertTrue(resolution.build.isNotBlank(), "${product.id}: blank build")
+            assertTrue(
+                bundledPluginRange.accepts(resolution.build),
+                "${product.id} ${resolution.version} (build ${resolution.build}) is outside " +
+                    "${bundledPluginRange.describe()} — `devrig backend download` would refuse it",
+            )
+
+            // Only data.services.jetbrains.com publishes a full build; the other two feeds stop at the
+            // platform baseline and MUST say so via buildIsBaseline (#429).
+            val expectBaseline = backendDownloadFeed(product).publishesBaselineOnly
+            assertEquals(expectBaseline, resolution.buildIsBaseline, "buildIsBaseline for ${product.id}")
+            assertEquals(expectBaseline, isPlatformBaselineOnly(resolution.build), "build shape for ${product.id}")
+
+            // #423: the build the unpacked artifact reports must pass validation against what the feed
+            // resolved to. For a baseline feed that is a full build on the same baseline.
+            val installedBuild = installedBuildFor(resolution.build, resolution.buildIsBaseline)
+            validateInstalledBuildNumber(
+                product = product,
+                expectedBuild = resolution.build,
+                expectedBuildIsBaseline = resolution.buildIsBaseline,
+                actualBuildNumber = installedBuild,
+                downloadedUrl = resolution.url,
+                archivePath = null,
+                bundleDir = tempDir.resolve("bundle/${product.id}"),
+                descriptorPath = tempDir.resolve("descriptor/${product.id}.json"),
+            )
+
+            // …and an artifact from the next baseline must still be refused.
+            assertFailsWith<ManagedBackendValidationException>(product.id) {
+                validateInstalledBuildNumber(
+                    product = product,
+                    expectedBuild = resolution.build,
+                    expectedBuildIsBaseline = resolution.buildIsBaseline,
+                    actualBuildNumber = installedBuild.replaceFirst(
+                        Regex("""(\D*)(\d{3})"""),
+                        "$1${ideBuildBaseline(resolution.build)!! + 1}",
+                    ),
+                    downloadedUrl = resolution.url,
+                    archivePath = null,
+                    bundleDir = tempDir.resolve("reject/${product.id}"),
+                    descriptorPath = tempDir.resolve("reject/${product.id}.json"),
+                )
+            }
+        }
+    }
+
+    /**
+     * The `product-info.json` build an install of [resolvedBuild] reports. A baseline feed only names
+     * the platform, so the artifact adds the build/patch segments (`262` -> `262.8665.258`); the
+     * products API already named the whole thing. Marker-style product-code prefixes are a separate
+     * path, covered by [IdeBuildMatchesTest].
+     */
+    private fun installedBuildFor(resolvedBuild: String, isBaseline: Boolean): String =
+        if (isBaseline) "$resolvedBuild.8665.258" else resolvedBuild
+}

--- a/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/BackendDownloadSmokeTest.kt
+++ b/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/BackendDownloadSmokeTest.kt
@@ -1,12 +1,9 @@
 /* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
 package com.jonnyzzz.mcpSteroid.devrig
 
-import com.jonnyzzz.mcpSteroid.ideDownloader.HostOs
 import com.jonnyzzz.mcpSteroid.ideDownloader.IdeProduct
-import com.jonnyzzz.mcpSteroid.ideDownloader.resolveHostOs
 import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.AfterEach
-import org.junit.jupiter.api.Assumptions.assumeTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
@@ -28,6 +25,11 @@ import kotlin.test.assertTrue
  *
  * Opt-in — `./gradlew :npx-kt:liveDownloadSmokeTest`. Each case pulls roughly 1-2 GB into the
  * JUnit temp dir and deletes it again, so it is deliberately out of every default run.
+ *
+ * Not on Windows: there the IDE ships as an NSIS `.exe`, whose unpack path needs the bundled
+ * `7z.exe` from a real installDist tree. That exclusion lives on the `liveDownloadSmokeTest`
+ * task (`enabled = !isWindows` in `npx-kt/build.gradle.kts`) — the task level is the only
+ * acceptable skip per the root CLAUDE.md; the test methods themselves are unconditional.
  */
 @Tag("live-download")
 class BackendDownloadSmokeTest {
@@ -53,9 +55,6 @@ class BackendDownloadSmokeTest {
         smokeDownload(IdeProduct.AndroidStudio, tempDir)
 
     private fun smokeDownload(product: IdeProduct, tempDir: Path) = runBlocking {
-        // Windows ships the IDE as an NSIS .exe, which needs the bundled 7z.exe from a real dist.
-        assumeTrue(resolveHostOs() != HostOs.WINDOWS, "the .exe unpack path needs an installDist 7z.exe")
-
         val homePaths = HomePaths(tempDir.resolve("home"))
         val manager = BackendManager(
             homePaths = homePaths,

--- a/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/BackendDownloadSmokeTest.kt
+++ b/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/BackendDownloadSmokeTest.kt
@@ -1,0 +1,92 @@
+/* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
+package com.jonnyzzz.mcpSteroid.devrig
+
+import com.jonnyzzz.mcpSteroid.ideDownloader.HostOs
+import com.jonnyzzz.mcpSteroid.ideDownloader.IdeProduct
+import com.jonnyzzz.mcpSteroid.ideDownloader.resolveHostOs
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assumptions.assumeTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.io.path.exists
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * The real thing: download an IDE off its live feed, unpack it, and let [BackendManager] validate the
+ * installed `product-info.json`. This is the only test that proves the #423 fix on a genuine artifact
+ * — the bug was that the build comparison rejected the install AFTER the whole transfer, so nothing
+ * short of a real download reproduces it.
+ *
+ * Covers the two products served by a baseline-only feed, which is exactly where the defect lived:
+ * `idea-community` (GitHub releases) and `android-studio` (Google's preview page).
+ *
+ * Opt-in — `./gradlew :npx-kt:liveDownloadSmokeTest`. Each case pulls roughly 1-2 GB into the
+ * JUnit temp dir and deletes it again, so it is deliberately out of every default run.
+ */
+@Tag("live-download")
+class BackendDownloadSmokeTest {
+
+    @BeforeEach
+    fun overrideDevrigRoot(@TempDir rootDir: Path) {
+        // DefaultManagedBackendDownloader asks DevrigRoot for the bundled 7-Zip, which only resolves
+        // inside an installDist tree. A stand-in root is enough: 7z.exe is a Windows-only code path.
+        Files.createDirectories(rootDir.resolve("devrig/lib"))
+        Files.writeString(rootDir.resolve("devrig/ij-plugin.zip"), "stand-in")
+        DevrigRootTestSupport.overrideCodeSource(rootDir.resolve("devrig/lib/devrig.jar"))
+    }
+
+    @AfterEach
+    fun restoreDevrigRoot() = DevrigRootTestSupport.reset()
+
+    @Test
+    fun `idea-community downloads, unpacks and validates`(@TempDir tempDir: Path) =
+        smokeDownload(IdeProduct.IntelliJIdeaCommunity, tempDir)
+
+    @Test
+    fun `android-studio downloads, unpacks and validates`(@TempDir tempDir: Path) =
+        smokeDownload(IdeProduct.AndroidStudio, tempDir)
+
+    private fun smokeDownload(product: IdeProduct, tempDir: Path) = runBlocking {
+        // Windows ships the IDE as an NSIS .exe, which needs the bundled 7z.exe from a real dist.
+        assumeTrue(resolveHostOs() != HostOs.WINDOWS, "the .exe unpack path needs an installDist 7z.exe")
+
+        val homePaths = HomePaths(tempDir.resolve("home"))
+        val manager = BackendManager(
+            homePaths = homePaths,
+            downloader = DefaultManagedBackendDownloader(archiveDownloadDir = homePaths.downloadsDir),
+            bundledPluginResolver = FixtureBundledPluginResolver(tempDir.resolve("dist/ij-plugin.zip")),
+            pluginBuildRange = PluginBuildRange(sinceBaseline = 261, untilBaseline = null),
+        )
+
+        val result = manager.download(BackendId(product, version = null))
+
+        assertEquals(product.installedProductCode, result.descriptor.productCode)
+        val installedBuild = result.descriptor.buildNumber
+        assertTrue(installedBuild != null && installedBuild.isNotBlank(), "${product.id}: no build in product-info.json")
+        // Assert through the descriptor's own launcher path — a macOS .dmg unpacks to an .app bundle
+        // whose product-info.json sits under Contents/Resources, a .tar.gz puts it at the root.
+        val bundleDir = result.backendDir.resolve(result.descriptor.bundleDirName)
+        assertTrue(
+            bundleDir.resolve(result.descriptor.launcherPath).exists(),
+            "${product.id}: the validated bundle must still be on disk with its launcher",
+        )
+        // The install survived validateInstalledBuildNumber; assert the baseline relation it checked,
+        // so a feed that starts publishing full builds shows up here rather than as a silent no-op.
+        val resolution = resolveBackendArchive(product = product)
+        println(
+            "[live-download] ${product.id} ${result.descriptor.version}: resolved build ${resolution.build} " +
+                "(baseline=${resolution.buildIsBaseline}) -> installed $installedBuild",
+        )
+        assertTrue(
+            ideBuildMatches(installedBuild, resolution.build, resolution.buildIsBaseline),
+            "${product.id}: installed $installedBuild does not match resolved ${resolution.build} " +
+                "(baseline=${resolution.buildIsBaseline})",
+        )
+    }
+}

--- a/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/IdeFeedFixtures.kt
+++ b/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/IdeFeedFixtures.kt
@@ -1,0 +1,101 @@
+/* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
+package com.jonnyzzz.mcpSteroid.devrig
+
+import com.jonnyzzz.mcpSteroid.ideDownloader.IdeProduct
+import org.apache.commons.compress.archivers.zip.ZipArchiveEntry
+import org.apache.commons.compress.archivers.zip.ZipArchiveOutputStream
+import java.nio.file.Files
+import java.nio.file.Path
+
+/**
+ * Recorded shapes of the three feeds `devrig backend download` reads, trimmed to the fields the
+ * resolvers actually consume. Shared by the offline all-products download test and the live-feed
+ * test, so both describe the same contract.
+ */
+
+/** One release of one product, as `data.services.jetbrains.com/products?code=…` serves it. */
+fun productsApiPayload(
+    product: IdeProduct,
+    version: String,
+    build: String,
+    fileName: String,
+    date: String = "2026-07-23",
+): String = """
+    [
+      {
+        "code": "${product.code}",
+        "name": "${product.displayName}",
+        "releases": [
+          {
+            "date": "$date",
+            "type": "release",
+            "version": "$version",
+            "build": "$build",
+            "downloads": {
+              "macM1": {
+                "link": "https://download.jetbrains.com/product/$fileName",
+                "checksumLink": "https://download.jetbrains.com/product/$fileName.sha256"
+              }
+            }
+          }
+        ]
+      }
+    ]
+""".trimIndent()
+
+/** A `JetBrains/intellij-community` releases page holding a single `<tag>/<version>` release. */
+fun githubCommunityReleasesJson(
+    product: IdeProduct,
+    version: String,
+    fileName: String,
+    publishedAt: String = "2026-07-16T13:32:03Z",
+): String {
+    val tag = when (product) {
+        IdeProduct.IntelliJIdeaCommunity -> "idea"
+        IdeProduct.PyCharmCommunity -> "pycharm"
+        else -> error("${product.id} is not served by the GitHub Community feed")
+    }
+    return """
+        [
+          {
+            "tag_name": "$tag/$version",
+            "prerelease": false,
+            "published_at": "$publishedAt",
+            "assets": [
+              {"name": "$fileName", "browser_download_url": "https://github.com/JetBrains/intellij-community/releases/download/$tag/$version/$fileName"}
+            ]
+          }
+        ]
+    """.trimIndent()
+}
+
+/** The `developer.android.com/studio/preview` download links for one preview build. */
+fun androidStudioPreviewHtml(version: String, macArmFileName: String): String = """
+    <table>
+      <a href="https://edgedl.me.gvt1.com/android/studio/install/$version/${macArmFileName.replace("-mac_arm.dmg", "-windows.exe")}">win</a>
+      <a href="https://edgedl.me.gvt1.com/android/studio/install/$version/$macArmFileName">mac arm</a>
+      <a href="https://edgedl.me.gvt1.com/android/studio/install/$version/${macArmFileName.replace("-mac_arm.dmg", "-mac.dmg")}">mac intel</a>
+      <a href="https://edgedl.me.gvt1.com/android/studio/ide-zips/$version/${macArmFileName.replace("-mac_arm.dmg", "-linux.tar.gz")}">linux</a>
+    </table>
+""".trimIndent()
+
+/** A minimal `ij-plugin.zip` — [BackendManager.download] deploys it after a successful install. */
+fun pluginZipFixture(zip: Path): Path {
+    if (Files.isRegularFile(zip)) return zip
+    Files.createDirectories(zip.parent)
+    ZipArchiveOutputStream(Files.newOutputStream(zip)).use { out ->
+        val bytes = "plugin".toByteArray(Charsets.UTF_8)
+        val entry = ZipArchiveEntry("mcp-steroid/lib/plugin.txt").apply {
+            size = bytes.size.toLong()
+            unixMode = 0b110_100_100
+        }
+        out.putArchiveEntry(entry)
+        out.write(bytes)
+        out.closeArchiveEntry()
+    }
+    return zip
+}
+
+class FixtureBundledPluginResolver(private val zip: Path) : BundledPluginResolver {
+    override fun resolveBundledPluginZip(): Path = pluginZipFixture(zip)
+}


### PR DESCRIPTION
#429 fixed the baseline-vs-full build comparison that rejected every `idea-community` download, but
the regression test that came with it only covered `idea-community`. The same defect lived in
`AndroidStudioCanaryReleases` — the canary resolver derives the build the same way — and nothing
asserted the contract for the other seven products at all.

This adds coverage for **all nine supported IDEs across all three feeds**, Android Studio included.

## What is tested

`AllIdeProductsDownloadTest` (default `:npx-kt:test`, offline) walks every `IdeProduct.knownProducts`
entry through the production path: feed dispatch → the real per-feed resolver over a recorded payload
→ `BackendManager.download` → unpack → `product-info.json` validation → descriptor. Per product it
asserts

- the feed's build shape and `buildIsBaseline` agree (only `data.services.jetbrains.com` publishes a
  full build; GitHub Community and the Android Studio preview page stop at the platform baseline),
- the resolved build is loadable by the bundled plugin (`plugin.xml` `since-build 261`),
- the build a real install of that artifact reports **passes** validation (`262` ↔ `262.8665.258`,
  `261` ↔ `AI-261.24374.151.2611.14049965`),
- an artifact from the next baseline is still **refused**, and the partial install is cleaned.

A new product added to `knownProducts` fails the test until it gets a row, so a fourth feed cannot
land without baseline coverage.

Verified as a real guard by mutation: reverting `ideBuildMatches` to the pre-#429 equality fails it,
and so does flipping Android Studio's `buildIsBaseline` back to `false`.

## Opt-in live tests

Vendor-feed calls stay out of every default run so an outage cannot redden a build:

- `:npx-kt:liveNetworkTest` (`live-network`) — all nine products resolve off the real feeds with a
  plugin-compatible build and a truthful `buildIsBaseline`. ~1 min, no archive download.
- `:npx-kt:liveDownloadSmokeTest` (`live-download`) — `idea-community` and `android-studio` really
  download, unpack and pass validation. Multi-GB, the only thing that reproduces #423 end to end.

Both were run green on macOS arm64 against the live feeds.

## Production change

The feed dispatch was duplicated in `DefaultManagedBackendDownloader.resolve` and
`ReleaseServiceAvailableBackendVersionResolver`; it is now one `resolveBackendArchive` /
`backendDownloadFeed` pair in `BackendDownloadFeeds.kt`, so the download path and the
`devrig backend download` list cannot drift. Behaviour is unchanged.
`resolveArchiveFromProductsApiPayload` becomes public — the same pure-resolver seam its two sibling
feeds already expose.
