### PR TITLE
devrig: resolve Android Studio by version, not by HTML order

### DIFF
--- a/intellij-downloader/src/buildsrc-shared/kotlin/com/jonnyzzz/mcpSteroid/ideDownloader/AndroidStudioDownloadPage.kt
+++ b/intellij-downloader/src/buildsrc-shared/kotlin/com/jonnyzzz/mcpSteroid/ideDownloader/AndroidStudioDownloadPage.kt
@@ -1,0 +1,174 @@
+/* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
+package com.jonnyzzz.mcpSteroid.ideDownloader
+
+// Parses a `developer.android.com` download page — `/studio` (stable) or `/studio/preview` (canary,
+// beta, RC) — into ALL the releases it advertises, and picks one of them deterministically.
+//
+// Google serves several generations from the same page: the preview page currently offers
+// `2026.1.4.3` (Quail 4 Canary 3) next to the older `2026.1.3.6` (Quail 3 RC 2). Which block comes
+// first in the HTML is Google's editorial choice, so taking the first matching download link resolves
+// whatever happens to be typed first — correct today, silently the older RC the day Google swaps the
+// sections. Selection here reads only the page CONTENT: links are grouped by the version in their
+// URL, and the pick is made by comparing version numbers.
+
+/** Release channel of an Android Studio build, as spelled in its download filename. */
+enum class AndroidStudioPageChannel(val token: String, val stability: Int) {
+    /** No channel segment (`android-studio-quail3-linux.tar.gz`) or a stable patch (`-panda4-patch1-`). */
+    RELEASE("release", 3),
+    RC("rc", 2),
+    BETA("beta", 1),
+    CANARY("canary", 0),
+}
+
+/** One Android Studio version as published on a download page, with every artifact link it lists. */
+data class AndroidStudioPageRelease(
+    /** Marketing version taken from the download URL, e.g. `2026.1.4.3`. */
+    val version: String,
+    val channel: AndroidStudioPageChannel,
+    /** Download URLs published for this version, in page order. */
+    val urls: List<String>,
+) {
+    /** The IntelliJ platform baseline this build is made of: `2026.1.4.3` -> 261. */
+    val platformBaseline: Int? get() = androidStudioPlatformBaseline(version)
+
+    fun assetEndingWith(suffix: String): String? = urls.firstOrNull { it.endsWith(suffix) }
+}
+
+/** The artifact chosen for one host out of an [AndroidStudioPageRelease]. */
+data class AndroidStudioPageDownload(
+    val release: AndroidStudioPageRelease,
+    val url: String,
+)
+
+/**
+ * Maps an Android Studio marketing version to its IntelliJ platform baseline: `2026.1.2.3` -> 261,
+ * `2025.3.4.7` -> 253. Android Studio tracks the platform it is built on as `YYYY.N`.
+ */
+fun androidStudioPlatformBaseline(version: String): Int? {
+    val match = Regex("""^(\d{4})\.(\d+)""").find(version) ?: return null
+    return (match.groupValues[1].toInt() % 100) * 10 + match.groupValues[2].toInt()
+}
+
+private val androidStudioDownloadUrlRegex =
+    Regex("""https://[^"'\s<>]*android-studio[^"'\s<>]*\.(?:zip|tar\.gz|dmg|exe)""")
+
+private val androidStudioUrlPathVersionRegex = Regex("""/(?:install|ide-zips)/(\d+(?:\.\d+)+)/""")
+
+private val androidStudioFileNameVersionRegex = Regex("""android-studio-(\d+(?:\.\d+)+)-""")
+
+private val androidStudioFileNameChannelRegex = Regex("""-(canary|beta|rc)\d*[-.]""", RegexOption.IGNORE_CASE)
+
+/** The marketing version a download URL belongs to, or null when the URL carries no version. */
+fun androidStudioVersionFromDownloadUrl(url: String): String? {
+    androidStudioUrlPathVersionRegex.find(url)?.let { return it.groupValues[1] }
+    return androidStudioFileNameVersionRegex.find(url.substringAfterLast('/'))?.groupValues?.get(1)
+}
+
+/** Every Android Studio release advertised on [html], each with all of its download links. */
+fun parseAndroidStudioDownloadPage(html: String): List<AndroidStudioPageRelease> {
+    val urlsByVersion = LinkedHashMap<String, MutableList<String>>()
+    for (match in androidStudioDownloadUrlRegex.findAll(html)) {
+        val url = match.value
+        val version = androidStudioVersionFromDownloadUrl(url) ?: continue
+        val urls = urlsByVersion.getOrPut(version) { mutableListOf() }
+        if (url !in urls) urls += url
+    }
+    return urlsByVersion.map { (version, urls) ->
+        AndroidStudioPageRelease(version, androidStudioChannelOf(urls), urls)
+    }
+}
+
+/**
+ * Compares two dotted numeric Android Studio versions segment by segment, so `2026.1.4.3` beats
+ * `2026.1.3.6` (a plain string compare would not). Missing segments count as `0`: `2026.1` < `2026.1.1`.
+ */
+fun compareAndroidStudioVersions(left: String, right: String): Int {
+    val leftSegments = left.split('.')
+    val rightSegments = right.split('.')
+    for (index in 0 until maxOf(leftSegments.size, rightSegments.size)) {
+        val leftSegment = leftSegments.getOrNull(index)?.toIntOrNull() ?: 0
+        val rightSegment = rightSegments.getOrNull(index)?.toIntOrNull() ?: 0
+        if (leftSegment != rightSegment) return leftSegment.compareTo(rightSegment)
+    }
+    return 0
+}
+
+/**
+ * Newest first. The marketing version decides; a tie falls back to the more stable channel (an RC
+ * before the canary of the same version), then to the raw version text — so the order is a total
+ * function of the page content and never of the order Google listed the blocks in.
+ */
+private val androidStudioNewestFirst: Comparator<AndroidStudioPageRelease> = Comparator { left, right ->
+    compareAndroidStudioVersions(right.version, left.version)
+        .takeIf { it != 0 }
+        ?: (right.channel.stability - left.channel.stability).takeIf { it != 0 }
+        ?: right.version.compareTo(left.version)
+}
+
+/**
+ * The releases matching [selector], newest first. A blank [selector] matches everything. Otherwise it
+ * is, in order: the exact marketing version (`2026.1.4.3`), a version prefix on a segment boundary
+ * (`2026.1` -> the newest `2026.1.x`), a platform baseline (`261` -> the newest build made of the 261
+ * platform), or a channel name (`canary`, `beta`, `rc`, `release`).
+ */
+fun androidStudioReleasesMatching(
+    releases: List<AndroidStudioPageRelease>,
+    selector: String?,
+): List<AndroidStudioPageRelease> {
+    val wanted = selector?.trim()?.takeIf { it.isNotEmpty() }
+    val matching = if (wanted == null) releases else releases.filter { it.matchesSelector(wanted) }
+    return matching.sortedWith(androidStudioNewestFirst)
+}
+
+/**
+ * Resolves the artifact ending in [assetSuffix] for [selector] (see [androidStudioReleasesMatching])
+ * out of the download page [html]. With no [selector] the newest release that publishes such an
+ * artifact wins; the HTML order of the release blocks is never consulted.
+ */
+fun resolveAndroidStudioPageDownload(
+    html: String,
+    pageUrl: String,
+    assetSuffix: String,
+    selector: String?,
+): AndroidStudioPageDownload {
+    val releases = parseAndroidStudioDownloadPage(html)
+    if (releases.isEmpty()) {
+        error("Could not find any android-studio download URL on $pageUrl. Page format may have changed.")
+    }
+
+    val candidates = androidStudioReleasesMatching(releases, selector)
+    if (candidates.isEmpty()) {
+        error(
+            "Android Studio '$selector' is not published on $pageUrl. " +
+                "Available: ${releases.describeReleases()}"
+        )
+    }
+
+    for (release in candidates) {
+        val url = release.assetEndingWith(assetSuffix) ?: continue
+        return AndroidStudioPageDownload(release, url)
+    }
+    error(
+        "No Android Studio download URL ending in '$assetSuffix' on $pageUrl " +
+            "(searched ${candidates.describeReleases()})"
+    )
+}
+
+private fun androidStudioChannelOf(urls: List<String>): AndroidStudioPageChannel {
+    val token = urls.firstNotNullOfOrNull { url ->
+        androidStudioFileNameChannelRegex.find(url.substringAfterLast('/'))?.groupValues?.get(1)
+    } ?: return AndroidStudioPageChannel.RELEASE
+    return AndroidStudioPageChannel.entries.firstOrNull { it.token.equals(token, ignoreCase = true) }
+        ?: AndroidStudioPageChannel.RELEASE
+}
+
+private fun AndroidStudioPageRelease.matchesSelector(selector: String): Boolean {
+    if (version == selector) return true
+    if (version.startsWith("$selector.")) return true
+    val baseline = selector.toIntOrNull()
+    if (baseline != null) return baseline in 100..999 && platformBaseline == baseline
+    return channel.token.equals(selector, ignoreCase = true)
+}
+
+private fun List<AndroidStudioPageRelease>.describeReleases(): String =
+    sortedWith(androidStudioNewestFirst).joinToString { "${it.version} (${it.channel.token})" }

