### PR TITLE
build: update download plugin to 5.7.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 @file:Suppress("HasPlatformType")
 
 plugins {
-    id("de.undercouch.download") version "5.6.0" apply false
+    id("de.undercouch.download") version "5.7.0" apply false
     id("org.jetbrains.intellij.platform") version "2.18.1" apply false
     id("com.github.node-gradle.node") version "7.1.0" apply false
     kotlin("jvm") version "2.3.20" apply false


### PR DESCRIPTION
## Summary

- update `de.undercouch.download` from 5.6.0 to 5.7.0

## Verification

- `:ocr-tesseract:test` — 4 passed