### PR TITLE
Teach agents to bootstrap headless IDEA backends

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ devrig install plugin
 **Requirements**
 
 - A JetBrains IDE — IntelliJ IDEA, PyCharm, GoLand, WebStorm, Rider, CLion, or Android Studio.
-- The IDE runs with a real display: the normal GUI on macOS/Windows, or under **Xvfb** (a virtual X display) on Linux/CI. True headless launches (`-Djava.awt.headless=true`) are unsupported (best-effort, see [#177](https://github.com/jonnyzzz/mcp-steroid/issues/177)) — see [Running devrig in CI](https://devrig.dev/docs/running-on-ci/).
+- The IDE runs with a real display: the normal GUI on macOS/Windows, or under **Xvfb** (a virtual X display) on Linux/CI. True AWT-headless launches (`-Djava.awt.headless=true`) are unsupported (best-effort, see [#177](https://github.com/jonnyzzz/mcp-steroid/issues/177)). A frontendless Remote Development backend is supported and is not AWT-headless — see [Running devrig in CI](https://devrig.dev/docs/running-on-ci/).
 - An MCP-compatible AI agent (Claude Code, Codex, or Gemini).
 
 **Faster plugin updates (optional):** add `https://devrig.dev/updatePlugins.xml` in **Settings > Plugins > Gear icon > Manage Plugin Repositories...**. Or install a ZIP from [GitHub Releases](https://github.com/jonnyzzz/mcp-steroid/releases) via **Install Plugin from Disk**.

--- a/TODO.md
+++ b/TODO.md
@@ -144,8 +144,10 @@
   `execute_code` and `take_screenshot`, and implemented by `renderWithOut` in `CliToolSupport.kt` (verified end to end —
   `devrig take_screenshot --out=<path>` writes the PNG and prints `Saved --out: <path>`). `--wait` is
   **not**: it parses, and a generic guard in `GeneratedToolRuntime.kt` then refuses with exit 64
-  (`--wait is accepted by the command line but no runtime acts on it yet`). Implement it as a
-  `list_windows` poll until the project reports initialized, and delete that guard plus its test.
+  (`--wait is accepted by the command line but no runtime acts on it yet`). Implement it as a project-list
+  poll until the target path appears; a frontendless Remote Development backend has no window. If a
+  frontend window exists, additionally poll its modal/indexing/initialized flags. Then delete the guard
+  plus its test.
 
 - [ ] **`--json` parse-time usage errors emit nothing on stdout (#284)**: a parse failure becomes
   `DevrigCommandParseError`, which prints to stderr and answers 64 with no `--json` envelope — the KDoc

--- a/TODO.md
+++ b/TODO.md
@@ -178,6 +178,17 @@
   pinned by `CliErrorEnvelopeTest`. It affected EVERY tool-side argument rejection, not just an absent
   `project_name`, so it would have outlived the inference work.
 
+- [ ] **Agent harnesses must gate the first task turn on MCP initialization**: initialize instructions
+  solve deferred-schema discovery only after the devrig MCP server reaches ready state. A Claude Code
+  run can still begin while the server is `pending`, see no `steroid_*` names or instructions, and commit
+  to shell text search before initialization completes. This is a client/harness readiness problem; add
+  a regression in the agent launcher instead of another server prompt or MCP tool.
+
+- [ ] **Pin an exact semantic oracle for the Keycloak Authenticator hierarchy E2E**: the headless-agent
+  discovery scenario currently gates the pinned checkout with a 70-FQN lower bound plus known indirect
+  implementors. Capture the canonical full set (or query it independently after the agent run) so future
+  Keycloak fixture changes can distinguish exact completeness from a strong workflow regression signal.
+
 - [ ] **Harden the CLI tool-spec metadata layer (#284 follow-up)**: three review findings deferred from
   PR #356. (1) `CliToolSpec.schema` exposes the mutable `ToolSchema` — any consumer can call
   `register()` after registration and change the advertised `inputSchema`; expose a read-only view

--- a/TODO.md
+++ b/TODO.md
@@ -86,6 +86,11 @@
     `coding-with-intellij-patterns.md` (3 sites).
 
 - [ ] **runInspectionsDirectly follow-ups (#69 ask 1)** — deliberately deferred, not work-in-progress.
+  - On IU-262/K2, `LoggingSimilarMessage` and `UnusedSymbol` can crash on a Kotlin file that references
+    generated prompt articles with `Cannot compute containing PSI for unknown source kind
+    KtFakeSourceElementKind.PluginGenerated`. Crash isolation preserves other findings and correctly
+    populates `failedTools`, but the file check remains `check_failed`; add a focused reproducer and fix or
+    filter the unsupported synthetic PSI path without hiding unrelated inspection failures.
   - *Deferred:* a `PsiFile`-accepting overload (and any richer per-file batch surface). It is a
     `McpScriptContext` surface growth — gated by PHILOSOPHY Tenet 3 / the 3-reviewer consensus, same
     as the explicit-`Project` overload (#94). Revisit only if that gate is cleared.

--- a/TODO.md
+++ b/TODO.md
@@ -116,6 +116,10 @@
     tune the 180-second readiness bound and the caller-cancellation behavior before widening support.
   - Put the pure Remote Development NDJSON parser/workflow contracts on a normal CI-backed task; the
     experimental task's direct-invocation guard currently keeps them out of aggregate CI runs.
+  - Redact Remote Development join-link fragments (`#jt=...`) from preserved managed-backend logs.
+    The Codex artifact review found one after the backend had stopped; the current sanitizer and invariant
+    cover `Authorization`/Bearer, `_ijt`, and `x-ijt` credentials only. Extend the pure sanitizer tests and
+    keep the shell artifact scan aligned before treating those logs as generally safe to publish.
   - Stream download progress to the agent (downloads can take minutes; CLI is silent until done).
   - Add bounded retry-on-read-timeout to the shared IDE downloader. It already resumes a pre-existing
     `.tmp` with `Range`, but a socket stall currently waits 15 minutes and fails the whole Gradle test or
@@ -129,11 +133,6 @@
   ignores unknown key; new devrig falls back to the singular `plugin` field), devrig-side id→kind
   classification, PidMarker contract-test updates. Spec in the #88 closing comments.
 
-- [ ] **Fix the pre-existing `:prompts:test` failure** (broken on `main` since before 2026-06-09):
-  `MarkdownArticleContractTest.testNoNonKotlinFences` fails on
-  `debugger/debug-attach-remote-jvm.md` (5 ```text fences at lines 10/26/66/101/123). The contract
-  bans non-kotlin fences; rewrite those blocks as prose/inline code or ```kotlin. Until fixed, every
-  prompts contract run reports this one failure (sessions treat it as "green if sole failure" — debt).
 - [ ] **devrig-naming.md id-scheme drift**: the naming-contract doc still specifies the old
   slug/bootHash exposed ids (`IntelliJ_IDEA_2025.3.3-AbC4Df01`) while the implementation has moved to
   `productCode-hash8` backend_names (`iu-9fk2a0xQ`) and pid-salted project names. The plugins[] section
@@ -185,7 +184,8 @@
   pinned by `CliErrorEnvelopeTest`. It affected EVERY tool-side argument rejection, not just an absent
   `project_name`, so it would have outlived the inference work.
 
-- [ ] **Agent harnesses must gate the first task turn on MCP initialization**: initialize instructions
+- [ ] **Deferred, non-gating: agent harnesses must gate the first task turn on MCP initialization**:
+  initialize instructions
   solve deferred-schema discovery only after the devrig MCP server reaches ready state. A Claude Code
   run can still begin while the server is `pending`, see no `steroid_*` names or instructions, and commit
   to shell text search before initialization completes. This is a client/harness readiness problem; add

--- a/docs/headless-agent-guidance.md
+++ b/docs/headless-agent-guidance.md
@@ -32,12 +32,12 @@ prompt currently supplies the exact download/start commands, every MCP step, and
 
 Three independent audits found the same agent-facing gaps:
 
-- `devrig backend` says only `No backends detected.` on a clean machine although initialization guidance
-  claims it lists available products. Bare `devrig backend download --json` is the real discovery path.
-- Initialization promotes explicit `backend start`, while `steroid_open_project` already starts the sole
+- The baseline `devrig backend` said only `No backends detected.` on a clean machine although initialization
+  guidance claimed it listed available products. Bare `devrig backend download --json` is the real discovery path.
+- Baseline initialization promoted explicit `backend start`, while `steroid_open_project` already starts the sole
   installed managed backend and waits for its MCP marker.
-- Only IDEA Ultimate baseline 262 uses the unattended Remote Development launcher. The current pre-IDE
-  guidance does not explain that choice or that no frontend window is required.
+- Only IDEA Ultimate baseline 262 uses the unattended Remote Development launcher. The previous pre-IDE
+  guidance did not explain that choice or that no frontend window was required.
 - Window/index flags can become ready before a first Maven import is configured. A hierarchy query can
   therefore return a plausible but incomplete result unless the agent awaits external-system readiness.
 - The backend-management article cannot bootstrap a zero-project session because
@@ -58,17 +58,15 @@ Three independent audits found the same agent-facing gaps:
 - [x] Run focused unit, prompt-generation, Kotlin-fence, and experimental harness contracts.
 - [x] Run two Claude scenarios in fresh containers, review their `<<<IMPROVEMENTS>>>` artifacts, and
   iterate on the observed frontendless-readiness and hierarchy-classification gaps.
-- [ ] Run the Codex scenario in a fresh container and review its `<<<IMPROVEMENTS>>>` artifact. Codex
-  remains locally blocked: `codex login status` reports not logged in and neither `OPENAI_API_KEY` nor
-  `CODEX_API_KEY` is available; the test remains enabled and unweakened. TeamCity has a credentialed
-  Keycloak Codex build, but its fixed filter also selects two older heavy scenarios and cannot be narrowed
-  for a custom build; focused validation would require a separate TeamCity/`jb` change.
-- [x] Run the final adversarial review and close its hierarchy-oracle finding. Its verdict remains no-go
-  only until the real Codex task-only Docker scenario supplies the missing runtime evidence.
+- [x] Run the Codex scenario in a fresh container through the local jb-central OpenAI route and review its
+  raw NDJSON plus `<<<IMPROVEMENTS>>>` artifact. The credential entered only the Codex CLI process; the
+  backend-environment assertion proved it did not reach IntelliJ.
+- [x] Run the final adversarial artifact review and close its runtime gate. The reviewer returned GO after
+  independently checking discovery, ordered tool calls, semantic output, backend invariants, and teardown.
 - [x] Reconcile the branch with current `origin/main` and preserve the new generated-CLI contracts while
   resolving conflicts.
 - [x] Rerun the focused post-rebase server, devrig, prompt/KtBlock, and pure experiment validation.
-- [x] Push the rebased branch, update PR #441, and obtain green compile plus Linux/Windows installer checks.
+- [x] Push the final rebased prompt iteration, update PR #441, and obtain green current-head checks.
 
 ## Validation status
 
@@ -90,14 +88,32 @@ Three independent audits found the same agent-facing gaps:
   successful semantic query. The raw PSI search contained 74 inheritors: 70 named implementing classes,
   two named sub-interfaces, and two anonymous/local implementations without qualified names. Its final
   answer contained the intended 70 named classes, and every backend/process assertion and teardown passed.
+- Passed the Codex task-only Docker scenario in 5m26s (6m15s for the full Gradle invocation with rebuild).
+  MCP initialization completed before the first tool call. Codex started with an empty project list,
+  discovered `devrig backend download --json`, installed the exact IU 2026.2.0.1 build, called
+  `steroid_open_project` with no explicit backend start, retained `keycloak-jybgaanr`, triggered and awaited
+  Maven configuration, fetched the hierarchy recipe, and completed every IDE call without error.
+  Its deep PSI search found 74 raw inheritors: 70 named implementing classes, two named sub-interfaces, and
+  two anonymous implementations. An independent `FilenameIndex`/`InheritanceUtil` scan matched the 70-class
+  set exactly, and the final answer emitted 70 unique class markers. Backend mode, managed plugin, trust and
+  noninteractive flags, API-credential isolation, the current Bearer/`_ijt` marker-credential invariant,
+  route liveness, stop, and process cleanup all passed. Artifact review found an expired Remote Development
+  `#jt` join fragment outside that sanitizer's coverage; `TODO.md` now tracks making preserved backend logs
+  generally publication-safe.
 - Independent reviews completed with the repository subagent quorum, `run-agent.sh` Codex, Claude Opus 5,
   and Claude Fable 5. Their findings were iterated into the current wording and assertions.
-- The final adversarial review explicitly remains no-go for claiming the whole Claude-and-Codex goal
-  complete until a real Codex task-only Docker run passes; model reviews are not treated as runtime proof.
+- The final adversarial artifact review returned GO for the full Claude-and-Codex goal. It kept the separate
+  MCP-initialization harness gate and exact pinned hierarchy oracle open because this successful run does not
+  implement either deferred regression.
 - The post-rebase matrix passed the focused server and devrig contracts, 16 prompt tests (including both
   type-hierarchy KtBlock cases), and eight pure experiment methods with zero failures, errors, or skips.
-- PR #441 is mergeable and its compile, Linux PowerShell Docker, and Windows PowerShell checks passed on
-  the rebased branch head.
+- After the final SDK-guidance iteration, `ExternalSystemFirstOpenPromptContractTest`, the corpus-wide
+  `MarkdownArticleContractTest`, and all ten `ExecuteCodeMavenKtBlocksCompilationTest` cases passed. The
+  edited Kotlin contract test is also clean under every enabled file-scoped inspection with no failed tools.
+- The final read-only review returned GO after verifying the conditional null-SDK behavior, module-aware
+  selection, canonical home validation, post-write read action, contract coverage, and KtBlock results.
+- PR #441 is mergeable; compile, Linux PowerShell Docker, and Windows PowerShell checks passed after the
+  final rebase and prompt iteration.
 - File-scoped IDE inspections ran on every changed production Kotlin file. They found no actionable
   changed-line diagnostic, but the `OpenProjectTool.kt` check is not called clean: two Kotlin/UAST
   inspections crashed on `KtFakeSourceElementKind.PluginGenerated`, so `failedTools` correctly made it
@@ -124,6 +140,27 @@ The second reflection also suggested documenting stdout/stderr separation for `d
 with `2>&1`, then correctly parsed stdout on its next call. Recommending diagnostic suppression would hide
 useful failures without fixing a product-guidance gap.
 
+## Codex iteration findings
+
+Codex's first action was `steroid_list_projects`; it did not need the task prompt to name devrig, an MCP
+tool, or a resource URI. Its reflection nevertheless suggested an explicit `steroid_*` discovery hint and a
+short first-open checklist. Both already exist in initialization and `steroid_open_project` output, and the
+raw trace shows Codex followed them, so duplicating them again would add prompt weight without changing the
+observed path.
+
+The hierarchy reflection similarly asked for unnamed-result guidance that the article already supplies.
+Codex used it correctly: two sub-interfaces and two anonymous implementations stayed outside the 70 FQN
+class markers and were reported separately. No further hierarchy wording changed.
+
+One headless-specific ambiguity was real: Maven configuration completed while
+`ProjectRootManager.getInstance(project).projectSdk` was null. The existing repair section was routed only
+from a visible yellow IDE banner, which a frontendless backend cannot show. The Maven first-open entry point
+now calls out the same programmatic SDK check but treats null as a warning, not an automatic failure. It keeps
+valid project-local PSI work intact and routes to SDK repair only when the task needs JDK-dependent capability
+or diagnostics show it is absent, after inspecting module SDKs instead of blindly choosing a registered JDK.
+The executable repair recipe canonicalizes and validates an explicit home through IntelliJ APIs, refuses
+ambiguous candidates, and performs every project/module SDK model read under a read action.
+
 ## Experiment discipline
 
 The Claude and Codex cases each use a new container; backend state is never shared. Assertions use raw
@@ -138,5 +175,7 @@ known sub-interfaces do not contribute to that count. It detects the observed st
 shallow searches, but it does not pin the entire upstream class set. The agent task still requires the full,
 untruncated named hierarchy; this E2E primarily gates autonomous backend discovery and IDE use.
 
-Docker agent runs are sequential. If local API credentials are unavailable, the tests continue to fail
-hard as designed; no runtime skip or weakened assertion is permitted.
+Docker agent runs are sequential. Local OpenAI access may come from direct credentials or the jb-central
+proxy wrapper used for this run; either way, credentials are injected only into the agent CLI process. If
+credentials are unavailable, the tests continue to fail hard as designed; no runtime skip or weakened
+assertion is permitted.

--- a/docs/headless-agent-guidance.md
+++ b/docs/headless-agent-guidance.md
@@ -60,7 +60,7 @@ Three independent audits found the same agent-facing gaps:
   `<<<IMPROVEMENTS>>>` artifacts. Locally blocked: Docker is available, but all Anthropic/OpenAI agent
   API-key environment variables are unset; the tests remain enabled and unweakened.
 - [x] Run final quorum review.
-- [ ] Commit atomically, push the branch, and open a PR.
+- [x] Commit atomically, push the branch, and open PR #441.
 
 ## Validation status
 

--- a/docs/headless-agent-guidance.md
+++ b/docs/headless-agent-guidance.md
@@ -96,6 +96,10 @@ Three independent audits found the same agent-facing gaps:
   complete until a real Codex task-only Docker run passes; model reviews are not treated as runtime proof.
 - The post-rebase matrix passed the focused server and devrig contracts, 16 prompt tests (including both
   type-hierarchy KtBlock cases), and eight pure experiment methods with zero failures, errors, or skips.
+- File-scoped IDE inspections ran on every changed production Kotlin file. They found no actionable
+  changed-line diagnostic, but the `OpenProjectTool.kt` check is not called clean: two Kotlin/UAST
+  inspections crashed on `KtFakeSourceElementKind.PluginGenerated`, so `failedTools` correctly made it
+  `check_failed`. The reproducible inspection-engine follow-up is recorded in `TODO.md`.
 
 ## Claude iteration findings
 

--- a/docs/headless-agent-guidance.md
+++ b/docs/headless-agent-guidance.md
@@ -56,11 +56,14 @@ Three independent audits found the same agent-facing gaps:
 - [x] Rework initialization, open-project descriptions, prompt entry points, backend article, and
   hierarchy guidance consistently.
 - [x] Run focused unit, prompt-generation, Kotlin-fence, and experimental harness contracts.
-- [ ] Run Claude and Codex scenarios sequentially in fresh containers and review their
-  `<<<IMPROVEMENTS>>>` artifacts. Locally blocked: Docker is available, but all Anthropic/OpenAI agent
-  API-key environment variables are unset; the tests remain enabled and unweakened.
-- [x] Run final quorum review.
-- [x] Commit atomically, push the branch, and open PR #441.
+- [x] Run two Claude scenarios in fresh containers, review their `<<<IMPROVEMENTS>>>` artifacts, and
+  iterate on the observed frontendless-readiness and hierarchy-classification gaps.
+- [ ] Run the Codex scenario in a fresh container and review its `<<<IMPROVEMENTS>>>` artifact. Codex
+  remains locally blocked: `codex login status` reports not logged in and neither `OPENAI_API_KEY` nor
+  `CODEX_API_KEY` is available; the test remains enabled and unweakened.
+- [ ] Resolve the final adversarial review, rerun focused validation, and obtain a go recommendation.
+- [ ] Reconcile the branch with current `origin/main`, rerun CI, commit the current iteration atomically,
+  and update PR #441.
 
 ## Validation status
 
@@ -69,8 +72,41 @@ Three independent audits found the same agent-facing gaps:
 - Passed markdown/payload round-trip, per-IDE availability, Maven/Gradle first-open import, and the changed
   type-hierarchy Kotlin block against IDEA stable and IDEA 2026.2 EAP.
 - Passed `:test-experiments:compileTestKotlin`, workflow helper tests, and the task-prompt purity method.
+- Passed the live Claude task-only Docker scenario in 7m53s. Claude autonomously discovered the empty
+  backend state, listed downloads, installed IU 2026.2.0.1, relied on `steroid_open_project` auto-start,
+  routed the project without a frontend, triggered and awaited Maven import for 136 modules, then found
+  72 named inheritors and correctly reported 70 named implementing classes after excluding two
+  sub-interfaces.
+  The harness also proved the IU-262 Remote Development process, managed MCP Steroid plugin, marker,
+  trusted/noninteractive environment, credential isolation, live Keycloak route, and clean shutdown.
+- Passed the post-iteration Claude scenario in 5m16s. The agent made no window, screenshot, or input calls;
+  fetched only the Maven readiness recipe; imported all 136 modules; and completed the hierarchy in one
+  successful semantic query. The raw PSI search contained 74 inheritors: 70 named implementing classes,
+  two named sub-interfaces, and two anonymous/local implementations without qualified names. Its final
+  answer contained the intended 70 named classes, and every backend/process assertion and teardown passed.
 - Independent reviews completed with the repository subagent quorum, `run-agent.sh` Codex, Claude Opus 5,
   and Claude Fable 5. Their findings were iterated into the current wording and assertions.
+
+## Claude iteration findings
+
+The first live task-only run validated the intended discovery path but found one remaining runtime
+contradiction: the result returned by `steroid_open_project` still made `steroid_list_windows` and a
+screenshot mandatory, even though a frontendless Remote Development backend has neither. The result
+guidance now leads with path polling through `steroid_list_projects`, treats windows as an optional
+attended-frontend signal, and names Maven/Gradle import as a separate readiness phase.
+
+Claude also correctly noticed that `ClassInheritorsSearch` returns sub-interfaces, abstract classes,
+concrete classes, and anonymous/local classes together. The hierarchy article now teaches that
+`checkDeep=true` crosses interface → sub-interface → class edges, classifies the bounded named result,
+reports unnamed counts separately, and keeps abstract classes unless the task requests concrete-only
+implementations. The fetch-resource routing description uses the exhaustive wording “every direct +
+transitive subtype / implementor.” The E2E score now removes the base/sub-interface types from its class
+count and rejects either known sub-interface in final `SUBTYPE:` markers.
+
+The second reflection also suggested documenting stdout/stderr separation for `devrig backend download
+--json`. That suggestion was not adopted: the transcript shows the agent explicitly merged the streams
+with `2>&1`, then correctly parsed stdout on its next call. Recommending diagnostic suppression would hide
+useful failures without fixing a product-guidance gap.
 
 ## Experiment discipline
 
@@ -81,9 +117,10 @@ lists, article fetches, and recoverable failed opens are recorded as quality sig
 steps.
 
 The semantic score is a lower-bound regression oracle for the pinned Keycloak commit: at least 70 distinct
-reported FQNs plus known indirect/cross-module implementors. It detects the observed stale-import result and
+named implementing-class FQNs plus known indirect/cross-module implementors. The base interface and two
+known sub-interfaces do not contribute to that count. It detects the observed stale-import result and
 shallow searches, but it does not pin the entire upstream class set. The agent task still requires the full,
-untruncated hierarchy; this E2E primarily gates autonomous backend discovery and IDE use.
+untruncated named hierarchy; this E2E primarily gates autonomous backend discovery and IDE use.
 
 Docker agent runs are sequential. If local API credentials are unavailable, the tests continue to fail
 hard as designed; no runtime skip or weakened assertion is permitted.

--- a/docs/headless-agent-guidance.md
+++ b/docs/headless-agent-guidance.md
@@ -1,0 +1,89 @@
+# Headless IDE agent guidance
+
+## Goal
+
+Make Claude Code and Codex autonomously discover, provision, open, and use an IntelliJ IDEA Ultimate
+2026.2 Remote Development backend through devrig on a clean machine. The agent should solve a semantic
+Keycloak type-hierarchy task with IntelliJ APIs without being handed devrig commands, MCP tool names, or
+the hierarchy recipe.
+
+This work changes prompts, descriptions, and behavioral tests. It does not add MCP tools or
+`McpScriptContext` helpers.
+
+## Success contract
+
+From a fresh container with devrig registered but no IDE installed or running, each agent must:
+
+1. Discover the `steroid_*` IDE capability from MCP initialization guidance.
+2. Discover and download IDEA Ultimate 2026.2.0.1.
+3. Open `/home/agent/keycloak`; `steroid_open_project` may auto-start the installed backend, so an
+   explicit `devrig backend start` is not required.
+4. Wait for both IDE reachability and Maven project-model readiness.
+5. Use a deep IntelliJ `ClassInheritorsSearch` with the returned opaque `project_name`.
+6. Return the complete `Authenticator` hierarchy and a prompt-only improvement reflection.
+7. Leave evidence that the live IDE is the trusted, unattended IU-262 Remote Development backend with
+   MCP Steroid installed and no agent credentials in its process environment.
+
+## Evidence from the merged scenario
+
+The merged E2E proves the Remote Development launcher, plugin installation, process marker, trusted
+environment, project route, and semantic hierarchy query. It does not prove autonomous discovery: its
+prompt currently supplies the exact download/start commands, every MCP step, and the hierarchy recipe.
+
+Three independent audits found the same agent-facing gaps:
+
+- `devrig backend` says only `No backends detected.` on a clean machine although initialization guidance
+  claims it lists available products. Bare `devrig backend download --json` is the real discovery path.
+- Initialization promotes explicit `backend start`, while `steroid_open_project` already starts the sole
+  installed managed backend and waits for its MCP marker.
+- Only IDEA Ultimate baseline 262 uses the unattended Remote Development launcher. The current pre-IDE
+  guidance does not explain that choice or that no frontend window is required.
+- Window/index flags can become ready before a first Maven import is configured. A hierarchy query can
+  therefore return a plausible but incomplete result unless the agent awaits external-system readiness.
+- The backend-management article cannot bootstrap a zero-project session because
+  `steroid_fetch_resource` requires a `project_name`; the essential clean-machine route must be in MCP
+  initialization and tool/CLI descriptions.
+
+## Working plan
+
+- [x] Create a fresh worktree and branch from `origin/main`.
+- [x] Audit the merged Remote Development E2E and every pre-IDE agent-visible surface.
+- [x] Obtain independent prompt, experiment, execute-code, and backend-lifecycle reviews.
+- [x] Replace scripted E2E instructions with a task-only Claude/Codex discovery prompt and raw-event
+  workflow assertions.
+- [x] Add red unit contracts for clean-machine discovery, auto-start, frontendless operation, and the two
+  readiness phases.
+- [x] Rework initialization, open-project descriptions, prompt entry points, backend article, and
+  hierarchy guidance consistently.
+- [x] Run focused unit, prompt-generation, Kotlin-fence, and experimental harness contracts.
+- [ ] Run Claude and Codex scenarios sequentially in fresh containers and review their
+  `<<<IMPROVEMENTS>>>` artifacts. Locally blocked: Docker is available, but all Anthropic/OpenAI agent
+  API-key environment variables are unset; the tests remain enabled and unweakened.
+- [x] Run final quorum review.
+- [ ] Commit atomically, push the branch, and open a PR.
+
+## Validation status
+
+- Passed focused devrig initialization, empty-backend output, zero-candidate recovery, and open-project
+  schema contracts.
+- Passed markdown/payload round-trip, per-IDE availability, Maven/Gradle first-open import, and the changed
+  type-hierarchy Kotlin block against IDEA stable and IDEA 2026.2 EAP.
+- Passed `:test-experiments:compileTestKotlin`, workflow helper tests, and the task-prompt purity method.
+- Independent reviews completed with the repository subagent quorum, `run-agent.sh` Codex, Claude Opus 5,
+  and Claude Fable 5. Their findings were iterated into the current wording and assertions.
+
+## Experiment discipline
+
+The Claude and Codex cases each use a new container; backend state is never shared. Assertions use raw
+NDJSON tool events, not decoded prose. A run must prove the ordered download/open/list/execute path and
+score the first successful deep hierarchy result as complete. Explicit CLI start, initial empty project
+lists, article fetches, and recoverable failed opens are recorded as quality signals rather than required
+steps.
+
+The semantic score is a lower-bound regression oracle for the pinned Keycloak commit: at least 70 distinct
+reported FQNs plus known indirect/cross-module implementors. It detects the observed stale-import result and
+shallow searches, but it does not pin the entire upstream class set. The agent task still requires the full,
+untruncated hierarchy; this E2E primarily gates autonomous backend discovery and IDE use.
+
+Docker agent runs are sequential. If local API credentials are unavailable, the tests continue to fail
+hard as designed; no runtime skip or weakened assertion is permitted.

--- a/docs/headless-agent-guidance.md
+++ b/docs/headless-agent-guidance.md
@@ -60,10 +60,15 @@ Three independent audits found the same agent-facing gaps:
   iterate on the observed frontendless-readiness and hierarchy-classification gaps.
 - [ ] Run the Codex scenario in a fresh container and review its `<<<IMPROVEMENTS>>>` artifact. Codex
   remains locally blocked: `codex login status` reports not logged in and neither `OPENAI_API_KEY` nor
-  `CODEX_API_KEY` is available; the test remains enabled and unweakened.
-- [ ] Resolve the final adversarial review, rerun focused validation, and obtain a go recommendation.
-- [ ] Reconcile the branch with current `origin/main`, rerun CI, commit the current iteration atomically,
-  and update PR #441.
+  `CODEX_API_KEY` is available; the test remains enabled and unweakened. TeamCity has a credentialed
+  Keycloak Codex build, but its fixed filter also selects two older heavy scenarios and cannot be narrowed
+  for a custom build; focused validation would require a separate TeamCity/`jb` change.
+- [x] Run the final adversarial review and close its hierarchy-oracle finding. Its verdict remains no-go
+  only until the real Codex task-only Docker scenario supplies the missing runtime evidence.
+- [x] Reconcile the branch with current `origin/main` and preserve the new generated-CLI contracts while
+  resolving conflicts.
+- [x] Rerun the focused post-rebase server, devrig, prompt/KtBlock, and pure experiment validation.
+- [ ] Push the rebased branch and update PR #441 and its CI status.
 
 ## Validation status
 
@@ -71,7 +76,8 @@ Three independent audits found the same agent-facing gaps:
   schema contracts.
 - Passed markdown/payload round-trip, per-IDE availability, Maven/Gradle first-open import, and the changed
   type-hierarchy Kotlin block against IDEA stable and IDEA 2026.2 EAP.
-- Passed `:test-experiments:compileTestKotlin`, workflow helper tests, and the task-prompt purity method.
+- Passed `:test-experiments:compileTestKotlin`, workflow helper tests, the task-prompt purity method, and
+  the implementing-class scoring/final-marker rejection regressions.
 - Passed the live Claude task-only Docker scenario in 7m53s. Claude autonomously discovered the empty
   backend state, listed downloads, installed IU 2026.2.0.1, relied on `steroid_open_project` auto-start,
   routed the project without a frontend, triggered and awaited Maven import for 136 modules, then found
@@ -86,6 +92,10 @@ Three independent audits found the same agent-facing gaps:
   answer contained the intended 70 named classes, and every backend/process assertion and teardown passed.
 - Independent reviews completed with the repository subagent quorum, `run-agent.sh` Codex, Claude Opus 5,
   and Claude Fable 5. Their findings were iterated into the current wording and assertions.
+- The final adversarial review explicitly remains no-go for claiming the whole Claude-and-Codex goal
+  complete until a real Codex task-only Docker run passes; model reviews are not treated as runtime proof.
+- The post-rebase matrix passed the focused server and devrig contracts, 16 prompt tests (including both
+  type-hierarchy KtBlock cases), and eight pure experiment methods with zero failures, errors, or skips.
 
 ## Claude iteration findings
 
@@ -101,7 +111,7 @@ concrete classes, and anonymous/local classes together. The hierarchy article no
 reports unnamed counts separately, and keeps abstract classes unless the task requests concrete-only
 implementations. The fetch-resource routing description uses the exhaustive wording “every direct +
 transitive subtype / implementor.” The E2E score now removes the base/sub-interface types from its class
-count and rejects either known sub-interface in final `SUBTYPE:` markers.
+count and rejects the base interface or either known sub-interface in final `SUBTYPE:` markers.
 
 The second reflection also suggested documenting stdout/stderr separation for `devrig backend download
 --json`. That suggestion was not adopted: the transcript shows the agent explicitly merged the streams

--- a/docs/headless-agent-guidance.md
+++ b/docs/headless-agent-guidance.md
@@ -68,7 +68,7 @@ Three independent audits found the same agent-facing gaps:
 - [x] Reconcile the branch with current `origin/main` and preserve the new generated-CLI contracts while
   resolving conflicts.
 - [x] Rerun the focused post-rebase server, devrig, prompt/KtBlock, and pure experiment validation.
-- [ ] Push the rebased branch and update PR #441 and its CI status.
+- [x] Push the rebased branch, update PR #441, and obtain green compile plus Linux/Windows installer checks.
 
 ## Validation status
 
@@ -96,6 +96,8 @@ Three independent audits found the same agent-facing gaps:
   complete until a real Codex task-only Docker run passes; model reviews are not treated as runtime proof.
 - The post-rebase matrix passed the focused server and devrig contracts, 16 prompt tests (including both
   type-hierarchy KtBlock cases), and eight pure experiment methods with zero failures, errors, or skips.
+- PR #441 is mergeable and its compile, Linux PowerShell Docker, and Windows PowerShell checks passed on
+  the rebased branch head.
 - File-scoped IDE inspections ran on every changed production Kotlin file. They found no actionable
   changed-line diagnostic, but the `OpenProjectTool.kt` check is not called clean: two Kotlin/UAST
   inspections crashed on `KtFakeSourceElementKind.PluginGenerated`, so `failedTools` correctly made it

--- a/ij-plugin/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/OpenProjectToolHandler.kt
+++ b/ij-plugin/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/OpenProjectToolHandler.kt
@@ -80,7 +80,7 @@ class OpenProjectToolHandlerIJ : OpenProjectToolHandler {
                 }
             }
 
-            builder.addTextContent(VERIFICATION_WORKFLOW)
+            builder.addTextContent(OPEN_PROJECT_VERIFICATION_WORKFLOW)
             if (!openProjectParams.trustProject) {
                 builder.addTextContent(
                     """
@@ -100,21 +100,3 @@ class OpenProjectToolHandlerIJ : OpenProjectToolHandler {
         return builder.build()
     }
 }
-
-private val VERIFICATION_WORKFLOW = """
-    Project opening initiated. The process runs in the background.
-
-    IMPORTANT: You MUST poll to verify the project is ready before using it.
-
-    VERIFICATION WORKFLOW:
-    1. Poll the window list every 2-3 seconds until:
-       - The project appears in the windows list
-       - modalDialogShowing is false
-       - indexingInProgress is false
-       - projectInitialized is true
-    2. If modalDialogShowing is true:
-       - Capture a screenshot to see the dialog
-       - Use the input tool or command to interact with the dialog
-    3. Capture a screenshot to visually confirm project is loaded
-    4. Verify with the project list that the project appears
-""".trimIndent()

--- a/mcp-steroid-server/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/FetchResourceToolHandler.kt
+++ b/mcp-steroid-server/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/FetchResourceToolHandler.kt
@@ -15,9 +15,13 @@ import com.jonnyzzz.mcpSteroid.mcp.string
 import com.jonnyzzz.mcpSteroid.prompts.generated.ResourcesIndex
 import com.jonnyzzz.mcpSteroid.prompts.generated.ide.FindDuplicatesPromptArticle
 import com.jonnyzzz.mcpSteroid.prompts.generated.ide.InspectAndFixPromptArticle
+import com.jonnyzzz.mcpSteroid.prompts.generated.ide.TypeHierarchyPromptArticle
+import com.jonnyzzz.mcpSteroid.prompts.generated.openProject.ManagingBackendsPromptArticle
 import com.jonnyzzz.mcpSteroid.prompts.generated.prompt.DebuggerSkillPromptArticle
 import com.jonnyzzz.mcpSteroid.prompts.generated.prompt.SkillPromptArticle
 import com.jonnyzzz.mcpSteroid.prompts.generated.prompt.TestSkillPromptArticle
+import com.jonnyzzz.mcpSteroid.prompts.generated.skill.ExecuteCodeGradlePromptArticle
+import com.jonnyzzz.mcpSteroid.prompts.generated.skill.ExecuteCodeMavenPromptArticle
 import com.jonnyzzz.mcpSteroid.prompts.generated.skill.CodingWithIntelliJPromptArticle
 import com.jonnyzzz.mcpSteroid.thisLogger
 
@@ -44,11 +48,18 @@ class FetchResourceToolHandler(
         val codingGuideUri = CodingWithIntelliJPromptArticle().uri
         val findDuplicatesUri = FindDuplicatesPromptArticle().uri
         val inspectAndFixUri = InspectAndFixPromptArticle().uri
+        val typeHierarchyUri = TypeHierarchyPromptArticle().uri
+        val managingBackendsUri = ManagingBackendsPromptArticle().uri
+        val executeCodeMavenUri = ExecuteCodeMavenPromptArticle().uri
+        val executeCodeGradleUri = ExecuteCodeGradlePromptArticle().uri
         return "Fetch a mcp-steroid:// skill guide by URI. Returns markdown with copy-paste Kotlin code recipes for steroid_execute_code. " +
                 "Running tests? → $testSkillUri | " +
                 "Debugging? → $debuggerUri | " +
                 "Find duplicates / clones / copy-pasted code / DRY violations? → $findDuplicatesUri (copy ONLY the 'Primary recipe — PSI body comparison' block; the Cross-check inspection path silently returns 0 clusters in fresh sessions) | " +
                 "Run a named inspection + quick fix? → $inspectAndFixUri | " +
+                "Find direct + indirect subtypes / implementors? → $typeHierarchyUri | " +
+                "First Maven/Gradle open or missing build model? → $executeCodeMavenUri / $executeCodeGradleUri | " +
+                "Managed backend lifecycle after opening a project? → $managingBackendsUri | " +
                 "Any IDE task? → $skillUri | " +
                 "Full reference? → $codingGuideUri"
     }
@@ -57,7 +68,8 @@ class FetchResourceToolHandler(
     override val cliAliases = listOf("prompt")
 
     val uri = InputSchemaElement.param("uri")
-        .description("The mcp-steroid:// URI to fetch (see the tool description for the canonical entry points, or fetch mcp-steroid://prompt/skill for the index)")
+        .description("The mcp-steroid:// URI to fetch (see the tool description for canonical entry points, " +
+            "or fetch ${SkillPromptArticle().uri} for the index)")
         .cliSynopsis("mcp-steroid:// resource URI to fetch")
         .cliMissingHint("missing --uri. Example:\n  devrig fetch_resource --uri=${SkillPromptArticle().uri}")
         .string()

--- a/mcp-steroid-server/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/FetchResourceToolHandler.kt
+++ b/mcp-steroid-server/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/FetchResourceToolHandler.kt
@@ -57,7 +57,7 @@ class FetchResourceToolHandler(
                 "Debugging? → $debuggerUri | " +
                 "Find duplicates / clones / copy-pasted code / DRY violations? → $findDuplicatesUri (copy ONLY the 'Primary recipe — PSI body comparison' block; the Cross-check inspection path silently returns 0 clusters in fresh sessions) | " +
                 "Run a named inspection + quick fix? → $inspectAndFixUri | " +
-                "Find direct + indirect subtypes / implementors? → $typeHierarchyUri | " +
+                "Find every direct + transitive subtype / implementor? → $typeHierarchyUri | " +
                 "First Maven/Gradle open or missing build model? → $executeCodeMavenUri / $executeCodeGradleUri | " +
                 "Managed backend lifecycle after opening a project? → $managingBackendsUri | " +
                 "Any IDE task? → $skillUri | " +

--- a/mcp-steroid-server/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/ListProjectsTool.kt
+++ b/mcp-steroid-server/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/ListProjectsTool.kt
@@ -13,7 +13,7 @@ import kotlinx.serialization.Serializable
  */
 class ListProjectsToolSpec(val handler: () -> ListProjectsToolHandler) : McpToolBase() {
     override val name = "steroid_list_projects"
-    override val description = "List all open projects in the IDE. Each entry has `project_name` (a unique routing key — pass it to steroid_execute_code and the other project-scoped tools) and `name` (the raw folder name, informational only); they are not equal. Resolve an entry's `backend_name` to the owning IDE's identity (`intellij` = `{name, version, build}`) via the `backends` lookup in the same response."
+    override val description = "List all open projects in the IDE. Each entry has `project_name` (a unique routing key — pass it to steroid_execute_code and the other project-scoped tools) and `name` (the raw folder name, informational only); they are not equal. Resolve an entry's `backend_name` to the owning IDE's identity (`intellij` = `{name, version, build}`) via the `backends` lookup in the same response. An empty devrig response means no project is routed yet, not that the IDE capability is unavailable: follow the server instructions (`devrig backend download --json` on a clean machine), then call steroid_open_project and poll this tool for the path."
     override val cliSynopsis = "list open projects and their routing keys"
 
     override suspend fun call(context: ToolCallContext): ToolCallResult {

--- a/mcp-steroid-server/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/McpSteroidTools.kt
+++ b/mcp-steroid-server/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/McpSteroidTools.kt
@@ -8,8 +8,9 @@ abstract class McpSteroidTools {
      * Registers the tools common to every backend surface.
      *
      * `steroid_open_project` is intentionally NOT registered here: its spec differs per surface
-     * (the in-IDE plugin advertises no `backend_name`, devrig advertises a required `backend_name`
-     * routing param). Each caller registers its own `OpenProjectToolSpec(...)` after this call,
+     * (the in-IDE plugin advertises no `backend_name`, devrig advertises an optional `backend_name`
+     * routing param for disambiguating multiple candidates). Each caller registers its own
+     * `OpenProjectToolSpec(...)` after this call,
      * using the public [handler] accessor to resolve the [OpenProjectToolHandler].
      */
     fun registerAll(server: McpServerCore) {

--- a/mcp-steroid-server/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/OpenProjectTool.kt
+++ b/mcp-steroid-server/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/OpenProjectTool.kt
@@ -194,3 +194,21 @@ interface OpenProjectToolHandler {
         callProgress: McpProgressReporter,
     ): ToolCallResult
 }
+
+val OPEN_PROJECT_VERIFICATION_WORKFLOW = """
+    Project opening initiated. The process runs in the background.
+
+    READINESS WORKFLOW:
+    1. Poll steroid_list_projects every 2-3 seconds until the target path appears. Keep its opaque project_name
+       and pass that routing key to project-scoped tools.
+    2. A frontendless Remote Development backend has no frontend window to wait for or screenshot. The project
+       listing is the routing signal; continue without steroid_list_windows.
+    3. If a frontend window exists, steroid_list_windows is an additional signal.
+       While polling, when modalDialogShowing is true, use steroid_take_screenshot and steroid_input to handle that dialog.
+       After handling any modal, keep polling until the project appears, indexingInProgress is false, and
+       projectInitialized is true.
+    4. Project listing and window flags prove IDE reachability, not Maven/Gradle build-model readiness. On a first
+       Maven/Gradle open, fetch ${ExecuteCodeMavenPromptArticle().uri} or
+       ${ExecuteCodeGradlePromptArticle().uri}, trigger and await configuration exactly as that recipe shows
+       (the Maven recipe uses Observation.awaitConfiguration(project)), then run indexed queries in smartReadAction.
+""".trimIndent()

--- a/mcp-steroid-server/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/OpenProjectTool.kt
+++ b/mcp-steroid-server/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/OpenProjectTool.kt
@@ -14,6 +14,9 @@ import com.jonnyzzz.mcpSteroid.mcp.get
 import com.jonnyzzz.mcpSteroid.mcp.param
 import com.jonnyzzz.mcpSteroid.mcp.required
 import com.jonnyzzz.mcpSteroid.mcp.string
+import com.jonnyzzz.mcpSteroid.prompts.generated.openProject.ManagingBackendsPromptArticle
+import com.jonnyzzz.mcpSteroid.prompts.generated.skill.ExecuteCodeGradlePromptArticle
+import com.jonnyzzz.mcpSteroid.prompts.generated.skill.ExecuteCodeMavenPromptArticle
 import com.jonnyzzz.mcpSteroid.thisLogger
 import java.nio.file.Files
 import java.nio.file.Path
@@ -25,9 +28,10 @@ import kotlinx.serialization.Serializable
 /**
  * Handler for the steroid_open_project MCP tool.
  *
- * This tool initiates opening a project in IntelliJ. It does NOT wait for the project
- * to fully open - instead it returns quickly so the client can interact with any dialogs
- * that may appear (such as the trust project dialog) using screenshot/input tools.
+ * This tool initiates opening a project in IntelliJ. A devrig-managed backend cold start may
+ * block until MCP is reachable; after forwarding the request, it does NOT wait for the project
+ * to fully open. A frontend client can interact with dialogs that appear (such as the trust
+ * project dialog) using screenshot/input tools.
  *
  * The tool can optionally trust the project path before opening, which allows skipping
  * the trust dialog.
@@ -74,7 +78,7 @@ class OpenProjectToolSpec(
                     "managed IDE is started automatically; the call blocks until the IDE is reachable. " +
                     "PREFER the backend that already has the same project — or another git worktree of " +
                     "the same repository — open: worktrees share build/index/VCS context, avoiding " +
-                    "redundant indexing. See mcp-steroid://open-project/managing-backends."
+                    "redundant indexing. See ${ManagingBackendsPromptArticle().uri}."
             )
             .cliSynopsis("backend id from `devrig backend --json` to target")
             .string()
@@ -131,27 +135,27 @@ class OpenProjectToolSpec(
     }
 
     private companion object {
-        const val BASE_DESCRIPTION = """Open a project in the IDE. This tool initiates the project opening process and returns quickly.
+        val BASE_DESCRIPTION = """Open a project in the IDE. Starting a managed backend may block until its MCP endpoint is reachable; the project-open request itself remains asynchronous.
 
-IMPORTANT: Project opening is ASYNCHRONOUS. This tool returns immediately; you MUST poll to verify the project is fully ready before using it.
+IMPORTANT: Project opening is ASYNCHRONOUS. Verify routing and build-model readiness separately.
 
 Verification Workflow:
 1. Call steroid_open_project with the project path
-2. Poll steroid_list_windows repeatedly (every 2-3 seconds) until:
-   - The project appears in the windows list
-   - modalDialogShowing is false (no dialogs blocking)
-   - indexingInProgress is false (indexing complete)
-   - projectInitialized is true
-3. If modalDialogShowing is true, use steroid_take_screenshot + steroid_input to handle dialogs
-4. Use steroid_take_screenshot to visually confirm the project is fully loaded
-5. Verify with steroid_list_projects that the project appears
+2. Poll steroid_list_projects until the path appears; keep its opaque project_name for project-scoped calls
+3. If a frontend window exists, steroid_list_windows reports modal/indexing/initialized state. An
+   unattended Remote Development backend needs no frontend or screenshot; do not block semantic work on one
+4. Project listing and window flags prove IDE reachability, not Maven/Gradle model import. On a first
+   Maven/Gradle open, fetch `${ExecuteCodeMavenPromptArticle().uri}` or
+   `${ExecuteCodeGradlePromptArticle().uri}`, trigger and await configuration exactly as that recipe
+   shows (the Maven recipe uses Observation.awaitConfiguration(project)), then run indexed queries in
+   smartReadAction
 
 Dialog Handling:
 - If trust_project=true (default), the trust dialog is skipped automatically
-- Other dialogs (project type, SDK selection, etc.) may still appear
-- Always check modalDialogShowing in steroid_list_windows response"""
+- Other dialogs (project type, SDK selection, etc.) may still appear in a frontend IDE
+- When steroid_list_windows reports modalDialogShowing=true, use steroid_take_screenshot + steroid_input"""
 
-        const val BACKEND_NAME_DESCRIPTION = """Choosing a backend (multiple IDEs):
+        val BACKEND_NAME_DESCRIPTION = """Choosing a backend (multiple IDEs):
 This connection can route to more than one running IDE. Call steroid_open_project WITHOUT a backend_name
 first: if there are several candidates the tool returns them in the error message — pick one and retry
 with backend_name set. PREFER the backend that already has the same project — or a git worktree of
@@ -160,11 +164,14 @@ indexing. A startable (installed but not running) managed IDE is started automat
 the call blocks until the IDE is reachable.
 
 Managing backends from the agent:
-To list/provision/run backends, call the devrig CLI (the same devrig you run as your MCP server):
-`devrig backend` (list), `devrig backend download <id>`, `devrig backend start <id>`,
-`devrig backend stop <id>`, `devrig backend provision <id>`. Backend ids come from `devrig backend
---json`. devrig is on your PATH as `devrig` — just run it.
-See mcp-steroid://open-project/managing-backends."""
+On a clean machine, `devrig backend download --json` lists product ids with their latest stable versions.
+Install one with `devrig backend download <id> [--version <version>]`; for an unattended IDEA 2026.2
+Remote Development backend use `devrig backend download idea-ultimate --version <version>`. Then call
+steroid_open_project: when it is the sole installed candidate, the tool starts it automatically and waits
+until it is reachable. No separate start and no frontend window are required. `devrig backend start/stop`
+remain available for explicit lifecycle diagnostics; `devrig backend provision` updates a running IDE.
+devrig is on PATH as `devrig` — just run it.
+See ${ManagingBackendsPromptArticle().uri}."""
     }
 }
 

--- a/mcp-steroid-server/src/test/kotlin/com/jonnyzzz/mcpSteroid/server/FetchResourceToolHandlerSchemaTest.kt
+++ b/mcp-steroid-server/src/test/kotlin/com/jonnyzzz/mcpSteroid/server/FetchResourceToolHandlerSchemaTest.kt
@@ -1,6 +1,7 @@
 /* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
 package com.jonnyzzz.mcpSteroid.server
 
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 
 class FetchResourceToolHandlerSchemaTest {
@@ -13,5 +14,16 @@ class FetchResourceToolHandlerSchemaTest {
         assertRequiredExactly(schema, "uri", "project_name")
         assertStringProperty(schema, "uri")
         assertStringProperty(schema, "project_name")
+    }
+
+    @Test
+    fun `description routes exhaustive implementor work to type hierarchy`() {
+        val description = FetchResourceToolHandler { unreachableHandler() }.description
+
+        assertTrue(
+            "Find every direct + transitive subtype / implementor" in description,
+            "fetch-resource routing must make exhaustive hierarchy discovery explicit: $description",
+        )
+        assertTrue("mcp-steroid://ide/type-hierarchy" in description, description)
     }
 }

--- a/mcp-steroid-server/src/test/kotlin/com/jonnyzzz/mcpSteroid/server/OpenProjectToolSpecSchemaTest.kt
+++ b/mcp-steroid-server/src/test/kotlin/com/jonnyzzz/mcpSteroid/server/OpenProjectToolSpecSchemaTest.kt
@@ -57,4 +57,33 @@ class OpenProjectToolSpecSchemaTest {
             "frontend window polling cannot be mandatory for a Remote Development backend: $description",
         )
     }
+
+    @Test
+    fun `post-open result guidance works with or without a frontend`() {
+        val guidance = OPEN_PROJECT_VERIFICATION_WORKFLOW
+
+        for (fact in listOf(
+            "Poll steroid_list_projects",
+            "opaque project_name",
+            "no frontend window",
+            "Maven/Gradle",
+            "Observation.awaitConfiguration",
+            "smartReadAction",
+            "when modalDialogShowing is true",
+        )) {
+            assertTrue(fact in guidance, "post-open result guidance must mention '$fact': $guidance")
+        }
+        assertFalse(
+            guidance.contains("MUST poll") && guidance.contains("steroid_list_windows"),
+            "frontend window polling cannot be mandatory in the tool result: $guidance",
+        )
+        assertFalse(
+            guidance.contains("Use steroid_take_screenshot to visually confirm"),
+            "a frontendless Remote Development backend has nothing to screenshot: $guidance",
+        )
+        assertFalse(
+            "Only then use" in guidance,
+            "modal handling must happen while polling, not after modalDialogShowing becomes false: $guidance",
+        )
+    }
 }

--- a/mcp-steroid-server/src/test/kotlin/com/jonnyzzz/mcpSteroid/server/OpenProjectToolSpecSchemaTest.kt
+++ b/mcp-steroid-server/src/test/kotlin/com/jonnyzzz/mcpSteroid/server/OpenProjectToolSpecSchemaTest.kt
@@ -1,6 +1,8 @@
 /* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
 package com.jonnyzzz.mcpSteroid.server
 
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 
 class OpenProjectToolSpecSchemaTest {
@@ -28,5 +30,31 @@ class OpenProjectToolSpecSchemaTest {
         // automatically. The required set does NOT include backend_name.
         assertRequiredExactly(schema, "project_path", "task_id", "reason")
         assertStringProperty(schema, "backend_name")
+    }
+
+    @Test
+    fun `devrig description explains clean install auto-start and frontendless readiness`() {
+        val description = OpenProjectToolSpec(includeBackendName = true) { unreachableHandler() }.description
+
+        for (fact in listOf(
+            "devrig backend download --json",
+            "starts it automatically",
+            "Remote Development",
+            "no frontend",
+            "steroid_list_projects",
+            "Maven",
+            "Gradle",
+            "Observation.awaitConfiguration",
+            "smartReadAction",
+            "mcp-steroid://skill/execute-code-maven",
+            "mcp-steroid://skill/execute-code-gradle",
+            "latest stable",
+        )) {
+            assertTrue(fact in description, "open-project description must mention '$fact': $description")
+        }
+        assertFalse(
+            description.contains("MUST poll") && description.contains("steroid_list_windows"),
+            "frontend window polling cannot be mandatory for a Remote Development backend: $description",
+        )
     }
 }

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/BackendCommand.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/BackendCommand.kt
@@ -345,6 +345,7 @@ fun renderBackendOutput3(
 
     if (s1Compatible.isEmpty() && s1Incompatible.isEmpty() && s2.isEmpty() && s3.isEmpty()) {
         out.println(NO_BACKENDS_DETECTED_MESSAGE)
+        out.println("To discover and install an IDE: devrig backend download --json")
         out.println()
         return
     }

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/server/DevrigOpenProjectToolHandler.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/server/DevrigOpenProjectToolHandler.kt
@@ -53,7 +53,10 @@ private fun candidateList(candidates: List<BackendCandidate>): String {
     // Tool payloads are served verbatim to BOTH surfaces (MCP clients over `devrig mcp`, and the CLI,
     // which never rewrites tool output) — so this text must stay surface-neutral: naming either
     // `steroid_list_projects` or `devrig list_projects` would be wrong for the other reader.
-    if (candidates.isEmpty()) return "No candidates are currently available; start an IDE, or list the open projects to find a reachable backend."
+    if (candidates.isEmpty()) {
+        return "No candidates are currently available. Run devrig backend download --json to discover " +
+            "and install an IDE, then retry this open-project command."
+    }
     val items = candidates.joinToString("\n") { c ->
         val tag = if (c.startable != null) " (startable)" else ""
         "  ${c.backendName} — ${c.displayName}$tag"

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/server/DevrigServerInstructions.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/server/DevrigServerInstructions.kt
@@ -1,6 +1,9 @@
 /* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
 package com.jonnyzzz.mcpSteroid.devrig.server
 
+import com.jonnyzzz.mcpSteroid.prompts.generated.skill.ExecuteCodeGradlePromptArticle
+import com.jonnyzzz.mcpSteroid.prompts.generated.skill.ExecuteCodeMavenPromptArticle
+
 /**
  * The `instructions` devrig returns from `initialize` (jonnyzzz/mcp-steroid#417).
  *
@@ -13,11 +16,11 @@ package com.jonnyzzz.mcpSteroid.devrig.server
  * verbatim, so the capability statement belongs here.
  *
  * Keep it SHORT and navigational: it costs context on every session. State what the backend is,
- * name the tool prefix so the agent can search for it, and point at the two entry points
- * (`steroid_list_projects` to see what is reachable, `devrig backend` to provision one). Depth
- * stays in the tool descriptions and the `mcp-steroid://` article corpus.
+ * name the tool prefix so the agent can search for it, and carry the clean-machine bootstrap facts
+ * that are otherwise hidden behind deferred schemas and project-scoped articles. Depth stays in the
+ * tool descriptions and the `mcp-steroid://` article corpus.
  */
-const val DEVRIG_MCP_SERVER_INSTRUCTIONS = """This server hands you a real JetBrains IDE (IntelliJ IDEA, PyCharm, WebStorm, Rider, ...) as a
+val DEVRIG_MCP_SERVER_INSTRUCTIONS = """This server hands you a real JetBrains IDE (IntelliJ IDEA, PyCharm, WebStorm, Rider, ...) as a
 tool backend: the resolved project model, indexes, inspections, refactorings, run configurations,
 the debugger and the IDE UI. Prefer it over grep/find/sed for anything about code SEMANTICS —
 call hierarchies, subtypes, references, symbol resolution, rename/refactor, running or debugging.
@@ -29,9 +32,18 @@ them before you decide the IDE is unavailable.
 
 Start here:
 - steroid_list_projects - which IDEs and projects are reachable right now.
-- No IDE reachable? Provision one from the shell with the `devrig` binary that serves this MCP
-  server — it is on your PATH: `devrig backend` lists them,
-  `devrig backend download <id>` installs one, `devrig backend start <id>` runs it.
-- steroid_open_project opens a project in a backend; steroid_execute_code runs Kotlin against
-  the live IntelliJ API for everything the narrow tool surface does not cover.
+- No IDE reachable? The `devrig` binary serving this MCP is on PATH as `devrig` (installed at
+  `~/.mcp-steroid/bin/devrig`). `devrig backend download --json` lists product ids with their latest stable
+  versions; pass `--version <version>` to pin another released version. For unattended Java/JVM
+  work on 2026.2, install `devrig backend download idea-ultimate --version <version>`. The multi-GB
+  download is cached and resumable; rerun it after a shell timeout.
+- Then call steroid_open_project. It starts the sole installed backend automatically and waits until
+  the IDE is reachable. IDEA Ultimate 2026.2 runs as an unattended Remote Development backend with
+  MCP Steroid included; no frontend window is required.
+- Poll steroid_list_projects until the path appears and use its opaque project_name. On a first
+  Maven/Gradle open, project listing proves routing, not build-model import: fetch
+  `${ExecuteCodeMavenPromptArticle().uri}` or `${ExecuteCodeGradlePromptArticle().uri}`, trigger and
+  await external-system configuration exactly as the recipe shows, then run indexed semantic queries.
+- steroid_execute_code runs Kotlin against the live IntelliJ API for everything the narrow tool
+  surface does not cover.
 - steroid_fetch_resource returns the mcp-steroid:// article corpus - the recipes for that API."""

--- a/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/BackendCommandRenderTest.kt
+++ b/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/BackendCommandRenderTest.kt
@@ -89,11 +89,14 @@ class BackendCommandRenderTest {
     // ------------------------------ shape ---------------------------------
 
     @Test
-    fun `empty output starts with the no-backends message`() {
+    fun `empty output points agents at product discovery`() {
         val text = render()
         val lines = text.lines()
         assertEquals("No backends detected.", lines[0])
-        assertEquals("", lines[1])
+        assertTrue(
+            text.contains("devrig backend download --json"),
+            "a clean machine must explain how to list downloadable IDEs; got:\n$text",
+        )
     }
 
     @Test
@@ -112,12 +115,11 @@ class BackendCommandRenderTest {
     }
 
     @Test
-    fun `empty inputs prints the no-backends message + trailing blank`() {
+    fun `empty inputs print the no-backends message and actionable download hint`() {
         val text = render()
         assertTrue(text.contains("No backends detected."), "missing message; got:\n$text")
-        val lines = text.lines()
-        assertEquals("No backends detected.", lines[0])
-        assertEquals("", lines[1])
+        assertTrue(text.contains("devrig backend download --json"), "missing clean-machine hint; got:\n$text")
+        assertTrue(text.endsWith("\n\n"), "empty output must retain its trailing blank line; got:\n$text")
     }
 
     // --------------------- S1: MCP Steroid backends -----------------------

--- a/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/server/DevrigServerInstructionsTest.kt
+++ b/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/server/DevrigServerInstructionsTest.kt
@@ -44,17 +44,35 @@ class DevrigServerInstructionsTest {
     }
 
     @Test
-    fun `the capability statement names the tool prefix and the IDE provisioning commands`(
+    fun `the capability statement explains the autonomous clean-machine route`(
         @TempDir tempDir: Path,
     ) {
         val instructions = runDevrigMcp(tempDir).initializeResult["instructions"]?.jsonPrimitive?.contentOrNull
             ?: error("initialize result has no instructions")
 
-        // The two facts an agent cannot discover any other way before loading a schema: the tool
-        // name prefix to search for, and how to get an IDE when none is running.
-        for (fact in listOf("steroid_", "devrig backend download", "devrig backend start")) {
+        // These facts are unreachable from deferred tool schemas and project-scoped articles when no
+        // IDE is installed. Initialization must carry the complete bootstrap route itself.
+        for (fact in listOf(
+            "steroid_",
+            "devrig backend download --json",
+            "idea-ultimate",
+            "2026.2",
+            "Remote Development",
+            "no frontend",
+            "starts the sole installed backend automatically",
+            "mcp-steroid://skill/execute-code-maven",
+            "mcp-steroid://skill/execute-code-gradle",
+            "~/.mcp-steroid/bin/devrig",
+            "latest stable",
+            "cached and resumable",
+            "trigger and",
+        )) {
             assertTrue(fact in instructions, "capability statement must mention '$fact': $instructions")
         }
+        assertTrue(
+            "devrig backend start" !in instructions,
+            "capability statement must present open_project auto-start as the default: $instructions",
+        )
     }
 
     @Test

--- a/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/server/DevrigToolBridgeClientTest.kt
+++ b/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/server/DevrigToolBridgeClientTest.kt
@@ -344,6 +344,9 @@ class DevrigToolBridgeClientTest {
         )
 
         assertEquals(true, result.isError)
+        val message = result.errorText()
+        assertTrue(message.contains("devrig backend download --json"), message)
+        assertTrue(message.contains("retry steroid_open_project"), message)
         // No bridge call was made.
         assertEquals(null, receivedAuth)
         assertEquals(null, receivedBody)

--- a/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/server/DevrigToolBridgeClientTest.kt
+++ b/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/server/DevrigToolBridgeClientTest.kt
@@ -346,7 +346,8 @@ class DevrigToolBridgeClientTest {
         assertEquals(true, result.isError)
         val message = result.errorText()
         assertTrue(message.contains("devrig backend download --json"), message)
-        assertTrue(message.contains("retry steroid_open_project"), message)
+        assertTrue(message.contains("retry this open-project command"), message)
+        assertTrue("steroid_open_project" !in message, message)
         // No bridge call was made.
         assertEquals(null, receivedAuth)
         assertEquals(null, receivedBody)

--- a/prompts/src/main/prompts/ide/type-hierarchy.md
+++ b/prompts/src/main/prompts/ide/type-hierarchy.md
@@ -1,6 +1,18 @@
 IDE: Type Hierarchy (Supertypes and Subtypes)
-[IU]
+[AI,IC,IU]
 Walks the supertype DAG and subtype tree of a class via PSI — the same APIs IntelliJ's Type Hierarchy view (Ctrl+H) uses. Project-scope subtypes; no lambdas.
+
+**First-open readiness:** on a newly opened Maven or Gradle project, window
+flags and `steroid_list_projects` can become ready before the external project
+model is imported. Fetch `mcp-steroid://skill/execute-code-maven` or
+`mcp-steroid://skill/execute-code-gradle`, trigger and await configuration exactly
+as that recipe shows (the Maven recipe uses `Observation.awaitConfiguration(project)`),
+then run this indexed query in `smartReadAction`. An unexpectedly tiny first
+hierarchy is an import-readiness failure, not an exhaustive result.
+
+The example caps output at 500 only to protect the response. For an exhaustive
+task, raise the cap as needed and fail/report `subsTruncated=true`; never present
+a truncated list as complete.
 
 ```kotlin
 import com.intellij.psi.CommonClassNames
@@ -17,13 +29,19 @@ data class TypeHierarchy(
 
 // Configuration - modify these for your use case
 val classFqn = "com.example.BaseType" // TODO: Set the class FQN
-val maxSubtypes = 50
+val maxSubtypes = 500
 
 val hierarchy = smartReadAction {
     val scope = projectScope()
     val baseClass = JavaPsiFacade.getInstance(project)
         .findClass(classFqn, GlobalSearchScope.allScope(project))
         ?: return@smartReadAction null
+
+    // Canonical exhaustive subtype query. The direct searches below reconstruct
+    // tree depth; this set proves that traversal did not silently miss a branch.
+    val expectedSubtypeFqns = ClassInheritorsSearch.search(baseClass, scope, true)
+        .findAll()
+        .mapNotNullTo(HashSet<String>()) { it.qualifiedName }
 
     val supers = mutableListOf<TypeHierarchyEntry>()
     val seenSupers = HashSet<String>()
@@ -58,6 +76,9 @@ val hierarchy = smartReadAction {
         }
     }
     walkSubs(baseClass, 1)
+    check(truncated || seenSubs.containsAll(expectedSubtypeFqns)) {
+        "Subtype traversal missed: " + (expectedSubtypeFqns - seenSubs).sorted().joinToString()
+    }
 
     TypeHierarchy(
         baseClass.qualifiedName ?: baseClass.name ?: classFqn,

--- a/prompts/src/main/prompts/ide/type-hierarchy.md
+++ b/prompts/src/main/prompts/ide/type-hierarchy.md
@@ -14,17 +14,36 @@ The example caps output at 500 only to protect the response. For an exhaustive
 task, raise the cap as needed and fail/report `subsTruncated=true`; never present
 a truncated list as complete.
 
+`ClassInheritorsSearch.search(base, scope, checkDeep=true)` crosses the whole graph
+from an interface, through sub-interfaces, to implementing classes. It returns every inheriting `PsiClass`,
+which mixes sub-interfaces, abstract classes, concrete classes, and possibly
+anonymous/local classes whose `qualifiedName` is null. Match the user's noun:
+for "classes that implement" exclude `isInterface`, but keep abstract classes
+unless the user explicitly asks only for concrete implementations. The recipe
+classifies named results and reports the unnamed count separately instead of
+silently presenting a named-only list as the whole raw search result.
+
 ```kotlin
 import com.intellij.psi.CommonClassNames
+import com.intellij.psi.PsiModifier
 import com.intellij.psi.search.GlobalSearchScope
 import com.intellij.psi.search.searches.ClassInheritorsSearch
 
-data class TypeHierarchyEntry(val depth: Int, val fqn: String)
+data class TypeHierarchyEntry(val depth: Int, val fqn: String, val kind: String)
+data class SubtypeCounts(
+    val total: Int,
+    val named: Int,
+    val unnamed: Int,
+    val subInterfaces: Int,
+    val abstractClasses: Int,
+    val concreteClasses: Int,
+)
 data class TypeHierarchy(
     val base: String,
     val supers: List<TypeHierarchyEntry>,
     val subs: List<TypeHierarchyEntry>,
     val subsTruncated: Boolean,
+    val subtypeCounts: SubtypeCounts,
 )
 
 // Configuration - modify these for your use case
@@ -39,9 +58,22 @@ val hierarchy = smartReadAction {
 
     // Canonical exhaustive subtype query. The direct searches below reconstruct
     // tree depth; this set proves that traversal did not silently miss a branch.
-    val expectedSubtypeFqns = ClassInheritorsSearch.search(baseClass, scope, true)
-        .findAll()
-        .mapNotNullTo(HashSet<String>()) { it.qualifiedName }
+    val expectedSubtypes = ClassInheritorsSearch.search(baseClass, scope, true).findAll()
+    val expectedSubtypeFqns = expectedSubtypes.mapNotNullTo(HashSet<String>()) { it.qualifiedName }
+    val namedImplementingClasses = expectedSubtypes.filter { it.qualifiedName != null && !it.isInterface }
+    val subtypeCounts = SubtypeCounts(
+        total = expectedSubtypes.size,
+        named = expectedSubtypeFqns.size,
+        unnamed = expectedSubtypes.count { it.qualifiedName == null },
+        subInterfaces = expectedSubtypes.count { it.qualifiedName != null && it.isInterface },
+        abstractClasses = namedImplementingClasses.count { it.hasModifierProperty(PsiModifier.ABSTRACT) },
+        concreteClasses = namedImplementingClasses.count { !it.hasModifierProperty(PsiModifier.ABSTRACT) },
+    )
+    fun kindOf(cls: PsiClass) = when {
+        cls.isInterface -> "interface"
+        cls.hasModifierProperty(PsiModifier.ABSTRACT) -> "abstract class"
+        else -> "concrete class"
+    }
 
     val supers = mutableListOf<TypeHierarchyEntry>()
     val seenSupers = HashSet<String>()
@@ -52,7 +84,7 @@ val hierarchy = smartReadAction {
             if (baseClass.isInterface && parent.qualifiedName == CommonClassNames.JAVA_LANG_OBJECT) continue
             val fqn = parent.qualifiedName ?: parent.name ?: continue
             if (!seenSupers.add(fqn)) continue
-            supers += TypeHierarchyEntry(depth, fqn)
+            supers += TypeHierarchyEntry(depth, fqn, kindOf(parent))
             walkSupers(parent, depth + 1)
         }
     }
@@ -69,9 +101,11 @@ val hierarchy = smartReadAction {
                 truncated = true
                 return
             }
-            val fqn = child.qualifiedName ?: child.name ?: continue
+            // The public result is FQN-based. Anonymous/local classes have no qualifiedName;
+            // subtypeCounts.unnamed makes that omission explicit.
+            val fqn = child.qualifiedName ?: continue
             if (!seenSubs.add(fqn)) continue
-            subs += TypeHierarchyEntry(depth, fqn)
+            subs += TypeHierarchyEntry(depth, fqn, kindOf(child))
             walkSubs(child, depth + 1)
         }
     }
@@ -85,6 +119,7 @@ val hierarchy = smartReadAction {
         supers,
         subs,
         truncated,
+        subtypeCounts,
     )
 }
 
@@ -100,7 +135,7 @@ if (hierarchy.supers.isEmpty()) {
     println("  (none — top of hierarchy)")
 } else {
     for (entry in hierarchy.supers) {
-        println("  " + "  ".repeat(entry.depth - 1) + "^ " + entry.fqn)
+        println("  " + "  ".repeat(entry.depth - 1) + "^ [${entry.kind}] " + entry.fqn)
     }
 }
 println()
@@ -110,9 +145,14 @@ if (hierarchy.subs.isEmpty()) {
     println("  (none — no inheritors found)")
 } else {
     for (entry in hierarchy.subs) {
-        println("  " + "  ".repeat(entry.depth - 1) + "v " + entry.fqn)
+        println("  " + "  ".repeat(entry.depth - 1) + "v [${entry.kind}] " + entry.fqn)
     }
 }
+println()
+val counts = hierarchy.subtypeCounts
+println("Raw subtype search: total=${counts.total}, named=${counts.named}, anonymous/local=${counts.unnamed}")
+println("Named categories: sub-interfaces=${counts.subInterfaces}, " +
+    "abstract implementing classes=${counts.abstractClasses}, concrete implementing classes=${counts.concreteClasses}")
 ```
 
 # See also

--- a/prompts/src/main/prompts/mcp-steroid-info.md
+++ b/prompts/src/main/prompts/mcp-steroid-info.md
@@ -2,21 +2,29 @@ MCP Steroid — a drop-in replacement for LSP that gives you full IntelliJ IDE c
 
 **To see, inspect, or control the IntelliJ IDEA IDE, you MUST use the `steroid_*` MCP tools** —
 `steroid_list_projects`, `steroid_execute_code`, `steroid_list_windows`, `steroid_take_screenshot`,
-`steroid_fetch_resource`, and friends. These tools *are* your access to the IDE: the IntelliJ IDE is
-running and connected for you right now. If the `steroid_*` tools are **not visible** in your tool list,
+`steroid_fetch_resource`, and friends. These tools *are* your access to the IDE: an IDE may already be
+connected, or devrig can provision and start one for you. If the `steroid_*` tools are **not visible** in your tool list,
 your client has **deferred their schemas** (Claude Code does this) — load them with `ToolSearch` (or your
 client's equivalent) **before you answer**. **Never report that you have "no IDE access", and never fall
 back to the shell or to `Read`/`Grep`/`Edit`, until you have loaded the `steroid_*` tools and actually
-tried them** — the IDE is there; the tools just need loading first.
+tried them** — the capability is configured; its schemas or managed backend may still need loading.
 
-This is a **STATEFUL** API — every call changes the IDE state. The IntelliJ IDE is running exclusively for you. Use it aggressively instead of manual file operations or shell commands.
+This is a **STATEFUL** API — once connected, every call changes the IDE state. Use the IntelliJ backend aggressively instead of manual file operations or shell commands.
 
 **File edits: always through MCP Steroid, even when Edit looks cheaper on tokens.** The native `Edit` tool writes to disk bypassing IntelliJ. VFS + PSI + search indices go stale, and the next semantic operation (find-references, rename, hierarchy search, inspections) returns inconsistent results until something forces a refresh. The 5-line `VfsUtil.saveText` recipe in `steroid_execute_code`'s tool description reads+writes in one call with auto-refresh; its 1.5–2.5× token overhead is cheaper than the debugging turns you spend when PSI disagrees with disk. This applies to every edit size, including 1–3 line changes.
 
 **Getting started:**
 1. Call `steroid_list_projects` to see what's open — route every project-scoped call by the `project_name` it returns (the unique, opaque key), never by the human-readable `name`; to map a file/dir path to a project, pick the one whose `path` is the longest prefix of your target path
-2. Use `steroid_fetch_resource` to read the `mcp-steroid://` skill guide for your task
-3. Use `steroid_execute_code` for any IDE automation task (including every file edit). The call
+2. On a clean devrig connection, if no project/IDE is reachable, run `devrig backend download --json`,
+   install the required product, then call `steroid_open_project`; it auto-starts a sole installed backend. For
+   unattended Java/JVM work on 2026.2 use IDEA Ultimate with a pinned 2026.2 version, which runs as a
+   frontendless Remote Development backend. No separate start or frontend window is required.
+3. Poll `steroid_list_projects` until the path appears and use its fresh `project_name`. On first
+   Maven/Gradle open, fetch `mcp-steroid://skill/execute-code-maven` or
+   `mcp-steroid://skill/execute-code-gradle`, then trigger and await external-system configuration exactly
+   as that recipe shows before indexed queries.
+4. Use `steroid_fetch_resource` to read the `mcp-steroid://` skill guide for your task
+5. Use `steroid_execute_code` for any IDE automation task (including every file edit). The call
    returns an `execution_id` header plus ONLY what the script explicitly prints (`println` /
    `printJson`) — the last expression's value is ignored by the runtime, so print everything
    you need to see

--- a/prompts/src/main/prompts/open-project/managing-backends.md
+++ b/prompts/src/main/prompts/open-project/managing-backends.md
@@ -8,6 +8,29 @@ Use this recipe when you need to open a project in a **specific
 product/version** (Rider for .NET, GoLand for Go, a particular build,
 etc.) or in a **not-yet-running IDE**.
 
+## Clean machine: install, then open
+
+If no IDE is installed or reachable, use the devrig binary on your PATH:
+
+```
+devrig backend download --json
+devrig backend download <product-id> --version <version>
+```
+
+The first command lists downloadable product ids with each product's latest stable
+version, build, and license tier; pass `--version <version>` to pin another released
+version. For unattended Java/JVM work on the supported 2026.2 line, choose
+`devrig backend download idea-ultimate --version <version>`. IDEA Ultimate
+262 is launched as a **frontendless Remote Development backend** with MCP
+Steroid included; plain AWT headless mode is a different, unsupported mode.
+
+After the download, call `steroid_open_project` with the project path. When
+the installed backend is the sole candidate, omit `backend_name`: devrig
+selects it, starts it, waits until its MCP endpoint is reachable, and sends
+the open request. Do not run `devrig backend start` first unless you are
+explicitly diagnosing lifecycle behavior. No frontend window or screenshot
+is required for semantic IDE work.
+
 ## How `steroid_open_project` resolves a backend
 
 When you call `steroid_open_project` through the devrig stdio MCP
@@ -25,7 +48,8 @@ server, devrig composes two candidate sources:
 **Without `backend_name`**: if exactly one candidate exists across S1
 and S3, `open_project` uses it automatically. If more than one
 candidate exists, it returns the list grouped by kind and asks you to
-call again with a chosen `backend_name`.
+call again with a chosen `backend_name`. A sole S3 candidate is started
+automatically.
 
 **With `backend_name`**: devrig resolves the name to a candidate. If
 the candidate is a startable managed backend, devrig **starts the IDE
@@ -102,7 +126,8 @@ explicitly control lifecycle. It is **not a prerequisite** to
 `open_project` — if the IDE you need is already installed (even if
 not running), `open_project` can start it.
 
-- `devrig backend` — shows four groups:
+- `devrig backend` — shows the current running/installed inventory. On a
+  completely clean machine it points to `devrig backend download --json`:
   - **MCP Steroid backends** (running, compatible) — you can open
     projects here now.
   - **Other IDEs (incompatible or no MCP Steroid)** — running IDEs with
@@ -113,29 +138,48 @@ not running), `open_project` can start it.
   - **Downloadable** — not listed individually; the footer points at the
     full-cycle install command `devrig backend download <product>`, which
     downloads + installs an IDE so it becomes startable.
-- `devrig backend --json` — machine-readable:
+- `devrig backend --json` — machine-readable current inventory:
   `{ tool, mcpSteroidBackends[], otherIdes[], startableBackends[] }`;
   each entry carries `compatible: <bool>`.
+- `devrig backend download --json` — list downloadable product ids and
+  versions on a clean machine.
 - `devrig backend download <id>` — fetch + install an IDE (may take
   minutes; cached and resumable). This is the full install cycle — the
   IDE then appears as startable.
 - `devrig backend start <id>` / `devrig backend stop <id>` — explicit
   lifecycle control.
 
-The `<id>` values appear in `devrig backend --json`.
+Download `<id>` values appear in `devrig backend download --json`.
 
 ## After opening — polling for readiness
 
-`steroid_open_project` returns once the project-open request is
-accepted. The project is not fully ready until indexing finishes:
+`steroid_open_project` has two distinct readiness phases:
 
-1. Poll `steroid_list_windows` every 2-3 seconds until:
+1. **Backend reachability.** For a startable backend, the call blocks until
+   devrig observes its MCP marker. A frontendless Remote Development backend
+   does not need a window or screenshot.
+2. **Project/model readiness.** The IDE accepts the open request
+   asynchronously. Poll `steroid_list_projects` until the target path appears
+   and keep the returned opaque `project_name`.
+
+If a frontend window exists, `steroid_list_windows` is an additional signal:
+
+1. Poll it every 2-3 seconds until:
    - The project appears in the list.
    - `modalDialogShowing` is `false`.
    - `indexingInProgress` is `false`.
    - `projectInitialized` is `true`.
 2. If `modalDialogShowing` is `true`, call `steroid_take_screenshot`
    to see the dialog and `steroid_input` to interact.
+
+These four flags describe IDE/window state, **not Maven or Gradle model
+import**. On a first open, they can become ready before external-system
+configuration begins. Before an indexed semantic query, fetch the matching
+`mcp-steroid://skill/execute-code-maven` or
+`mcp-steroid://skill/execute-code-gradle` recipe, trigger and await sync exactly
+as it shows (the Maven recipe uses `Observation.awaitConfiguration(project)`),
+and run index-dependent work in `smartReadAction`. Treat an unexpectedly tiny first result as incomplete
+project configuration, not as an exhaustive semantic answer.
 
 When several IDEs are running, each `windows[]` / `backgroundTasks[]`
 entry carries a `backend_name` — use it to track the right IDE.

--- a/prompts/src/main/prompts/open-project/open-trusted.md
+++ b/prompts/src/main/prompts/open-project/open-trusted.md
@@ -34,10 +34,15 @@ The tool will:
 
 ### Step 2: Wait for Project to Load
 
-Wait 2-5 seconds for the project to initialize. The time depends on:
+Poll `steroid_list_projects` until the target path appears. Backend startup, first open, and indexing can
+take minutes; a fixed sleep is not a readiness check. The time depends on:
 - Project size
 - Number of files to index
 - Installed plugins
+
+Keep the fresh opaque `project_name` returned for that path. If a frontend exists, `steroid_list_windows`
+can additionally report IDE indexing and modal state. A frontendless Remote Development backend needs no
+window or screenshot.
 
 ### Step 3: Verify Project is Open
 
@@ -73,7 +78,10 @@ identity (`intellij` = `{name, version, build}`) — see
 
 ### Step 4: Start Working
 
-Now you can use `steroid_execute_code` with the project:
+On a first Maven/Gradle open, fetch `mcp-steroid://skill/execute-code-maven` or
+`mcp-steroid://skill/execute-code-gradle`, then trigger and await configuration exactly as that recipe
+shows before indexed semantic queries. Then use
+`steroid_execute_code` with the fresh project routing key:
 
 ```kotlin
 val executeCodeJson = """
@@ -96,7 +104,7 @@ println(executeCodeJson)
 → steroid_open_project(project_path="/Users/me/projects/my-app", task_id="open-app", reason="Opening to add feature", trust_project=true)
 ← Project opening initiated...
 
-→ [wait 3 seconds]
+→ [poll until the path appears]
 
 → steroid_list_projects()
 ← {"projects":[{"project_name":"my-app-9fk2a0xq","name":"my-app","path":"/Users/me/projects/my-app","backend_name":"iu-9fk2a0xq"}],
@@ -129,7 +137,7 @@ Related project opening examples:
 Related MCP tools:
 - `steroid_open_project` - Tool for opening projects via MCP
 - `steroid_list_projects` - List all open projects
-- `steroid_list_windows` - Check project initialization status
+- `steroid_list_windows` - Optional frontend IDE/index/modal status
 
 Overview resources:
 - [Open Project Examples Overview](mcp-steroid://open-project/overview) - All project opening workflows

--- a/prompts/src/main/prompts/open-project/open-with-dialogs.md
+++ b/prompts/src/main/prompts/open-project/open-with-dialogs.md
@@ -6,6 +6,9 @@ Open a project and handle dialogs interactively.
 
 Open a project and interactively handle any dialogs that appear.
 
+Use this only when the selected IDE has a frontend. An unattended Remote Development backend needs no
+frontend or screenshot; prefer `trust_project=true` and verify it through `steroid_list_projects`.
+
 ## Workflow
 
 ### Step 1: Open the Project (Without Trust)

--- a/prompts/src/main/prompts/open-project/overview.md
+++ b/prompts/src/main/prompts/open-project/overview.md
@@ -10,7 +10,8 @@ This guide explains how to open projects in IntelliJ using the MCP Steroid plugi
 
 ### `steroid_open_project`
 
-Opens a project in the IDE. This tool initiates the project opening process and returns quickly.
+Opens a project in the IDE. A managed backend cold start may block until MCP is reachable; only the
+project-open phase is asynchronous.
 
 **Parameters:**
 - `project_path` (required): Absolute path to the project directory
@@ -20,8 +21,8 @@ Opens a project in the IDE. This tool initiates the project opening process and 
 
 ## Important: Project Opening is Asynchronous
 
-Project opening is **asynchronous** - the `steroid_open_project` tool returns immediately after
-initiating the open operation. You **MUST poll** to verify the project is fully ready.
+Project opening is **asynchronous**. Verify IDE routing first, then build-model readiness. A managed
+backend may also need to start; devrig handles that before forwarding the open request.
 
 ## Verification Workflow (Required)
 
@@ -29,17 +30,17 @@ After calling `steroid_open_project`, follow this workflow:
 
 ```
 1. Call steroid_open_project(project_path="/path/to/project", trust_project=true, ...)
-2. Poll steroid_list_windows() every 2-3 seconds until:
-   - The project appears in the windows list
-   - modalDialogShowing is false (no dialogs blocking)
-   - indexingInProgress is false (indexing complete)
-   - projectInitialized is true
-3. If modalDialogShowing is true:
-   - Call steroid_take_screenshot() to see the dialog
-   - Use steroid_input() to interact with the dialog
-4. Use steroid_take_screenshot() to visually confirm project is loaded
-5. Verify with steroid_list_projects() that the project appears
+2. Poll steroid_list_projects() until the target path appears; keep its fresh project_name
+3. If a frontend window exists, steroid_list_windows() reports modal/indexing/initialized state
+4. Only when modalDialogShowing=true, use screenshot/input to diagnose the frontend dialog
+5. For a first Maven/Gradle open, fetch `mcp-steroid://skill/execute-code-maven` or
+   `mcp-steroid://skill/execute-code-gradle`, then trigger and await configuration exactly as that recipe
+   shows before indexed semantic queries
 ```
+
+An unattended Remote Development backend can have no frontend window. Do not block on
+`steroid_list_windows` or visual confirmation; project routing plus a successful project-scoped call is
+the non-visual readiness path. Window flags also do not prove Maven/Gradle import completion.
 
 ## Window Info Fields for Polling
 
@@ -50,7 +51,7 @@ After calling `steroid_open_project`, follow this workflow:
 | `project_name` | The single routing key for the window's project (null if not a project window). Look up that project's human-readable `name` and `path` via `steroid_list_projects` by this key. |
 | `modalDialogShowing` | True if any modal dialog is showing in IDE |
 | `indexingInProgress` | True if project is indexing (dumb mode) |
-| `projectInitialized` | True if project is fully initialized |
+| `projectInitialized` | True if the IDE project is initialized; does not prove Maven/Gradle model import |
 
 To find the right project for a file or directory path, pick the project (from `steroid_list_projects`) whose `path` is the longest prefix of your target path — this disambiguates nested checkouts and git worktrees.
 
@@ -62,8 +63,9 @@ When you trust the project and want to skip dialogs:
 
 ```
 1. steroid_open_project(project_path="/path/to/project", trust_project=true, ...)
-2. Poll steroid_list_windows() until indexingInProgress=false and projectInitialized=true
-3. steroid_list_projects() to verify project is open
+2. Poll steroid_list_projects() until the target path appears and keep project_name
+3. If a frontend exists, optionally check steroid_list_windows()
+4. Await first Maven/Gradle model import before indexed queries
 ```
 
 Resource: `mcp-steroid://open-project/open-trusted`
@@ -125,18 +127,6 @@ steroid_open_project(
 )
 ```
 
-### Opening in New Window
-
-```
-steroid_open_project(
-    project_path="/Users/me/projects/another-project",
-    task_id="open-in-new-window",
-    reason="Opening second project for comparison",
-    trust_project=true,
-    force_new_frame=true
-)
-```
-
 ### Checking if Project is Already Open
 
 Before opening, you can check if the project is already open:
@@ -151,9 +141,9 @@ return immediately with a message indicating the project is already open.
 ## Troubleshooting
 
 ### Project not appearing in list
-- Poll `steroid_list_windows()` - check if `indexingInProgress` is still true
-- Wait for indexing to complete (can take several minutes for large projects)
-- Use `steroid_take_screenshot()` to see if there's a dialog waiting
+- Continue polling `steroid_list_projects()`; backend start and project open can take several minutes
+- If a frontend window exists, check `steroid_list_windows()` for indexing or a modal dialog
+- Only then use `steroid_take_screenshot()` to inspect that dialog
 - Check IDE logs for errors
 
 ### Trust dialog keeps appearing
@@ -161,9 +151,11 @@ return immediately with a message indicating the project is already open.
 - Or use `steroid_input()` to click the "Trust Project" button
 
 ### Project opens but is empty/broken
-- Check `steroid_list_windows()` for `projectInitialized` status
-- Wait for `indexingInProgress` to become false
-- The project may need additional configuration
+- For Maven/Gradle, fetch `mcp-steroid://skill/execute-code-maven` or
+  `mcp-steroid://skill/execute-code-gradle`, then trigger and await external-system configuration exactly
+  as that recipe shows
+- Then run the indexed query in `smartReadAction`
+- If a frontend exists, also check `steroid_list_windows()` for IDE indexing/initialization
 - Check if all required plugins are installed via `steroid_execute_code`
 - Some projects require specific SDKs to be configured
 
@@ -180,6 +172,7 @@ return immediately with a message indicating the project is already open.
 | `mcp-steroid://open-project/open-trusted` | Example: Open with automatic trust |
 | `mcp-steroid://open-project/open-with-dialogs` | Example: Open with dialog handling |
 | `mcp-steroid://open-project/open-via-code` | Example: Open via IntelliJ APIs |
+| `mcp-steroid://open-project/managing-backends` | devrig install/auto-start and Remote Development readiness |
 
 ---
 
@@ -195,6 +188,7 @@ return immediately with a message indicating the project is already open.
 - [Open Trusted](mcp-steroid://open-project/open-trusted) - Auto-trust project opening
 - [Open with Dialogs](mcp-steroid://open-project/open-with-dialogs) - Interactive dialog handling
 - [Open via Code](mcp-steroid://open-project/open-via-code) - Programmatic opening
+- [Managing IDE backends](mcp-steroid://open-project/managing-backends) - Clean-machine install and auto-start
 
 ### Related Example Guides
 - [IDE Examples](mcp-steroid://ide/overview) - IDE power operations

--- a/prompts/src/main/prompts/prompt/skill.md
+++ b/prompts/src/main/prompts/prompt/skill.md
@@ -28,6 +28,7 @@ Before reading further, if your task matches one of these, skip straight to the 
 | List enabled inspections in the project | `mcp-steroid://ide/inspection-summary` |
 | Multi-file literal-text edit | one `steroid_execute_code` script: read + replace + save all files in a single `writeAction { }` |
 | Find usages of a symbol | `mcp-steroid://lsp/find-references` |
+| Find every direct/indirect subtype or implementor | `mcp-steroid://ide/type-hierarchy` |
 | Run / debug a test | `mcp-steroid://ide/demo-debug-test` |
 | Run Maven / Gradle tests | `mcp-steroid://skill/execute-code-maven`, `mcp-steroid://skill/execute-code-gradle` |
 | API discovery / exploration | continue reading this guide |
@@ -38,10 +39,21 @@ The full index is in the "MCP Resources (Use Them)" section below.
 
 ```
 1. steroid_list_projects → get list of open projects
-2. Pick the `project_name` of the one you want (the unique routing key — NOT the human-readable `name`)
-3. steroid_execute_code → run Kotlin code with that project_name
-4. steroid_execute_feedback → report success/failure for tracking
+2. Empty on a clean machine? Run `devrig backend download --json`, install the required product, then
+   call steroid_open_project. It auto-starts a sole installed backend; no separate start is required.
+3. Poll steroid_list_projects until the path appears, then pick its `project_name` (the unique routing
+   key — NOT the human-readable `name`). Do not reuse a key from before an IDE/project restart.
+4. On a first Maven/Gradle open, fetch `mcp-steroid://skill/execute-code-maven` or
+   `mcp-steroid://skill/execute-code-gradle`, then trigger and await external-system configuration exactly
+   as that recipe shows.
+5. steroid_execute_code → run Kotlin code with that project_name
+6. steroid_execute_feedback → report success/failure for tracking
 ```
+
+For unattended Java/JVM work on 2026.2, install IDEA Ultimate with a pinned 2026.2 version. devrig launches it as a
+frontendless Remote Development backend with MCP Steroid included, so a window or screenshot is not a
+readiness requirement. Full lifecycle details: `mcp-steroid://open-project/managing-backends` (fetch it
+after `steroid_list_projects` supplies a project_name).
 
 Each `steroid_list_projects` entry has TWO name fields: `project_name` (the within-IDE-unique,
 opaque routing KEY you pass back to every project-scoped tool) and `name` (the human-readable
@@ -148,9 +160,11 @@ computes but never prints returns no data, just a `HINT:` about the missing prin
 Rate execution results. Use after `steroid_execute_code`.
 
 ### `steroid_open_project`
-Open a project in the IDE. This tool initiates the project opening process and returns quickly.
+Open a project in the IDE. A managed backend cold start may block until MCP is reachable; only the
+project-open phase is asynchronous.
 
-**IMPORTANT**: This tool does NOT wait for the project to fully open. The project opening process may show dialogs (such as "Trust Project", project type selection, etc.) that require interaction. Use `steroid_take_screenshot` and `steroid_input` tools to interact with any dialogs that appear.
+Through devrig, a sole installed managed backend is selected and started automatically; backend startup
+waits until MCP is reachable. The project-open request itself remains asynchronous.
 
 **Parameters:**
 - `project_path` (required): Absolute path to the project directory to open
@@ -161,17 +175,20 @@ Open a project in the IDE. This tool initiates the project opening process and r
 **Workflow:**
 1. Call `steroid_open_project` with the project path
 2. If `trust_project=true`, the project will be trusted automatically (no trust dialog)
-3. Call `steroid_take_screenshot` to see the current IDE state
-4. If dialogs are shown, use `steroid_input` to interact with them
-5. Call `steroid_list_projects` to verify the project is open
+3. Poll `steroid_list_projects` until the path appears and keep its fresh `project_name`
+4. If a frontend exists, use `steroid_list_windows`; only use screenshot/input when it reports a modal
+5. A frontendless Remote Development backend has no required window. For a first Maven/Gradle open, await
+   the build-system model using its execute-code sync recipe before indexed semantic queries
 
 ## MCP Resources (Use Them)
 
-This server exposes built-in resources through the MCP resource APIs. These are the fastest way to load full examples and guides without guessing or copy/pasting from the web.
+This server exposes built-in articles through `steroid_fetch_resource`. These are the fastest way to load full examples and guides without guessing or copy/pasting from the web.
 
 **How to access resources:**
 1. Call `steroid_fetch_resource` with a `mcp-steroid://` URI to load the content.
-2. Or use `list_mcp_resources` to browse all available resources.
+
+The fetch tool is project-scoped because articles render for the target IDE. On a clean machine, use the
+initialize instructions and open-project description to bootstrap; fetch articles after a project appears.
 
 **Key resources provided by this server:**
 - `mcp-steroid://prompt/skill` - This guide as a resource.
@@ -185,6 +202,7 @@ This server exposes built-in resources through the MCP resource APIs. These are 
 - `mcp-steroid://debugger/<id>` - Runnable Kotlin scripts (e.g., `set-line-breakpoint`, `debug-run-configuration`, `debug-session-control`, `debug-list-threads`, `debug-thread-dump`).
 - `mcp-steroid://open-project/overview` - Guide for opening projects via MCP.
 - `mcp-steroid://open-project/<id>` - Project opening examples (e.g., `open-trusted`, `open-with-dialogs`, `open-via-code`).
+- `mcp-steroid://open-project/managing-backends` - devrig download, auto-start, Remote Development, and readiness phases.
 
 These resources are designed to be plugged directly into `steroid_execute_code` after you configure file paths/positions.
 

--- a/prompts/src/main/prompts/skill/execute-code-gradle.md
+++ b/prompts/src/main/prompts/skill/execute-code-gradle.md
@@ -6,9 +6,12 @@ Running Gradle syncs and tests through IntelliJ ExternalSystem APIs instead of n
 
 Use this resource when a `steroid_execute_code` script must run Gradle work from inside IntelliJ. For simple final verification from an agent shell, the Bash tool can run `./gradlew` directly. Inside `steroid_execute_code`, never spawn a nested Gradle process with `ProcessBuilder("./gradlew")`; use IntelliJ's Gradle ExternalSystem APIs.
 
-## Sync after build.gradle.kts Change
+## First open or build-script change: trigger and await Gradle import
 
-After modifying `build.gradle`, `build.gradle.kts`, or `settings.gradle.kts`, trigger a Gradle re-import and wait for final import tasks before compiling, running tests, or using indexed PSI:
+On a newly opened Gradle project, routing can finish before the Gradle model exists. On first open—or
+after modifying `build.gradle`, `build.gradle.kts`, or `settings.gradle.kts`—run this recipe to trigger a
+Gradle re-import and wait for final import tasks before compiling, running tests, or using indexed PSI.
+Waiting for smart mode alone does not trigger an import.
 
 ```kotlin[IU]
 import com.intellij.openapi.externalSystem.importing.ImportSpecBuilder

--- a/prompts/src/main/prompts/skill/execute-code-maven.md
+++ b/prompts/src/main/prompts/skill/execute-code-maven.md
@@ -11,6 +11,14 @@ Before the first indexed semantic query, go directly to **Trigger and await Mave
 that recipe even when no POM was edited. Scheduling the update starts the import;
 `Observation.awaitConfiguration(project)` only awaits work, so calling it alone is not a trigger.
 
+A frontendless backend cannot show the yellow project-JDK banner. Check
+`ProjectRootManager.getInstance(project).projectSdk`, but a null project SDK is a warning, not automatic failure:
+imported project-local source PSI can still be valid. When the task needs JDK library resolution,
+compilation, inspections, or refactoring that resolves JDK symbols, inspect module SDKs and unresolved JDK
+references. Follow **Fix: "Project JDK is not defined" Banner** and trigger the import again only when the
+needed capability is absent or diagnostics identify the SDK. Do not mutate SDK configuration merely because
+the project-level value is null.
+
 ## Agent: Run One Maven Test Method (two-call pattern)
 
 When an agent task asks for "run one fast test through Maven" — pick a plain JUnit method, then run it through IntelliJ's Maven integration. **Do NOT shell out to `./mvnw` or `mvn` via the `Bash` tool**, and do NOT use `ProcessBuilder("./mvnw")` inside `steroid_execute_code`. Both bypass the IDE entirely and defeat the value of MCP Steroid.
@@ -221,60 +229,78 @@ Maven builds and inspections will fail. Fix it immediately before doing any othe
 typically whatever `JAVA_HOME` is set to. Using a different JDK can cause language-level
 mismatches and re-import failures.
 
-**Step 1: Check existing registered SDKs first**
+**Step 1: Reuse an unambiguous module or Maven-environment SDK**
 
-IntelliJ may already have a Java SDK registered from a previous session or auto-detection.
-Reuse it instead of scanning the filesystem:
+Prefer a Java SDK already assigned to the project's modules. Otherwise match an existing registration to
+`JAVA_HOME`, or create that exact SDK. Never choose the first global registration: it may belong to another
+project or language level. When neither source is unambiguous, determine the required JDK from the POM and set
+`explicitJdkPath` before running the recipe.
 
 ```kotlin[IU]
 import com.intellij.openapi.projectRoots.JavaSdk
 import com.intellij.openapi.projectRoots.ProjectJdkTable
 import com.intellij.openapi.projectRoots.impl.SdkConfigurationUtil
 import com.intellij.openapi.projectRoots.ex.JavaSdkUtil
+import com.intellij.openapi.module.ModuleManager
+import com.intellij.openapi.roots.ModuleRootManager
 import com.intellij.openapi.roots.ProjectRootManager
 import com.intellij.openapi.application.edtWriteAction
+import com.intellij.openapi.util.io.FileUtil
 import com.intellij.platform.backend.observation.Observation
 import org.jetbrains.idea.maven.project.MavenProjectsManager
 import org.jetbrains.idea.maven.buildtool.MavenSyncSpec
 
-// 1. Use already-registered Java SDK if available (preferred — no filesystem scan needed)
-// getSdksOfType() is the correct API; allJdks includes all types (JavaScript, Python, etc.)
-val registeredSdk = ProjectJdkTable.getInstance().getSdksOfType(JavaSdk.getInstance()).firstOrNull()
+// 1. Prefer one Java SDK already assigned consistently across modules.
+val javaSdkType = JavaSdk.getInstance()
+val (registeredSdks, moduleJavaSdks, currentSdk) = readAction {
+    val registered = ProjectJdkTable.getInstance().getSdksOfType(javaSdkType).toList()
+    val moduleSdks = ModuleManager.getInstance(project).modules
+        .mapNotNull { module -> ModuleRootManager.getInstance(module).sdk }
+        .filter { it.sdkType == javaSdkType }
+        .distinctBy { it.homePath ?: it.name }
+    Triple(registered, moduleSdks, ProjectRootManager.getInstance(project).projectSdk)
+}
+val moduleSdk = moduleJavaSdks.singleOrNull()
 
-// 2. Otherwise: find JDK on disk — same JDK Maven uses (JAVA_HOME), then scan /usr/lib/jvm/
-val jdkPath = if (registeredSdk == null) {
-    val candidates = listOfNotNull(
-        System.getenv("JAVA_HOME"),
-        *java.io.File("/usr/lib/jvm").listFiles()
-            ?.filter { it.isDirectory }?.sortedByDescending { it.name }
-            ?.map { it.absolutePath }?.toTypedArray() ?: emptyArray(),
-        System.getProperty("java.home"),   // IntelliJ JBR — always present, last resort
-    )
-    candidates.firstOrNull { java.io.File(it, "bin/java").exists() }
-} else null
+// 2. Otherwise use an explicit project requirement, or the exact Maven environment JDK. Set the
+// explicit path only after reading the POM/compiler level; never guess from a global registration.
+val explicitJdkPath: String? = null // TODO: set when the project requirement is known
+val desiredJdkPath = (explicitJdkPath ?: System.getenv("JAVA_HOME"))
+    ?.let(FileUtil::toCanonicalPath)
+    ?.takeIf { javaSdkType.isValidSdkHome(it) }
+val registeredDesiredSdk = readAction {
+    desiredJdkPath?.let { desired ->
+        registeredSdks.firstOrNull { sdk ->
+            sdk.homePath?.let(FileUtil::toCanonicalPath) == desired
+        }
+    }
+}
 
-val currentSdk = ProjectRootManager.getInstance(project).projectSdk
 when {
     currentSdk != null -> println("Project SDK already set: ${currentSdk.name}")
-    registeredSdk != null -> {
-        edtWriteAction { JavaSdkUtil.applyJdkToProject(project, registeredSdk) }
-        println("Applied registered SDK: ${registeredSdk.name}")
+    moduleSdk != null -> {
+        edtWriteAction { JavaSdkUtil.applyJdkToProject(project, moduleSdk) }
+        println("Applied the modules' Java SDK: ${moduleSdk.name}")
     }
-    jdkPath != null -> {
-        // Check for duplicate before creating (createAndAddSDK does NOT deduplicate by path)
-        val existing = ProjectJdkTable.getInstance().getSdksOfType(JavaSdk.getInstance())
-            .firstOrNull { it.homePath == jdkPath }
-        val sdk = existing ?: edtWriteAction { SdkConfigurationUtil.createAndAddSDK(jdkPath, JavaSdk.getInstance()) }
+    moduleJavaSdks.size > 1 -> {
+        println("Modules already use multiple Java SDKs; preserving their per-module assignments")
+    }
+    desiredJdkPath != null -> {
+        val sdk = registeredDesiredSdk
+            ?: edtWriteAction { SdkConfigurationUtil.createAndAddSDK(desiredJdkPath, javaSdkType) }
         if (sdk != null) {
             edtWriteAction { JavaSdkUtil.applyJdkToProject(project, sdk) }
-            println("Applied SDK from: $jdkPath (${sdk.name})")
-        } else println("ERROR: createAndAddSDK returned null for $jdkPath")
+            println("Applied SDK from: $desiredJdkPath (${sdk.name})")
+        } else error("createAndAddSDK returned null for $desiredJdkPath")
     }
-    else -> println("ERROR: No JDK found. Contents of /usr/lib/jvm: ${java.io.File("/usr/lib/jvm").list()?.toList()}")
+    else -> error(
+        "No unambiguous Java SDK: modules have none and JAVA_HOME/explicitJdkPath does not identify one"
+    )
 }
 
 // 3. Trigger Maven re-sync — initial import may have failed without a JDK
-if (ProjectRootManager.getInstance(project).projectSdk != null) {
+val configuredProjectSdk = readAction { ProjectRootManager.getInstance(project).projectSdk }
+if (configuredProjectSdk != null) {
     MavenProjectsManager.getInstance(project)
         .scheduleUpdateAllMavenProjects(MavenSyncSpec.full("after-jdk-fix", explicit = true))
     Observation.awaitConfiguration(project)
@@ -282,7 +308,10 @@ if (ProjectRootManager.getInstance(project).projectSdk != null) {
 }
 ```
 
-**When to run this**: Before any Maven or inspection call if the editor shows the JDK banner.
+**When to run this**: Before any Maven or inspection call if the editor shows the JDK banner. In a
+frontendless backend with a null `ProjectRootManager.getInstance(project).projectSdk`, run it only when the
+task needs JDK-dependent capabilities or diagnostics show missing SDK/JDK resolution; first inspect module
+SDKs instead of blindly choosing the first registered JDK.
 **Why same JDK as Maven**: Maven was configured for `JAVA_HOME` — using a different JDK causes
 language-level mismatches and re-import failures.
 

--- a/prompts/src/main/prompts/skill/execute-code-maven.md
+++ b/prompts/src/main/prompts/skill/execute-code-maven.md
@@ -4,6 +4,13 @@ Running Maven builds and tests via IntelliJ Maven APIs instead of ProcessBuilder
 
 # Execute Code: Maven Patterns
 
+## First open: trigger the Maven import before semantic work
+
+On a newly opened Maven project, routing and IDE initialization can finish before the Maven model exists.
+Before the first indexed semantic query, go directly to **Trigger and await Maven import** below and run
+that recipe even when no POM was edited. Scheduling the update starts the import;
+`Observation.awaitConfiguration(project)` only awaits work, so calling it alone is not a trigger.
+
 ## Agent: Run One Maven Test Method (two-call pattern)
 
 When an agent task asks for "run one fast test through Maven" — pick a plain JUnit method, then run it through IntelliJ's Maven integration. **Do NOT shell out to `./mvnw` or `mvn` via the `Bash` tool**, and do NOT use `ProcessBuilder("./mvnw")` inside `steroid_execute_code`. Both bypass the IDE entirely and defeat the value of MCP Steroid.
@@ -125,9 +132,10 @@ After each install round, re-issue the test launch+poll. Stop after at most TWO 
 
 ---
 
-## Sync after pom.xml Change
+## Trigger and await Maven import
 
-After modifying `pom.xml`, trigger a full Maven re-import and wait for completion before compiling or running tests:
+On a first open or after modifying `pom.xml`, trigger a full Maven re-import and wait for completion
+before compiling, running tests, or using indexed PSI:
 
 ```kotlin[IU]
 import org.jetbrains.idea.maven.project.MavenProjectsManager

--- a/prompts/src/test/kotlin/com/jonnyzzz/mcpSteroid/prompts/ExternalSystemFirstOpenPromptContractTest.kt
+++ b/prompts/src/test/kotlin/com/jonnyzzz/mcpSteroid/prompts/ExternalSystemFirstOpenPromptContractTest.kt
@@ -1,0 +1,37 @@
+/* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
+package com.jonnyzzz.mcpSteroid.prompts
+
+import com.jonnyzzz.mcpSteroid.prompts.generated.skill.ExecuteCodeGradlePromptArticle
+import com.jonnyzzz.mcpSteroid.prompts.generated.skill.ExecuteCodeMavenPromptArticle
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class ExternalSystemFirstOpenPromptContractTest {
+    @Test
+    fun `Maven recipe triggers first import before awaiting configuration`() {
+        val prompt = ExecuteCodeMavenPromptArticle().readPayload(PromptsContext("IU", 253))
+
+        for (fact in listOf(
+            "First open",
+            "scheduleUpdateAllMavenProjects",
+            "Observation.awaitConfiguration(project)",
+            "calling it alone is not a trigger",
+        )) {
+            assertTrue(fact in prompt, "Maven first-open recipe must mention '$fact': $prompt")
+        }
+    }
+
+    @Test
+    fun `Gradle recipe triggers first import and awaits final tasks`() {
+        val prompt = ExecuteCodeGradlePromptArticle().readPayload(PromptsContext("IU", 253))
+
+        for (fact in listOf(
+            "First open",
+            "ExternalSystemUtil.refreshProject",
+            "onFinalTasksFinished",
+            "Waiting for smart mode alone does not trigger",
+        )) {
+            assertTrue(fact in prompt, "Gradle first-open recipe must mention '$fact': $prompt")
+        }
+    }
+}

--- a/prompts/src/test/kotlin/com/jonnyzzz/mcpSteroid/prompts/ExternalSystemFirstOpenPromptContractTest.kt
+++ b/prompts/src/test/kotlin/com/jonnyzzz/mcpSteroid/prompts/ExternalSystemFirstOpenPromptContractTest.kt
@@ -3,6 +3,7 @@ package com.jonnyzzz.mcpSteroid.prompts
 
 import com.jonnyzzz.mcpSteroid.prompts.generated.skill.ExecuteCodeGradlePromptArticle
 import com.jonnyzzz.mcpSteroid.prompts.generated.skill.ExecuteCodeMavenPromptArticle
+import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 
@@ -13,12 +14,36 @@ class ExternalSystemFirstOpenPromptContractTest {
 
         for (fact in listOf(
             "First open",
+            "ProjectRootManager.getInstance(project).projectSdk",
+            "null project SDK is a warning, not automatic failure",
+            "task needs JDK library resolution",
             "scheduleUpdateAllMavenProjects",
             "Observation.awaitConfiguration(project)",
             "calling it alone is not a trigger",
         )) {
             assertTrue(fact in prompt, "Maven first-open recipe must mention '$fact': $prompt")
         }
+
+        assertTrue(
+            "ModuleRootManager.getInstance(module).sdk" in prompt,
+            "Maven SDK repair must consider configured module SDKs before global registrations: $prompt",
+        )
+        assertTrue(
+            "No unambiguous Java SDK" in prompt,
+            "Maven SDK repair must fail visibly instead of guessing among registered SDKs: $prompt",
+        )
+        assertTrue(
+            "FileUtil::toCanonicalPath" in prompt && "javaSdkType.isValidSdkHome" in prompt,
+            "Maven SDK repair must canonicalize and validate an explicit JDK home through IntelliJ APIs: $prompt",
+        )
+        assertTrue(
+            "val configuredProjectSdk = readAction" in prompt,
+            "Maven SDK repair must read the post-write project SDK under a read action: $prompt",
+        )
+        assertFalse(
+            "getSdksOfType(JavaSdk.getInstance()).firstOrNull()" in prompt,
+            "Maven SDK repair must not blindly apply the first registered JDK: $prompt",
+        )
     }
 
     @Test

--- a/prompts/src/test/kotlin/com/jonnyzzz/mcpSteroid/prompts/PerIdeAvailabilityContractTest.kt
+++ b/prompts/src/test/kotlin/com/jonnyzzz/mcpSteroid/prompts/PerIdeAvailabilityContractTest.kt
@@ -55,6 +55,9 @@ class PerIdeAvailabilityContractTest {
             // Genuinely plugin-bound: the Maven integration plugin (org.jetbrains.idea.maven)
             // is bundled only in IDEA among the supported product codes; every fence needs it.
             "skill/execute-code-maven" to "Maven plugin is bundled only in IDEA",
+            // Genuinely Java-plugin-bound: PsiClass, JavaPsiFacade, and ClassInheritorsSearch are
+            // available in the IDEA family (IU/IC/AI), not in the other supported products.
+            "ide/type-hierarchy" to "Java PSI hierarchy APIs are bundled only in the IDEA family (IU/IC/AI)",
             // The entries below entered the corpus when the `mcp-steroid://ide/<id>` shorthand
             // list in prompt/skill became part of the audit (#98). Every fence in each of them
             // drives a Java-plugin refactoring processor (com.intellij.refactoring.* java-impl

--- a/prompts/src/test/kotlin/com/jonnyzzz/mcpSteroid/prompts/TypeHierarchyPromptContractTest.kt
+++ b/prompts/src/test/kotlin/com/jonnyzzz/mcpSteroid/prompts/TypeHierarchyPromptContractTest.kt
@@ -1,0 +1,33 @@
+/* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
+package com.jonnyzzz.mcpSteroid.prompts
+
+import com.jonnyzzz.mcpSteroid.prompts.generated.ide.TypeHierarchyPromptArticle
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class TypeHierarchyPromptContractTest {
+    @Test
+    fun `exhaustive implementor recipe distinguishes interfaces and classes`() {
+        val prompt = TypeHierarchyPromptArticle().readPayload(PromptsContext("IU", 262))
+
+        for (fact in listOf(
+            "ClassInheritorsSearch",
+            "sub-interfaces",
+            "abstract classes",
+            "concrete classes",
+            "!it.isInterface",
+            "PsiModifier.ABSTRACT",
+            "checkDeep=true",
+            "anonymous/local",
+            "qualifiedName",
+            "subsTruncated",
+        )) {
+            assertTrue(fact in prompt, "type-hierarchy prompt must mention '$fact': $prompt")
+        }
+        assertFalse(
+            Regex("""val (subInterfaces|abstractClasses|concreteClasses): List<String>""").containsMatchIn(prompt),
+            "the capped hierarchy tree must not be followed by unbounded duplicate category lists: $prompt",
+        )
+    }
+}

--- a/test-experiments/src/test/kotlin/com/jonnyzzz/mcpSteroid/integration/tests/DevrigRemoteDevelopmentKeycloakTypeHierarchyTest.kt
+++ b/test-experiments/src/test/kotlin/com/jonnyzzz/mcpSteroid/integration/tests/DevrigRemoteDevelopmentKeycloakTypeHierarchyTest.kt
@@ -13,14 +13,21 @@ import com.jonnyzzz.mcpSteroid.integration.infra.streamDevrigLogsToConsole
 import com.jonnyzzz.mcpSteroid.testHelper.AiAgentSession
 import com.jonnyzzz.mcpSteroid.testHelper.DockerClaudeSession
 import com.jonnyzzz.mcpSteroid.testHelper.DockerCodexSession
+import com.jonnyzzz.mcpSteroid.testHelper.ProjectHomeDirectory
 import com.jonnyzzz.mcpSteroid.testHelper.docker.startProcessInContainer
 import com.jonnyzzz.mcpSteroid.testHelper.git.BareRepoCache
 import com.jonnyzzz.mcpSteroid.testHelper.git.GitDriver
 import com.jonnyzzz.mcpSteroid.testHelper.process.assertExitCode
 import com.jonnyzzz.mcpSteroid.testHelper.runWithCloseableStack
 import java.io.File
+import java.time.Instant
 import java.util.concurrent.TimeUnit
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonPrimitive
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.Timeout
@@ -41,6 +48,23 @@ class DevrigRemoteDevelopmentKeycloakTypeHierarchyTest {
     fun `codex installs devrig and uses a remote development backend for keycloak hierarchy`() =
         runScenario("codex")
 
+    @Test
+    fun `agent prompt requests the outcome without scripting the bootstrap recipe`() {
+        val prompt = buildPrompt()
+        for (forbidden in listOf(
+            "devrig",
+            "steroid_",
+            "mcp-steroid://",
+            "ClassInheritorsSearch",
+            "Observation.awaitConfiguration",
+        )) {
+            assertTrue(forbidden !in prompt) { "Task-only prompt must not reveal '$forbidden':\n$prompt" }
+        }
+        for (required in listOf(PROJECT_DIR, IDE_VERSION, KeycloakTypeHierarchyScenario.INTERFACE_FQN)) {
+            assertTrue(required in prompt) { "Task-only prompt must state the reproducible outcome '$required':\n$prompt" }
+        }
+    }
+
     private fun runScenario(agentName: String) = runWithCloseableStack { lifetime ->
         BareRepoCache.ensureRepo(KEYCLOAK_REPO_URL, IdeTestFolders.repoCacheDir)
 
@@ -60,6 +84,7 @@ class DevrigRemoteDevelopmentKeycloakTypeHierarchyTest {
 
         prepareKeycloak(container)
         installDevrigForAgent(container, agentName)
+        assertCleanBackendState(container)
         streamDevrigLogsToConsole(lifetime, File(container.runDir, "devrig-logs"), console)
 
         var backendMayBeRunning = false
@@ -76,8 +101,10 @@ class DevrigRemoteDevelopmentKeycloakTypeHierarchyTest {
             ).awaitForProcessFinish()
             backendMayBeRunning = true
 
-            val toolScore = assertAgentWorkflow(result.rawStdout)
+            val workflow = assertAgentWorkflow(result.rawStdout)
             val finalAnswerScore = assertFinalAnswer(result.rawStdout)
+            val improvements = assertImprovements(result.rawStdout)
+            val improvementsArtifact = saveImprovements(container, agentName, workflow, improvements)
 
             assertRemoteBackendState(container)
             if (agentName == "codex" && result.exitCode == 137) {
@@ -87,8 +114,9 @@ class DevrigRemoteDevelopmentKeycloakTypeHierarchyTest {
             }
             console.writeSuccess(
                 "$agentName completed the hierarchy through the IU 262 Remote Development backend " +
-                    "(${toolScore.reportedCount} tool-result subtypes, " +
-                    "${finalAnswerScore.reportedCount} final-answer subtypes)",
+                    "(${workflow.hierarchyScore.reportedCount} tool-result subtypes, " +
+                    "${finalAnswerScore.reportedCount} final-answer subtypes, " +
+                    "${workflow.startMode}; improvements: $improvementsArtifact)",
             )
         } finally {
             try {
@@ -157,78 +185,208 @@ class DevrigRemoteDevelopmentKeycloakTypeHierarchyTest {
             else -> error("Unknown agent: $agentName")
         }
 
-    private fun buildPrompt(): String = buildString {
-        appendLine("# Open Keycloak in a devrig-managed IDE and report its complete Authenticator hierarchy")
-        appendLine()
-        appendLine("This is a clean machine. devrig is installed and registered as your `mcp-steroid` server,")
-        appendLine("but no IDE is installed or running. You must provision and start the IDE yourself.")
-        appendLine()
-        appendLine("1. Use your shell tool to run this exact download command:")
-        appendLine("   \"$INSTALLED_DEVRIG\" backend download idea-ultimate --version $IDE_VERSION")
-        appendLine("2. Use your shell tool to run this exact start command:")
-        appendLine("   \"$INSTALLED_DEVRIG\" backend start idea-ultimate --version $IDE_VERSION")
-        appendLine("3. Call `steroid_open_project` with `project_path=$PROJECT_DIR`. The IDE is a headless Remote")
-        appendLine("   Development backend, so no frontend window is expected. Its first boot and project import can")
-        appendLine("   take several minutes; if it is not reachable yet, wait and retry the MCP call.")
-        appendLine("4. After open_project succeeds, call `steroid_list_projects`. Its successful result must contain")
-        appendLine("   the Keycloak path `$PROJECT_DIR`. If it does not yet, retry open_project/list_projects until it does.")
-        appendLine("5. Only after Keycloak appears in list_projects, complete this semantic task in that managed IDE:")
-        appendLine()
-        append(KeycloakTypeHierarchyScenario.mcpTaskInstructions())
+    private fun assertCleanBackendState(container: DevrigContainer) {
+        container.execAndAssertWithConsoleStream(
+            description = "prove the agent starts with no installed or running managed IDE",
+            timeoutSeconds = 30,
+            script = $$"""
+                set -euo pipefail
+                backend_root=/home/agent/.mcp-steroid/backends
+                state_root=/home/agent/.mcp-steroid/state
+                marker_root=/home/agent/.mcp-steroid/markers
+                test ! -d "$backend_root" || test -z "$(find "$backend_root" -mindepth 1 -print -quit)"
+                test ! -d "$state_root" || test -z "$(find "$state_root" -type f -name '*.pid' -print -quit)"
+                test ! -d "$marker_root" || test -z "$(find "$marker_root" -type f -name '*.mcp-steroid' -print -quit)"
+            """.trimIndent(),
+        )
     }
 
-    private fun assertAgentWorkflow(rawNdjson: String): TypeHierarchyScore {
+    private fun buildPrompt(): String = buildString {
+        appendLine("# Report Keycloak's complete Authenticator hierarchy")
+        appendLine()
+        appendLine("The pinned Keycloak checkout is at `$PROJECT_DIR`.")
+        appendLine()
+        appendLine("Do this with IntelliJ IDEA Ultimate $IDE_VERSION. This clean machine starts with no JetBrains IDE")
+        appendLine("installed or running. Work autonomously with the capabilities already configured for you.")
+        appendLine()
+        append(KeycloakTypeHierarchyScenario.baselineTaskInstructions())
+        appendLine()
+        appendLine("After the result, explain what was hard or unclear about discovering the IDE capability,")
+        appendLine("installing or starting a suitable backend, opening the project, waiting for readiness, and using")
+        appendLine("IDE semantics. Suggest prompt, tool-description, server-instruction, or built-in guidance article")
+        appendLine("improvements only; do not propose new tools or API methods.")
+        appendLine()
+        appendLine("<<<IMPROVEMENTS>>>")
+        appendLine("(your reflection)")
+        appendLine("<<<END_IMPROVEMENTS>>>")
+    }
+
+    private fun assertAgentWorkflow(rawNdjson: String): AgentWorkflowEvidence {
         val calls = decodeAgentToolCalls(rawNdjson)
         assertTrue(calls.isNotEmpty()) { "No Claude/Codex tool calls were decoded from raw NDJSON." }
 
-        assertSuccessfulCommand(calls, INSTALLED_DEVRIG, "backend download idea-ultimate", "--version $IDE_VERSION")
-        assertSuccessfulCommand(calls, INSTALLED_DEVRIG, "backend start idea-ultimate", "--version $IDE_VERSION")
+        val downloadIndex = successfulIdeaDownloadIndex(calls)
+        assertTrue(downloadIndex >= 0) {
+            "Raw agent events do not contain a successful IU $IDE_VERSION download. ${summarizeCalls(calls)}"
+        }
 
-        val openedProject = calls.any { call ->
+        val openIndex = calls.indexOfFirstAfter(downloadIndex) { call ->
             call.toolName == "steroid_open_project" &&
                 call.argumentText("project_path") == PROJECT_DIR &&
                 call.hasSuccessfulResult()
         }
-        assertTrue(openedProject) {
+        assertTrue(openIndex >= 0) {
             "Raw agent events do not contain a successful steroid_open_project for $PROJECT_DIR. " +
                 summarizeCalls(calls)
         }
 
-        val listedKeycloak = calls.any { call ->
+        val listIndex = calls.indexOfFirstAfter(openIndex) { call ->
             call.toolName == "steroid_list_projects" &&
                 call.hasSuccessfulResult() &&
                 call.result?.text?.contains(PROJECT_DIR) == true
         }
-        assertTrue(listedKeycloak) {
+        assertTrue(listIndex >= 0) {
             "Raw agent events do not contain a successful steroid_list_projects result with $PROJECT_DIR. " +
                 summarizeCalls(calls)
         }
-
-        val hierarchyExecutions = calls.filter { call ->
-            if (call.toolName != "steroid_execute_code" || !call.hasSuccessfulResult()) return@filter false
+        val hierarchyExecutions = calls.withIndex().mapNotNull { (index, call) ->
+            if (index <= listIndex || call.toolName != "steroid_execute_code") return@mapNotNull null
             val code = call.argumentText("code")
-            code.contains("ClassInheritorsSearch") &&
-                code.contains("findAll") &&
-                DEEP_SEARCH_ARGUMENT.containsMatchIn(code)
+            if (!code.contains(CLASS_HIERARCHY_API)) {
+                return@mapNotNull null
+            }
+            val latestProjectName = latestProjectNameForPath(calls, index, PROJECT_DIR)
+                ?: return@mapNotNull null
+            if (call.argumentText("project_name") != latestProjectName) return@mapNotNull null
+            HierarchyExecution(index, call, latestProjectName)
         }
         assertTrue(hierarchyExecutions.isNotEmpty()) {
-            "Raw agent events do not contain a successful deep ClassInheritorsSearch execution. " +
+            "Raw agent events do not contain a deep ClassInheritorsSearch routed with the latest " +
+                "project_name for $PROJECT_DIR. " +
                 summarizeCalls(calls)
         }
-        val scores = hierarchyExecutions.map { call ->
-            scoreTypeHierarchy(
-                call.result?.text.orEmpty(),
-                KeycloakTypeHierarchyScenario.requiredTransitive,
-                KeycloakTypeHierarchyScenario.MIN_TOTAL,
-            )
+        val firstSuccessfulHierarchy = hierarchyExecutions.firstOrNull { it.call.hasSuccessfulResult() }
+            ?: error("Every deep ClassInheritorsSearch execution failed. ${summarizeCalls(calls)}")
+        val hierarchyScore = scoreTypeHierarchy(
+            firstSuccessfulHierarchy.call.result?.text.orEmpty(),
+            KeycloakTypeHierarchyScenario.requiredTransitive,
+            E2E_MIN_TOTAL,
+        )
+        assertTrue(hierarchyScore.complete) {
+            "The first successful deep ClassInheritorsSearch was incomplete: " +
+                "reported=${hierarchyScore.reportedCount}, missing=${hierarchyScore.missingRequired}. " +
+                "This usually means the project model/import was not ready. ${summarizeCalls(calls)}"
         }
-        val bestScore = scores.maxBy { it.reportedCount }
-        assertTrue(scores.any { it.complete }) {
-            "No successful deep ClassInheritorsSearch tool result contained the complete hierarchy: " +
-                "best reported=${bestScore.reportedCount}, missing=${bestScore.missingRequired}. " +
-                summarizeCalls(calls)
+
+        val explicitStart = successfulCommandIndex(calls, "backend start idea-ultimate") >= 0
+        val startMode = if (explicitStart) "explicit-cli-start" else "open-project-auto-start"
+        val failedOpenAttempts = calls.count { it.toolName == "steroid_open_project" && it.result?.isError == true }
+        val hierarchyErrors = hierarchyExecutions.count { it.call.result?.isError != false }
+        val emptyProjectLists = calls.take(listIndex).count { call ->
+            call.toolName == "steroid_list_projects" &&
+                call.hasSuccessfulResult() &&
+                call.result?.text?.contains(PROJECT_DIR) != true
         }
-        return scores.first { it.complete }
+        val fetchedArticles = calls.asSequence()
+            .filter { it.toolName == "steroid_fetch_resource" }
+            .map { it.argumentText("uri") }
+            .filter { it.isNotBlank() }
+            .distinct()
+            .toList()
+        val readinessSyncBeforeHierarchy = calls.take(firstSuccessfulHierarchy.index).any { call ->
+            if (call.toolName != "steroid_execute_code") return@any false
+            val code = call.argumentText("code")
+            "Observation.awaitConfiguration" in code &&
+                ("MavenProjectsManager" in code || "scheduleUpdate" in code)
+        }
+        val summary = buildString {
+            appendLine("download discovered: yes")
+            appendLine("start mode: $startMode")
+            appendLine("failed open attempts: $failedOpenAttempts")
+            appendLine("empty project-list results before routing: $emptyProjectLists")
+            appendLine("list_windows used: ${calls.any { it.toolName == "steroid_list_windows" }}")
+            appendLine("screenshot used: ${calls.any { it.toolName == "steroid_take_screenshot" }}")
+            appendLine("input used: ${calls.any { it.toolName == "steroid_input" }}")
+            appendLine("fetched articles: ${fetchedArticles.ifEmpty { listOf("none") }.joinToString()}")
+            appendLine("Maven trigger+await before hierarchy: $readinessSyncBeforeHierarchy")
+            appendLine("execute attempts/errors: ${hierarchyExecutions.size}/$hierarchyErrors")
+            appendLine("project_name: ${firstSuccessfulHierarchy.projectName}")
+            appendLine("tool-result subtype count: ${hierarchyScore.reportedCount}")
+        }
+        return AgentWorkflowEvidence(hierarchyScore, startMode, summary)
+    }
+
+    private fun latestProjectNameForPath(
+        calls: List<AgentToolCall>,
+        beforeIndex: Int,
+        projectPath: String,
+    ): String? {
+        for (index in (beforeIndex - 1) downTo 0) {
+            val call = calls[index]
+            val text = call.result?.text.orEmpty()
+            if (call.toolName == "steroid_list_projects" && call.hasSuccessfulResult() && projectPath in text) {
+                return projectNameForPath(text, projectPath)
+            }
+        }
+        return null
+    }
+
+    private fun projectNameForPath(resultText: String, projectPath: String): String {
+        val root = Json.parseToJsonElement(resultText) as? JsonObject
+            ?: error("steroid_list_projects did not return a JSON object: $resultText")
+        val projects = root["projects"] as? JsonArray
+            ?: error("steroid_list_projects result has no projects array: $resultText")
+        val project = projects.filterIsInstance<JsonObject>().singleOrNull { candidate ->
+            candidate["path"]?.jsonPrimitive?.contentOrNull == projectPath
+        } ?: error("steroid_list_projects result does not contain exactly one $projectPath entry: $resultText")
+        return project["project_name"]?.jsonPrimitive?.contentOrNull
+            ?: error("Keycloak project entry has no project_name: $project")
+    }
+
+    private fun assertImprovements(rawNdjson: String): String {
+        val finalResponse = decodeAgentFinalResponse(rawNdjson)
+            ?: error("Raw agent events do not contain a final user-visible response.")
+        val match = IMPROVEMENTS_BLOCK.findAll(finalResponse).lastOrNull()
+            ?: error("Final response has no <<<IMPROVEMENTS>>> block: $finalResponse")
+        val improvements = match.groupValues[1].trim()
+        assertTrue(improvements.isNotBlank() && !improvements.startsWith("(your reflection")) {
+            "Final response contains only the improvements placeholder: $finalResponse"
+        }
+        return improvements
+    }
+
+    private fun saveImprovements(
+        container: DevrigContainer,
+        agentName: String,
+        workflow: AgentWorkflowEvidence,
+        improvements: String,
+    ): File {
+        val content = buildString {
+            appendLine("# Headless backend: agent reflection ($agentName)")
+            appendLine()
+            appendLine("Generated by DevrigRemoteDevelopmentKeycloakTypeHierarchyTest on ${Instant.now()}.")
+            appendLine()
+            appendLine("## Machine summary")
+            appendLine()
+            append(workflow.summary)
+            appendLine()
+            appendLine("## Agent reflection")
+            appendLine()
+            appendLine(improvements)
+        }
+        val artifactName = "IMPROVEMENTS-headless-backend-$agentName.md"
+        val runArtifact = container.runDir.resolve(artifactName)
+        runArtifact.writeText(content)
+
+        val improvementsDir = ProjectHomeDirectory.requireProjectHomeDirectory()
+            .resolve("test-experiments/build/improvements")
+            .toFile()
+        assertTrue(improvementsDir.mkdirs() || improvementsDir.isDirectory) {
+            "Failed to create improvements directory: $improvementsDir"
+        }
+        val buildArtifact = improvementsDir.resolve(artifactName)
+        buildArtifact.writeText(content)
+        return buildArtifact
     }
 
     private fun assertFinalAnswer(rawNdjson: String): TypeHierarchyScore {
@@ -237,7 +395,7 @@ class DevrigRemoteDevelopmentKeycloakTypeHierarchyTest {
         val score = scoreTypeHierarchy(
             finalResponse.orEmpty(),
             KeycloakTypeHierarchyScenario.requiredTransitive,
-            KeycloakTypeHierarchyScenario.MIN_TOTAL,
+            E2E_MIN_TOTAL,
         )
         assertTrue(score.complete) {
             "The agent final response does not contain the complete hierarchy: " +
@@ -246,16 +404,31 @@ class DevrigRemoteDevelopmentKeycloakTypeHierarchyTest {
         return score
     }
 
-    private fun assertSuccessfulCommand(calls: List<AgentToolCall>, vararg fragments: String) {
-        val succeeded = calls.any { candidate ->
+    private fun successfulCommandIndex(calls: List<AgentToolCall>, vararg fragments: String): Int =
+        calls.indexOfFirst { candidate ->
             (candidate.toolName.equals("Bash", ignoreCase = true) || candidate.toolName == "command_execution") &&
                 fragments.all { it in candidate.argumentText("command") } &&
                 candidate.hasSuccessfulResult()
         }
-        assertTrue(succeeded) {
-            "Raw agent events do not contain a successful shell command with ${fragments.toList()}. " +
-                summarizeCalls(calls)
+
+    private fun successfulIdeaDownloadIndex(calls: List<AgentToolCall>): Int =
+        calls.indexOfFirst { candidate ->
+            val command = candidate.argumentText("command")
+            (candidate.toolName.equals("Bash", ignoreCase = true) ||
+                candidate.toolName == "command_execution") &&
+                "backend download idea-ultimate" in command &&
+                ("--version $IDE_VERSION" in command || "--version=$IDE_VERSION" in command) &&
+                candidate.hasSuccessfulResult()
         }
+
+    private inline fun List<AgentToolCall>.indexOfFirstAfter(
+        previousIndex: Int,
+        predicate: (AgentToolCall) -> Boolean,
+    ): Int {
+        for (index in (previousIndex + 1)..lastIndex) {
+            if (predicate(this[index])) return index
+        }
+        return -1
     }
 
     private fun assertRemoteBackendState(container: DevrigContainer) {
@@ -488,6 +661,18 @@ class DevrigRemoteDevelopmentKeycloakTypeHierarchyTest {
         limit = 20,
     ) { call -> "${call.toolName}(${call.arguments}) result=${call.result?.isError}" }
 
+    private data class AgentWorkflowEvidence(
+        val hierarchyScore: TypeHierarchyScore,
+        val startMode: String,
+        val summary: String,
+    )
+
+    private data class HierarchyExecution(
+        val index: Int,
+        val call: AgentToolCall,
+        val projectName: String,
+    )
+
     companion object {
         private const val PROJECT_DIR = "/home/agent/keycloak"
         private const val INSTALLED_DEVRIG = "/home/agent/.mcp-steroid/bin/devrig"
@@ -498,14 +683,17 @@ class DevrigRemoteDevelopmentKeycloakTypeHierarchyTest {
         // product-info.json / backend.json stores the numeric build; the runtime marker uses IU-<build>.
         private const val IDE_DESCRIPTOR_BUILD = "262.8665.337"
         private const val IDE_BUILD = "IU-262.8665.337"
+        // Lower-bound oracle for the pinned commit; exact-set follow-up is tracked in TODO.md.
+        private const val E2E_MIN_TOTAL = 70
+        const val CLASS_HIERARCHY_API = "ClassInheritorsSearch"
         const val BEARER_TOKEN_CHARACTERS = "A-Za-z0-9._~+/=-"
         const val MARKER_CREDENTIAL_VALUE_CHARACTERS = "A-Za-z0-9._~+/%=-"
         private val BEARER_CREDENTIAL = Regex("Bearer\\s+[$BEARER_TOKEN_CHARACTERS]+")
         private val IJT_QUERY_CREDENTIAL = Regex("([?&]_ijt=)[^&\"\\s]+")
         private val IJT_HEADER_CREDENTIAL = Regex("(\"x-ijt\"\\s*:\\s*\")[^\"]*(\")")
-        val DEEP_SEARCH_ARGUMENT = Regex(
-            "ClassInheritorsSearch\\s*\\.\\s*search\\s*\\(\\s*[^,]+,\\s*[^,]+," +
-                "\\s*(?:checkDeep\\s*=\\s*)?true\\s*\\)",
+        val IMPROVEMENTS_BLOCK = Regex(
+            pattern = """<<<\s*IMPROVEMENTS\s*>>>\s*\n([\s\S]*?)\n\s*<<<\s*END_IMPROVEMENTS\s*>>>""",
+            options = setOf(RegexOption.IGNORE_CASE),
         )
 
         fun redactMarkerCredentials(text: String): String {

--- a/test-experiments/src/test/kotlin/com/jonnyzzz/mcpSteroid/integration/tests/DevrigRemoteDevelopmentKeycloakTypeHierarchyTest.kt
+++ b/test-experiments/src/test/kotlin/com/jonnyzzz/mcpSteroid/integration/tests/DevrigRemoteDevelopmentKeycloakTypeHierarchyTest.kt
@@ -28,6 +28,8 @@ import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.contentOrNull
 import kotlinx.serialization.json.jsonPrimitive
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.Timeout
@@ -62,6 +64,42 @@ class DevrigRemoteDevelopmentKeycloakTypeHierarchyTest {
         }
         for (required in listOf(PROJECT_DIR, IDE_VERSION, KeycloakTypeHierarchyScenario.INTERFACE_FQN)) {
             assertTrue(required in prompt) { "Task-only prompt must state the reproducible outcome '$required':\n$prompt" }
+        }
+        assertEquals(
+            1,
+            prompt.lineSequence().count { "Work autonomously with the capabilities already configured for you." in it },
+            "Task-only prompt must state its autonomy instruction exactly once:\n$prompt",
+        )
+    }
+
+    @Test
+    fun `keycloak hierarchy score counts implementing classes only`() {
+        val output = buildString {
+            appendLine("CLS: ${KeycloakTypeHierarchyScenario.INTERFACE_FQN}")
+            for (fqn in KeycloakTypeHierarchyScenario.subInterfaces) appendLine("SUBTYPE: $fqn")
+            for (fqn in KeycloakTypeHierarchyScenario.requiredTransitive) appendLine("CLS: $fqn")
+        }
+
+        val score = scoreKeycloakImplementingClasses(
+            output,
+            KeycloakTypeHierarchyScenario.requiredTransitive.size,
+        )
+
+        assertEquals(KeycloakTypeHierarchyScenario.requiredTransitive, score.reported)
+        assertEquals(KeycloakTypeHierarchyScenario.requiredTransitive.size, score.reportedCount)
+        assertTrue(score.complete)
+    }
+
+    @Test
+    fun `final subtype markers reject base and sub-interfaces`() {
+        val interfaces = KeycloakTypeHierarchyScenario.subInterfaces + KeycloakTypeHierarchyScenario.INTERFACE_FQN
+        for (fqn in interfaces) {
+            val failure = assertThrows(AssertionError::class.java) {
+                assertFinalSubtypeMarkersContainClassesOnly("SUBTYPE: $fqn")
+            }
+            assertTrue(fqn in failure.message.orEmpty()) {
+                "Failure must identify the interface reported as a class: ${failure.message}"
+            }
         }
     }
 
@@ -267,9 +305,8 @@ class DevrigRemoteDevelopmentKeycloakTypeHierarchyTest {
         }
         val firstSuccessfulHierarchy = hierarchyExecutions.firstOrNull { it.call.hasSuccessfulResult() }
             ?: error("Every deep ClassInheritorsSearch execution failed. ${summarizeCalls(calls)}")
-        val hierarchyScore = scoreTypeHierarchy(
+        val hierarchyScore = scoreKeycloakImplementingClasses(
             firstSuccessfulHierarchy.call.result?.text.orEmpty(),
-            KeycloakTypeHierarchyScenario.requiredTransitive,
             E2E_MIN_TOTAL,
         )
         assertTrue(hierarchyScore.complete) {
@@ -392,16 +429,46 @@ class DevrigRemoteDevelopmentKeycloakTypeHierarchyTest {
     private fun assertFinalAnswer(rawNdjson: String): TypeHierarchyScore {
         val finalResponse = decodeAgentFinalResponse(rawNdjson)
         assertTrue(finalResponse != null) { "Raw agent events do not contain a final user-visible response." }
-        val score = scoreTypeHierarchy(
-            finalResponse.orEmpty(),
-            KeycloakTypeHierarchyScenario.requiredTransitive,
-            E2E_MIN_TOTAL,
-        )
+        assertFinalSubtypeMarkersContainClassesOnly(finalResponse.orEmpty())
+        val score = scoreKeycloakImplementingClasses(finalResponse.orEmpty(), E2E_MIN_TOTAL)
         assertTrue(score.complete) {
             "The agent final response does not contain the complete hierarchy: " +
                 "reported=${score.reportedCount}, missing=${score.missingRequired}."
         }
         return score
+    }
+
+    private fun scoreKeycloakImplementingClasses(output: String, minTotal: Int): TypeHierarchyScore {
+        val markedClasses = IMPLEMENTING_CLASS_MARKER.findAll(output)
+            .map { it.groupValues[1].trim().trim('.') }
+            .toSet()
+        val scoreInput = if (markedClasses.isEmpty()) {
+            output
+        } else {
+            markedClasses.joinToString("\n") { "SUBTYPE: $it" }
+        }
+        val raw = scoreTypeHierarchy(
+            scoreInput,
+            KeycloakTypeHierarchyScenario.requiredTransitive,
+            minTotal,
+        )
+        val reportedClasses = raw.reported - KeycloakTypeHierarchyScenario.INTERFACE_FQN -
+            KeycloakTypeHierarchyScenario.subInterfaces
+        return raw.copy(
+            reported = reportedClasses,
+            reportedCount = reportedClasses.size,
+            complete = raw.missingRequired.isEmpty() && reportedClasses.size >= minTotal,
+        )
+    }
+
+    private fun assertFinalSubtypeMarkersContainClassesOnly(output: String) {
+        val markers = SUBTYPE_MARKER.findAll(output).map { it.groupValues[1].trim().trim('.') }.toSet()
+        assertTrue(markers.isNotEmpty()) { "Final answer has no SUBTYPE markers: $output" }
+        val interfaces = KeycloakTypeHierarchyScenario.subInterfaces + KeycloakTypeHierarchyScenario.INTERFACE_FQN
+        val wronglyReportedInterfaces = markers intersect interfaces
+        assertTrue(wronglyReportedInterfaces.isEmpty()) {
+            "Final SUBTYPE markers must contain implementing classes, not interfaces: $wronglyReportedInterfaces"
+        }
     }
 
     private fun successfulCommandIndex(calls: List<AgentToolCall>, vararg fragments: String): Int =
@@ -691,6 +758,9 @@ class DevrigRemoteDevelopmentKeycloakTypeHierarchyTest {
         private val BEARER_CREDENTIAL = Regex("Bearer\\s+[$BEARER_TOKEN_CHARACTERS]+")
         private val IJT_QUERY_CREDENTIAL = Regex("([?&]_ijt=)[^&\"\\s]+")
         private val IJT_HEADER_CREDENTIAL = Regex("(\"x-ijt\"\\s*:\\s*\")[^\"]*(\")")
+        private val IMPLEMENTING_CLASS_MARKER =
+            Regex("""(?im)^\s*(?:CLS|SUBTYPE)\s*:\s*([\w.$]+)""")
+        private val SUBTYPE_MARKER = Regex("""(?im)^\s*SUBTYPE\s*:\s*([\w.$]+)""")
         val IMPROVEMENTS_BLOCK = Regex(
             pattern = """<<<\s*IMPROVEMENTS\s*>>>\s*\n([\s\S]*?)\n\s*<<<\s*END_IMPROVEMENTS\s*>>>""",
             options = setOf(RegexOption.IGNORE_CASE),

--- a/test-experiments/src/test/kotlin/com/jonnyzzz/mcpSteroid/integration/tests/DevrigRemoteDevelopmentWorkflowTest.kt
+++ b/test-experiments/src/test/kotlin/com/jonnyzzz/mcpSteroid/integration/tests/DevrigRemoteDevelopmentWorkflowTest.kt
@@ -17,17 +17,29 @@ class DevrigRemoteDevelopmentWorkflowTest {
                 .findAll()
         """.trimIndent()
 
-        assertTrue(DevrigRemoteDevelopmentKeycloakTypeHierarchyTest.DEEP_SEARCH_ARGUMENT.containsMatchIn(code))
+        assertTrue(DevrigRemoteDevelopmentKeycloakTypeHierarchyTest.CLASS_HIERARCHY_API in code)
     }
 
     @Test
-    fun `deep hierarchy verifier rejects false followed by unrelated true`() {
+    fun `hierarchy verifier accepts manual deep traversal built from direct searches`() {
         val code = """
-            val inheritors = ClassInheritorsSearch.search(baseClass, scope, false).findAll()
-            val unrelated = true
+            fun walk(type: PsiClass) {
+                ClassInheritorsSearch.search(type, scope, false).forEach { child ->
+                    println(child.qualifiedName)
+                    walk(child)
+                }
+            }
+            walk(baseClass)
         """.trimIndent()
 
-        assertTrue(!DevrigRemoteDevelopmentKeycloakTypeHierarchyTest.DEEP_SEARCH_ARGUMENT.containsMatchIn(code))
+        assertTrue(DevrigRemoteDevelopmentKeycloakTypeHierarchyTest.CLASS_HIERARCHY_API in code)
+    }
+
+    @Test
+    fun `hierarchy verifier rejects code without the IntelliJ hierarchy API`() {
+        val code = "val unrelated = true"
+
+        assertTrue(DevrigRemoteDevelopmentKeycloakTypeHierarchyTest.CLASS_HIERARCHY_API !in code)
     }
 
     @Test

--- a/test-experiments/src/test/kotlin/com/jonnyzzz/mcpSteroid/integration/tests/KeycloakTypeHierarchyScenario.kt
+++ b/test-experiments/src/test/kotlin/com/jonnyzzz/mcpSteroid/integration/tests/KeycloakTypeHierarchyScenario.kt
@@ -13,6 +13,11 @@ object KeycloakTypeHierarchyScenario {
         "org.keycloak.authentication.authenticators.broker.IdpConfirmLinkAuthenticator",
     )
 
+    val subInterfaces: Set<String> = setOf(
+        "org.keycloak.authentication.AuthenticationFlowCallback",
+        "org.keycloak.authentication.authenticators.conditional.ConditionalAuthenticator",
+    )
+
     fun mcpTaskInstructions(): String = buildString {
         appendLine("Task: list EVERY class that implements the interface `$INTERFACE_FQN`,")
         appendLine("INCLUDING transitive/indirect implementors (a class that extends an abstract base which")


### PR DESCRIPTION
## Summary

- teach Claude and Codex to discover, download, auto-start, and route into an IDEA Ultimate 2026.2 frontendless Remote Development backend
- distinguish backend reachability, project routing, and Maven/Gradle import readiness across initialization, tool descriptions, prompt articles, and post-open results
- turn the Keycloak hierarchy scenario into a task-only workflow with ordered raw-NDJSON evidence, class-only completeness scoring, and improvement artifacts
- teach frontendless Maven agents to treat a null project SDK as a capability warning, reuse only an unambiguous module or exact environment SDK, validate its home, and never select the first global registration
- document the maintained plan, measured Claude/Codex evidence, review verdict, and deferred follow-ups

## Verification

- rebased onto current `origin/main`; focused server, devrig, prompt-generation, prompt/KtBlock, and pure experiment contracts pass
- final prompt iteration: `ExternalSystemFirstOpenPromptContractTest`, corpus-wide `MarkdownArticleContractTest`, and all 10 `ExecuteCodeMavenKtBlocksCompilationTest` cases pass
- edited Kotlin contract test is clean under all enabled file-scoped inspections with an empty `failedTools` list
- two fresh-container Claude task-only runs pass in 7m53s and 5m16s: autonomous IU 2026.2.0.1 download, `steroid_open_project` auto-start, frontendless routing, 136-module Maven import, complete semantic hierarchy, managed-plugin/marker/trust/credential-isolation/teardown assertions
- fresh-container Codex task-only run passes through jb-central in 5m26s (6m15s full Gradle invocation): empty-state discovery, IU download, on-demand open, Maven readiness, hierarchy query, backend invariants, and teardown
- Codex found 74 raw inheritors: 70 named implementing classes, 2 named sub-interfaces, and 2 anonymous implementations; an independent PSI scan matched all 70 named classes exactly
- live `jbcentral status` reports JetBrains Team authentication, a running proxy, and Codex wired; the API credential entered only the Codex CLI process and the backend-environment assertion proved it did not reach IntelliJ
- repository-agent quorum plus Codex, Claude Opus 5, and Claude Fable 5 reviews were iterated; final adversarial review is GO

## Deferred follow-ups

- add a deterministic launcher gate for the MCP-initialization race
- pin the exact Keycloak hierarchy oracle rather than only the current lower-bound/subset harness assertion
- implement the frontendless CLI `--wait` loop and remaining backend lifecycle hardening
- redact expired Remote Development `#jt` join fragments before treating preserved backend logs as safe to publish

## Inspection note

File-scoped IDE inspections ran on all changed production Kotlin files. No actionable changed-line finding appeared, but two Kotlin/UAST inspections crashed on `KtFakeSourceElementKind.PluginGenerated`; `failedTools` correctly made that historical production-file check `check_failed`. The reproducible inspection-engine follow-up remains in `TODO.md`; compile and focused tests are green.