--- a/intellij-downloader/src/buildsrc-shared/kotlin/com/jonnyzzz/mcpSteroid/ideDownloader/AndroidStudioReleaseLookup.kt
+++ b/intellij-downloader/src/buildsrc-shared/kotlin/com/jonnyzzz/mcpSteroid/ideDownloader/AndroidStudioReleaseLookup.kt
@@ -27,6 +27,10 @@ private val androidStudioReleaseLookupLog =
  * Android Studio does NOT publish Linux ARM64 or Windows ARM64 builds. Those combos throw
  * with a clear message so callers can pick a different IDE / architecture.
  *
+ * The page can advertise more than one version at a time (a fresh release next to the previous
+ * patch), so the release is picked by version number rather than by HTML order — see
+ * [resolveAndroidStudioPageDownload].
+ *
  * Channels other than stable (canary, beta) live on a separate page and are not yet supported.
  *
  * @param channel only `STABLE` is supported (Android Studio's `EAP` channel = canary, served
@@ -80,64 +84,45 @@ internal fun resolveAndroidStudioArchiveFromHtml(
     html: String,
 ): IdeArchiveResolution {
     // Each download is an absolute https URL into edgedl.me.gvt1.com/android/studio/...
-    // We pull every match out of the page and pick by suffix — that's stable across
-    // the marketing-name segment in the filename ("panda4-patch1"), which we can't
-    // derive from the updates.xml alone.
-    val allUrls = Regex("""https://[^"'\s<>]*android-studio[^"'\s<>]*\.(?:zip|tar\.gz|dmg|exe)""")
-        .findAll(html)
-        .map { it.value }
-        .toSet()
-    val checksumsByFileName = androidStudioChecksumsByFileName(html)
-
-    if (allUrls.isEmpty()) {
-        error("Could not find any android-studio download URL on $pageUrl. Page format may have changed.")
-    }
-
-    val wantedSuffixes: List<String> = when (os) {
+    // We pull every match out of the page and pick the artifact by suffix — that's stable
+    // across the marketing-name segment in the filename ("panda4-patch1"), which we can't
+    // derive from the updates.xml alone. Which RELEASE the artifact belongs to is decided by
+    // version number, not by where Google placed the link on the page.
+    val wantedSuffix = when (os) {
         HostOs.LINUX -> {
             require(!architecture.isArmArch) {
                 "Android Studio does not publish a Linux ARM64 build (only x86_64 .tar.gz). " +
                     "Pick another product or architecture."
             }
-            listOf("-linux.tar.gz")
+            "-linux.tar.gz"
         }
-        HostOs.MAC -> if (architecture.isArmArch) listOf("-mac_arm.dmg") else listOf("-mac.dmg")
+        HostOs.MAC -> if (architecture.isArmArch) "-mac_arm.dmg" else "-mac.dmg"
         HostOs.WINDOWS -> {
             require(!architecture.isArmArch) {
                 "Android Studio does not publish a Windows ARM64 build. " +
                     "Pick x86_64 or another product."
             }
-            listOf("-windows.exe")
+            "-windows.exe"
         }
     }
 
-    for (suffix in wantedSuffixes) {
-        val match = allUrls.firstOrNull { it.endsWith(suffix) }
-        if (match != null) {
-            val resolvedVersion = inferAndroidStudioVersion(match)
-            if (!version.isNullOrBlank() && version != resolvedVersion) {
-                error(
-                    "Android Studio $version is not the current stable archive on $pageUrl " +
-                        "(current stable is $resolvedVersion). Version-pinned Android Studio downloads " +
-                        "are not supported by this downloader yet."
-                )
-            }
-            return IdeArchiveResolution(
-                product = IdeProduct.AndroidStudio,
-                channel = channel,
-                version = resolvedVersion,
-                build = resolvedVersion,
-                url = match,
-                downloadKey = suffix.removePrefix("-").removeSuffix(".tar.gz").removeSuffix(".dmg")
-                    .removeSuffix(".zip").removeSuffix(".exe"),
-                expectedSha256 = checksumsByFileName[downloadFilenameFromUrl(match)],
-            )
-        }
-    }
+    val download = resolveAndroidStudioPageDownload(
+        html = html,
+        pageUrl = pageUrl,
+        assetSuffix = wantedSuffix,
+        selector = version,
+    )
+    val checksumsByFileName = androidStudioChecksumsByFileName(html)
 
-    error(
-        "No Android Studio download URL ending in ${wantedSuffixes.joinToString()} found on $pageUrl. " +
-            "URLs discovered: ${allUrls.sorted().joinToString()}"
+    return IdeArchiveResolution(
+        product = IdeProduct.AndroidStudio,
+        channel = channel,
+        version = download.release.version,
+        build = download.release.version,
+        url = download.url,
+        downloadKey = wantedSuffix.removePrefix("-").removeSuffix(".tar.gz").removeSuffix(".dmg")
+            .removeSuffix(".zip").removeSuffix(".exe"),
+        expectedSha256 = checksumsByFileName[downloadFilenameFromUrl(download.url)],
     )
 }
 
@@ -155,17 +140,6 @@ internal fun androidStudioChecksumsByFileName(html: String): Map<String, String>
     }
 }
 
-internal fun inferAndroidStudioVersion(url: String): String {
-    val pathVersion = Regex("""/(?:install|ide-zips)/([0-9]+(?:\.[0-9]+)+)/""")
-        .find(url)
-        ?.groupValues
-        ?.get(1)
-    if (pathVersion != null) return pathVersion
-
-    val fileName = url.substringAfterLast('/')
-    val version = Regex("""android-studio-([0-9]+(?:\.[0-9]+)+)-""")
-        .find(fileName)
-        ?.groupValues
-        ?.get(1)
-    return version ?: error("Could not infer Android Studio version from download URL: $url")
-}
+internal fun inferAndroidStudioVersion(url: String): String =
+    androidStudioVersionFromDownloadUrl(url)
+        ?: error("Could not infer Android Studio version from download URL: $url")

--- a/intellij-downloader/src/test/kotlin/com/jonnyzzz/mcpSteroid/ideDownloader/AndroidStudioDownloadPageTest.kt
+++ b/intellij-downloader/src/test/kotlin/com/jonnyzzz/mcpSteroid/ideDownloader/AndroidStudioDownloadPageTest.kt
@@ -1,0 +1,135 @@
+/* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
+package com.jonnyzzz.mcpSteroid.ideDownloader
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
+import org.junit.Test
+
+/**
+ * A download page can advertise several generations at once, in whatever order Google types them.
+ * These tests keep the resolution a function of the page content only.
+ */
+class AndroidStudioDownloadPageTest {
+
+    /** Two generations, the OLDER one first — the layout that used to resolve to the older build. */
+    private val twoGenerationsOlderFirst = """
+        <html><body>
+          <a href="https://edgedl.me.gvt1.com/android/studio/install/2026.1.3.6/android-studio-quail3-rc2-windows.exe">win</a>
+          <a href="https://edgedl.me.gvt1.com/android/studio/install/2026.1.3.6/android-studio-quail3-rc2-mac_arm.dmg">mac arm</a>
+          <a href="https://edgedl.me.gvt1.com/android/studio/ide-zips/2026.1.3.6/android-studio-quail3-rc2-linux.tar.gz">linux</a>
+          <a href="https://edgedl.me.gvt1.com/android/studio/install/2026.1.4.3/android-studio-quail4-canary3-windows.exe">win</a>
+          <a href="https://edgedl.me.gvt1.com/android/studio/install/2026.1.4.3/android-studio-quail4-canary3-mac_arm.dmg">mac arm</a>
+          <a href="https://edgedl.me.gvt1.com/android/studio/ide-zips/2026.1.4.3/android-studio-quail4-canary3-linux.tar.gz">linux</a>
+        </body></html>
+    """.trimIndent()
+
+    @Test
+    fun `parses every version on the page with its channel and links`() {
+        val releases = parseAndroidStudioDownloadPage(twoGenerationsOlderFirst)
+
+        assertEquals(setOf("2026.1.3.6", "2026.1.4.3"), releases.map { it.version }.toSet())
+        val canary = releases.single { it.version == "2026.1.4.3" }
+        assertEquals(AndroidStudioPageChannel.CANARY, canary.channel)
+        assertEquals(261, canary.platformBaseline)
+        assertEquals(3, canary.urls.size)
+        assertEquals(AndroidStudioPageChannel.RC, releases.single { it.version == "2026.1.3.6" }.channel)
+    }
+
+    @Test
+    fun `a stable page release carries no channel token`() {
+        val releases = parseAndroidStudioDownloadPage(
+            """<a href="https://edgedl.me.gvt1.com/android/studio/ide-zips/2025.3.4.7/android-studio-panda4-patch1-linux.tar.gz">x</a>"""
+        )
+
+        assertEquals(AndroidStudioPageChannel.RELEASE, releases.single().channel)
+        assertEquals(253, releases.single().platformBaseline)
+    }
+
+    @Test
+    fun `the newest release wins regardless of where it sits in the html`() {
+        val download = resolveAndroidStudioPageDownload(
+            html = twoGenerationsOlderFirst,
+            pageUrl = "fixture://android-studio/preview",
+            assetSuffix = "-linux.tar.gz",
+            selector = null,
+        )
+
+        assertEquals("2026.1.4.3", download.release.version)
+        assertTrue(download.url, download.url.endsWith("android-studio-quail4-canary3-linux.tar.gz"))
+    }
+
+    @Test
+    fun `an exact version selector pins that release`() {
+        val download = resolveAndroidStudioPageDownload(
+            twoGenerationsOlderFirst, "fixture://android-studio/preview", "-linux.tar.gz", "2026.1.3.6",
+        )
+
+        assertEquals("2026.1.3.6", download.release.version)
+    }
+
+    @Test
+    fun `a platform baseline selector resolves to the newest build of that baseline`() {
+        val nextGeneration =
+            """<a href="https://edgedl.me.gvt1.com/android/studio/ide-zips/2026.2.1.1/android-studio-rabbit1-canary1-linux.tar.gz">x</a>"""
+        val html = twoGenerationsOlderFirst.replace("</body>", "$nextGeneration</body>")
+
+        assertEquals(
+            "2026.1.4.3",
+            resolveAndroidStudioPageDownload(html, "fixture://p", "-linux.tar.gz", "261").release.version,
+        )
+        assertEquals(
+            "2026.2.1.1",
+            resolveAndroidStudioPageDownload(html, "fixture://p", "-linux.tar.gz", "262").release.version,
+        )
+        assertEquals(
+            "2026.2.1.1",
+            resolveAndroidStudioPageDownload(html, "fixture://p", "-linux.tar.gz", null).release.version,
+        )
+    }
+
+    @Test
+    fun `a generation that lacks the wanted artifact falls back to the next newest`() {
+        val html = twoGenerationsOlderFirst.replace(
+            """<a href="https://edgedl.me.gvt1.com/android/studio/ide-zips/2026.1.4.3/android-studio-quail4-canary3-linux.tar.gz">linux</a>""",
+            "",
+        )
+
+        val download = resolveAndroidStudioPageDownload(html, "fixture://p", "-linux.tar.gz", null)
+
+        assertEquals("2026.1.3.6", download.release.version)
+    }
+
+    @Test
+    fun `an unknown selector fails naming the versions the page offers`() {
+        val message = errorMessageOf {
+            resolveAndroidStudioPageDownload(twoGenerationsOlderFirst, "fixture://p", "-linux.tar.gz", "2025.3")
+        }
+
+        assertTrue(message, message.contains("2026.1.4.3 (canary)"))
+        assertTrue(message, message.contains("2026.1.3.6 (rc)"))
+    }
+
+    @Test
+    fun `an empty page fails with the page format hint`() {
+        val message = errorMessageOf {
+            resolveAndroidStudioPageDownload("<html></html>", "fixture://p", "-linux.tar.gz", null)
+        }
+
+        assertTrue(message, message.contains("Page format may have changed"))
+    }
+
+    @Test
+    fun `versions compare segment-wise and not as text`() {
+        assertTrue(compareAndroidStudioVersions("2026.1.4.3", "2026.1.3.6") > 0)
+        assertTrue(compareAndroidStudioVersions("2026.1.10.0", "2026.1.9.9") > 0)
+        assertTrue(compareAndroidStudioVersions("2026.1", "2026.1.1") < 0)
+        assertEquals(0, compareAndroidStudioVersions("2026.1.4.3", "2026.1.4.3"))
+    }
+
+    private inline fun errorMessageOf(block: () -> Unit): String {
+        try { block() } catch (e: Throwable) { return e.message.orEmpty() }
+        fail("Expected an exception; none thrown")
+        @Suppress("UNREACHABLE_CODE") throw AssertionError()
+    }
+}

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/AndroidStudioCanaryReleases.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/AndroidStudioCanaryReleases.kt
@@ -6,6 +6,7 @@ import com.jonnyzzz.mcpSteroid.ideDownloader.HostOs
 import com.jonnyzzz.mcpSteroid.ideDownloader.IdeArchiveResolution
 import com.jonnyzzz.mcpSteroid.ideDownloader.IdeChannel
 import com.jonnyzzz.mcpSteroid.ideDownloader.IdeProduct
+import com.jonnyzzz.mcpSteroid.ideDownloader.resolveAndroidStudioPageDownload
 import com.jonnyzzz.mcpSteroid.ideDownloader.resolveHostArchitecture
 import com.jonnyzzz.mcpSteroid.ideDownloader.resolveHostOs
 import java.io.IOException
@@ -20,15 +21,6 @@ import java.net.URI
  */
 const val ANDROID_STUDIO_PREVIEW_PAGE: String = "https://developer.android.com/studio/preview"
 
-/**
- * Maps an Android Studio marketing version to its IntelliJ platform baseline: `2026.1.2.3` -> 261,
- * `2025.3.4.7` -> 253. Android Studio tracks the platform it is built on as `YYYY.N`.
- */
-fun androidStudioPlatformBaseline(version: String): Int? {
-    val match = Regex("""^(\d{4})\.(\d+)""").find(version) ?: return null
-    return (match.groupValues[1].toInt() % 100) * 10 + match.groupValues[2].toInt()
-}
-
 private fun androidStudioPreviewSuffix(os: HostOs, architecture: HostArchitecture): String = when (os) {
     HostOs.LINUX -> {
         require(!architecture.isArmArch) { "Android Studio publishes no Linux ARM64 build; pick x86_64 or another product." }
@@ -41,14 +33,16 @@ private fun androidStudioPreviewSuffix(os: HostOs, architecture: HostArchitectur
     }
 }
 
-private fun inferAndroidStudioCanaryVersion(url: String): String =
-    Regex("""/(?:install|ide-zips)/([0-9]+(?:\.[0-9]+)+)/""").find(url)?.groupValues?.get(1)
-        ?: error("Could not infer the Android Studio canary version from $url")
-
 /**
  * Resolves the Android Studio canary archive from the preview page HTML (pure — no I/O, so it is
  * unit testable). The download URLs are absolute `edgedl.me.gvt1.com` links picked by OS/arch suffix
  * (stable across the codename segment, e.g. `quail2-canary3`); the build is the platform baseline.
+ *
+ * The preview page publishes SEVERAL generations at once — `2026.1.4.3` (Quail 4 Canary 3) next to
+ * the older `2026.1.3.6` (Quail 3 RC 2) — in an order Google is free to change. All of them are
+ * parsed and the newest wins ([resolveAndroidStudioPageDownload]); [version] pins a specific one by
+ * exact version (`2026.1.4.3`), version prefix (`2026.1`), platform baseline (`261`) or channel
+ * (`canary`, `rc`, `beta`).
  */
 fun resolveAndroidStudioCanaryArchiveFromHtml(
     html: String,
@@ -56,21 +50,14 @@ fun resolveAndroidStudioCanaryArchiveFromHtml(
     architecture: HostArchitecture,
     version: String? = null,
 ): IdeArchiveResolution {
-    val urls = Regex("""https://[^"'\s<>]*android-studio[^"'\s<>]*\.(?:zip|tar\.gz|dmg|exe)""")
-        .findAll(html).map { it.value }.toSet()
-    require(urls.isNotEmpty()) {
-        "No android-studio download URL on $ANDROID_STUDIO_PREVIEW_PAGE — the page format may have changed."
-    }
-
-    val suffix = androidStudioPreviewSuffix(os, architecture)
-    val url = urls.firstOrNull { it.endsWith(suffix) }
-        ?: error("No Android Studio canary asset ending in '$suffix' on $ANDROID_STUDIO_PREVIEW_PAGE (found: ${urls.sorted()})")
-
-    val resolvedVersion = inferAndroidStudioCanaryVersion(url)
-    require(version.isNullOrBlank() || version == resolvedVersion) {
-        "Android Studio canary $version is not the current preview build (current is $resolvedVersion); version pinning is not supported."
-    }
-    val baseline = androidStudioPlatformBaseline(resolvedVersion)
+    val download = resolveAndroidStudioPageDownload(
+        html = html,
+        pageUrl = ANDROID_STUDIO_PREVIEW_PAGE,
+        assetSuffix = androidStudioPreviewSuffix(os, architecture),
+        selector = version,
+    )
+    val resolvedVersion = download.release.version
+    val baseline = download.release.platformBaseline
 
     return IdeArchiveResolution(
         product = IdeProduct.AndroidStudio,
@@ -80,8 +67,8 @@ fun resolveAndroidStudioCanaryArchiveFromHtml(
         // The preview page only exposes the marketing version, so the build is the platform baseline
         // (`262`) while the installed artifact reports the full `262.8665.258.2621.14049965`.
         buildIsBaseline = baseline != null,
-        url = url,
-        downloadKey = url.substringAfterLast('/'),
+        url = download.url,
+        downloadKey = download.url.substringAfterLast('/'),
     )
 }
 

--- a/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/AndroidStudioCanaryReleasesTest.kt
+++ b/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/AndroidStudioCanaryReleasesTest.kt
@@ -3,6 +3,7 @@ package com.jonnyzzz.mcpSteroid.devrig
 
 import com.jonnyzzz.mcpSteroid.ideDownloader.HostArchitecture
 import com.jonnyzzz.mcpSteroid.ideDownloader.HostOs
+import com.jonnyzzz.mcpSteroid.ideDownloader.androidStudioPlatformBaseline
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
@@ -20,6 +21,12 @@ class AndroidStudioCanaryReleasesTest {
           <a href="https://edgedl.me.gvt1.com/android/studio/ide-zips/2026.1.2.3/android-studio-quail2-canary3-linux.tar.gz">linux</a>
         </table>
     """.trimIndent()
+
+    /** developer.android.com/studio/preview as recorded on 2026-08-03: canary 2026.1.4.3 listed first. */
+    private val recordedPreviewPage = fixture("android-studio-preview.html")
+
+    /** The same two generations with the blocks swapped: the OLDER RC comes first in the HTML. */
+    private val recordedPreviewPageRcFirst = fixture("android-studio-preview-rc-first.html")
 
     @Test
     fun `platform baseline derives from the YYYY-N marketing version`() {
@@ -59,4 +66,86 @@ class AndroidStudioCanaryReleasesTest {
             resolveAndroidStudioCanaryArchiveFromHtml(html, HostOs.LINUX, HostArchitecture.ARM64)
         }
     }
+
+    @Test
+    fun `recorded preview page resolves the newest of the two generations it lists`() {
+        val archive = resolveAndroidStudioCanaryArchiveFromHtml(
+            recordedPreviewPage, HostOs.MAC, HostArchitecture.ARM64,
+        )
+        assertEquals("2026.1.4.3", archive.version)
+        assertTrue(archive.url.endsWith("android-studio-quail4-canary3-mac_arm.dmg"), archive.url)
+    }
+
+    @Test
+    fun `the html order of the release blocks does not decide which build is picked`() {
+        // Google is free to reorder the sections; the older RC first must NOT downgrade the resolution.
+        assertTrue(
+            recordedPreviewPageRcFirst.indexOf("/2026.1.3.6/") < recordedPreviewPageRcFirst.indexOf("/2026.1.4.3/"),
+            "fixture must list the older RC first, otherwise it does not guard anything",
+        )
+
+        for (os in listOf(HostOs.MAC, HostOs.LINUX, HostOs.WINDOWS)) {
+            val archive = resolveAndroidStudioCanaryArchiveFromHtml(
+                recordedPreviewPageRcFirst, os, HostArchitecture.X86_64,
+            )
+            assertEquals("2026.1.4.3", archive.version, "resolved the first block in the HTML on $os")
+            assertEquals("261", archive.build)
+            assertTrue(archive.url.contains("quail4-canary3"), archive.url)
+        }
+    }
+
+    @Test
+    fun `an exact version request picks that release and not the newest`() {
+        val archive = resolveAndroidStudioCanaryArchiveFromHtml(
+            recordedPreviewPage, HostOs.MAC, HostArchitecture.ARM64, version = "2026.1.3.6",
+        )
+        assertEquals("2026.1.3.6", archive.version)
+        assertTrue(archive.url.endsWith("android-studio-quail3-rc2-mac_arm.dmg"), archive.url)
+    }
+
+    @Test
+    fun `a version prefix request picks the newest patch of that generation`() {
+        val archive = resolveAndroidStudioCanaryArchiveFromHtml(
+            recordedPreviewPage, HostOs.MAC, HostArchitecture.ARM64, version = "2026.1.3",
+        )
+        assertEquals("2026.1.3.6", archive.version)
+    }
+
+    @Test
+    fun `a platform baseline request resolves to the newest build on that baseline`() {
+        val archive = resolveAndroidStudioCanaryArchiveFromHtml(
+            recordedPreviewPageRcFirst, HostOs.MAC, HostArchitecture.ARM64, version = "261",
+        )
+        assertEquals("2026.1.4.3", archive.version)
+        assertEquals("261", archive.build)
+        assertTrue(archive.buildIsBaseline)
+    }
+
+    @Test
+    fun `a channel request picks the newest build of that channel`() {
+        val rc = resolveAndroidStudioCanaryArchiveFromHtml(
+            recordedPreviewPage, HostOs.MAC, HostArchitecture.ARM64, version = "rc",
+        )
+        assertEquals("2026.1.3.6", rc.version)
+
+        val canary = resolveAndroidStudioCanaryArchiveFromHtml(
+            recordedPreviewPage, HostOs.MAC, HostArchitecture.ARM64, version = "canary",
+        )
+        assertEquals("2026.1.4.3", canary.version)
+    }
+
+    @Test
+    fun `an unavailable version fails listing what the page does offer`() {
+        val error = assertThrows<IllegalStateException> {
+            resolveAndroidStudioCanaryArchiveFromHtml(
+                recordedPreviewPage, HostOs.MAC, HostArchitecture.ARM64, version = "2025.3.4.7",
+            )
+        }
+        assertTrue(error.message!!.contains("2026.1.4.3 (canary)"), error.message!!)
+        assertTrue(error.message!!.contains("2026.1.3.6 (rc)"), error.message!!)
+    }
+
+    private fun fixture(name: String): String =
+        javaClass.classLoader.getResource("fixtures/$name")?.readText()
+            ?: error("Missing test fixture: fixtures/$name")
 }

--- a/npx-kt/src/test/resources/fixtures/android-studio-preview-rc-first.html
+++ b/npx-kt/src/test/resources/fixtures/android-studio-preview-rc-first.html
@@ -1,0 +1,254 @@
+<!doctype html>
+<!--
+  Recorded from https://developer.android.com/studio/preview on 2026-08-03, trimmed to the
+  download-button blocks (their markup as served, trailing whitespace stripped).
+
+  The page serves TWO generations at once: Quail 4 | 2026.1.4 Canary 3 (2026.1.4.3) and the
+  older Quail 3 | 2026.1.3 RC 2 (2026.1.3.6). Same blocks as android-studio-preview.html with the two generations SWAPPED: the older RC
+  comes first. Google controls this order; the resolver must not.
+-->
+<html><body>
+
+<!-- ===== Quail 3 | 2026.1.3 RC 2 ===== -->
+<div class="buttons">
+
+          <button class="button button-disabled">
+            <span class="lang-float">Download Android Studio Quail 3 | 2026.1.3 RC 2
+                  for Windows
+            </span>
+          </button>
+          <a class="button button-primary
+               devsite-dialog-close gc-analytics-event"
+               data-category="beta_win_bundle_download" data-action="download"
+
+               href="https://edgedl.me.gvt1.com/android/studio/install/2026.1.3.6/android-studio-quail3-rc2-windows.exe"
+               id="agree-button__beta_win_bundle_download"
+            >Download Android Studio Quail 3 | 2026.1.3 RC 2
+             for
+              Windows
+
+          </a>
+
+            <p><em>android-studio-quail3-rc2-windows.exe</em></p>
+
+
+      </div>
+<div class="buttons">
+
+          <div class="multiple-download-container">
+
+              <h3 class="hide-from-toc" id="dynamic_data.setvar.dialog_download_message" data-text="                 Select the version of Android Studio that's right for your Mac:               " tabindex="-1">
+                Select the version of Android Studio that's right for your Mac:
+              </h3>
+
+            <h4 class="hide-from-toc" id="dynamic_data.setvar.dialog_product_name" data-text="               Android Studio Quail 3 | 2026.1.3 RC 2             " tabindex="-1">
+              Android Studio Quail 3 | 2026.1.3 RC 2
+            </h4>
+            <div class="multiple-download-options">
+              <div class="multiple-download-option">
+                <button class="button button-disabled">
+                  Mac with Apple chip
+                </button>
+                <a
+                   class="button button-primary devsite-dialog-close gc-analytics-event"
+                   data-action="download"
+                   data-category="beta_mac_arm_bundle_download"
+                   href="https://edgedl.me.gvt1.com/android/studio/install/2026.1.3.6/android-studio-quail3-rc2-mac_arm.dmg"
+                   id="agree-button__beta_mac_arm_bundle_download"
+                >
+                  Mac with Apple chip
+                </a>
+
+                  <p><em>android-studio-quail3-rc2-mac_arm.dmg</em></p>
+
+              </div>
+              <div class="multiple-download-option">
+                <button class="button button-disabled">
+                  Mac with Intel chip
+                </button>
+                <a
+                   class="button devsite-dialog-close gc-analytics-event"
+                   data-action="download"
+                   data-category="beta_mac_bundle_download"
+                   href="https://edgedl.me.gvt1.com/android/studio/install/2026.1.3.6/android-studio-quail3-rc2-mac.dmg"
+                   id="agree-button__beta_mac_bundle_download"
+                >
+                  Mac with Intel chip
+                </a>
+
+                  <p><em>android-studio-quail3-rc2-mac.dmg</em></p>
+
+              </div>
+            </div>
+          </div>
+
+      </div>
+<div class="buttons">
+
+          <button class="button button-disabled">
+            <span class="lang-float">Download Android Studio Quail 3 | 2026.1.3 RC 2
+                  for Linux
+            </span>
+          </button>
+          <a class="button button-primary
+               devsite-dialog-close gc-analytics-event"
+               data-category="beta_linux_bundle_download" data-action="download"
+
+               href="https://edgedl.me.gvt1.com/android/studio/ide-zips/2026.1.3.6/android-studio-quail3-rc2-linux.tar.gz"
+               id="agree-button__beta_linux_bundle_download"
+            >Download Android Studio Quail 3 | 2026.1.3 RC 2
+             for
+              Linux
+
+          </a>
+
+            <p><em>android-studio-quail3-rc2-linux.tar.gz</em></p>
+
+
+      </div>
+<div class="buttons">
+
+          <button class="button button-disabled">
+            <span class="lang-float">Download Android Studio Quail 3 | 2026.1.3 RC 2
+                  for ChromeOS
+            </span>
+          </button>
+          <a class="button button-primary
+               devsite-dialog-close gc-analytics-event"
+               data-category="beta_chrome_os_bundle_download" data-action="download"
+
+               href="https://edgedl.me.gvt1.com/android/studio/install/2026.1.3.6/android-studio-quail3-rc2-cros.deb"
+               id="agree-button__beta_chrome_os_bundle_download"
+            >Download Android Studio Quail 3 | 2026.1.3 RC 2
+             for
+              ChromeOS
+
+          </a>
+
+            <p><em>android-studio-quail3-rc2-cros.deb</em></p>
+
+
+      </div>
+
+<!-- ===== Quail 4 | 2026.1.4 Canary 3 ===== -->
+<div class="buttons">
+
+          <button class="button button-disabled">
+            <span class="lang-float">Download Android Studio Quail 4 | 2026.1.4 Canary 3
+                  for Windows
+            </span>
+          </button>
+          <a class="button button-primary
+               devsite-dialog-close gc-analytics-event"
+               data-category="canary_win_bundle_download" data-action="download"
+
+               href="https://edgedl.me.gvt1.com/android/studio/install/2026.1.4.3/android-studio-quail4-canary3-windows.exe"
+               id="agree-button__canary_win_bundle_download"
+            >Download Android Studio Quail 4 | 2026.1.4 Canary 3
+             for
+              Windows
+
+          </a>
+
+            <p><em>android-studio-quail4-canary3-windows.exe</em></p>
+
+
+      </div>
+<div class="buttons">
+
+          <div class="multiple-download-container">
+
+              <h3 class="hide-from-toc" id="dynamic_data.setvar.dialog_download_message" data-text="                 Select the version of Android Studio that's right for your Mac:               " tabindex="-1">
+                Select the version of Android Studio that's right for your Mac:
+              </h3>
+
+            <h4 class="hide-from-toc" id="dynamic_data.setvar.dialog_product_name" data-text="               Android Studio Quail 4 | 2026.1.4 Canary 3             " tabindex="-1">
+              Android Studio Quail 4 | 2026.1.4 Canary 3
+            </h4>
+            <div class="multiple-download-options">
+              <div class="multiple-download-option">
+                <button class="button button-disabled">
+                  Mac with Apple chip
+                </button>
+                <a
+                   class="button button-primary devsite-dialog-close gc-analytics-event"
+                   data-action="download"
+                   data-category="canary_mac_arm_bundle_download"
+                   href="https://edgedl.me.gvt1.com/android/studio/install/2026.1.4.3/android-studio-quail4-canary3-mac_arm.dmg"
+                   id="agree-button__canary_mac_arm_bundle_download"
+                >
+                  Mac with Apple chip
+                </a>
+
+                  <p><em>android-studio-quail4-canary3-mac_arm.dmg</em></p>
+
+              </div>
+              <div class="multiple-download-option">
+                <button class="button button-disabled">
+                  Mac with Intel chip
+                </button>
+                <a
+                   class="button devsite-dialog-close gc-analytics-event"
+                   data-action="download"
+                   data-category="canary_mac_bundle_download"
+                   href="https://edgedl.me.gvt1.com/android/studio/install/2026.1.4.3/android-studio-quail4-canary3-mac.dmg"
+                   id="agree-button__canary_mac_bundle_download"
+                >
+                  Mac with Intel chip
+                </a>
+
+                  <p><em>android-studio-quail4-canary3-mac.dmg</em></p>
+
+              </div>
+            </div>
+          </div>
+
+      </div>
+<div class="buttons">
+
+          <button class="button button-disabled">
+            <span class="lang-float">Download Android Studio Quail 4 | 2026.1.4 Canary 3
+                  for Linux
+            </span>
+          </button>
+          <a class="button button-primary
+               devsite-dialog-close gc-analytics-event"
+               data-category="canary_linux_bundle_download" data-action="download"
+
+               href="https://edgedl.me.gvt1.com/android/studio/ide-zips/2026.1.4.3/android-studio-quail4-canary3-linux.tar.gz"
+               id="agree-button__canary_linux_bundle_download"
+            >Download Android Studio Quail 4 | 2026.1.4 Canary 3
+             for
+              Linux
+
+          </a>
+
+            <p><em>android-studio-quail4-canary3-linux.tar.gz</em></p>
+
+
+      </div>
+<div class="buttons">
+
+          <button class="button button-disabled">
+            <span class="lang-float">Download Android Studio Quail 4 | 2026.1.4 Canary 3
+                  for ChromeOS
+            </span>
+          </button>
+          <a class="button button-primary
+               devsite-dialog-close gc-analytics-event"
+               data-category="canary_chrome_os_bundle_download" data-action="download"
+
+               href="https://edgedl.me.gvt1.com/android/studio/install/2026.1.4.3/android-studio-quail4-canary3-cros.deb"
+               id="agree-button__canary_chrome_os_bundle_download"
+            >Download Android Studio Quail 4 | 2026.1.4 Canary 3
+             for
+              ChromeOS
+
+          </a>
+
+            <p><em>android-studio-quail4-canary3-cros.deb</em></p>
+
+
+      </div>
+
+</body></html>

--- a/npx-kt/src/test/resources/fixtures/android-studio-preview.html
+++ b/npx-kt/src/test/resources/fixtures/android-studio-preview.html
@@ -1,0 +1,253 @@
+<!doctype html>
+<!--
+  Recorded from https://developer.android.com/studio/preview on 2026-08-03, trimmed to the
+  download-button blocks (their markup as served, trailing whitespace stripped).
+
+  The page serves TWO generations at once: Quail 4 | 2026.1.4 Canary 3 (2026.1.4.3) and the
+  older Quail 3 | 2026.1.3 RC 2 (2026.1.3.6). Recorded order: canary first, RC second.
+-->
+<html><body>
+
+<!-- ===== Quail 4 | 2026.1.4 Canary 3 ===== -->
+<div class="buttons">
+
+          <button class="button button-disabled">
+            <span class="lang-float">Download Android Studio Quail 4 | 2026.1.4 Canary 3
+                  for Windows
+            </span>
+          </button>
+          <a class="button button-primary
+               devsite-dialog-close gc-analytics-event"
+               data-category="canary_win_bundle_download" data-action="download"
+
+               href="https://edgedl.me.gvt1.com/android/studio/install/2026.1.4.3/android-studio-quail4-canary3-windows.exe"
+               id="agree-button__canary_win_bundle_download"
+            >Download Android Studio Quail 4 | 2026.1.4 Canary 3
+             for
+              Windows
+
+          </a>
+
+            <p><em>android-studio-quail4-canary3-windows.exe</em></p>
+
+
+      </div>
+<div class="buttons">
+
+          <div class="multiple-download-container">
+
+              <h3 class="hide-from-toc" id="dynamic_data.setvar.dialog_download_message" data-text="                 Select the version of Android Studio that's right for your Mac:               " tabindex="-1">
+                Select the version of Android Studio that's right for your Mac:
+              </h3>
+
+            <h4 class="hide-from-toc" id="dynamic_data.setvar.dialog_product_name" data-text="               Android Studio Quail 4 | 2026.1.4 Canary 3             " tabindex="-1">
+              Android Studio Quail 4 | 2026.1.4 Canary 3
+            </h4>
+            <div class="multiple-download-options">
+              <div class="multiple-download-option">
+                <button class="button button-disabled">
+                  Mac with Apple chip
+                </button>
+                <a
+                   class="button button-primary devsite-dialog-close gc-analytics-event"
+                   data-action="download"
+                   data-category="canary_mac_arm_bundle_download"
+                   href="https://edgedl.me.gvt1.com/android/studio/install/2026.1.4.3/android-studio-quail4-canary3-mac_arm.dmg"
+                   id="agree-button__canary_mac_arm_bundle_download"
+                >
+                  Mac with Apple chip
+                </a>
+
+                  <p><em>android-studio-quail4-canary3-mac_arm.dmg</em></p>
+
+              </div>
+              <div class="multiple-download-option">
+                <button class="button button-disabled">
+                  Mac with Intel chip
+                </button>
+                <a
+                   class="button devsite-dialog-close gc-analytics-event"
+                   data-action="download"
+                   data-category="canary_mac_bundle_download"
+                   href="https://edgedl.me.gvt1.com/android/studio/install/2026.1.4.3/android-studio-quail4-canary3-mac.dmg"
+                   id="agree-button__canary_mac_bundle_download"
+                >
+                  Mac with Intel chip
+                </a>
+
+                  <p><em>android-studio-quail4-canary3-mac.dmg</em></p>
+
+              </div>
+            </div>
+          </div>
+
+      </div>
+<div class="buttons">
+
+          <button class="button button-disabled">
+            <span class="lang-float">Download Android Studio Quail 4 | 2026.1.4 Canary 3
+                  for Linux
+            </span>
+          </button>
+          <a class="button button-primary
+               devsite-dialog-close gc-analytics-event"
+               data-category="canary_linux_bundle_download" data-action="download"
+
+               href="https://edgedl.me.gvt1.com/android/studio/ide-zips/2026.1.4.3/android-studio-quail4-canary3-linux.tar.gz"
+               id="agree-button__canary_linux_bundle_download"
+            >Download Android Studio Quail 4 | 2026.1.4 Canary 3
+             for
+              Linux
+
+          </a>
+
+            <p><em>android-studio-quail4-canary3-linux.tar.gz</em></p>
+
+
+      </div>
+<div class="buttons">
+
+          <button class="button button-disabled">
+            <span class="lang-float">Download Android Studio Quail 4 | 2026.1.4 Canary 3
+                  for ChromeOS
+            </span>
+          </button>
+          <a class="button button-primary
+               devsite-dialog-close gc-analytics-event"
+               data-category="canary_chrome_os_bundle_download" data-action="download"
+
+               href="https://edgedl.me.gvt1.com/android/studio/install/2026.1.4.3/android-studio-quail4-canary3-cros.deb"
+               id="agree-button__canary_chrome_os_bundle_download"
+            >Download Android Studio Quail 4 | 2026.1.4 Canary 3
+             for
+              ChromeOS
+
+          </a>
+
+            <p><em>android-studio-quail4-canary3-cros.deb</em></p>
+
+
+      </div>
+
+<!-- ===== Quail 3 | 2026.1.3 RC 2 ===== -->
+<div class="buttons">
+
+          <button class="button button-disabled">
+            <span class="lang-float">Download Android Studio Quail 3 | 2026.1.3 RC 2
+                  for Windows
+            </span>
+          </button>
+          <a class="button button-primary
+               devsite-dialog-close gc-analytics-event"
+               data-category="beta_win_bundle_download" data-action="download"
+
+               href="https://edgedl.me.gvt1.com/android/studio/install/2026.1.3.6/android-studio-quail3-rc2-windows.exe"
+               id="agree-button__beta_win_bundle_download"
+            >Download Android Studio Quail 3 | 2026.1.3 RC 2
+             for
+              Windows
+
+          </a>
+
+            <p><em>android-studio-quail3-rc2-windows.exe</em></p>
+
+
+      </div>
+<div class="buttons">
+
+          <div class="multiple-download-container">
+
+              <h3 class="hide-from-toc" id="dynamic_data.setvar.dialog_download_message" data-text="                 Select the version of Android Studio that's right for your Mac:               " tabindex="-1">
+                Select the version of Android Studio that's right for your Mac:
+              </h3>
+
+            <h4 class="hide-from-toc" id="dynamic_data.setvar.dialog_product_name" data-text="               Android Studio Quail 3 | 2026.1.3 RC 2             " tabindex="-1">
+              Android Studio Quail 3 | 2026.1.3 RC 2
+            </h4>
+            <div class="multiple-download-options">
+              <div class="multiple-download-option">
+                <button class="button button-disabled">
+                  Mac with Apple chip
+                </button>
+                <a
+                   class="button button-primary devsite-dialog-close gc-analytics-event"
+                   data-action="download"
+                   data-category="beta_mac_arm_bundle_download"
+                   href="https://edgedl.me.gvt1.com/android/studio/install/2026.1.3.6/android-studio-quail3-rc2-mac_arm.dmg"
+                   id="agree-button__beta_mac_arm_bundle_download"
+                >
+                  Mac with Apple chip
+                </a>
+
+                  <p><em>android-studio-quail3-rc2-mac_arm.dmg</em></p>
+
+              </div>
+              <div class="multiple-download-option">
+                <button class="button button-disabled">
+                  Mac with Intel chip
+                </button>
+                <a
+                   class="button devsite-dialog-close gc-analytics-event"
+                   data-action="download"
+                   data-category="beta_mac_bundle_download"
+                   href="https://edgedl.me.gvt1.com/android/studio/install/2026.1.3.6/android-studio-quail3-rc2-mac.dmg"
+                   id="agree-button__beta_mac_bundle_download"
+                >
+                  Mac with Intel chip
+                </a>
+
+                  <p><em>android-studio-quail3-rc2-mac.dmg</em></p>
+
+              </div>
+            </div>
+          </div>
+
+      </div>
+<div class="buttons">
+
+          <button class="button button-disabled">
+            <span class="lang-float">Download Android Studio Quail 3 | 2026.1.3 RC 2
+                  for Linux
+            </span>
+          </button>
+          <a class="button button-primary
+               devsite-dialog-close gc-analytics-event"
+               data-category="beta_linux_bundle_download" data-action="download"
+
+               href="https://edgedl.me.gvt1.com/android/studio/ide-zips/2026.1.3.6/android-studio-quail3-rc2-linux.tar.gz"
+               id="agree-button__beta_linux_bundle_download"
+            >Download Android Studio Quail 3 | 2026.1.3 RC 2
+             for
+              Linux
+
+          </a>
+
+            <p><em>android-studio-quail3-rc2-linux.tar.gz</em></p>
+
+
+      </div>
+<div class="buttons">
+
+          <button class="button button-disabled">
+            <span class="lang-float">Download Android Studio Quail 3 | 2026.1.3 RC 2
+                  for ChromeOS
+            </span>
+          </button>
+          <a class="button button-primary
+               devsite-dialog-close gc-analytics-event"
+               data-category="beta_chrome_os_bundle_download" data-action="download"
+
+               href="https://edgedl.me.gvt1.com/android/studio/install/2026.1.3.6/android-studio-quail3-rc2-cros.deb"
+               id="agree-button__beta_chrome_os_bundle_download"
+            >Download Android Studio Quail 3 | 2026.1.3 RC 2
+             for
+              ChromeOS
+
+          </a>
+
+            <p><em>android-studio-quail3-rc2-cros.deb</em></p>
+
+
+      </div>
+
+</body></html>


### PR DESCRIPTION
## Problem

`developer.android.com/studio/preview` serves **several generations at once**. Right now:

| Version | Channel | Filename |
|---|---|---|
| `2026.1.4.3` | Canary 3 | `android-studio-quail4-canary3-*` |
| `2026.1.3.6` | RC 2 | `android-studio-quail3-rc2-*` |

`resolveAndroidStudioCanaryArchiveFromHtml` pulled every `android-studio-*.{dmg,exe,tar.gz,zip}` URL
out of the page and took **the first one matching the host suffix**:

```kotlin
val url = urls.firstOrNull { it.endsWith(suffix) }
```

So the resolved build is whichever generation Google happened to type first. Today the canary block
comes first and the result is correct — the day the sections are swapped devrig silently installs the
older RC, with no error and no signal. `AndroidStudioReleaseLookup` (the stable `/studio` page) has
the same first-match-wins shape.

Found while checking `#431`, which added Android Studio to the download coverage added by `#429`:
that test pins the build shape, not which of the page's versions is chosen.

Version pinning was rejected outright on both paths ("version pinning is not supported"), even though
every other feed supports it.

## Fix

New `AndroidStudioDownloadPage.kt` (in `:intellij-downloader`, shared by both pages) parses the page
into **all** the releases it advertises — version from the download URL path, channel from the
filename (`-canary3-`, `-rc2-`, `-beta1-`, none = release), every artifact link — and selects by
comparing version numbers:

- no request → the newest release that publishes an artifact for this OS/arch (falls through to the
  next-newest if a generation lacks it);
- `2026.1.4.3` → that exact version;
- `2026.1` → newest patch of that generation (segment boundary, so `2026.1` never matches `2026.10`);
- `261` → newest build on that platform baseline (the artifact then reports `261.26222.65.…`);
- `canary` / `rc` / `beta` → newest build of that channel.

Channel never overrides the version: a same-version tie breaks toward the more stable channel, so the
order is a total function of the page content. This keeps today's behaviour (canary 2026.1.4.3 wins)
while making it independent of Google's layout.

`resolveAndroidStudioArchiveFromHtml` (stable page) now routes through the same selector and keeps its
SHA-256 table lookup; `inferAndroidStudioVersion` became a thin wrapper over the shared regexes.

## Tests

`AndroidStudioCanaryReleasesTest` gains the **recorded** preview page (2026-08-03, trimmed to the
download-button blocks) plus the same page with the two generations **swapped** so the older RC comes
first — the layout that used to resolve wrong. It asserts the canary still wins on mac/linux/windows,
and covers exact / prefix / baseline / channel pinning and the error message that lists what the page
does offer. `AndroidStudioDownloadPageTest` covers the parser and selector directly.

Verified as a real guard by mutation: dropping the newest-first sort fails
`the html order of the release blocks does not decide which build is picked` and
`a platform baseline request resolves to the newest build on that baseline` (and 2 in the downloader
suite); restoring it makes them pass.

Green: `./gradlew :npx-kt:test :intellij-downloader:test` — 1404 + 103 tests, 0 failures.

Real download on macOS arm64: `devrig backend download android-studio` resolved `2026.1.4.3` /
baseline `261`, fetched `android-studio-quail4-canary3-mac_arm.dmg`, unpacked and validated — the
install reports `261.26222.65.2614.15978069`, matching the baseline. Artifacts deleted afterwards.

## Not in this PR

`IdeChannel.EAP` for Android Studio in `:intellij-downloader` is still unimplemented (only `STABLE` is
accepted), so `IdeDistribution.Latest(AndroidStudio, EAP, "2026.1")` in `AndroidStudio261Test` still
cannot resolve. The shared parser is what that would need; wiring it is a separate change.
