### PR TITLE
devrig: add PhpStorm, RubyMine, DataGrip, RustRover and MPS to the IDE product catalog

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -237,7 +237,7 @@ silently skips both. Direct `./gradlew :test-integration:test --tests '...'` sti
 | `:npx-kt:liveDownloadSmokeTest` | `idea-community` + `android-studio` really download, unpack and pass `product-info.json` validation (`live-download` tag) | multi-GB per case |
 | `:intellij-downloader:liveNetworkTest` | products-API filename tokens still match (JUnit4 `LiveNetwork` category) | seconds |
 
-The offline equivalent runs by default: `AllIdeProductsDownloadTest` walks all nine products through
+The offline equivalent runs by default: `AllIdeProductsDownloadTest` walks every catalog product through
 recorded payloads of all three feeds.
 
 **TeamCity DSL** lives in a separate repo (`~/Work/mcp-steroid-teamcity`). See its own `CLAUDE.md` for the

--- a/intellij-downloader/build.gradle.kts
+++ b/intellij-downloader/build.gradle.kts
@@ -77,6 +77,9 @@ tasks.test {
     useJUnit {
         excludeCategories("com.jonnyzzz.mcpSteroid.ideDownloader.LiveNetwork")
     }
+    // ProductCatalogDocsDriftTest reads the published docs / CLI help straight from the
+    // working tree, so it needs the repo root rather than the module dir.
+    systemProperty("mcp.repo.root", rootProject.layout.projectDirectory.asFile.absolutePath)
     // OS-specific skip lives inside each test (`Assume.assumeTrue` / `assumeFalse`).
     // SevenZipLocatorTest needs the Windows-bundled resources → Windows-only.
     // IdeUnpackerSecurityTest hits tar path-separator behavior that differs on

--- a/intellij-downloader/src/buildsrc-shared/kotlin/com/jonnyzzz/mcpSteroid/ideDownloader/IdeProduct.kt
+++ b/intellij-downloader/src/buildsrc-shared/kotlin/com/jonnyzzz/mcpSteroid/ideDownloader/IdeProduct.kt
@@ -146,6 +146,84 @@ sealed interface IdeProduct {
         override val urlFilenameTokens = listOf("CLion-")
     }
 
+    /**
+     * RustRover. The products feed serves only the `release` and `eap` channels for `RR` — there is
+     * no `rc` stream — which both [IdeChannel] values already cover.
+     */
+    data object RustRover : IdeProduct {
+        override val id = "rustrover"
+        override val displayName = "RustRover"
+        override val code = "RR"
+        override val launcherExecutable = "rustrover"
+        override val licenseTier = LicenseTier.FreeForNonCommercial
+        // HEAD evidence: RustRover archives use case-sensitive RustRover-* filenames.
+        override val urlFilenameTokens = listOf("RustRover-")
+    }
+
+    // ---- Paid IDEs ----
+
+    data object PhpStorm : IdeProduct {
+        override val id = "phpstorm"
+        override val displayName = "PhpStorm"
+        override val code = "PS"
+        override val launcherExecutable = "phpstorm"
+        override val licenseTier = LicenseTier.Paid
+        // HEAD evidence: PhpStorm archives use case-sensitive PhpStorm-* filenames (served under /webide/).
+        override val urlFilenameTokens = listOf("PhpStorm-")
+    }
+
+    data object RubyMine : IdeProduct {
+        override val id = "rubymine"
+        override val displayName = "RubyMine"
+        override val code = "RM"
+        override val launcherExecutable = "rubymine"
+        override val licenseTier = LicenseTier.Paid
+        // HEAD evidence: RubyMine archives use case-sensitive RubyMine-* filenames (served under /ruby/).
+        override val urlFilenameTokens = listOf("RubyMine-")
+    }
+
+    /**
+     * DataGrip. **Two different codes are in play, deliberately:** the products API is queried with
+     * `DG` (`alternativeCodes: ["DB"]`), while the feed's `intellijProductCode` — and therefore the
+     * `productCode` a real install writes into `product-info.json` — is `DB`. Same split as
+     * `IIU`→`IU` and `PCP`→`PY`, so [installedProductCode] carries `DB` and validation passes.
+     * `DB` is also the spelling `prompts/AGENTS.md` uses, so the alias map accepts both.
+     */
+    data object DataGrip : IdeProduct {
+        override val id = "datagrip"
+        override val displayName = "DataGrip"
+        override val code = "DG"
+        override val launcherExecutable = "datagrip"
+        override val licenseTier = LicenseTier.Paid
+        override val installedProductCode = "DB"
+        // HEAD evidence: DataGrip archives use LOWERCASE datagrip-* filenames, unlike its sibling IDEs.
+        override val urlFilenameTokens = listOf("datagrip-")
+    }
+
+    // ---- Free IDE ----
+
+    /**
+     * MPS (Apache 2.0, free). Its feed entry is the odd one in the catalog:
+     *
+     *  - **no `linuxARM64` and no `windowsARM64` distribution** in any release, so those two hosts
+     *    are simply not published; the resolver reports that explicitly instead of suggesting
+     *    `--version` (see `unpublishedPlatformFailureMessage`).
+     *  - it additionally offers a cross-platform `zip` that the OS/arch → download-key mapping does
+     *    not use. We deliberately do NOT fall back to it: that archive carries no per-host JBR, so
+     *    "resolved" would mean an install that cannot launch — a worse outcome than a clear error.
+     *  - `mac` / `macM1` are `.dmg`, same as every other JetBrains IDE, and `unpackIdeArchive`
+     *    already mounts those via `hdiutil` on a macOS host.
+     */
+    data object Mps : IdeProduct {
+        override val id = "mps"
+        override val displayName = "MPS"
+        override val code = "MPS"
+        override val launcherExecutable = "mps"
+        override val licenseTier = LicenseTier.Free
+        // HEAD evidence: MPS archives use case-sensitive MPS-* filenames (mac adds a -macos infix).
+        override val urlFilenameTokens = listOf("MPS-")
+    }
+
     // ---- Google-published IDE ----
 
     /**
@@ -163,8 +241,11 @@ sealed interface IdeProduct {
 
     /**
      * Catch-all for any JetBrains product not in the well-known list. The caller
-     * supplies the public product `code` (e.g. "RR", "AC", "DG") and a license tier
-     * so paid/free policies still work. Everything else is descriptive metadata.
+     * supplies the public product `code` (e.g. "DS" for DataSpell, or "AC") and a license
+     * tier so paid/free policies still work. Everything else is descriptive metadata.
+     *
+     * This is the escape hatch for the products listed as deliberately out of scope next to
+     * [knownProducts] — reaching one does not require editing the catalog.
      */
     data class Custom(
         override val id: String,
@@ -178,7 +259,32 @@ sealed interface IdeProduct {
         // Lazy-initialized to avoid a class-init cycle: data-object references to
         // IdeProduct constants trigger the Companion's <clinit>, which in turn would
         // touch those same data objects mid-init and pick up null entries.
-        /** All hard-coded products this module ships aliases for. */
+        /**
+         * All hard-coded products this module ships aliases for.
+         *
+         * ### Products we deliberately do NOT ship (not an oversight — do not "fix" this)
+         *
+         * The scope boundary for a devrig backend is: an IntelliJ-platform IDE that the
+         * products feed publishes as a self-contained desktop distribution, and that we can
+         * validate end to end. The following were evaluated and rejected on purpose:
+         *
+         *  - **DataSpell (`DS`)** — deliberately NOT added. In scope technically, left out by
+         *    decision; revisit only on an explicit request, not as catalog cleanup.
+         *  - **GitClient (`GIG`)** — deliberately NOT added. Same: an explicit decision, not a gap.
+         *  - **CLion Nova (`CLN`)** — deliberately NOT added because it is dead: the feed reports
+         *    `alternativeCodes: [CL]` and `intellijProductCode: CL`, i.e. Nova was folded back into
+         *    regular CLion. It is already covered by [CLion] (`CL`); a separate entry would be a
+         *    duplicate of the same artifacts.
+         *  - **Gateway (`GW`)** — a thin remote-development client, not a backend IDE.
+         *  - **JetBrains Air / Fleet** — not IntelliJ-platform desktop IDE distributions.
+         *  - **AppCode (`AC`)** — discontinued by JetBrains.
+         *  - **PhpStorm Light** — a stripped SKU of the [PhpStorm] entry we already ship.
+         *  - **Aqua** — test-automation IDE, out of the agreed backend scope.
+         *  - **Writerside / Qodana** — not IDEs (authoring tool / static-analysis platform).
+         *
+         * Anything genuinely missing can still be reached through [Custom] without touching
+         * this list.
+         */
         val knownProducts: List<IdeProduct> by lazy {
             listOf(
                 IntelliJIdea,
@@ -189,6 +295,11 @@ sealed interface IdeProduct {
                 WebStorm,
                 Rider,
                 CLion,
+                RustRover,
+                PhpStorm,
+                RubyMine,
+                DataGrip,
+                Mps,
                 AndroidStudio,
             )
         }
@@ -222,6 +333,13 @@ sealed interface IdeProduct {
                 put("go", GoLand)
                 put("ws", WebStorm)
                 put("cl", CLion)
+                put("php", PhpStorm)
+                put("ruby", RubyMine)
+                put("rust", RustRover)
+                // DataGrip answers to both spellings on purpose: `DG` is the products-API code we
+                // query with, `DB` is its alternativeCode / intellijProductCode and the spelling
+                // prompts/AGENTS.md already uses. Accepting both avoids a third spelling.
+                put("db", DataGrip)
                 put("ai", AndroidStudio)
                 put("studio", AndroidStudio)
                 put("androidstudio", AndroidStudio)

--- a/intellij-downloader/src/buildsrc-shared/kotlin/com/jonnyzzz/mcpSteroid/ideDownloader/IdeReleaseLookup.kt
+++ b/intellij-downloader/src/buildsrc-shared/kotlin/com/jonnyzzz/mcpSteroid/ideDownloader/IdeReleaseLookup.kt
@@ -198,6 +198,8 @@ fun resolveArchiveFromProductsApiPayload(
                 candidateReleases = candidateReleases,
                 offeredDownloadKeys = offeredDownloadKeys,
                 productsApiUrl = productsApiUrl,
+                wantedVersion = wantedVersion,
+                buildPrefix = buildPrefix,
             )
         )
     }
@@ -211,6 +213,10 @@ fun resolveArchiveFromProductsApiPayload(
  *
  * Kept separate from [resolveArchiveFailureMessage] so the advice is truthful: retrying with
  * `--version` cannot help, and the caller should pick another host platform instead.
+ *
+ * When a `--version`/build filter was active only the matching releases were inspected, so the
+ * message must not over-claim "not a supported host" — releases outside the filter may still
+ * publish the platform.
  */
 private fun unpublishedPlatformFailureMessage(
     product: IdeProduct,
@@ -221,10 +227,24 @@ private fun unpublishedPlatformFailureMessage(
     candidateReleases: Int,
     offeredDownloadKeys: Set<String>,
     productsApiUrl: String,
-): String = "JetBrains publishes no '$downloadKey' distribution for ${product.displayName} " +
-    "(code=${product.code}): none of the $candidateReleases '${channel.apiValue}' releases carries that " +
-    "download key, so $os/$architecture is not a supported host for this product. " +
-    "Keys the feed does offer: ${offeredDownloadKeys.sorted().joinToString()}. Feed: $productsApiUrl"
+    wantedVersion: String?,
+    buildPrefix: String?,
+): String {
+    val offered = "Keys the feed does offer: ${offeredDownloadKeys.sorted().joinToString()}. Feed: $productsApiUrl"
+    val filters = listOfNotNull(
+        wantedVersion?.let { "version '$it'" },
+        buildPrefix?.let { "build prefix '$it'" },
+    )
+    if (filters.isNotEmpty()) {
+        return "JetBrains publishes no '$downloadKey' distribution of ${product.displayName} " +
+            "(code=${product.code}) in the $candidateReleases '${channel.apiValue}' release(s) matching " +
+            "${filters.joinToString(" and ")} — releases outside that filter may still cover " +
+            "$os/$architecture; drop the filter to check. $offered"
+    }
+    return "JetBrains publishes no '$downloadKey' distribution for ${product.displayName} " +
+        "(code=${product.code}): none of the $candidateReleases '${channel.apiValue}' releases carries that " +
+        "download key, so $os/$architecture is not a supported host for this product. $offered"
+}
 
 internal fun IdeProduct.acceptsDownloadFilename(filename: String): Boolean {
     val tokens = urlFilenameTokens

--- a/intellij-downloader/src/buildsrc-shared/kotlin/com/jonnyzzz/mcpSteroid/ideDownloader/IdeReleaseLookup.kt
+++ b/intellij-downloader/src/buildsrc-shared/kotlin/com/jonnyzzz/mcpSteroid/ideDownloader/IdeReleaseLookup.kt
@@ -145,6 +145,12 @@ fun resolveArchiveFromProductsApiPayload(
     val downloadKey = resolveDownloadKey(os, architecture)
     val wantedVersion = version?.takeIf { it.isNotBlank() }
     val skippedWrongFilename = mutableListOf<String>()
+    // Distinguishes "no release carries a `linuxARM64` download" (the product is simply not
+    // published for that platform — MPS ships no Linux/Windows ARM64 at all) from "releases
+    // carry it but every filename belongs to another edition". The two need different advice.
+    var candidateReleases = 0
+    var releasesOfferingDownloadKey = 0
+    val offeredDownloadKeys = linkedSetOf<String>()
 
     for (release in releases.filterIsInstance<JsonObject>()) {
         val type = (release["type"] as? JsonPrimitive)?.content
@@ -156,8 +162,11 @@ fun resolveArchiveFromProductsApiPayload(
         if (wantedVersion != null && wantedVersion != releaseVersion && wantedVersion != build) continue
         if (buildPrefix != null && !build.startsWith(buildPrefix)) continue
 
+        candidateReleases++
         val downloads = release["downloads"] as? JsonObject ?: continue
+        offeredDownloadKeys += downloads.keys
         val platformDownload = downloads[downloadKey] as? JsonObject ?: continue
+        releasesOfferingDownloadKey++
         val link = (platformDownload["link"] as? JsonPrimitive)?.content ?: continue
         if (link.isBlank()) continue
         val checksumLink = (platformDownload["checksumLink"] as? JsonPrimitive)?.content?.takeIf { it.isNotBlank() }
@@ -178,8 +187,44 @@ fun resolveArchiveFromProductsApiPayload(
         )
     }
 
+    if (candidateReleases > 0 && releasesOfferingDownloadKey == 0) {
+        error(
+            unpublishedPlatformFailureMessage(
+                product = product,
+                channel = channel,
+                downloadKey = downloadKey,
+                os = os,
+                architecture = architecture,
+                candidateReleases = candidateReleases,
+                offeredDownloadKeys = offeredDownloadKeys,
+                productsApiUrl = productsApiUrl,
+            )
+        )
+    }
     error(resolveArchiveFailureMessage(product, channel, wantedVersion, buildPrefix, downloadKey, productsApiUrl, skippedWrongFilename))
 }
+
+/**
+ * The feed answered, releases exist in the requested channel, and not one of them publishes a
+ * [downloadKey] distribution — i.e. JetBrains does not ship this product for this OS/arch at all.
+ * MPS is the in-catalog example: it has no `linuxARM64` and no `windowsARM64` entry in any release.
+ *
+ * Kept separate from [resolveArchiveFailureMessage] so the advice is truthful: retrying with
+ * `--version` cannot help, and the caller should pick another host platform instead.
+ */
+private fun unpublishedPlatformFailureMessage(
+    product: IdeProduct,
+    channel: IdeChannel,
+    downloadKey: String,
+    os: HostOs,
+    architecture: HostArchitecture,
+    candidateReleases: Int,
+    offeredDownloadKeys: Set<String>,
+    productsApiUrl: String,
+): String = "JetBrains publishes no '$downloadKey' distribution for ${product.displayName} " +
+    "(code=${product.code}): none of the $candidateReleases '${channel.apiValue}' releases carries that " +
+    "download key, so $os/$architecture is not a supported host for this product. " +
+    "Keys the feed does offer: ${offeredDownloadKeys.sorted().joinToString()}. Feed: $productsApiUrl"
 
 internal fun IdeProduct.acceptsDownloadFilename(filename: String): Boolean {
     val tokens = urlFilenameTokens

--- a/intellij-downloader/src/main/kotlin/com/jonnyzzz/mcpSteroid/ideDownloader/Main.kt
+++ b/intellij-downloader/src/main/kotlin/com/jonnyzzz/mcpSteroid/ideDownloader/Main.kt
@@ -14,8 +14,10 @@ private val ideDownloaderMainLog = LoggerFactory.getLogger("com.jonnyzzz.mcpSter
  *
  * Arguments:
  *   --product            IDE product: idea-ultimate, idea-community, pycharm-pro,
- *                        pycharm-community, goland, webstorm, rider, clion
- *                        (default: idea-ultimate; legacy aliases idea/pycharm accepted)
+ *                        pycharm-community, goland, webstorm, rider, clion, rustrover,
+ *                        phpstorm, rubymine, datagrip, mps, android-studio
+ *                        (default: idea-ultimate; legacy aliases idea/pycharm accepted,
+ *                        datagrip also answers to db)
  *   --channel            Release channel: stable, eap (default: stable)
  *   --output-dir         Directory to store downloaded archives (required)
  *   --url                Direct download URL (overrides --product/--channel resolution)

--- a/intellij-downloader/src/test/kotlin/com/jonnyzzz/mcpSteroid/ideDownloader/IdeReleaseLookupTest.kt
+++ b/intellij-downloader/src/test/kotlin/com/jonnyzzz/mcpSteroid/ideDownloader/IdeReleaseLookupTest.kt
@@ -8,6 +8,7 @@ import kotlinx.serialization.json.buildJsonArray
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Assert.fail
 import org.junit.Test
@@ -227,6 +228,197 @@ class IdeReleaseLookupTest {
                 product.acceptsDownloadFilename(filename),
             )
         }
+    }
+
+    /**
+     * The offline matrix above runs off recorded fixtures, so it cannot catch JetBrains renaming an
+     * archive or dropping an edition. This walks the SAME assertions against the live products API
+     * for every catalog product. Opt-in (`:intellij-downloader:liveNetworkTest`) so a vendor-feed
+     * outage cannot redden a default build.
+     */
+    @Test
+    @Category(LiveNetwork::class)
+    fun `live feed resolves every catalog product on every published OS-arch combo`() {
+        val products = IdeProduct.knownProducts.filterNot { it === IdeProduct.AndroidStudio }
+        val failures = mutableListOf<String>()
+        for (product in products) {
+            for (os in HostOs.values()) {
+                for (arch in HostArchitecture.values()) {
+                    val expectedUnpublished = product.id in unpublishedPlatforms &&
+                        (os to arch) in unpublishedPlatforms.getValue(product.id)
+                    try {
+                        val resolution = resolveArchive(product, IdeChannel.STABLE, os = os, architecture = arch)
+                        if (expectedUnpublished) {
+                            failures += "${product.code} on $os/$arch is listed as unpublished but the live " +
+                                "feed now serves ${resolution.url} — drop it from unpublishedPlatforms"
+                            continue
+                        }
+                        val filename = downloadFilenameFromUrl(resolution.url)
+                        if (!product.acceptsDownloadFilename(filename)) {
+                            failures += "${product.code} on $os/$arch resolved $filename, which none of " +
+                                "${product.urlFilenameTokens} accepts"
+                        }
+                    } catch (e: Exception) {
+                        if (!expectedUnpublished) {
+                            failures += "${product.code} on $os/$arch failed to resolve: ${e.message}"
+                        }
+                    }
+                }
+            }
+        }
+        assertTrue("Live feed resolution failures:\n${failures.joinToString("\n")}", failures.isEmpty())
+    }
+
+    /**
+     * Every catalog product must resolve on every host the feed publishes it for. A new
+     * `knownProducts` entry fails here until its fixture exists and its filename tokens are right,
+     * so a product cannot land in the CLI list while being undownloadable.
+     *
+     * [unpublishedPlatforms] is the explicit, per-product allow-list of OS/arch combos JetBrains
+     * does not publish at all; those are asserted to fail with the dedicated diagnostic rather than
+     * silently skipped.
+     */
+    @Test
+    fun `every catalog product resolves on every published OS-arch combo`() {
+        val products = IdeProduct.knownProducts.filterNot { it === IdeProduct.AndroidStudio }
+        for (product in products) {
+            for (os in HostOs.values()) {
+                for (arch in HostArchitecture.values()) {
+                    val expectedUnpublished = product.id in unpublishedPlatforms &&
+                        (os to arch) in unpublishedPlatforms.getValue(product.id)
+                    if (expectedUnpublished) {
+                        val ex = expectError {
+                            resolveArchiveFromFixtures(product, IdeChannel.STABLE, os = os, architecture = arch)
+                        }
+                        assertTrue(
+                            "${product.code} on $os/$arch must fail with the unpublished-platform " +
+                                "diagnostic, got: ${ex.message}",
+                            ex.message!!.contains("publishes no '${resolveDownloadKey(os, arch)}' distribution"),
+                        )
+                        continue
+                    }
+                    val resolution = resolveArchiveFromFixtures(product, IdeChannel.STABLE, os = os, architecture = arch)
+                    assertExpectedExtension(product, os, arch, resolution.url)
+                    val filename = downloadFilenameFromUrl(resolution.url)
+                    assertTrue(
+                        "${product.code} resolved $filename on $os/$arch, expected one of ${product.urlFilenameTokens}",
+                        product.acceptsDownloadFilename(filename),
+                    )
+                }
+            }
+        }
+    }
+
+    /**
+     * MPS is the only catalog product with platform gaps: its feed entry carries no `linuxARM64`
+     * and no `windowsARM64` download key in any release. Verified against the live feed; the
+     * fixture reproduces it.
+     */
+    private val unpublishedPlatforms: Map<String, Set<Pair<HostOs, HostArchitecture>>> = mapOf(
+        IdeProduct.Mps.id to setOf(
+            HostOs.LINUX to HostArchitecture.ARM64,
+            HostOs.WINDOWS to HostArchitecture.ARM64,
+        ),
+    )
+
+    @Test
+    fun `MPS Linux ARM64 names the keys the feed does offer instead of suggesting a version retry`() {
+        val ex = expectError {
+            resolveArchiveFromFixtures(
+                IdeProduct.Mps,
+                IdeChannel.STABLE,
+                os = HostOs.LINUX,
+                architecture = HostArchitecture.ARM64,
+            )
+        }
+        val message = ex.message!!
+        assertTrue("expected the offered keys listed, got: $message", message.contains("linux, mac, macM1"))
+        assertTrue("expected product code, got: $message", message.contains("code=MPS"))
+        assertFalse("must not advise --version for an unpublished platform, got: $message", message.contains("--version"))
+    }
+
+    @Test
+    fun `DataGrip is queried as DG but validates the installed code DB`() {
+        assertEquals("DG", IdeProduct.DataGrip.code)
+        assertEquals("DB", IdeProduct.DataGrip.installedProductCode)
+        assertTrue(IdeProduct.fromString("datagrip") === IdeProduct.DataGrip)
+        assertTrue(IdeProduct.fromString("DG") === IdeProduct.DataGrip)
+        // `DB` is the spelling prompts/AGENTS.md uses — it must reach the same product.
+        assertTrue(IdeProduct.fromString("DB") === IdeProduct.DataGrip)
+    }
+
+    @Test
+    fun `newly added products resolve via fromString and carry a verified license tier`() {
+        assertTrue(IdeProduct.fromString("phpstorm") === IdeProduct.PhpStorm)
+        assertTrue(IdeProduct.fromString("PS") === IdeProduct.PhpStorm)
+        assertTrue(IdeProduct.fromString("php") === IdeProduct.PhpStorm)
+        assertTrue(IdeProduct.fromString("rubymine") === IdeProduct.RubyMine)
+        assertTrue(IdeProduct.fromString("RM") === IdeProduct.RubyMine)
+        assertTrue(IdeProduct.fromString("rustrover") === IdeProduct.RustRover)
+        assertTrue(IdeProduct.fromString("RR") === IdeProduct.RustRover)
+        assertTrue(IdeProduct.fromString("mps") === IdeProduct.Mps)
+        assertTrue(IdeProduct.fromString("MPS") === IdeProduct.Mps)
+
+        assertEquals(LicenseTier.Paid, IdeProduct.PhpStorm.licenseTier)
+        assertEquals(LicenseTier.Paid, IdeProduct.RubyMine.licenseTier)
+        assertEquals(LicenseTier.Paid, IdeProduct.DataGrip.licenseTier)
+        assertEquals(LicenseTier.FreeForNonCommercial, IdeProduct.RustRover.licenseTier)
+        assertEquals(LicenseTier.Free, IdeProduct.Mps.licenseTier)
+    }
+
+    /**
+     * #430: every product code the prompt pipeline claims to support must have a downloadable
+     * backend. The prompt codes are `ApplicationInfo` codes, so they compare against
+     * [IdeProduct.installedProductCode] — which is exactly why DataGrip carries `DB` and not `DG`.
+     * Source list: `prompts/AGENTS.md` "Common codes" + `PerIdeAvailabilityContractTest`.
+     */
+    @Test
+    fun `every prompt-pipeline product code has a downloadable backend`() {
+        val promptPipelineCodes = listOf("IU", "IC", "AI", "RD", "CL", "GO", "PY", "WS", "RM", "DB")
+        val installedCodes = IdeProduct.knownProducts.map { it.installedProductCode }.toSet()
+        val missing = promptPipelineCodes.filterNot { it in installedCodes }
+        assertTrue(
+            "prompts ship for $missing but devrig cannot download a backend for them; " +
+                "installedProductCode values in the catalog: ${installedCodes.sorted()}",
+            missing.isEmpty(),
+        )
+    }
+
+    @Test
+    fun `catalog product ids and installed codes are unique`() {
+        val ids = IdeProduct.knownProducts.map { it.id }
+        assertEquals("duplicate product ids in knownProducts: $ids", ids.size, ids.toSet().size)
+        val installedCodes = IdeProduct.knownProducts.map { it.installedProductCode }
+        assertEquals(
+            "duplicate installedProductCode in knownProducts: $installedCodes",
+            installedCodes.size,
+            installedCodes.toSet().size,
+        )
+        // Every id must round-trip through the alias map to the very same product.
+        for (product in IdeProduct.knownProducts) {
+            assertTrue("${product.id} must round-trip via fromString", IdeProduct.fromString(product.id) === product)
+            assertTrue("${product.code} must round-trip via fromString", IdeProduct.fromString(product.code) === product)
+        }
+    }
+
+    /**
+     * Guards the in/out-of-scope decision recorded next to `knownProducts`: DataSpell (`DS`),
+     * GitClient (`GIG`) and CLion Nova (`CLN`) were evaluated and left out on purpose. If someone
+     * adds one without also revisiting that decision, this fails and points at the comment.
+     */
+    @Test
+    fun `deliberately excluded product codes stay out of the catalog`() {
+        val excluded = listOf("DS", "GIG", "CLN", "GW", "AC")
+        val catalogCodes = IdeProduct.knownProducts.map { it.code }.toSet()
+        for (code in excluded) {
+            assertFalse(
+                "$code is documented as deliberately excluded next to IdeProduct.knownProducts — " +
+                    "adding it needs that decision revisited first",
+                code in catalogCodes,
+            )
+        }
+        // CLion Nova is dead upstream: the feed folds it into CL, which we already ship.
+        assertTrue("CL must stay in the catalog — it covers CLion Nova", "CL" in catalogCodes)
     }
 
     @Test

--- a/intellij-downloader/src/test/kotlin/com/jonnyzzz/mcpSteroid/ideDownloader/IdeReleaseLookupTest.kt
+++ b/intellij-downloader/src/test/kotlin/com/jonnyzzz/mcpSteroid/ideDownloader/IdeReleaseLookupTest.kt
@@ -337,6 +337,31 @@ class IdeReleaseLookupTest {
         assertFalse("must not advise --version for an unpublished platform, got: $message", message.contains("--version"))
     }
 
+    /**
+     * With a `--version` filter only the matching releases were inspected, so the diagnostic must
+     * not over-claim "not a supported host" — releases outside the filter may still publish the
+     * platform. It names the filter instead.
+     */
+    @Test
+    fun `unpublished-platform diagnostic under a version filter does not claim the host is unsupported`() {
+        val ex = expectError {
+            resolveArchiveFromFixtures(
+                IdeProduct.Mps,
+                IdeChannel.STABLE,
+                os = HostOs.LINUX,
+                architecture = HostArchitecture.ARM64,
+                version = "2026.1",
+            )
+        }
+        val message = ex.message!!
+        assertTrue("expected the filter named, got: $message", message.contains("matching version '2026.1'"))
+        assertTrue("expected the offered keys listed, got: $message", message.contains("linux, mac, macM1"))
+        assertFalse(
+            "a filtered lookup must not claim the host is unsupported, got: $message",
+            message.contains("not a supported host"),
+        )
+    }
+
     @Test
     fun `DataGrip is queried as DG but validates the installed code DB`() {
         assertEquals("DG", IdeProduct.DataGrip.code)

--- a/intellij-downloader/src/test/kotlin/com/jonnyzzz/mcpSteroid/ideDownloader/ProductCatalogDocsDriftTest.kt
+++ b/intellij-downloader/src/test/kotlin/com/jonnyzzz/mcpSteroid/ideDownloader/ProductCatalogDocsDriftTest.kt
@@ -1,0 +1,58 @@
+/* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
+package com.jonnyzzz.mcpSteroid.ideDownloader
+
+import org.junit.Assert.assertTrue
+import org.junit.Assume.assumeTrue
+import org.junit.Test
+import java.io.File
+
+/**
+ * `IdeProduct.knownProducts` is the single source of truth for the product catalog, but two
+ * user-facing surfaces restate it in prose: the published `devrig backend download` docs and the
+ * standalone downloader's `--product` help. Both used to drift silently — #430 shipped nine
+ * products while the README promised "any IntelliJ-based IDE".
+ *
+ * This test fails when either surface stops listing every catalog id, so adding a product to the
+ * catalog forces the docs edit in the same commit.
+ */
+class ProductCatalogDocsDriftTest {
+
+    private val repoRoot: File?
+        get() = System.getProperty("mcp.repo.root")?.let(::File)?.takeIf { it.isDirectory }
+
+    @Test
+    fun `published devrig docs list every catalog product id`() {
+        val docs = repoFile("website/content/docs/devrig.md") ?: return
+        val text = docs.readText()
+        val missing = IdeProduct.knownProducts.map { it.id }.filterNot { text.contains("`$it`") }
+        assertTrue(
+            "${docs.path} does not list ${missing} as `<id>` — the docs' \"Known product ids\" line " +
+                "must cover every IdeProduct.knownProducts entry",
+            missing.isEmpty(),
+        )
+    }
+
+    @Test
+    fun `standalone downloader --product help lists every catalog product id`() {
+        val main = repoFile("intellij-downloader/src/main/kotlin/com/jonnyzzz/mcpSteroid/ideDownloader/Main.kt")
+            ?: return
+        // The help text lives in the file's KDoc; matching the whole file is enough to catch drift
+        // without pinning the exact wrapping.
+        val text = main.readText()
+        val missing = IdeProduct.knownProducts.map { it.id }.filterNot { text.contains(it) }
+        assertTrue(
+            "${main.path} --product help does not mention $missing",
+            missing.isEmpty(),
+        )
+    }
+
+    private fun repoFile(relativePath: String): File? {
+        val root = repoRoot
+        // Keep the suite green where the property is absent (e.g. running the class straight from
+        // an IDE) instead of failing for an environment reason.
+        assumeTrue("mcp.repo.root is not set — skipping docs drift check", root != null)
+        val file = File(root, relativePath)
+        assumeTrue("$relativePath not found under $root — skipping docs drift check", file.isFile)
+        return file
+    }
+}

--- a/intellij-downloader/src/test/kotlin/com/jonnyzzz/mcpSteroid/ideDownloader/ProductCatalogDocsDriftTest.kt
+++ b/intellij-downloader/src/test/kotlin/com/jonnyzzz/mcpSteroid/ideDownloader/ProductCatalogDocsDriftTest.kt
@@ -2,7 +2,6 @@
 package com.jonnyzzz.mcpSteroid.ideDownloader
 
 import org.junit.Assert.assertTrue
-import org.junit.Assume.assumeTrue
 import org.junit.Test
 import java.io.File
 
@@ -17,12 +16,9 @@ import java.io.File
  */
 class ProductCatalogDocsDriftTest {
 
-    private val repoRoot: File?
-        get() = System.getProperty("mcp.repo.root")?.let(::File)?.takeIf { it.isDirectory }
-
     @Test
     fun `published devrig docs list every catalog product id`() {
-        val docs = repoFile("website/content/docs/devrig.md") ?: return
+        val docs = repoFile("website/content/docs/devrig.md")
         val text = docs.readText()
         val missing = IdeProduct.knownProducts.map { it.id }.filterNot { text.contains("`$it`") }
         assertTrue(
@@ -35,7 +31,6 @@ class ProductCatalogDocsDriftTest {
     @Test
     fun `standalone downloader --product help lists every catalog product id`() {
         val main = repoFile("intellij-downloader/src/main/kotlin/com/jonnyzzz/mcpSteroid/ideDownloader/Main.kt")
-            ?: return
         // The help text lives in the file's KDoc; matching the whole file is enough to catch drift
         // without pinning the exact wrapping.
         val text = main.readText()
@@ -46,13 +41,18 @@ class ProductCatalogDocsDriftTest {
         )
     }
 
-    private fun repoFile(relativePath: String): File? {
-        val root = repoRoot
-        // Keep the suite green where the property is absent (e.g. running the class straight from
-        // an IDE) instead of failing for an environment reason.
-        assumeTrue("mcp.repo.root is not set — skipping docs drift check", root != null)
+    /**
+     * Hard requirements, not assumptions: the Gradle test task always sets `mcp.repo.root`
+     * (see `intellij-downloader/build.gradle.kts`), and a missing docs file is exactly the drift
+     * this guard exists to catch — skipping would let the docs vanish silently.
+     */
+    private fun repoFile(relativePath: String): File {
+        val rootPath = System.getProperty("mcp.repo.root")
+            ?: error("mcp.repo.root system property is not set — the :intellij-downloader:test Gradle task always sets it")
+        val root = File(rootPath)
+        assertTrue("mcp.repo.root=$rootPath is not a directory", root.isDirectory)
         val file = File(root, relativePath)
-        assumeTrue("$relativePath not found under $root — skipping docs drift check", file.isFile)
+        assertTrue("$relativePath not found under $root — the docs drift guard must see the published docs", file.isFile)
         return file
     }
 }

--- a/intellij-downloader/src/test/resources/fixtures/products-DG.json
+++ b/intellij-downloader/src/test/resources/fixtures/products-DG.json
@@ -1,0 +1,55 @@
+[
+  {
+    "code": "DG",
+    "releases": [
+      {
+        "build": "262.9437.70",
+        "date": "2026-07-30",
+        "downloads": {
+          "linux": {
+            "checksumLink": "https://download.jetbrains.com/datagrip/datagrip-2026.2.2.tar.gz.sha256",
+            "link": "https://download.jetbrains.com/datagrip/datagrip-2026.2.2.tar.gz",
+            "size": 1082147165
+          },
+          "linuxARM64": {
+            "checksumLink": "https://download.jetbrains.com/datagrip/datagrip-2026.2.2-aarch64.tar.gz.sha256",
+            "link": "https://download.jetbrains.com/datagrip/datagrip-2026.2.2-aarch64.tar.gz",
+            "size": 1105792859
+          },
+          "mac": {
+            "checksumLink": "https://download.jetbrains.com/datagrip/datagrip-2026.2.2.dmg.sha256",
+            "link": "https://download.jetbrains.com/datagrip/datagrip-2026.2.2.dmg",
+            "size": 1061305648
+          },
+          "macM1": {
+            "checksumLink": "https://download.jetbrains.com/datagrip/datagrip-2026.2.2-aarch64.dmg.sha256",
+            "link": "https://download.jetbrains.com/datagrip/datagrip-2026.2.2-aarch64.dmg",
+            "size": 1013387580
+          },
+          "thirdPartyLibrariesJson": {
+            "checksumLink": "https://resources.jetbrains.com/storage/third-party-libraries/datagrip/datagrip-2026.2.2-third-party-libraries.json.sha256",
+            "link": "https://resources.jetbrains.com/storage/third-party-libraries/datagrip/datagrip-2026.2.2-third-party-libraries.json",
+            "size": 58144
+          },
+          "windows": {
+            "checksumLink": "https://download.jetbrains.com/datagrip/datagrip-2026.2.2.exe.sha256",
+            "link": "https://download.jetbrains.com/datagrip/datagrip-2026.2.2.exe",
+            "size": 844885888
+          },
+          "windowsARM64": {
+            "checksumLink": "https://download.jetbrains.com/datagrip/datagrip-2026.2.2-aarch64.exe.sha256",
+            "link": "https://download.jetbrains.com/datagrip/datagrip-2026.2.2-aarch64.exe",
+            "size": 835658552
+          },
+          "windowsZip": {
+            "checksumLink": "https://download.jetbrains.com/datagrip/datagrip-2026.2.2.win.zip.sha256",
+            "link": "https://download.jetbrains.com/datagrip/datagrip-2026.2.2.win.zip",
+            "size": 1094403228
+          }
+        },
+        "type": "release",
+        "version": "2026.2.2"
+      }
+    ]
+  }
+]

--- a/intellij-downloader/src/test/resources/fixtures/products-MPS.json
+++ b/intellij-downloader/src/test/resources/fixtures/products-MPS.json
@@ -1,0 +1,40 @@
+[
+  {
+    "code": "MPS",
+    "releases": [
+      {
+        "build": "261.25134.779",
+        "date": "2026-07-14",
+        "downloads": {
+          "linux": {
+            "checksumLink": "https://download.jetbrains.com/mps/2026.1/MPS-2026.1.tar.gz.sha256",
+            "link": "https://download.jetbrains.com/mps/2026.1/MPS-2026.1.tar.gz",
+            "size": 899056360
+          },
+          "mac": {
+            "checksumLink": "https://download.jetbrains.com/mps/2026.1/MPS-2026.1-macos.dmg.sha256",
+            "link": "https://download.jetbrains.com/mps/2026.1/MPS-2026.1-macos.dmg",
+            "size": 883022328
+          },
+          "macM1": {
+            "checksumLink": "https://download.jetbrains.com/mps/2026.1/MPS-2026.1-macos-aarch64.dmg.sha256",
+            "link": "https://download.jetbrains.com/mps/2026.1/MPS-2026.1-macos-aarch64.dmg",
+            "size": 872832236
+          },
+          "windows": {
+            "checksumLink": "https://download.jetbrains.com/mps/2026.1/MPS-2026.1.exe.sha256",
+            "link": "https://download.jetbrains.com/mps/2026.1/MPS-2026.1.exe",
+            "size": 745269984
+          },
+          "zip": {
+            "checksumLink": "https://download.jetbrains.com/mps/2026.1/MPS-2026.1.zip.sha256",
+            "link": "https://download.jetbrains.com/mps/2026.1/MPS-2026.1.zip",
+            "size": 697222081
+          }
+        },
+        "type": "release",
+        "version": "2026.1"
+      }
+    ]
+  }
+]

--- a/intellij-downloader/src/test/resources/fixtures/products-PS.json
+++ b/intellij-downloader/src/test/resources/fixtures/products-PS.json
@@ -1,0 +1,55 @@
+[
+  {
+    "code": "PS",
+    "releases": [
+      {
+        "build": "262.8665.325",
+        "date": "2026-07-23",
+        "downloads": {
+          "linux": {
+            "checksumLink": "https://download.jetbrains.com/webide/PhpStorm-2026.2.0.1.tar.gz.sha256",
+            "link": "https://download.jetbrains.com/webide/PhpStorm-2026.2.0.1.tar.gz",
+            "size": 1099882393
+          },
+          "linuxARM64": {
+            "checksumLink": "https://download.jetbrains.com/webide/PhpStorm-2026.2.0.1-aarch64.tar.gz.sha256",
+            "link": "https://download.jetbrains.com/webide/PhpStorm-2026.2.0.1-aarch64.tar.gz",
+            "size": 1123140282
+          },
+          "mac": {
+            "checksumLink": "https://download.jetbrains.com/webide/PhpStorm-2026.2.0.1.dmg.sha256",
+            "link": "https://download.jetbrains.com/webide/PhpStorm-2026.2.0.1.dmg",
+            "size": 1076546955
+          },
+          "macM1": {
+            "checksumLink": "https://download.jetbrains.com/webide/PhpStorm-2026.2.0.1-aarch64.dmg.sha256",
+            "link": "https://download.jetbrains.com/webide/PhpStorm-2026.2.0.1-aarch64.dmg",
+            "size": 1028484031
+          },
+          "thirdPartyLibrariesJson": {
+            "checksumLink": "https://resources.jetbrains.com/storage/third-party-libraries/webide/PhpStorm-2026.2.0.1-third-party-libraries.json.sha256",
+            "link": "https://resources.jetbrains.com/storage/third-party-libraries/webide/PhpStorm-2026.2.0.1-third-party-libraries.json",
+            "size": 67621
+          },
+          "windows": {
+            "checksumLink": "https://download.jetbrains.com/webide/PhpStorm-2026.2.0.1.exe.sha256",
+            "link": "https://download.jetbrains.com/webide/PhpStorm-2026.2.0.1.exe",
+            "size": 830151040
+          },
+          "windowsARM64": {
+            "checksumLink": "https://download.jetbrains.com/webide/PhpStorm-2026.2.0.1-aarch64.exe.sha256",
+            "link": "https://download.jetbrains.com/webide/PhpStorm-2026.2.0.1-aarch64.exe",
+            "size": 820496360
+          },
+          "windowsZip": {
+            "checksumLink": "https://download.jetbrains.com/webide/PhpStorm-2026.2.0.1.win.zip.sha256",
+            "link": "https://download.jetbrains.com/webide/PhpStorm-2026.2.0.1.win.zip",
+            "size": 1112830767
+          }
+        },
+        "type": "release",
+        "version": "2026.2.0.1"
+      }
+    ]
+  }
+]

--- a/intellij-downloader/src/test/resources/fixtures/products-RM.json
+++ b/intellij-downloader/src/test/resources/fixtures/products-RM.json
@@ -1,0 +1,55 @@
+[
+  {
+    "code": "RM",
+    "releases": [
+      {
+        "build": "262.8665.308",
+        "date": "2026-07-21",
+        "downloads": {
+          "linux": {
+            "checksumLink": "https://download.jetbrains.com/ruby/RubyMine-2026.2.tar.gz.sha256",
+            "link": "https://download.jetbrains.com/ruby/RubyMine-2026.2.tar.gz",
+            "size": 1070534777
+          },
+          "linuxARM64": {
+            "checksumLink": "https://download.jetbrains.com/ruby/RubyMine-2026.2-aarch64.tar.gz.sha256",
+            "link": "https://download.jetbrains.com/ruby/RubyMine-2026.2-aarch64.tar.gz",
+            "size": 1094122063
+          },
+          "mac": {
+            "checksumLink": "https://download.jetbrains.com/ruby/RubyMine-2026.2.dmg.sha256",
+            "link": "https://download.jetbrains.com/ruby/RubyMine-2026.2.dmg",
+            "size": 1048051866
+          },
+          "macM1": {
+            "checksumLink": "https://download.jetbrains.com/ruby/RubyMine-2026.2-aarch64.dmg.sha256",
+            "link": "https://download.jetbrains.com/ruby/RubyMine-2026.2-aarch64.dmg",
+            "size": 999698624
+          },
+          "thirdPartyLibrariesJson": {
+            "checksumLink": "https://resources.jetbrains.com/storage/third-party-libraries/ruby/RubyMine-2026.2-third-party-libraries.json.sha256",
+            "link": "https://resources.jetbrains.com/storage/third-party-libraries/ruby/RubyMine-2026.2-third-party-libraries.json",
+            "size": 69105
+          },
+          "windows": {
+            "checksumLink": "https://download.jetbrains.com/ruby/RubyMine-2026.2.exe.sha256",
+            "link": "https://download.jetbrains.com/ruby/RubyMine-2026.2.exe",
+            "size": 801593856
+          },
+          "windowsARM64": {
+            "checksumLink": "https://download.jetbrains.com/ruby/RubyMine-2026.2-aarch64.exe.sha256",
+            "link": "https://download.jetbrains.com/ruby/RubyMine-2026.2-aarch64.exe",
+            "size": 792195280
+          },
+          "windowsZip": {
+            "checksumLink": "https://download.jetbrains.com/ruby/RubyMine-2026.2.win.zip.sha256",
+            "link": "https://download.jetbrains.com/ruby/RubyMine-2026.2.win.zip",
+            "size": 1092523125
+          }
+        },
+        "type": "release",
+        "version": "2026.2"
+      }
+    ]
+  }
+]

--- a/intellij-downloader/src/test/resources/fixtures/products-RR.json
+++ b/intellij-downloader/src/test/resources/fixtures/products-RR.json
@@ -1,0 +1,55 @@
+[
+  {
+    "code": "RR",
+    "releases": [
+      {
+        "build": "262.8665.323",
+        "date": "2026-07-22",
+        "downloads": {
+          "linux": {
+            "checksumLink": "https://download.jetbrains.com/rustrover/RustRover-2026.2.tar.gz.sha256",
+            "link": "https://download.jetbrains.com/rustrover/RustRover-2026.2.tar.gz",
+            "size": 1349812167
+          },
+          "linuxARM64": {
+            "checksumLink": "https://download.jetbrains.com/rustrover/RustRover-2026.2-aarch64.tar.gz.sha256",
+            "link": "https://download.jetbrains.com/rustrover/RustRover-2026.2-aarch64.tar.gz",
+            "size": 1371586057
+          },
+          "mac": {
+            "checksumLink": "https://download.jetbrains.com/rustrover/RustRover-2026.2.dmg.sha256",
+            "link": "https://download.jetbrains.com/rustrover/RustRover-2026.2.dmg",
+            "size": 1278532505
+          },
+          "macM1": {
+            "checksumLink": "https://download.jetbrains.com/rustrover/RustRover-2026.2-aarch64.dmg.sha256",
+            "link": "https://download.jetbrains.com/rustrover/RustRover-2026.2-aarch64.dmg",
+            "size": 1226238794
+          },
+          "thirdPartyLibrariesJson": {
+            "checksumLink": "https://resources.jetbrains.com/storage/third-party-libraries/rustrover/RustRover-2026.2-third-party-libraries.json.sha256",
+            "link": "https://resources.jetbrains.com/storage/third-party-libraries/rustrover/RustRover-2026.2-third-party-libraries.json",
+            "size": 65541
+          },
+          "windows": {
+            "checksumLink": "https://download.jetbrains.com/rustrover/RustRover-2026.2.exe.sha256",
+            "link": "https://download.jetbrains.com/rustrover/RustRover-2026.2.exe",
+            "size": 1059168424
+          },
+          "windowsARM64": {
+            "checksumLink": "https://download.jetbrains.com/rustrover/RustRover-2026.2-aarch64.exe.sha256",
+            "link": "https://download.jetbrains.com/rustrover/RustRover-2026.2-aarch64.exe",
+            "size": 1026969664
+          },
+          "windowsZip": {
+            "checksumLink": "https://download.jetbrains.com/rustrover/RustRover-2026.2.win.zip.sha256",
+            "link": "https://download.jetbrains.com/rustrover/RustRover-2026.2.win.zip",
+            "size": 1427659201
+          }
+        },
+        "type": "release",
+        "version": "2026.2"
+      }
+    ]
+  }
+]

--- a/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/AllIdeProductsDownloadTest.kt
+++ b/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/AllIdeProductsDownloadTest.kt
@@ -27,8 +27,8 @@ import kotlin.test.assertTrue
  * `data.services.jetbrains.com` publishes a full build number; the GitHub Community releases and
  * the Android Studio preview page publish just the platform baseline (`262`) while the artifact
  * itself reports `262.8665.258`. Comparing those for equality rejected the install AFTER the full
- * multi-hundred-MB transfer. The fix landed with an idea-community test only, so this walks all
- * nine products — Android Studio included, whose canary resolver derives the build the same way.
+ * multi-hundred-MB transfer. The fix landed with an idea-community test only, so this walks every
+ * catalog product — Android Studio included, whose canary resolver derives the build the same way.
  *
  * Live-feed coverage of the same contract is [AllIdeProductsLiveFeedTest] (tag `live-network`) and
  * real downloads are [BackendDownloadSmokeTest] (tag `live-download`).
@@ -101,6 +101,35 @@ class AllIdeProductsDownloadTest {
             IdeProduct.CLion, BackendDownloadFeed.JETBRAINS_PRODUCTS_API,
             version = "2026.2.0.1", resolvedBuild = "262.8665.321", installedBuild = "262.8665.321",
             fileName = "CLion-2026.2.0.1-aarch64.dmg",
+        ),
+        // The #430 additions, mirroring intellij-downloader's recorded fixtures (products-*.json).
+        ProductFeedCase(
+            IdeProduct.RustRover, BackendDownloadFeed.JETBRAINS_PRODUCTS_API,
+            version = "2026.2", resolvedBuild = "262.8665.323", installedBuild = "262.8665.323",
+            fileName = "RustRover-2026.2-aarch64.dmg",
+        ),
+        ProductFeedCase(
+            IdeProduct.PhpStorm, BackendDownloadFeed.JETBRAINS_PRODUCTS_API,
+            version = "2026.2.0.1", resolvedBuild = "262.8665.325", installedBuild = "262.8665.325",
+            fileName = "PhpStorm-2026.2.0.1-aarch64.dmg",
+        ),
+        ProductFeedCase(
+            IdeProduct.RubyMine, BackendDownloadFeed.JETBRAINS_PRODUCTS_API,
+            version = "2026.2", resolvedBuild = "262.8665.308", installedBuild = "262.8665.308",
+            fileName = "RubyMine-2026.2-aarch64.dmg",
+        ),
+        // DataGrip is queried as DG but a real install reports productCode DB — installedProductCode
+        // carries the split, and the download validation must accept it.
+        ProductFeedCase(
+            IdeProduct.DataGrip, BackendDownloadFeed.JETBRAINS_PRODUCTS_API,
+            version = "2026.2.2", resolvedBuild = "262.9437.70", installedBuild = "262.9437.70",
+            fileName = "datagrip-2026.2.2-aarch64.dmg",
+        ),
+        // MPS lags the platform by one baseline (261) — still inside the bundled plugin's range.
+        ProductFeedCase(
+            IdeProduct.Mps, BackendDownloadFeed.JETBRAINS_PRODUCTS_API,
+            version = "2026.1", resolvedBuild = "261.25134.779", installedBuild = "261.25134.779",
+            fileName = "MPS-2026.1-macos-aarch64.dmg",
         ),
     )
 

--- a/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/BackendCommandDownloadListTest.kt
+++ b/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/BackendCommandDownloadListTest.kt
@@ -88,17 +88,24 @@ class BackendCommandDownloadListTest {
         assertEquals(setOf("tool", "available"), root.keys)
         assertEquals("devrig", root["tool"]!!.jsonObject["name"]!!.jsonPrimitive.content)
         val available = root["available"]!!.jsonArray.map { it.jsonObject }
+        // Grouped by license tier (free, then free-for-non-commercial, then paid), catalog order
+        // within each group.
         assertEquals(
             listOf(
                 "idea-community",
                 "pycharm-community",
+                "mps",
                 "android-studio",
                 "goland",
                 "webstorm",
                 "rider",
                 "clion",
+                "rustrover",
                 "idea-ultimate",
                 "pycharm-pro",
+                "phpstorm",
+                "rubymine",
+                "datagrip",
             ),
             available.map { it["id"]!!.jsonPrimitive.content },
         )
@@ -180,7 +187,11 @@ class BackendCommandDownloadListTest {
         collectAvailableBackendDownloads(versionResolver = resolver)
 
         assertEquals(
-            setOf("idea-community", "pycharm-community", "android-studio", "goland", "webstorm", "rider", "clion", "idea-ultimate", "pycharm-pro"),
+            setOf(
+                "idea-community", "pycharm-community", "mps", "android-studio",
+                "goland", "webstorm", "rider", "clion", "rustrover",
+                "idea-ultimate", "pycharm-pro", "phpstorm", "rubymine", "datagrip",
+            ),
             resolver.calls.toSet(),
         )
     }

--- a/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/BackendManagerDownloadValidationTest.kt
+++ b/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/BackendManagerDownloadValidationTest.kt
@@ -209,6 +209,13 @@ class BackendManagerDownloadValidationTest {
             IdeProduct.WebStorm to "WS",
             IdeProduct.Rider to "RD",
             IdeProduct.CLion to "CL",
+            IdeProduct.RustRover to "RR",
+            IdeProduct.PhpStorm to "PS",
+            IdeProduct.RubyMine to "RM",
+            // DataGrip is queried as DG but a real install reports DB (feed intellijProductCode) —
+            // the same code split as IIU→IU and PCP→PY.
+            IdeProduct.DataGrip to "DB",
+            IdeProduct.Mps to "MPS",
             IdeProduct.AndroidStudio to "AI",
         )
         assertEquals(expectedCodes.keys, IdeProduct.knownProducts.toSet())

--- a/test-integration/src/main/kotlin/com/jonnyzzz/mcpSteroid/integration/infra/ide-product.kt
+++ b/test-integration/src/main/kotlin/com/jonnyzzz/mcpSteroid/integration/infra/ide-product.kt
@@ -64,6 +64,57 @@ enum class IdeProduct(
         jetbrainsProductCode = "CL",
         hasJavaSdk = false,
     ),
+    PhpStorm(
+        id = "phpstorm",
+        dockerImageBase = "phpstorm-agent",
+        launcherExecutable = "phpstorm",
+        displayName = "PhpStorm",
+        jetbrainsProductCode = "PS",
+        hasJavaSdk = false,
+    ),
+    RubyMine(
+        id = "rubymine",
+        dockerImageBase = "rubymine-agent",
+        launcherExecutable = "rubymine",
+        displayName = "RubyMine",
+        jetbrainsProductCode = "RM",
+        hasJavaSdk = false,
+    ),
+    RustRover(
+        id = "rustrover",
+        dockerImageBase = "rustrover-agent",
+        launcherExecutable = "rustrover",
+        displayName = "RustRover",
+        jetbrainsProductCode = "RR",
+        hasJavaSdk = false,
+    ),
+    /**
+     * DataGrip. [jetbrainsProductCode] is the products-API code `DG`; a real install's
+     * `product-info.json` reports `DB` instead (the feed's `intellijProductCode`) — see
+     * `IdeProduct.DataGrip.installedProductCode` in the downloader catalog.
+     */
+    DataGrip(
+        id = "datagrip",
+        dockerImageBase = "datagrip-agent",
+        launcherExecutable = "datagrip",
+        displayName = "DataGrip",
+        jetbrainsProductCode = "DG",
+        hasJavaSdk = false,
+    ),
+    /**
+     * MPS. `hasJavaSdk = false` verified against a real 2026.1 install: despite targeting the JVM,
+     * MPS bundles only `mps-kotlin` and no `com.intellij.java`, so `JavaSdk` is off the script
+     * classpath. Published without Linux/Windows ARM64 distributions — the Docker matrix is
+     * linux x64, so that gap does not affect these tests.
+     */
+    Mps(
+        id = "mps",
+        dockerImageBase = "mps-agent",
+        launcherExecutable = "mps",
+        displayName = "MPS",
+        jetbrainsProductCode = "MPS",
+        hasJavaSdk = false,
+    ),
 
     /**
      * Android Studio (Google) — an IntelliJ-platform IDE with a different plugin/SDK surface. Reuses the
@@ -88,8 +139,17 @@ enum class IdeProduct(
             "webstorm", "ws" -> WebStorm
             "rider", "rd", "dotnet" -> Rider
             "clion", "cl", "cpp", "c++" -> CLion
+            "phpstorm", "ps", "php" -> PhpStorm
+            "rubymine", "rm", "ruby" -> RubyMine
+            "rustrover", "rr", "rust" -> RustRover
+            // DataGrip answers to DG (products-API code) and DB (its intellijProductCode).
+            "datagrip", "dg", "db" -> DataGrip
+            "mps" -> Mps
             "androidstudio", "android-studio", "android", "as", "ai" -> AndroidStudio
-            else -> error("Unsupported test.integration.ide.product='$rawValue'. Use one of: idea, pycharm, goland, webstorm, rider, clion, android-studio.")
+            else -> error(
+                "Unsupported test.integration.ide.product='$rawValue'. Use one of: " +
+                    entries.joinToString { it.id } + "."
+            )
         }
     }
 }

--- a/test-integration/src/main/kotlin/com/jonnyzzz/mcpSteroid/integration/infra/intelliJ-download.kt
+++ b/test-integration/src/main/kotlin/com/jonnyzzz/mcpSteroid/integration/infra/intelliJ-download.kt
@@ -75,6 +75,11 @@ private fun IdeProduct.toDownloaderProduct(): DownloaderProduct = when (this) {
     IdeProduct.WebStorm -> DownloaderProduct.WebStorm
     IdeProduct.Rider -> DownloaderProduct.Rider
     IdeProduct.CLion -> DownloaderProduct.CLion
+    IdeProduct.PhpStorm -> DownloaderProduct.PhpStorm
+    IdeProduct.RubyMine -> DownloaderProduct.RubyMine
+    IdeProduct.RustRover -> DownloaderProduct.RustRover
+    IdeProduct.DataGrip -> DownloaderProduct.DataGrip
+    IdeProduct.Mps -> DownloaderProduct.Mps
     IdeProduct.AndroidStudio -> DownloaderProduct.AndroidStudio
 }
 

--- a/test-integration/src/test/docker/datagrip-agent/Dockerfile
+++ b/test-integration/src/test/docker/datagrip-agent/Dockerfile
@@ -1,0 +1,19 @@
+ARG BASE_IMAGE=mcp-steroid-ide-base-test
+FROM ${BASE_IMAGE}
+
+USER root
+
+# Copy and extract DataGrip archive (pre-downloaded by Gradle)
+COPY ide.tar.gz /tmp/ide.tar.gz
+RUN mkdir -p /opt/idea && chmod a+rwx /opt && \
+    tar -xzf /tmp/ide.tar.gz -C /opt/idea --strip-components=1 && \
+    rm /tmp/ide.tar.gz
+
+USER agent
+WORKDIR /home/agent
+
+ENV PATH="/home/agent/.local/bin:/opt/idea/bin:/usr/local/bin:/usr/bin:$PATH"
+ENV SHELL=/bin/bash
+ENV HOME=/home/agent
+
+CMD ["sleep", "infinity"]

--- a/test-integration/src/test/docker/mps-agent/Dockerfile
+++ b/test-integration/src/test/docker/mps-agent/Dockerfile
@@ -1,0 +1,19 @@
+ARG BASE_IMAGE=mcp-steroid-ide-base-test
+FROM ${BASE_IMAGE}
+
+USER root
+
+# Copy and extract MPS archive (pre-downloaded by Gradle)
+COPY ide.tar.gz /tmp/ide.tar.gz
+RUN mkdir -p /opt/idea && chmod a+rwx /opt && \
+    tar -xzf /tmp/ide.tar.gz -C /opt/idea --strip-components=1 && \
+    rm /tmp/ide.tar.gz
+
+USER agent
+WORKDIR /home/agent
+
+ENV PATH="/home/agent/.local/bin:/opt/idea/bin:/usr/local/bin:/usr/bin:$PATH"
+ENV SHELL=/bin/bash
+ENV HOME=/home/agent
+
+CMD ["sleep", "infinity"]

--- a/test-integration/src/test/docker/phpstorm-agent/Dockerfile
+++ b/test-integration/src/test/docker/phpstorm-agent/Dockerfile
@@ -1,0 +1,19 @@
+ARG BASE_IMAGE=mcp-steroid-ide-base-test
+FROM ${BASE_IMAGE}
+
+USER root
+
+# Copy and extract PhpStorm archive (pre-downloaded by Gradle)
+COPY ide.tar.gz /tmp/ide.tar.gz
+RUN mkdir -p /opt/idea && chmod a+rwx /opt && \
+    tar -xzf /tmp/ide.tar.gz -C /opt/idea --strip-components=1 && \
+    rm /tmp/ide.tar.gz
+
+USER agent
+WORKDIR /home/agent
+
+ENV PATH="/home/agent/.local/bin:/opt/idea/bin:/usr/local/bin:/usr/bin:$PATH"
+ENV SHELL=/bin/bash
+ENV HOME=/home/agent
+
+CMD ["sleep", "infinity"]

--- a/test-integration/src/test/docker/rubymine-agent/Dockerfile
+++ b/test-integration/src/test/docker/rubymine-agent/Dockerfile
@@ -1,0 +1,19 @@
+ARG BASE_IMAGE=mcp-steroid-ide-base-test
+FROM ${BASE_IMAGE}
+
+USER root
+
+# Copy and extract RubyMine archive (pre-downloaded by Gradle)
+COPY ide.tar.gz /tmp/ide.tar.gz
+RUN mkdir -p /opt/idea && chmod a+rwx /opt && \
+    tar -xzf /tmp/ide.tar.gz -C /opt/idea --strip-components=1 && \
+    rm /tmp/ide.tar.gz
+
+USER agent
+WORKDIR /home/agent
+
+ENV PATH="/home/agent/.local/bin:/opt/idea/bin:/usr/local/bin:/usr/bin:$PATH"
+ENV SHELL=/bin/bash
+ENV HOME=/home/agent
+
+CMD ["sleep", "infinity"]

--- a/test-integration/src/test/docker/rustrover-agent/Dockerfile
+++ b/test-integration/src/test/docker/rustrover-agent/Dockerfile
@@ -1,0 +1,19 @@
+ARG BASE_IMAGE=mcp-steroid-ide-base-test
+FROM ${BASE_IMAGE}
+
+USER root
+
+# Copy and extract RustRover archive (pre-downloaded by Gradle)
+COPY ide.tar.gz /tmp/ide.tar.gz
+RUN mkdir -p /opt/idea && chmod a+rwx /opt && \
+    tar -xzf /tmp/ide.tar.gz -C /opt/idea --strip-components=1 && \
+    rm /tmp/ide.tar.gz
+
+USER agent
+WORKDIR /home/agent
+
+ENV PATH="/home/agent/.local/bin:/opt/idea/bin:/usr/local/bin:/usr/bin:$PATH"
+ENV SHELL=/bin/bash
+ENV HOME=/home/agent
+
+CMD ["sleep", "infinity"]

--- a/website/content/docs/devrig.md
+++ b/website/content/docs/devrig.md
@@ -98,7 +98,11 @@ installs a managed backend under devrig's home directory. The `id` accepts
 `idea-community`, `idea-community:2026.1`, or `idea-community-2026.1`.
 
 Known product ids: `idea-ultimate`, `idea-community`, `pycharm-pro`,
-`pycharm-community`, `goland`, `webstorm`, `rider`, `clion`, `android-studio`.
+`pycharm-community`, `goland`, `webstorm`, `rider`, `clion`, `rustrover`,
+`phpstorm`, `rubymine`, `datagrip`, `mps`, `android-studio`.
+
+MPS is published without a Linux ARM64 or Windows ARM64 distribution, so those two
+hosts report the platform as unavailable rather than downloading a mismatched archive.
 
 ### `devrig backend start [<id>] [--version <v>] [--json]`
 


### PR DESCRIPTION
Fixes #430

devrig only knew nine IDEs, so `devrig backend download` presented itself as "these nine" and asking
for a PhpStorm or RubyMine backend by name was a hard error. This extends the product catalog to
fourteen.

## Added (5)

| Product | id | API code | `product-info.json` code | License tier |
|---|---|---|---|---|
| PhpStorm | `phpstorm` | `PS` | `PS` | paid |
| RubyMine | `rubymine` | `RM` | `RM` | paid |
| DataGrip | `datagrip` | `DG` | **`DB`** | paid |
| RustRover | `rustrover` | `RR` | `RR` | free for non-commercial |
| MPS | `mps` | `MPS` | `MPS` | free |

**DataGrip's two codes are deliberate.** The products feed is queried with `DG`
(`alternativeCodes: ["DB"]`), but its `intellijProductCode` is `DB`, so a real install writes
`productCode: DB` into `product-info.json`. `installedProductCode` carries `DB` — the same split
already handled for `IIU`→`IU` and `PCP`→`PY` — and the alias map accepts both spellings. `DB` is
also the code `prompts/AGENTS.md` and `PerIdeAvailabilityContractTest` use, so this closes the
prompts-ship-for-it/devrig-cannot-download-it mismatch the issue described (a test now asserts every
prompt-pipeline code has a downloadable backend).

**MPS is the odd feed entry.** It publishes no `linuxARM64` and no `windowsARM64` distribution in any
release. It does offer a cross-platform `zip`, which we deliberately do **not** fall back to: that
archive carries no per-host JBR, so "resolved" would mean an install that cannot launch. Instead the
resolver now separates "the feed publishes no such platform" from "filenames belong to another
edition" and reports the download keys the feed does offer, rather than advising a `--version` retry
that cannot help. Its `mac`/`macM1` `.dmg` needs no special handling — `unpackIdeArchive` already
mounts DMGs via `hdiutil`.

## Deliberately NOT added

Recorded as code comments next to `IdeProduct.knownProducts` so this does not read as an oversight to
a future reader, and guarded by a test that fails if one is added without revisiting the decision:

- **DataSpell (`DS`)** — consciously left out by decision.
- **GitClient (`GIG`)** — consciously left out by decision.
- **CLion Nova (`CLN`)** — dead upstream: the feed reports `alternativeCodes: [CL]` and
  `intellijProductCode: CL`, i.e. folded back into regular CLion, which we already ship as `CL`. A
  separate entry would duplicate the same artifacts.
- **Gateway (`GW`)** — a thin remote-development client, not a backend IDE.
- **JetBrains Air / Fleet** — not IntelliJ-platform desktop distributions.
- **AppCode (`AC`)** — discontinued.
- **PhpStorm Light** — a stripped SKU of the `phpstorm` entry now shipped.
- **Aqua** — test-automation IDE, outside the agreed backend scope.
- **Writerside / Qodana** — not IDEs.

`IdeProduct.Custom` remains the escape hatch for any of these without touching the catalog.

## Where it changed

- `IdeProduct.kt` — the five entries, the alias additions (`php`, `ruby`, `rust`, `db`), and the
  out-of-scope decision comment.
- `IdeReleaseLookup.kt` — the unpublished-platform diagnostic.
- `Main.kt` `--product` help, `website/content/docs/devrig.md` "Known product ids".
- `test-integration/.../infra/ide-product.kt` — five matrix entries plus their Dockerfiles;
  `intelliJ-download.kt` product mapping (its exhaustive `when` caught the omission at compile time).
- No edits were needed in `BackendId.kt`, `BackendDownloadListCommand.kt`, `BackendLocalListCommand.kt`
  or `BackendCommand.kt`: all four already derive from `knownProducts`, so the new products flow into
  id parsing, the download list, local listing and ordering for free. The list groups them by license
  tier as before.

## Verification

- **Metadata verified against reality, not guessed.** All five Linux archives were really downloaded
  and their `product-info.json` read: `PS`/`RM`/`RR`/`MPS` report their own code, DataGrip reports
  `DB`, and each `launch.launcherPath` matches the `launcherExecutable` recorded here. MPS's
  `hasJavaSdk = false` was confirmed the same way (it bundles only `mps-kotlin`, no
  `com.intellij.java`).
- **Real end-to-end download** through the production path (resolve → download → unpack → validate)
  for DataGrip and MPS on macOS arm64 (`.dmg` via `hdiutil`): `productCode` and `buildNumber` both
  matched the resolved build exactly. Downloads were cleaned up afterwards.
- **Offline matrix** (`:intellij-downloader:test`) walks every catalog product across all six
  OS/arch combos off recorded fixtures. A new `knownProducts` entry fails until its fixture exists
  and its filename tokens are right, so a product cannot land in the CLI list while being
  undownloadable. MPS's two ARM64 gaps are asserted as explicit unpublished-platform errors.
- **Live feed matrix** (`:intellij-downloader:liveNetworkTest`, opt-in) repeats the same assertions
  against the real products API — green for all 13 feed-served products × 6 combos.
- **Docs drift** — `ProductCatalogDocsDriftTest` fails when the published docs or the `--product`
  help stop listing a catalog id (an acceptance criterion of #430).
- **Mutation-checked, so the guards are real:** flipping DataGrip's filename token to the wrong case
  or its mapping back to `DG` reds three tests; dropping `mps` from `devrig.md` reds the drift test.
- `./gradlew :intellij-downloader:test :npx-kt:test` green (103 + 1397 tests, 0 failures);
  `:test-integration` and `:prompts` compile clean.

`:prompts:test` was not run to completion: its IDE matrix is a hand-maintained list
(`idea`/`rider`/`clion`/`pycharm`), not derived from `knownProducts`, so this diff does not change it,
and the task downloads ~10 GB of IDE distributions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
