### PR TITLE
Move execution history to shared collision-safe storage

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,7 +55,7 @@ When reporting a bug, please include:
 - Steps to reproduce the issue
 - Expected vs. actual behavior
 - IDE version, OS, and MCP Steroid version
-- Relevant log snippets (from `.idea/mcp-steroid/` if applicable)
+- Relevant log snippets (from `~/.mcp-steroid/runs/` if applicable)
 
 Feature requests should describe the use case and motivation, not just the desired solution.
 

--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ MCP Steroid can be configured via IntelliJ's Registry (`Help > Find Action > Reg
 |--------------|---------|-------------|
 | `mcp.steroid.server.port` | 6315 | MCP server port (0 for auto-assign) |
 | `mcp.steroid.server.host` | 127.0.0.1 | Bind address (use 0.0.0.0 for Docker) |
-| `mcp.steroid.storage.path` | (empty) | Custom storage path (default: .idea/mcp-steroid/) |
+| `mcp.steroid.storage.path` | (empty) | Custom storage path (default: `~/.mcp-steroid/runs/`) |
 
 See the full [Configuration Documentation](https://devrig.dev/docs/configuration/) on the website.
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -11,7 +11,7 @@ This document is a concise architecture map. For authoritative details, see `AGE
 - Vision tools: screenshot/input tooling with artifact storage.
 - OCR helper: external `ocr-tesseract` app invoked via process client.
 - Kotlinc helper: bundled Kotlin compiler invoked via process client.
-- Storage: execution logs/artifacts (append-only, under `.idea/mcp-steroid/`).
+- Storage: execution logs/artifacts (append-only, under `~/.mcp-steroid/runs/` by default).
 - **devrig CLI** (`npx-kt/`): stateless stdio MCP server + `backend` /
   `project` CLI that discovers IntelliJ instances on the host and
   routes tool calls to them. Project / IDE naming is governed by the

--- a/execution-storage/src/main/kotlin/com/jonnyzzz/mcpSteroid/storage/ExecutionStorage.kt
+++ b/execution-storage/src/main/kotlin/com/jonnyzzz/mcpSteroid/storage/ExecutionStorage.kt
@@ -2,6 +2,7 @@
 package com.jonnyzzz.mcpSteroid.storage
 
 import com.jonnyzzz.mcpSteroid.server.ExecCodeParams
+import com.jonnyzzz.mcpSteroid.server.ExecutionBackendProvenance
 import com.jonnyzzz.mcpSteroid.server.FeedbackParams
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -11,12 +12,13 @@ import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.encodeToJsonElement
 import kotlinx.serialization.json.jsonObject
+import java.nio.file.FileAlreadyExistsException
 import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.StandardOpenOption
-import java.time.LocalDateTime
+import java.time.Clock
+import java.time.ZoneOffset
 import java.time.format.DateTimeFormatter
-import kotlin.io.path.deleteIfExists
 import kotlin.io.path.isRegularFile
 import kotlin.io.path.writeText
 
@@ -51,27 +53,43 @@ data class ExecutionProjectInfo(
     val basePath: String?,
 )
 
+/** Backend identity captured at execution time. */
+data class ExecutionBackendInfo(
+    val kind: Char,
+    val name: String,
+) {
+    init {
+        require(kind in 'a'..'z' || kind in 'A'..'Z' || kind in '0'..'9') {
+            "Backend kind must be one ASCII letter or digit: $kind"
+        }
+        require(name.isNotBlank()) { "Backend name must not be blank" }
+    }
+}
+
 /**
  * File-based storage for execution history.
  * APPEND-ONLY: Files are never deleted, only added.
  *
  * Directory structure:
  * {baseDir}/                           - Base folder (host-supplied; on the IDE
- *                                        side it resolves to .idea/mcp-steroid)
+ *                                        side it defaults to ~/.mcp-steroid/runs)
  *   {execution-id}/
+ *     backend_name.txt                 - Full backend_name for this execution
  *     project.txt                      - Project name (line 1) and path (line 2)
  *     tool.json                        - Tool name + arguments metadata
  *     script.kts                       - Original code submitted by LLM
  *     params.json                      - Execution parameters
  *     output.jsonl                     - Output messages (append-only)
  *
- * The two providers are resolved lazily on each call so hosts can react
+ * The providers are resolved lazily on each call so hosts can react
  * to runtime configuration changes (e.g. an IDE Registry key swap) without
  * recreating the storage instance.
  */
 open class ExecutionStorage(
     private val baseDirProvider: () -> Path,
     private val projectInfoProvider: () -> ExecutionProjectInfo,
+    private val backendInfoProvider: () -> ExecutionBackendInfo,
+    private val clock: Clock = Clock.systemUTC(),
 ) {
     val json = Json {
         prettyPrint = true
@@ -86,9 +104,21 @@ open class ExecutionStorage(
     private val baseDir: Path
         get() = baseDirProvider()
 
+    companion object {
+        private const val EXECUTION_SLOT_PRIME = 997L
+        private const val MAX_EXECUTION_ID_LENGTH = 240
+        private const val MAX_PROJECT_SLUG_LENGTH = 80
+        private const val MAX_TASK_SLUG_LENGTH = 120
+        private val SAFE_EXECUTION_ID = Regex("[a-zA-Z0-9_-]+")
+        private val INVALID_SLUG_CHARACTERS = Regex("[^a-zA-Z0-9_-]+")
+        private val UTC_SECONDS_FORMATTER = DateTimeFormatter
+            .ofPattern("uuuuMMdd'T'HHmmss")
+            .withZone(ZoneOffset.UTC)
+    }
 
     private val ExecutionId.dir: Path
         get() {
+            require(SAFE_EXECUTION_ID.matches(executionId)) { "Invalid execution ID: $executionId" }
             val dir = baseDir.resolve(executionId)
             Files.createDirectories(dir)
             return dir
@@ -153,7 +183,7 @@ open class ExecutionStorage(
     }
 
     fun findExecutionId(executionId: String) : ExecutionId? {
-        if (executionId.contains("/") || executionId.contains("..")) return null
+        if (!SAFE_EXECUTION_ID.matches(executionId)) return null
 
         // tool.json is the universal sentinel: every writeToolMetadata() call writes it,
         // covering writeNewExecution / writeExecutionFeedback / writeToolCall.
@@ -164,39 +194,79 @@ open class ExecutionStorage(
     }
 
     suspend fun writeExecutionFeedback(taskId: String, element: FeedbackParams) : ExecutionId {
-        val executionId = newExecutionId("feedback-$taskId")
+        val backendInfo = backendInfo(element.executionBackend)
+        val executionId = newExecutionId(taskId, backendInfo)
         writeToolMetadata(executionId, "steroid_execute_feedback", json.encodeToJsonElement(element).jsonObject, taskId)
         writeCodeExecutionData(executionId, "feedback.json", element)
         writeCodeExecutionData(executionId, "execution-id.txt", executionId.executionId)
-        writeProjectInfo(executionId)
+        writeExecutionIdentity(executionId, backendInfo)
         return executionId
     }
 
-    private fun newExecutionId(taskId: String): ExecutionId {
-        val pattern = DateTimeFormatter.ofPattern("yyyyMMdd'T'HHmmss")
-        val timestamp = LocalDateTime.now().format(pattern)
-        val invalidPath = Regex("[^a-zA-Z0-9_-]+", RegexOption.IGNORE_CASE)
-        val id = "eid_" + timestamp + "-" + invalidPath.replace(taskId, "_")
-        return ExecutionId(id)
+    private fun newExecutionId(taskId: String, backendInfo: ExecutionBackendInfo): ExecutionId {
+        val projectSlug = slug(projectInfoProvider().name, "project", MAX_PROJECT_SLUG_LENGTH)
+        val taskSlug = slug(taskId, "task", MAX_TASK_SLUG_LENGTH)
+        var attempt = 0L
+
+        Files.createDirectories(baseDir)
+        while (true) {
+            val now = clock.instant()
+            val timestamp = UTC_SECONDS_FORMATTER.format(now)
+            val millisecondSlot = Math.floorMod(
+                Math.floorMod(now.toEpochMilli(), EXECUTION_SLOT_PRIME) + attempt,
+                EXECUTION_SLOT_PRIME,
+            )
+            val slot = millisecondSlot.toString().padStart(3, '0')
+            val id = "eid_$timestamp-$slot-$projectSlug-${backendInfo.kind}-$taskSlug"
+            check(id.length <= MAX_EXECUTION_ID_LENGTH) { "Execution ID exceeds $MAX_EXECUTION_ID_LENGTH characters" }
+            try {
+                Files.createDirectory(baseDir.resolve(id))
+                return ExecutionId(id)
+            } catch (e: FileAlreadyExistsException) {
+                attempt++
+            }
+        }
     }
 
+    private fun slug(value: String, fallback: String, maxLength: Int): String {
+        val normalized = INVALID_SLUG_CHARACTERS.replace(value, "_")
+            .trim('_')
+            .ifBlank { fallback }
+        if (normalized.length <= maxLength) return normalized
+
+        val hashSuffix = "_" + value.hashCode().toUInt().toString(36)
+        return normalized
+            .take(maxLength - hashSuffix.length)
+            .trimEnd('_') + hashSuffix
+    }
+
+    private fun backendInfo(provenance: ExecutionBackendProvenance?): ExecutionBackendInfo =
+        provenance?.let { ExecutionBackendInfo(kind = it.kind, name = it.name) } ?: backendInfoProvider()
+
     suspend fun writeNewExecution(exec: ExecCodeParams) : ExecutionId {
-        val executionId = newExecutionId(exec.taskId)
+        val backendInfo = backendInfo(exec.executionBackend)
+        val executionId = newExecutionId(exec.taskId, backendInfo)
         writeToolMetadata(executionId, "steroid_execute_code", json.encodeToJsonElement(exec).jsonObject, exec.taskId)
         writeCodeExecutionData(executionId, "reason.txt", exec.reason)
         writeCodeExecutionData(executionId, "script.kts", exec.code)
         writeCodeExecutionData(executionId, "execution-id.txt", executionId.executionId)
-        writeProjectInfo(executionId)
+        writeExecutionIdentity(executionId, backendInfo)
 
         return executionId
     }
 
-    suspend fun writeToolCall(toolName: String, arguments: JsonObject, taskId: String? = null): ExecutionId {
-        val executionId = newExecutionId(taskId ?: "tool-$toolName")
+    suspend fun writeToolCall(
+        toolName: String,
+        arguments: JsonObject,
+        taskId: String? = null,
+        executionBackend: ExecutionBackendProvenance? = null,
+    ): ExecutionId {
+        val backendInfo = backendInfo(executionBackend)
+        val executionId = newExecutionId(taskId ?: "tool-$toolName", backendInfo)
         writeToolMetadata(executionId, toolName, arguments, taskId)
         writeCodeExecutionData(executionId, "params.json", arguments)
         writeCodeExecutionData(executionId, "execution-id.txt", executionId.executionId)
-        writeProjectInfo(executionId)
+        writeExecutionIdentity(executionId, backendInfo)
         return executionId
     }
 
@@ -208,7 +278,7 @@ open class ExecutionStorage(
     ) {
         val metadata = ToolCallMetadata(
             toolName = toolName,
-            timestamp = LocalDateTime.now().format(DateTimeFormatter.ISO_LOCAL_DATE_TIME),
+            timestamp = clock.instant().toString(),
             projectName = projectInfoProvider().name,
             taskId = taskId,
             arguments = arguments ?: buildJsonObject { }
@@ -223,6 +293,11 @@ open class ExecutionStorage(
             info.basePath?.let { appendLine(it) }
         }
         writeCodeExecutionData(executionId, "project.txt", content)
+    }
+
+    private suspend fun writeExecutionIdentity(executionId: ExecutionId, backendInfo: ExecutionBackendInfo) {
+        writeProjectInfo(executionId)
+        writeCodeExecutionData(executionId, "backend_name.txt", backendInfo.name + "\n")
     }
 
     suspend fun writeWrappedScript(executionId: ExecutionId, code: String) {

--- a/execution-storage/src/test/kotlin/com/jonnyzzz/mcpSteroid/storage/ExecutionStorageTest.kt
+++ b/execution-storage/src/test/kotlin/com/jonnyzzz/mcpSteroid/storage/ExecutionStorageTest.kt
@@ -2,14 +2,18 @@
 package com.jonnyzzz.mcpSteroid.storage
 
 import com.jonnyzzz.mcpSteroid.server.ExecCodeParams
+import com.jonnyzzz.mcpSteroid.server.ExecutionBackendProvenance
 import com.jonnyzzz.mcpSteroid.server.FeedbackParams
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeout
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.serialization.json.put
 import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertNotEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
@@ -19,6 +23,9 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
 import java.nio.file.Files
 import java.nio.file.Path
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneOffset
 import kotlin.time.Duration.Companion.seconds
 
 /**
@@ -38,12 +45,16 @@ class ExecutionStorageTest {
 
     private val projectName = "test-project"
     private val projectPath = "/tmp/test-project"
+    private val backendName = "iu-test1234"
+    private val fixedClock = Clock.fixed(Instant.parse("2026-08-03T00:00:00.123Z"), ZoneOffset.UTC)
 
     @BeforeEach
     fun setUp() {
         storage = ExecutionStorage(
             baseDirProvider = { tempDir },
             projectInfoProvider = { ExecutionProjectInfo(projectName, projectPath) },
+            backendInfoProvider = { ExecutionBackendInfo(kind = 's', name = backendName) },
+            clock = fixedClock,
         )
     }
 
@@ -52,11 +63,13 @@ class ExecutionStorageTest {
         taskId: String = "test-task",
         reason: String = "test",
         timeout: Int = 60,
+        executionBackend: ExecutionBackendProvenance? = null,
     ) = ExecCodeParams(
         taskId = taskId,
         code = code,
         reason = reason,
         timeout = timeout,
+        executionBackend = executionBackend,
     )
 
     private fun runStorageTest(block: suspend () -> Unit) = runBlocking {
@@ -64,11 +77,104 @@ class ExecutionStorageTest {
     }
 
     @Test
-    fun `writeNewExecution returns id with eid_ prefix and task id`() = runStorageTest {
+    fun `writeNewExecution id includes utc time millisecond slot project backend and task`() = runStorageTest {
+        val executionId = storage.writeNewExecution(testExecParams("println(\"Hello\")"))
+        val expectedSlot = Math.floorMod(fixedClock.instant().toEpochMilli(), 997L)
+            .toString()
+            .padStart(3, '0')
+
+        assertEquals(
+            "eid_20260803T000000-$expectedSlot-test-project-s-test-task",
+            executionId.executionId,
+            "ID should contain UTC time, the epoch-millisecond modulo-997 slot, project, backend kind, and task",
+        )
+    }
+
+    @Test
+    fun `writeNewExecution persists full backend name`() = runStorageTest {
         val executionId = storage.writeNewExecution(testExecParams("println(\"Hello\")"))
 
-        assertTrue(executionId.executionId.startsWith("eid_"), "ID should start with eid_")
-        assertTrue(executionId.executionId.contains("test"), "ID should contain task ID")
+        val backendNamePath = tempDir.resolve(executionId.executionId).resolve("backend_name.txt")
+        assertTrue(Files.exists(backendNamePath), "backend_name.txt should exist")
+        assertEquals(backendName, Files.readString(backendNamePath).trim())
+    }
+
+    @Test
+    fun `devrig backend kind is included as one character`() = runStorageTest {
+        val devrigBackendName = "iu-devrig123"
+        val devrigStorage = ExecutionStorage(
+            baseDirProvider = { tempDir },
+            projectInfoProvider = { ExecutionProjectInfo(projectName, projectPath) },
+            backendInfoProvider = { ExecutionBackendInfo(kind = 's', name = backendName) },
+            clock = fixedClock,
+        )
+
+        val executionId = devrigStorage.writeNewExecution(testExecParams(
+            code = "println(1)",
+            executionBackend = ExecutionBackendProvenance(kind = 'd', name = devrigBackendName),
+        ))
+
+        assertTrue(executionId.executionId.contains("-$projectName-d-test-task"), executionId.executionId)
+        assertEquals(devrigBackendName,
+            Files.readString(tempDir.resolve(executionId.executionId).resolve("backend_name.txt")).trim())
+    }
+
+    @Test
+    fun `concurrent unicode and cross-tool calls reserve distinct directories`() = runStorageTest {
+        val secondStorage = ExecutionStorage(
+            baseDirProvider = { tempDir },
+            projectInfoProvider = { ExecutionProjectInfo(projectName, projectPath) },
+            backendInfoProvider = { ExecutionBackendInfo(kind = 's', name = backendName) },
+            clock = fixedClock,
+        )
+        val taskId = "screenshot-同じ-task"
+
+        val executionIds = coroutineScope {
+            (0 until 8).map { index ->
+                async(Dispatchers.Default) {
+                    val target = if (index % 2 == 0) storage else secondStorage
+                    if (index == 0) {
+                        target.writeToolCall(
+                            toolName = "steroid_take_screenshot",
+                            arguments = buildJsonObject { put("task_id", taskId) },
+                            taskId = taskId,
+                        )
+                    } else {
+                        target.writeNewExecution(testExecParams("println($index)", taskId = taskId))
+                    }
+                }
+            }.awaitAll()
+        }
+
+        assertEquals(8, executionIds.map { it.executionId }.toSet().size)
+        executionIds.forEach { executionId ->
+            assertTrue(Files.isDirectory(tempDir.resolve(executionId.executionId)), executionId.executionId)
+        }
+    }
+
+    @Test
+    fun `long project and task names stay within filesystem component limits`() = runStorageTest {
+        val longProjectName = "project-" + "p".repeat(230)
+        val longTaskId = "task-" + "t".repeat(180)
+        val longNameStorage = ExecutionStorage(
+            baseDirProvider = { tempDir },
+            projectInfoProvider = { ExecutionProjectInfo(longProjectName, projectPath) },
+            backendInfoProvider = { ExecutionBackendInfo(kind = 's', name = backendName) },
+            clock = fixedClock,
+        )
+
+        val executionId = longNameStorage.writeNewExecution(
+            testExecParams("println(1)", taskId = longTaskId),
+        )
+
+        assertTrue(executionId.executionId.length <= 240, executionId.executionId)
+        assertTrue(Files.isDirectory(tempDir.resolve(executionId.executionId)), executionId.executionId)
+        val metadata = storage.json.decodeFromString(
+            ToolCallMetadata.serializer(),
+            Files.readString(tempDir.resolve(executionId.executionId).resolve("tool.json")),
+        )
+        assertEquals(longProjectName, metadata.projectName)
+        assertEquals(longTaskId, metadata.taskId)
     }
 
     @Test
@@ -105,6 +211,35 @@ class ExecutionStorageTest {
     }
 
     @Test
+    fun `execution types keep the original task slug and metadata`() = runStorageTest {
+        val taskId = "same-task"
+        val executeId = storage.writeNewExecution(testExecParams("println(1)", taskId = taskId))
+        val screenshotId = storage.writeToolCall(
+            toolName = "steroid_take_screenshot",
+            arguments = buildJsonObject { put("task_id", taskId) },
+            taskId = taskId,
+        )
+        val feedbackId = storage.writeExecutionFeedback(
+            taskId = taskId,
+            element = FeedbackParams(
+                taskId = taskId,
+                successRating = 1.0,
+                explanation = "ok",
+                code = null,
+            ),
+        )
+
+        listOf(executeId, screenshotId, feedbackId).forEach { executionId ->
+            assertTrue(executionId.executionId.endsWith("-same-task"), executionId.executionId)
+            val metadata = storage.json.decodeFromString(
+                ToolCallMetadata.serializer(),
+                Files.readString(tempDir.resolve(executionId.executionId).resolve("tool.json")),
+            )
+            assertEquals(taskId, metadata.taskId)
+        }
+    }
+
+    @Test
     fun `different task ids produce different execution ids`() = runStorageTest {
         val id1 = storage.writeNewExecution(testExecParams("println(\"Hello\")", taskId = "task-1"))
         val id2 = storage.writeNewExecution(testExecParams("println(\"Hello\")", taskId = "task-2"))
@@ -130,6 +265,12 @@ class ExecutionStorageTest {
         assertNull(storage.findExecutionId("../etc/passwd"))
         assertNull(storage.findExecutionId("foo/bar"))
         assertNull(storage.findExecutionId(".."))
+
+        val windowsShapedId = "foo\\bar"
+        val windowsShapedDir = tempDir.resolve(windowsShapedId)
+        Files.createDirectories(windowsShapedDir)
+        Files.writeString(windowsShapedDir.resolve("tool.json"), "{}")
+        assertNull(storage.findExecutionId(windowsShapedId))
     }
 
     /**

--- a/ij-plugin/CLAUDE.md
+++ b/ij-plugin/CLAUDE.md
@@ -401,16 +401,13 @@ script.
 Registry keys: `mcp.steroid.server.port`, `.host`, `.execution.timeout`, `.dialog.killer.enabled`,
 `.demo.enabled`, `.storage.path`, `.kotlinc.parameters`, `.kotlinc.home`.
 
-### WSL-hosted project on a Windows IDE — `mcp.steroid.storage.path` workaround ([#78](https://github.com/jonnyzzz/mcp-steroid/issues/78))
+### WSL-hosted projects and `mcp.steroid.storage.path` ([#78](https://github.com/jonnyzzz/mcp-steroid/issues/78))
 
-When a Windows-side IDE opens a project under `\\wsl$\…` / `\\wsl.localhost\…`, every
-`steroid_execute_code` fails: the kotlinc working dir is the per-execution `compiled/` folder under
-`{project}/.idea/mcp-steroid/` (on the WSL filesystem), so the eel/ijent layer derives the WSL
-environment and routes `cmd.exe /c kotlinc.bat …` into the distro, where `cmd.exe` doesn't exist
-(`os error 2`). **Workaround:** set `mcp.steroid.storage.path` (the storage override, empty =
-`.idea/mcp-steroid`) to a native Windows path so the working dir leaves the `\\wsl$` volume and the
-spawn targets Windows. Proper fix (pass an `EelDescriptor`/spawn request targeting the local Windows
-env regardless of the working dir's filesystem) is still open.
+Execution storage defaults to the IDE user's native `~/.mcp-steroid/runs/` directory, not the project.
+That keeps kotlinc's per-execution `compiled/` working directory off `\\wsl$\…` /
+`\\wsl.localhost\…` when a Windows IDE opens a WSL-hosted project. If
+`mcp.steroid.storage.path` is customized in this setup, keep the override on a native Windows volume;
+pointing it back into WSL recreates the eel/ijent environment-routing failure from #78.
 
 ### Kotlinc version-mismatch workaround
 

--- a/ij-plugin/build.gradle.kts
+++ b/ij-plugin/build.gradle.kts
@@ -360,6 +360,28 @@ intellijPlatformTesting {
     }
 }
 
+// Isolate MCP execution storage for every in-process IntelliJ Platform test JVM
+// in this module (`test`, `integrationTest`, and any future Test task). Plugin
+// code persists execution folders via StoragePaths, which defaults to the REAL
+// ~/.mcp-steroid/runs of whoever runs the tests. The "mcp.steroid.storage.path"
+// registry key resolves user-stored values first, then System.getProperty(key),
+// then the bundled default — so one JVM-level system property redirects ALL test
+// classes without per-class setUp code (see RegistryValue.resolveNotRequiredValue).
+// The per-run directory is computed inside an argument provider: fresh on every
+// execution, and NOT fingerprinted as a task input, so it cannot break build
+// caching / up-to-date checks the way a timestamped systemProperty() would.
+// The contract is pinned by ExecutionStorageTaskTest.testExecutionStorageIsIsolatedFromRealUserHome.
+tasks.withType<Test>().configureEach {
+    val taskName = name
+    val testRunsBaseDir = layout.buildDirectory.dir("mcp-steroid-test-runs").get().asFile
+    // `lazy` so the timestamp is minted once per task execution even if Gradle
+    // asks the provider for its arguments more than once while forking the JVM.
+    val runDir by lazy { testRunsBaseDir.resolve("$taskName-${System.currentTimeMillis()}") }
+    jvmArgumentProviders.add(CommandLineArgumentProvider {
+        listOf("-Dmcp.steroid.storage.path=${runDir.absolutePath}")
+    })
+}
+
 tasks {
     test {
         useJUnit()

--- a/ij-plugin/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/NpxBridgeService.kt
+++ b/ij-plugin/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/NpxBridgeService.kt
@@ -1,6 +1,7 @@
 /* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
 package com.jonnyzzz.mcpSteroid.server
 
+import com.intellij.openapi.application.ApplicationInfo
 import com.intellij.openapi.components.Service
 import com.intellij.openapi.components.service
 import com.intellij.openapi.diagnostic.thisLogger
@@ -77,16 +78,7 @@ class NpxBridgeService {
         val session = serverCore.sessionManager.createSession()
         val progressToken = "npx-${UUID.randomUUID()}"
 
-        val argsWithMeta = injectProgressMeta(request.arguments, progressToken)
-        val rawParams = buildJsonObject {
-            put("name", request.name)
-            put("arguments", argsWithMeta)
-        }
-        val params = ToolCallParams(
-            name = request.name,
-            arguments = argsWithMeta,
-            rawArguments = rawParams
-        )
+        val params = buildToolCallParams(request, progressToken)
 
         val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
         val emitMutex = Mutex()
@@ -186,6 +178,31 @@ class NpxBridgeService {
         }
     }
 
+    /**
+     * Builds a bridge-owned tool call. [ToolCallParams.trustedArguments] is transient, so neither an
+     * old devrig request nor spoofed JSON arguments can control execution-storage provenance.
+     */
+    fun buildToolCallParams(request: NpxBridgeToolCallRequest, progressToken: String): ToolCallParams {
+        val argsWithMeta = injectProgressMeta(request.arguments, progressToken)
+        val rawParams = buildJsonObject {
+            put("name", request.name)
+            put("arguments", argsWithMeta)
+        }
+        val backendName = backendNameForMarker(
+            ProcessHandle.current().pid(),
+            ApplicationInfo.getInstance().build.asString(),
+        )
+        return ToolCallParams(
+            name = request.name,
+            arguments = argsWithMeta,
+            rawArguments = rawParams,
+            trustedArguments = buildJsonObject {
+                put(EXECUTION_BACKEND_KIND_ARGUMENT, "d")
+                put(EXECUTION_BACKEND_NAME_ARGUMENT, backendName)
+            },
+        )
+    }
+
     private fun injectProgressMeta(arguments: JsonObject?, progressToken: String): JsonObject {
         val args = arguments ?: buildJsonObject { }
         val existingMeta = args["_meta"]?.jsonObject
@@ -209,4 +226,3 @@ class NpxBridgeService {
         fun getInstance(): NpxBridgeService = service()
     }
 }
-

--- a/ij-plugin/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/VisionInputToolHandler.kt
+++ b/ij-plugin/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/VisionInputToolHandler.kt
@@ -2,7 +2,6 @@
 package com.jonnyzzz.mcpSteroid.server
 
 import com.intellij.openapi.components.service
-import com.intellij.openapi.diagnostic.thisLogger
 import com.jonnyzzz.mcpSteroid.mcp.ToolCallResult
 import com.jonnyzzz.mcpSteroid.mcp.builder
 import com.jonnyzzz.mcpSteroid.storage.executionStorage
@@ -12,6 +11,7 @@ import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.withTimeout
 import kotlinx.serialization.json.*
+import kotlin.time.Duration.Companion.milliseconds
 
 /** Fixed allowance for delivering the non-delay steps of an input sequence (issue #309). */
 private const val INPUT_DISPATCH_TIMEOUT_MS = 60_000L
@@ -25,7 +25,8 @@ class VisionInputToolHandlerIJ : VisionInputToolHandler {
         val executionId = project.executionStorage.writeToolCall(
             toolName = "steroid_input",
             arguments = json.encodeToJsonElement(inputParams).jsonObject,
-            taskId = "input-${inputParams.taskId}"
+            taskId = inputParams.taskId,
+            executionBackend = inputParams.executionBackend,
         )
         project.executionStorage.writeCodeExecutionData(executionId, "reason.txt", inputParams.reason)
 
@@ -48,14 +49,14 @@ class VisionInputToolHandlerIJ : VisionInputToolHandler {
             log("WARNING: Heavy endpoint. Prefer steroid_execute_code for regular automation.")
             log("Using window_id: $windowId")
 
-            withTimeout(timeoutMs) {
+            withTimeout(timeoutMs.milliseconds) {
                 VisionService.getInstance(project).executeInput(windowId, inputParams.sequence)
             }
             log("Input sequence executed successfully.")
         } catch (e: TimeoutCancellationException) {
             // A domain error the agent must see, not a control-flow signal — caught BEFORE the
             // generic CancellationException rethrow (same pattern as ScriptExecutor.executeCodeBlocks).
-            val message = "Input execution timed out after ${timeoutMs} ms — the input events could not be " +
+            val message = "Input execution timed out after $timeoutMs ms — the input events could not be " +
                     "delivered to window_id $windowId (EDT busy or window not processing events)"
             builder.addTextContent("ERROR: $message").markAsError()
             project.executionStorage.writeCodeErrorEvent(executionId, message)

--- a/ij-plugin/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/VisionScreenshotToolHandler.kt
+++ b/ij-plugin/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/VisionScreenshotToolHandler.kt
@@ -28,7 +28,8 @@ class VisionScreenshotToolHandlerIJ : VisionScreenshotToolHandler {
         val executionId = project.executionStorage.writeToolCall(
             toolName = "steroid_take_screenshot",
             arguments = json.encodeToJsonElement(screenshotParams).jsonObject,
-            taskId = "screenshot-$taskId"
+            taskId = taskId,
+            executionBackend = screenshotParams.executionBackend,
         )
         project.executionStorage.writeCodeExecutionData(executionId, "reason.txt", reason)
 

--- a/ij-plugin/src/main/kotlin/com/jonnyzzz/mcpSteroid/storage/ExecutionStorage.kt
+++ b/ij-plugin/src/main/kotlin/com/jonnyzzz/mcpSteroid/storage/ExecutionStorage.kt
@@ -1,9 +1,11 @@
 /* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
 package com.jonnyzzz.mcpSteroid.storage
 
+import com.intellij.openapi.application.ApplicationInfo
 import com.intellij.openapi.components.Service
 import com.intellij.openapi.components.service
 import com.intellij.openapi.project.Project
+import com.jonnyzzz.mcpSteroid.server.backendNameForMarker
 import kotlinx.coroutines.CoroutineScope
 
 inline val Project.executionStorage: ExecutionStorage get() = service<IjExecutionStorage>()
@@ -12,10 +14,9 @@ inline val Project.executionStorage: ExecutionStorage get() = service<IjExecutio
  * IntelliJ-side wrapper for the generic [ExecutionStorage] file storage.
  *
  * The base class (in the `:execution-storage` module) is IDE-free; this
- * service supplies the two callbacks it needs — the per-project storage
- * dir resolved via [StoragePaths] (which knows about the IDE's Registry
- * keys and `.idea` layout) and the [Project] identity captured at write
- * time.
+ * service supplies the callbacks it needs — the global storage
+ * dir resolved via [StoragePaths], the [Project] identity captured at write
+ * time, and this IDE backend's identity.
  *
  * `coroutineScope` is unused today but is kept in the constructor to opt
  * into IntelliJ's service-scoped coroutine lifecycle, matching the previous
@@ -29,4 +30,13 @@ class IjExecutionStorage(
 ) : ExecutionStorage(
     baseDirProvider = { project.storagePaths.getGetMcpRunDir() },
     projectInfoProvider = { ExecutionProjectInfo(name = project.name, basePath = project.basePath) },
+    backendInfoProvider = {
+        ExecutionBackendInfo(
+            kind = 's',
+            name = backendNameForMarker(
+                ProcessHandle.current().pid(),
+                ApplicationInfo.getInstance().build.asString(),
+            ),
+        )
+    },
 )

--- a/ij-plugin/src/main/kotlin/com/jonnyzzz/mcpSteroid/storage/StoragePaths.kt
+++ b/ij-plugin/src/main/kotlin/com/jonnyzzz/mcpSteroid/storage/StoragePaths.kt
@@ -1,23 +1,21 @@
 /* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
 package com.jonnyzzz.mcpSteroid.storage
 
-import com.intellij.openapi.application.PathManager
 import com.intellij.openapi.components.Service
 import com.intellij.openapi.components.service
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.registry.Registry
 import java.nio.file.Files
 import java.nio.file.Path
-import java.nio.file.Paths
 
 /**
  * Central service for managing MCP storage paths.
  *
- * Default storage location: {project}/.idea/mcp-steroid/
+ * Default storage location: ~/.mcp-steroid/runs/
  * Execution folders: {storage}/{execution-id}/
  *
  * Registry keys for customization:
- * - mcp.steroid.storage.path - Override storage folder path (empty = .idea/mcp-steroid)
+ * - mcp.steroid.storage.path - Override storage folder path (empty = ~/.mcp-steroid/runs)
  */
 @Service(Service.Level.PROJECT)
 class StoragePaths(private val project: Project) {
@@ -41,7 +39,7 @@ class StoragePaths(private val project: Project) {
 
     /**
      * The base directory for MCP execution storage.
-     * Default: {project}/.idea/mcp-steroid/
+     * Default: ~/.mcp-steroid/runs/
      *
      * Can be overridden via registry key "mcp.steroid.storage.path".
      */
@@ -52,8 +50,7 @@ class StoragePaths(private val project: Project) {
                 return@run Path.of(customPath)
             }
 
-            val base = resolveDotIdeaFolder(project) ?: PathManager.getTempDir().resolve("mcp-steroid")
-            return@run base.resolve("mcp-steroid")
+            return@run Path.of(System.getProperty("user.home"), ".mcp-steroid", "runs")
         }
 
         Files.createDirectories(path)

--- a/ij-plugin/src/main/resources/META-INF/plugin.xml
+++ b/ij-plugin/src/main/resources/META-INF/plugin.xml
@@ -118,7 +118,7 @@
 
         <!-- Storage folder configuration -->
         <registryKey key="mcp.steroid.storage.path" defaultValue=""
-            description="Custom path for MCP execution storage. Empty (default) uses .idea/mcp-steroid/"/>
+            description="Custom path for MCP execution storage. Empty (default) uses ~/.mcp-steroid/runs/"/>
         <registryKey key="mcp.steroid.idea.description.enabled" defaultValue="true"
             description="Generate .idea/mcp-steroid.md description file in projects"/>
 

--- a/ij-plugin/src/test/kotlin/com/jonnyzzz/mcpSteroid/execution/ExecutionStorageTaskTest.kt
+++ b/ij-plugin/src/test/kotlin/com/jonnyzzz/mcpSteroid/execution/ExecutionStorageTaskTest.kt
@@ -30,8 +30,6 @@ class ExecutionStorageTaskTest : BasePlatformTestCase() {
     override fun setUp() {
         setServerPortProperties()
         super.setUp()
-        val isolatedStorage = Path.of(requireNotNull(project.basePath), ".mcp-steroid-test-runs")
-        Registry.get("mcp.steroid.storage.path").setValue(isolatedStorage.toString(), testRootDisposable)
     }
 
     /**
@@ -42,9 +40,42 @@ class ExecutionStorageTaskTest : BasePlatformTestCase() {
     }
 
     fun testDefaultStorageLivesUnderMcpSteroidHome() {
-        Registry.get("mcp.steroid.storage.path").setValue("", testRootDisposable)
-        val expected = Path.of(System.getProperty("user.home"), ".mcp-steroid", "runs")
-        assertEquals(expected, project.storagePaths.getGetMcpRunDir())
+        // The Gradle test JVM isolates execution storage via the
+        // -Dmcp.steroid.storage.path system property (see ij-plugin/build.gradle.kts),
+        // and the registry falls back to that property whenever no user value is
+        // stored. Clear it for this test so the true production default is observable.
+        val isolationProperty = System.clearProperty("mcp.steroid.storage.path")
+        try {
+            // setValue busts the RegistryValue string cache left by earlier tests; an
+            // empty value equals the bundled default, so the platform drops the stored
+            // entry and resolution falls through to the (cleared) system property and
+            // then to the bundled default "".
+            Registry.get("mcp.steroid.storage.path").setValue("", testRootDisposable)
+            val expected = Path.of(System.getProperty("user.home"), ".mcp-steroid", "runs")
+            assertEquals(expected, project.storagePaths.getGetMcpRunDir())
+        } finally {
+            if (isolationProperty != null) {
+                System.setProperty("mcp.steroid.storage.path", isolationProperty)
+            }
+        }
+    }
+
+    /**
+     * Pins the JVM-wide test isolation contract: ij-plugin's Gradle Test tasks pass
+     * `-Dmcp.steroid.storage.path=<build-dir temp>` (see `ij-plugin/build.gradle.kts`),
+     * and the registry resolves that system property whenever no user value is stored.
+     * Without it, EVERY execution-running test class in this module would persist real
+     * execution folders into the developer's actual `~/.mcp-steroid/runs`.
+     */
+    fun testExecutionStorageIsIsolatedFromRealUserHome() {
+        val realRuns = Path.of(System.getProperty("user.home"), ".mcp-steroid", "runs")
+        val actual = project.storagePaths.getGetMcpRunDir()
+        assertFalse(
+            "Test-run execution storage must not point at the real $realRuns — " +
+                "the mcp.steroid.storage.path isolation property is missing (run via Gradle, " +
+                "or check ij-plugin/build.gradle.kts tasks.withType<Test> block)",
+            actual.startsWith(realRuns),
+        )
     }
 
     fun testSuccessFileAndWrappedScriptCreated(): Unit = timeoutRunBlocking(30.seconds) {

--- a/ij-plugin/src/test/kotlin/com/jonnyzzz/mcpSteroid/execution/ExecutionStorageTaskTest.kt
+++ b/ij-plugin/src/test/kotlin/com/jonnyzzz/mcpSteroid/execution/ExecutionStorageTaskTest.kt
@@ -1,7 +1,9 @@
 /* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
 package com.jonnyzzz.mcpSteroid.execution
 
+import com.intellij.openapi.application.ApplicationInfo
 import com.intellij.openapi.components.service
+import com.intellij.openapi.util.registry.Registry
 import com.intellij.testFramework.common.timeoutRunBlocking
 import com.intellij.testFramework.fixtures.BasePlatformTestCase
 import com.jonnyzzz.mcpSteroid.mcp.ContentItem
@@ -9,6 +11,7 @@ import com.jonnyzzz.mcpSteroid.getExecutionIdFromResult
 import com.jonnyzzz.mcpSteroid.setServerPortProperties
 import com.jonnyzzz.mcpSteroid.testExecParams
 import com.jonnyzzz.mcpSteroid.server.NoOpProgressReporter
+import com.jonnyzzz.mcpSteroid.server.backendNameForMarker
 import com.jonnyzzz.mcpSteroid.storage.storagePaths
 import java.nio.file.Path
 import kotlin.io.path.exists
@@ -27,6 +30,8 @@ class ExecutionStorageTaskTest : BasePlatformTestCase() {
     override fun setUp() {
         setServerPortProperties()
         super.setUp()
+        val isolatedStorage = Path.of(requireNotNull(project.basePath), ".mcp-steroid-test-runs")
+        Registry.get("mcp.steroid.storage.path").setValue(isolatedStorage.toString(), testRootDisposable)
     }
 
     /**
@@ -34,6 +39,12 @@ class ExecutionStorageTaskTest : BasePlatformTestCase() {
      */
     private fun getExecutionDir(executionId: String): Path {
         return project.storagePaths.getGetMcpRunDir().resolve(executionId)
+    }
+
+    fun testDefaultStorageLivesUnderMcpSteroidHome() {
+        Registry.get("mcp.steroid.storage.path").setValue("", testRootDisposable)
+        val expected = Path.of(System.getProperty("user.home"), ".mcp-steroid", "runs")
+        assertEquals(expected, project.storagePaths.getGetMcpRunDir())
     }
 
     fun testSuccessFileAndWrappedScriptCreated(): Unit = timeoutRunBlocking(30.seconds) {
@@ -46,6 +57,14 @@ class ExecutionStorageTaskTest : BasePlatformTestCase() {
         val execDir = getExecutionDir(executionId)
 
         assertTrue("Execution directory should exist: $execDir", execDir.exists())
+        assertTrue("Execution ID should include the project name and direct-plugin backend kind: $executionId",
+            executionId.contains("-${project.name}-s-"))
+
+        val backendName = backendNameForMarker(
+            pid = ProcessHandle.current().pid(),
+            build = ApplicationInfo.getInstance().build.asString(),
+        )
+        assertEquals(backendName, execDir.resolve("backend_name.txt").readText().trim())
 
         val successFile = execDir.resolve("success.txt")
         assertTrue("success.txt should exist", successFile.exists())

--- a/ij-plugin/src/test/kotlin/com/jonnyzzz/mcpSteroid/server/NpxBridgeServiceTest.kt
+++ b/ij-plugin/src/test/kotlin/com/jonnyzzz/mcpSteroid/server/NpxBridgeServiceTest.kt
@@ -1,0 +1,46 @@
+/* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
+package com.jonnyzzz.mcpSteroid.server
+
+import com.intellij.openapi.application.ApplicationInfo
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
+import com.jonnyzzz.mcpSteroid.mcp.McpSession
+import com.jonnyzzz.mcpSteroid.mcp.ToolCallContext
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+
+class NpxBridgeServiceTest : BasePlatformTestCase() {
+    fun testBridgeAddsAuthoritativeProvenanceWhenOldDevrigSendsNone() {
+        assertAuthoritativeBridgeProvenance(buildJsonObject { })
+    }
+
+    fun testBridgeOverridesSpoofedProvenanceArguments() {
+        assertAuthoritativeBridgeProvenance(buildJsonObject {
+            put(EXECUTION_BACKEND_KIND_ARGUMENT, "s")
+            put(EXECUTION_BACKEND_NAME_ARGUMENT, "spoofed-backend")
+        })
+    }
+
+    private fun assertAuthoritativeBridgeProvenance(arguments: kotlinx.serialization.json.JsonObject) {
+        val params = NpxBridgeService.getInstance().buildToolCallParams(
+            request = NpxBridgeToolCallRequest(
+                name = "steroid_execute_code",
+                arguments = arguments,
+            ),
+            progressToken = "test-progress",
+        )
+        val context = ToolCallContext(
+            params = params,
+            session = McpSession(),
+            mcpProgressReporter = NoOpProgressReporter,
+        )
+        val expectedBackendName = backendNameForMarker(
+            ProcessHandle.current().pid(),
+            ApplicationInfo.getInstance().build.asString(),
+        )
+
+        assertEquals(
+            ExecutionBackendProvenance(kind = 'd', name = expectedBackendName),
+            context.executionBackendProvenance(),
+        )
+    }
+}

--- a/mcp-core/src/main/kotlin/com/jonnyzzz/mcpSteroid/mcp/McpProtocol.kt
+++ b/mcp-core/src/main/kotlin/com/jonnyzzz/mcpSteroid/mcp/McpProtocol.kt
@@ -179,6 +179,10 @@ data class ToolCallParams(
 
     @Transient
     val rawArguments: JsonObject = buildJsonObject {  },
+
+    /** Transport-owned metadata that cannot be supplied through MCP JSON. */
+    @Transient
+    val trustedArguments: JsonObject = buildJsonObject {  },
 )
 
 @Serializable

--- a/mcp-steroid-server/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/ExecuteCodeTool.kt
+++ b/mcp-steroid-server/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/ExecuteCodeTool.kt
@@ -22,6 +22,7 @@ import com.jonnyzzz.mcpSteroid.prompts.generated.skill.CodingWithIntelliJContext
 import com.jonnyzzz.mcpSteroid.prompts.generated.skill.ExecuteCodeToolDescriptionPromptArticle
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.Transient
 
 /**
  * How `steroid_execute_code` prepares the IDE and handles modal dialogs around the script.
@@ -75,6 +76,8 @@ data class ExecCodeParams(
 
     /** How to treat IDE modality around the script. See [ModalMode]. Default [ModalMode.SMART_NON_MODAL]. */
     val modal: ModalMode = ModalMode.DEFAULT,
+
+    @Transient val executionBackend: ExecutionBackendProvenance? = null,
 )
 
 /**
@@ -171,6 +174,7 @@ class ExecuteCodeToolSpec(val handler: () -> ExecuteCodeToolHandler) : McpToolBa
             reason = reason,
             timeout = timeout,
             modal = modal,
+            executionBackend = context.executionBackendProvenance(),
         )
 
         return handler().executeCode(projectName, execCodeParams, context.mcpProgressReporter)

--- a/mcp-steroid-server/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/ExecuteFeedbackTool.kt
+++ b/mcp-steroid-server/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/ExecuteFeedbackTool.kt
@@ -16,6 +16,7 @@ import com.jonnyzzz.mcpSteroid.mcp.param
 import com.jonnyzzz.mcpSteroid.mcp.required
 import com.jonnyzzz.mcpSteroid.mcp.string
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.Transient
 
 /**
  * Handler for the steroid_execute_feedback MCP tool.
@@ -115,7 +116,8 @@ class ExecuteFeedbackToolSpec(val handler: () -> ExecuteFeedbackToolHandler) : M
             taskId = taskId,
             successRating = successRating,
             explanation = explanation,
-            code = code
+            code = code,
+            executionBackend = context.executionBackendProvenance(),
         )
 
         return handler().handleFeedback(projectName, params)
@@ -127,7 +129,8 @@ data class FeedbackParams(
     val taskId: String,
     val successRating: Double,
     val explanation: String?,
-    val code: String?
+    val code: String?,
+    @Transient val executionBackend: ExecutionBackendProvenance? = null,
 )
 
 interface ExecuteFeedbackToolHandler {

--- a/mcp-steroid-server/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/ExecutionBackendProvenance.kt
+++ b/mcp-steroid-server/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/ExecutionBackendProvenance.kt
@@ -1,0 +1,36 @@
+/* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
+package com.jonnyzzz.mcpSteroid.server
+
+import com.jonnyzzz.mcpSteroid.mcp.ToolCallContext
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonPrimitive
+
+const val EXECUTION_BACKEND_KIND_ARGUMENT = "_execution_backend_kind"
+const val EXECUTION_BACKEND_NAME_ARGUMENT = "_execution_backend_name"
+
+/** Storage-only provenance added by a routing backend and omitted from persisted tool arguments. */
+data class ExecutionBackendProvenance(
+    val kind: Char,
+    val name: String,
+) {
+    init {
+        require(kind in 'a'..'z' || kind in 'A'..'Z' || kind in '0'..'9') {
+            "Execution backend kind must be one ASCII letter or digit: $kind"
+        }
+        require(name.isNotBlank()) { "Execution backend name must not be blank" }
+    }
+}
+
+fun ToolCallContext.executionBackendProvenance(): ExecutionBackendProvenance? =
+    params.trustedArguments.executionBackendProvenance()
+
+fun JsonObject.executionBackendProvenance(): ExecutionBackendProvenance? {
+    val kindValue = this[EXECUTION_BACKEND_KIND_ARGUMENT]?.jsonPrimitive?.contentOrNull
+    val name = this[EXECUTION_BACKEND_NAME_ARGUMENT]?.jsonPrimitive?.contentOrNull
+    if (kindValue == null && name == null) return null
+
+    require(kindValue?.length == 1) { "$EXECUTION_BACKEND_KIND_ARGUMENT must contain exactly one character" }
+    require(!name.isNullOrBlank()) { "$EXECUTION_BACKEND_NAME_ARGUMENT must not be blank" }
+    return ExecutionBackendProvenance(kind = kindValue.single(), name = name)
+}

--- a/mcp-steroid-server/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/VisionInputTool.kt
+++ b/mcp-steroid-server/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/VisionInputTool.kt
@@ -15,6 +15,7 @@ import com.jonnyzzz.mcpSteroid.vision.InputSequenceParser
 import com.jonnyzzz.mcpSteroid.vision.InputStep
 import com.jonnyzzz.mcpSteroid.vision.InputTarget
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.Transient
 
 /**
  * Handler for the steroid_input MCP tool.
@@ -87,6 +88,7 @@ class VisionInputToolSpec(val handler: () -> VisionInputToolHandler) : McpToolBa
             windowId = windowId,
             sequence = parsed,
             rawSequence = sequence,
+            executionBackend = context.executionBackendProvenance(),
         ))
     }
 }
@@ -98,6 +100,7 @@ data class InputParams(
     val windowId: String,
     val sequence: List<InputStep>,
     val rawSequence: String? = null,
+    @Transient val executionBackend: ExecutionBackendProvenance? = null,
 )
 
 interface VisionInputToolHandler {

--- a/mcp-steroid-server/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/VisionScreenshotTool.kt
+++ b/mcp-steroid-server/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/VisionScreenshotTool.kt
@@ -5,6 +5,7 @@ import com.jonnyzzz.mcpSteroid.mcp.ToolCallContext
 import com.jonnyzzz.mcpSteroid.mcp.ToolCallResult
 import com.jonnyzzz.mcpSteroid.mcp.get
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.Transient
 
 /**
  * Handler for the steroid_take_screenshot MCP tool.
@@ -49,7 +50,16 @@ class VisionScreenshotToolSpec(val handler: () -> VisionScreenshotToolHandler) :
         val reason = context[reason]
         val windowId = context[windowId]
 
-        return handler().screenshotWindow(projectName, ScreenshotParams(taskId, reason, windowId), context.mcpProgressReporter)
+        return handler().screenshotWindow(
+            projectName,
+            ScreenshotParams(
+                taskId = taskId,
+                reason = reason,
+                windowId = windowId,
+                executionBackend = context.executionBackendProvenance(),
+            ),
+            context.mcpProgressReporter,
+        )
     }
 }
 
@@ -57,7 +67,8 @@ class VisionScreenshotToolSpec(val handler: () -> VisionScreenshotToolHandler) :
 data class ScreenshotParams(
     val taskId: String,
     val reason: String,
-    val windowId: String? = null
+    val windowId: String? = null,
+    @Transient val executionBackend: ExecutionBackendProvenance? = null,
 )
 
 interface VisionScreenshotToolHandler {
@@ -67,4 +78,3 @@ interface VisionScreenshotToolHandler {
         mcpProgressReporter: McpProgressReporter
     ): ToolCallResult
 }
-

--- a/mcp-steroid-server/src/test/kotlin/com/jonnyzzz/mcpSteroid/server/ExecutionBackendProvenanceTest.kt
+++ b/mcp-steroid-server/src/test/kotlin/com/jonnyzzz/mcpSteroid/server/ExecutionBackendProvenanceTest.kt
@@ -1,0 +1,75 @@
+/* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
+package com.jonnyzzz.mcpSteroid.server
+
+import com.jonnyzzz.mcpSteroid.mcp.McpJson
+import com.jonnyzzz.mcpSteroid.mcp.McpSession
+import com.jonnyzzz.mcpSteroid.mcp.ToolCallContext
+import com.jonnyzzz.mcpSteroid.mcp.ToolCallParams
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Test
+
+class ExecutionBackendProvenanceTest {
+    @Test
+    fun `direct callers cannot spoof storage provenance`() {
+        val spoofedArguments = buildJsonObject {
+            put(EXECUTION_BACKEND_KIND_ARGUMENT, "d")
+            put(EXECUTION_BACKEND_NAME_ARGUMENT, "spoofed-backend")
+        }
+        val context = ToolCallContext(
+            params = ToolCallParams(name = "steroid_execute_code", arguments = spoofedArguments),
+            session = McpSession(),
+            mcpProgressReporter = NoOpProgressReporter,
+        )
+
+        assertNull(context.executionBackendProvenance())
+    }
+
+    @Test
+    fun `trusted bridge arguments parse backend kind and full name`() {
+        val trustedArguments = buildJsonObject {
+            put(EXECUTION_BACKEND_KIND_ARGUMENT, "d")
+            put(EXECUTION_BACKEND_NAME_ARGUMENT, "iu-47qi79c1")
+        }
+        val context = ToolCallContext(
+            params = ToolCallParams(
+                name = "steroid_execute_code",
+                trustedArguments = trustedArguments,
+            ),
+            session = McpSession(),
+            mcpProgressReporter = NoOpProgressReporter,
+        )
+
+        assertEquals(
+            ExecutionBackendProvenance(kind = 'd', name = "iu-47qi79c1"),
+            context.executionBackendProvenance(),
+        )
+    }
+
+    @Test
+    fun `partial hidden provenance fails fast`() {
+        val arguments = buildJsonObject { put(EXECUTION_BACKEND_KIND_ARGUMENT, "d") }
+
+        assertThrows(IllegalArgumentException::class.java) { arguments.executionBackendProvenance() }
+    }
+
+    @Test
+    fun `storage provenance is transient in execution params JSON`() {
+        val params = ExecCodeParams(
+            taskId = "task",
+            code = "println(1)",
+            reason = "test",
+            timeout = 30,
+            executionBackend = ExecutionBackendProvenance(kind = 'd', name = "iu-47qi79c1"),
+        )
+
+        val json = McpJson.encodeToString(ExecCodeParams.serializer(), params)
+        assertFalse(json.contains("executionBackend"), json)
+        assertFalse(json.contains(EXECUTION_BACKEND_NAME_ARGUMENT), json)
+        assertFalse(json.contains(EXECUTION_BACKEND_KIND_ARGUMENT), json)
+    }
+}

--- a/npx-kt/build.gradle.kts
+++ b/npx-kt/build.gradle.kts
@@ -63,10 +63,8 @@ dependencies {
     // Brings :mcp-core and :prompts transitively.
     implementation(project(":mcp-steroid-server"))
 
-    // IDE-free ExecutionStorage core. Lets devrig persist execution
-    // history with the same on-disk layout the IntelliJ plugin uses, so
-    // downstream tooling that reads .idea/mcp-steroid/{eid}/ artefacts
-    // works against both backends without conditional logic.
+    // IDE-free ExecutionStorage core. Keeps the canonical
+    // ~/.mcp-steroid/runs/{eid}/ layout available to devrig-side tooling.
     implementation(project(":execution-storage"))
 
     // Managed backends reuse the existing IntelliJ downloader/unpacker instead

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/HomePaths.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/HomePaths.kt
@@ -12,7 +12,7 @@ class HomePaths(val home: Path) {
     val cachesDir: Path get() = home.resolve("caches")
     val downloadsDir: Path get() = home.resolve("downloads")
     val stateDir: Path get() = home.resolve("state")
-    val executionStorageDir: Path get() = home.resolve("execution-storage")
+    val executionStorageDir: Path get() = home.resolve("runs")
 
     /**
      * Auto-update coordination files (`lock`, `update-<pid>-version-<v>`, `updated-<v>`, counters,

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/ManagedBackend.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/ManagedBackend.kt
@@ -753,7 +753,7 @@ private fun String.pathKey(): String =
 
 fun writeBackendVmOptions(homePaths: HomePaths, id: String, bundleDirName: String): Path {
     val cacheDir = homePaths.cacheDir(id).toAbsolutePath().normalize()
-    listOf("config", "system", "logs", "plugins", "execution-storage").forEach { Files.createDirectories(cacheDir.resolve(it)) }
+    listOf("config", "system", "logs", "plugins").forEach { Files.createDirectories(cacheDir.resolve(it)) }
     Files.createDirectories(homePaths.backendDir(id))
     val path = homePaths.backendDir(id).resolve("$bundleDirName.vmoptions")
     val content = buildString {
@@ -768,7 +768,6 @@ fun writeBackendVmOptions(homePaths: HomePaths, id: String, bundleDirName: Strin
         // disable mcp.steroid updates/analytics here.
         appendLine("-Dmcp.steroid.idea.description.enabled=false")
         appendLine("-Dmcp.steroid.dialog.killer.enabled=true")
-        appendLine("-Dmcp.steroid.storage.path=${cacheDir.resolve("execution-storage")}")
         appendLine("-Djb.consents.confirmation.enabled=false")
         appendLine("-Djb.privacy.policy.text=<!--999.999-->")
         appendLine("-Djb.privacy.policy.ai.assistant.text=<!--999.999-->")

--- a/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/HomePathsTest.kt
+++ b/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/HomePathsTest.kt
@@ -32,7 +32,7 @@ class HomePathsTest {
         assertEquals(tempDir.resolve("caches"), paths.cachesDir)
         assertEquals(tempDir.resolve("downloads"), paths.downloadsDir)
         assertEquals(tempDir.resolve("state"), paths.stateDir)
-        assertEquals(tempDir.resolve("execution-storage"), paths.executionStorageDir)
+        assertEquals(tempDir.resolve("runs"), paths.executionStorageDir)
         assertEquals(tempDir.resolve("update"), paths.updateDir)
         assertEquals(tempDir.resolve("backends/idea-community-2025.3.3"), paths.backendDir("idea-community-2025.3.3"))
         assertEquals(tempDir.resolve("caches/idea-community-2025.3.3"), paths.cacheDir("idea-community-2025.3.3"))
@@ -51,7 +51,7 @@ class HomePathsTest {
         listOf(paths.logsDir, paths.backendsDir, paths.cachesDir, paths.downloadsDir, paths.stateDir, paths.binDir, paths.updateDir).forEach { dir ->
             assertTrue(dir.isDirectory(), "$dir should be a directory")
         }
-        assertTrue(!Files.exists(paths.executionStorageDir), "execution-storage is reserved and not created yet")
+        assertTrue(!Files.exists(paths.executionStorageDir), "runs is plugin-owned and not created by devrig startup")
     }
 
     @Test

--- a/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/VmOptionsWriterTest.kt
+++ b/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/VmOptionsWriterTest.kt
@@ -35,7 +35,6 @@ class VmOptionsWriterTest {
             "-Xmx2048m",
             "-Dmcp.steroid.idea.description.enabled=false",
             "-Dmcp.steroid.dialog.killer.enabled=true",
-            "-Dmcp.steroid.storage.path=${cacheDir.resolve("execution-storage")}",
             "-Djb.consents.confirmation.enabled=false",
             "-Djb.privacy.policy.text=<!--999.999-->",
             "-Djb.privacy.policy.ai.assistant.text=<!--999.999-->",
@@ -53,10 +52,14 @@ class VmOptionsWriterTest {
         // The managed IDE should behave like a normal install: report analytics and check for updates.
         assertFalse(content.contains("mcp.steroid.updates.enabled"), "must not disable updates in the managed IDE")
         assertFalse(content.contains("mcp.steroid.analytics.enabled"), "must not disable analytics in the managed IDE")
+        assertFalse(content.contains("mcp.steroid.backend.kind"),
+            "backend kind is per-call provenance, not a managed-IDE launch property")
 
-        listOf("config", "system", "logs", "plugins", "execution-storage").forEach { child ->
+        listOf("config", "system", "logs", "plugins").forEach { child ->
             assertTrue(homePaths.cacheDir(id).resolve(child).exists(), "$child cache directory should exist")
         }
+        assertFalse(homePaths.cacheDir(id).resolve("execution-storage").exists(),
+            "managed backends should use the shared ~/.mcp-steroid/runs storage")
         assertFalse(homePaths.backendDir(id).resolve("IntelliJ IDEA CE.app/Contents/bin/idea.vmoptions").exists(),
             "vmoptions must be a sibling to the bundle, not written inside the signed macOS app")
     }

--- a/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/server/DevrigToolBridgeClientTest.kt
+++ b/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/server/DevrigToolBridgeClientTest.kt
@@ -10,13 +10,14 @@ import com.jonnyzzz.mcpSteroid.devrig.DevrigBeacon
 import com.jonnyzzz.mcpSteroid.devrig.HomePaths
 import com.jonnyzzz.mcpSteroid.devrig.InstalledBackend
 import com.jonnyzzz.mcpSteroid.server.backendNameForMarker
-import com.jonnyzzz.mcpSteroid.devrig.backendNameForPort
 import com.jonnyzzz.mcpSteroid.devrig.monitor.DiscoveredIde
 import com.jonnyzzz.mcpSteroid.devrig.startableBackendName
 import com.jonnyzzz.mcpSteroid.devrig.testDevrigEndpoint
 import com.jonnyzzz.mcpSteroid.testHelper.CloseableStackHost
 import com.jonnyzzz.mcpSteroid.devrig.monitor.IdeMonitorState
 import com.jonnyzzz.mcpSteroid.server.ExecCodeParams
+import com.jonnyzzz.mcpSteroid.server.EXECUTION_BACKEND_KIND_ARGUMENT
+import com.jonnyzzz.mcpSteroid.server.EXECUTION_BACKEND_NAME_ARGUMENT
 import com.jonnyzzz.mcpSteroid.server.ModalMode
 import com.jonnyzzz.mcpSteroid.server.FeedbackParams
 import com.jonnyzzz.mcpSteroid.server.InputParams
@@ -25,7 +26,6 @@ import com.jonnyzzz.mcpSteroid.server.NoOpProgressReporter
 import com.jonnyzzz.mcpSteroid.server.OpenProjectParams
 import com.jonnyzzz.mcpSteroid.devrig.monitor.IdeProjectState
 import com.jonnyzzz.mcpSteroid.server.ScreenshotParams
-import com.jonnyzzz.mcpSteroid.devrig.server.DevrigBackendService
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.cio.CIO
 import io.ktor.client.plugins.HttpTimeout
@@ -48,6 +48,7 @@ import kotlin.coroutines.cancellation.CancellationException
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.CompletableDeferred
@@ -170,6 +171,8 @@ class DevrigToolBridgeClientTest {
             "original-project",
             json["arguments"]?.jsonObject?.get("project_name")?.jsonPrimitive?.content,
         )
+        assertNull(json["arguments"]?.jsonObject?.get(EXECUTION_BACKEND_KIND_ARGUMENT))
+        assertNull(json["arguments"]?.jsonObject?.get(EXECUTION_BACKEND_NAME_ARGUMENT))
     }
 
     @Test
@@ -210,6 +213,8 @@ class DevrigToolBridgeClientTest {
         assertEquals("verify contract", arguments["reason"]?.jsonPrimitive?.content)
         assertEquals(42, arguments["timeout"]?.jsonPrimitive?.content?.toInt())
         assertEquals("unleashed", arguments["modal"]?.jsonPrimitive?.content)
+        assertNull(arguments[EXECUTION_BACKEND_KIND_ARGUMENT])
+        assertNull(arguments[EXECUTION_BACKEND_NAME_ARGUMENT])
     }
 
     @Test

--- a/test-integration/src/test/kotlin/com/jonnyzzz/mcpSteroid/integration/tests/DevrigManagedBackendGuiIntegrationTest.kt
+++ b/test-integration/src/test/kotlin/com/jonnyzzz/mcpSteroid/integration/tests/DevrigManagedBackendGuiIntegrationTest.kt
@@ -75,13 +75,16 @@ class DevrigManagedBackendGuiIntegrationTest {
             "-Didea.plugins.path=$cacheBase/plugins",
             "-Dmcp.steroid.idea.description.enabled=false",
             "-Dmcp.steroid.dialog.killer.enabled=true",
-            "-Dmcp.steroid.storage.path=$cacheBase/execution-storage",
             "-Djb.consents.confirmation.enabled=false",
         )
         requiredVmOptions.forEach { expected ->
             assertTrue(expected in vmOptionLines) {
                 "managed backend vmoptions missing line: $expected\n--- $vmOptionsPath ---\n$vmOptions"
             }
+        }
+        assertFalse(vmOptionLines.any { it.startsWith("-Dmcp.steroid.storage.path=") }) {
+            "managed backends must use shared ~/.mcp-steroid/runs storage, not override it\n" +
+                "--- $vmOptionsPath ---\n$vmOptions"
         }
         // A managed backend behaves like a normal install for updates/analytics — devrig production must
         // NOT inject the disabling flags (commit 4f36412e "let managed backends report analytics and check
@@ -169,6 +172,7 @@ class DevrigManagedBackendGuiIntegrationTest {
                 test -d "/home/agent/.mcp-steroid/caches/$$id/system"
                 test -d "/home/agent/.mcp-steroid/caches/$$id/logs"
                 test -d "/home/agent/.mcp-steroid/caches/$$id/plugins"
+                test ! -e "/home/agent/.mcp-steroid/caches/$$id/execution-storage"
                 test "$(find "/home/agent/.mcp-steroid/caches/$$id/logs" -type f | wc -l)" -gt 0
             """.trimIndent(),
         )

--- a/website/content/docs/configuration.md
+++ b/website/content/docs/configuration.md
@@ -25,7 +25,7 @@ MCP Steroid can be configured via IntelliJ's Registry (`Help > Find Action > Reg
 
 | Registry Key | Default | Description |
 |-------------|---------|-------------|
-| `mcp.steroid.storage.path` | (empty) | Custom path for MCP execution storage. Empty uses `.idea/mcp-steroid/`. |
+| `mcp.steroid.storage.path` | (empty) | Custom path for MCP execution storage. Empty uses `~/.mcp-steroid/runs/`. |
 | `mcp.steroid.idea.description.enabled` | `true` | Generate `.idea/mcp-steroid.md` description file in projects. |
 
 ## Demo Mode
@@ -55,7 +55,7 @@ The **Dialog Killer** feature automatically closes modal dialogs before code exe
 When you call `steroid_execute_code`:
 
 1. **Detection**: Checks if a modal dialog is currently open using `ModalityState`
-2. **Screenshot**: Captures a screenshot of the dialog for debugging (saved to `.idea/mcp-steroid/{execution-id}-dialog-killer/`)
+2. **Screenshot**: Captures a screenshot of the dialog for debugging (saved in `~/.mcp-steroid/runs/{execution-id}/`)
 3. **Closure**: Closes all modal dialogs owned by the project frame using `doCancelAction()`
 4. **Logging**: Reports the activity via IDE log and MCP progress messages
 5. **Execution**: Proceeds with your code execution normally
@@ -70,9 +70,9 @@ You might want to disable the dialog killer (`mcp.steroid.dialog.killer.enabled 
 
 ### Screenshot Location
 
-When dialogs are detected and closed, a screenshot is automatically saved to:
+When dialogs are detected and closed, a screenshot is automatically saved to the current execution:
 ```
-.idea/mcp-steroid/{execution-id}-dialog-killer/screenshot.png
+~/.mcp-steroid/runs/{execution-id}/screenshot.png
 ```
 
 This helps you understand what was blocking the IDE and verify the dialog killer is working correctly.

--- a/website/content/docs/how-to-debug-ide.md
+++ b/website/content/docs/how-to-debug-ide.md
@@ -182,7 +182,7 @@ steroid_take_screenshot(
 ```
 
 **Result:**
-- Screenshot saved to `.idea/mcp-steroid/[execution-id]/screenshot.png`
+- Screenshot saved to `~/.mcp-steroid/runs/[execution-id]/screenshot.png`
 - Component tree saved to `screenshot-tree.md`
 - Metadata in `screenshot-meta.json`
 
@@ -552,7 +552,7 @@ screencapture -w /tmp/target-ide-screenshot.png
 
 ```bash
 # Read component tree from screenshot
-cat .idea/mcp-steroid/[execution-id]/screenshot-tree.md
+cat ~/.mcp-steroid/runs/[execution-id]/screenshot-tree.md
 
 # Look for specific components
 grep -i "your-component" screenshot-tree.md

--- a/website/content/docs/learning-methodology.md
+++ b/website/content/docs/learning-methodology.md
@@ -17,7 +17,7 @@ refined through data-driven iteration -- a user manual designed specifically for
 
 ## The operating loop
 
-Every agent call is recorded in the `.idea/mcp-steroid` folder. Each invocation includes the caller's stated _reason_
+Every agent call is recorded under `~/.mcp-steroid/runs/`. Each invocation includes the caller's stated _reason_
 for the call, and agents periodically send feedback with a text message and a score.
 
 This telemetry drives continuous improvement. We analyze call patterns, failure modes, and feedback signals
@@ -26,7 +26,7 @@ sophisticated tasks across the full surface of IntelliJ-platform IDEs -- includi
 both private and public.
 
 We are looking for your support:
-- Share your `.idea/mcp-steroid` logs from real plugin usage
+- Share your `~/.mcp-steroid/runs` logs from real plugin usage
 - Submit complete project and task scenarios for benchmarking
 
 Submissions are accepted through [Need Your Experiments and Support](/docs/need-your-experiments-and-support/).

--- a/website/content/docs/need-your-experiments-and-support.md
+++ b/website/content/docs/need-your-experiments-and-support.md
@@ -17,8 +17,8 @@ If your repository works in an IntelliJ-based IDE, it is in scope. Support the p
 ## Usage logs sharing
 
 Beyond full scenario submissions, you can help by sharing your tool call logs.
-The `.idea/mcp-steroid` folder in your project contains a log of every tool call
-your AI agent sent to the plugin. This data helps us fine-tune prompts, skills,
+The `~/.mcp-steroid/runs` folder contains a log of every stored tool call across
+your projects. Each run records its project identity. This data helps us fine-tune prompts, skills,
 and documentation to make agents more effective.
 
 For details on how we process this data, see [Learning Methodology](/docs/learning-methodology/).

--- a/website/content/docs/project-assessment-2026-02-22.md
+++ b/website/content/docs/project-assessment-2026-02-22.md
@@ -240,7 +240,7 @@ MCP Steroid is built and maintained by a solo developer. Continued development, 
 
 - **Sponsor on GitHub** — [github.com/sponsors/jonnyzzz](https://github.com/sponsors/jonnyzzz)
 - **Submit real-world scenarios** — share your repositories and workflows so we can benchmark and improve. See [Support the Project](/docs/need-your-experiments-and-support/) for the submission template
-- **Share usage logs** — the `.idea/mcp-steroid` folder in your project contains tool call logs that help us fine-tune prompts and skills
+- **Share usage logs** — `~/.mcp-steroid/runs` contains tool call logs that help us fine-tune prompts and skills
 - **Report issues** — [github.com/jonnyzzz/mcp-steroid/issues](https://github.com/jonnyzzz/mcp-steroid/issues)
 - **Join the community** — [Discord server](https://discord.gg/e9qgQ7NeTC) or message Eugene on [LinkedIn](https://linkedin.com/in/jonnyzzz)
 

--- a/website/content/docs/strategy.md
+++ b/website/content/docs/strategy.md
@@ -42,7 +42,7 @@ We run the same task twice -- same model, same repo -- once with the IDE through
 agent, and score every run on machine-checkable evidence rather than on what the agent claims about itself. See the
 [experiment findings](/docs/experiment-findings/) for the verified results, including the runs where the IDE path did not win.
 
-We are collecting scenarios and execution logs from real MCP Steroid sessions (share your `.idea/mcp-steroid` folder with us).
+We are collecting scenarios and execution logs from real MCP Steroid sessions (share your `~/.mcp-steroid/runs` folder with us).
 
 The collected data is analyzed to identify sharp edges in the current implementation and to improve prompts, skills,
 and documentation. AI agents help us craft the better product for AI agents. This is an iterative process; we have


### PR DESCRIPTION
## Summary

- move execution history from project `.idea` folders to `~/.mcp-steroid/runs` and update active documentation/configuration
- reserve execution directories atomically with UTC time, an epoch-millisecond modulo-997 slot, bounded project/task slugs, and one-character backend provenance
- persist the full backend identity in `backend_name.txt`, preserve original task IDs across tool types, and harden execution-ID path validation
- stamp devrig provenance authoritatively inside the IDE bridge while keeping persisted tool JSON and older devrig clients compatible

## Verification

- `:mcp-core:test` — 121 tests, 0 failures
- `:execution-storage:test` — 16 tests, 0 failures
- `:mcp-steroid-server:test` — 83 tests, 0 failures
- `:npx-kt:test` — 1,397 tests, 4 existing skips, 0 failures
- `:ij-plugin:test` — 280 tests, 1 existing skip, 0 failures
- `DevrigManagedBackendGuiIntegrationTest` — 1 test, 0 failures
- IntelliJ inspections ran on every changed production Kotlin file; new/modified code is clean (baseline-only findings remain in untouched declarations)
- `git diff --check`

Closes #280
Closes #414