### PR TITLE
Document frontendless backend agent lessons

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,8 +103,10 @@ devrig install plugin
 **Requirements**
 
 - A JetBrains IDE — IntelliJ IDEA, PyCharm, GoLand, WebStorm, Rider, CLion, or Android Studio.
-- The IDE runs with a real display: the normal GUI on macOS/Windows, or under **Xvfb** (a virtual X display) on Linux/CI. True AWT-headless launches (`-Djava.awt.headless=true`) are unsupported (best-effort, see [#177](https://github.com/jonnyzzz/mcp-steroid/issues/177)). A frontendless Remote Development backend is supported and is not AWT-headless — see [Running devrig in CI](https://devrig.dev/docs/running-on-ci/).
+- A standard desktop IDE runs with a real display: the normal GUI on macOS/Windows, or under **Xvfb** (a virtual X display) on Linux/CI. Plain non-backend headless mode is unsupported (best-effort, see [#177](https://github.com/jonnyzzz/mcp-steroid/issues/177)); a frontendless Remote Development backend is supported. Backend product mode, not the presence of a client window or the raw AWT-headless flag alone, determines that distinction — see [Running devrig in CI](https://devrig.dev/docs/running-on-ci/).
 - An MCP-compatible AI agent (Claude Code, Codex, or Gemini).
+
+For a clean machine with no IDE running, an agent can discover the download catalog with `devrig backend download --json`, install IDEA Ultimate 2026.2, and call `steroid_open_project`. The managed IU-262 backend starts on demand as a frontendless Remote Development backend with MCP Steroid included; no separate start command or client window is required. Readiness is the project path plus Maven/Gradle import, not a screenshot. See the [devrig CLI guide](https://devrig.dev/docs/devrig/#frontendless-intellij-idea-ultimate-20262).
 
 **Faster plugin updates (optional):** add `https://devrig.dev/updatePlugins.xml` in **Settings > Plugins > Gear icon > Manage Plugin Repositories...**. Or install a ZIP from [GitHub Releases](https://github.com/jonnyzzz/mcp-steroid/releases) via **Install Plugin from Disk**.
 

--- a/TODO.md
+++ b/TODO.md
@@ -116,7 +116,8 @@
     tune the 180-second readiness bound and the caller-cancellation behavior before widening support.
   - Put the pure Remote Development NDJSON parser/workflow contracts on a normal CI-backed task; the
     experimental task's direct-invocation guard currently keeps them out of aggregate CI runs.
-  - Redact Remote Development join-link fragments (`#jt=...`) from preserved managed-backend logs.
+  - Redact Remote Development join-link fragments (`#jt=...`) from preserved managed-backend logs
+    ([#448](https://github.com/jonnyzzz/mcp-steroid/issues/448)).
     The Codex artifact review found one after the backend had stopped; the current sanitizer and invariant
     cover `Authorization`/Bearer, `_ijt`, and `x-ijt` credentials only. Extend the pure sanitizer tests and
     keep the shell artifact scan aligned before treating those logs as generally safe to publish.

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -37,6 +37,12 @@ rather than mirroring their contents into per-folder guides):
   content-addressed cache, bundled Corretto JDK, two-key signed
   self-update, auto-GC, agent registration wizard, dev-mode
   pre-population, and a native-binary alternative appendix.
+- [`devrig-remote-development-backend-e2e.md`](devrig-remote-development-backend-e2e.md) —
+  shipped IU-262 native Remote Development backend contract, Docker fixture, lifecycle evidence,
+  and follow-up risks.
+- [`headless-agent-guidance.md`](headless-agent-guidance.md) — task-only Claude/Codex autonomy
+  follow-up: clean-machine backend discovery, frontendless readiness, Maven import, hierarchy scoring,
+  credential isolation, and measured agent evidence.
 - [`native-mcp-tools-design.md`](native-mcp-tools-design.md) —
   research record + spec for listing/calling the IntelliJ MCP Server
   plugin's native tools: validated LIST/CALL recipes (261→master),

--- a/docs/devrig-remote-development-backend-e2e.md
+++ b/docs/devrig-remote-development-backend-e2e.md
@@ -1,9 +1,8 @@
 # devrig Remote Development backend E2E
 
-Status: implementation complete; final review and PR in progress
-Owner branch: `feat/devrig-remote-backend-e2e`
-Worktree: `/Users/jonnyzzz/Work/mcp-steroid-wt-devrig-remote-backend`
-Started: 2026-07-31
+Status: shipped in [PR #411](https://github.com/jonnyzzz/mcp-steroid/pull/411); task-only
+Claude/Codex autonomy follow-up shipped in [PR #441](https://github.com/jonnyzzz/mcp-steroid/pull/441)
+Started: 2026-07-31; autonomy validation completed: 2026-08-05
 
 ## Goal
 
@@ -48,9 +47,10 @@ The work is complete only when all of these are demonstrated:
   development backend.
 - `steroid_open_project`, `steroid_list_projects`, and `steroid_execute_code` work against Keycloak
   without a frontend client.
-- The reused hierarchy scorer finds at least 40 inheritors of
-  `org.keycloak.authentication.Authenticator`, including:
-  `UsernamePasswordForm`, `OTPFormAuthenticator`, and `IdpConfirmLinkAuthenticator`.
+- The task-only hierarchy scorer finds at least 70 distinct named implementing-class FQNs for
+  `org.keycloak.authentication.Authenticator`, including `UsernamePasswordForm`,
+  `OTPFormAuthenticator`, and `IdpConfirmLinkAuthenticator`. The base interface and the two known
+  sub-interfaces do not count; unnamed/local implementations are reported separately.
 - All unit/contract tests and both Docker cases pass from the dedicated worktree, with no ignored warning
   or unexplained error in the relevant IDE/devrig logs.
 - A three-reviewer quorum, including Claude `claude-fable-5` and `claude-opus-5`, reports no blockers
@@ -151,7 +151,11 @@ Managed backend startup remains project-agnostic:
    bridge endpoint. Persist and return that marker PID, which may differ from the launcher PID.
 3. Route `steroid_open_project`; the managed backend already trusts user-requested project paths through
    `REMOTE_DEV_TRUST_PROJECTS=1`.
-4. Poll the project/window readiness surface and then run the semantic task.
+4. Poll `steroid_list_projects` until the requested path appears and retain its opaque `project_name`.
+   Poll `steroid_list_windows` only when an attended frontend exists; a frontendless backend normally has
+   no window.
+5. Trigger and await Maven/Gradle configuration before the first indexed semantic query. Backend reachability,
+   project routing, and external-system readiness are separate gates.
 
 This keeps the existing agent-facing contract and avoids duplicate project-open requests.
 
@@ -174,10 +178,12 @@ mandatory.
 The container receives local devrig installation artifacts and a persistent IDE archive download cache,
 but the user home and devrig managed state are new for every test method.
 
-Claude and Codex use the repository's real agent-session drivers and real API credentials. The prompt
-states the user task and required output markers, but does not hand the agent the hierarchy answer or a
-filesystem-grep recipe. Raw NDJSON is retained so the test can prove the agent called devrig/MCP rather
-than merely mentioning it.
+Claude and Codex use the repository's real agent-session drivers and agent-scoped API credentials. A local
+gateway may be supplied through the standard API-key/base-URL environment variables, but private bootstrap
+helpers remain outside this repository. The prompt states only the user outcome and required output markers:
+it does not name devrig, MCP tools, resource URIs, `ClassInheritorsSearch`, or the bootstrap recipe. Raw
+NDJSON is retained so the test can prove the agent called devrig/MCP rather than merely mentioning it, and
+the backend process environment is checked to prove agent credentials did not cross into IntelliJ.
 
 ## Test-first work plan
 
@@ -231,7 +237,9 @@ than merely mentioning it.
 
 - Resolved stable IntelliJ IDEA Ultimate `2026.2.0.1`, build `IU-262.8665.337`.
 - Started the native `bin/remote-dev-server run` process without a project argument or frontend.
-- Observed `IDE run mode: remote development (backend)` in the IDE log.
+- Observed `IDE run mode: remote development (backend)` with `headless=false` in the validated native
+  IU-262 IDE log. Remote Development product mode is the support boundary; another backend command such as
+  `rdserver-headless` can report a raw headless flag and still classify as a supported backend.
 - Confirmed the devrig state PID equals the MCP Steroid marker PID.
 - Opened Keycloak afterward through `steroid_open_project`.
 - Executed deep `ClassInheritorsSearch` for `org.keycloak.authentication.Authenticator` and received
@@ -299,9 +307,10 @@ than merely mentioning it.
   in-container JVM thread dumps were captured before they were allowed to continue. Both teardown
   paths stopped IU and left no Docker containers or managed backend processes.
 - Both preserved idea and launcher logs are sanitized for Bearer headers, IntelliJ `_ijt` URL tokens,
-  and `x-ijt` JSON header values while retaining safe diagnostics. The four artifacts from both passing
-  Docker runs were re-sanitized locally and verify at zero marker-credential matches. Production full-
-  marker logging remains tracked by [#405](https://github.com/jonnyzzz/mcp-steroid/issues/405).
+  and `x-ijt` JSON header values while retaining safe diagnostics. Production full-marker logging remains
+  tracked by [#405](https://github.com/jonnyzzz/mcp-steroid/issues/405). A later artifact audit found an
+  expired Remote Development `#jt` join fragment outside those patterns; [#448](https://github.com/jonnyzzz/mcp-steroid/issues/448)
+  tracks extending the sanitizer and shell scan. Do not publish raw backend logs until that follow-up lands.
 - A post-quorum Docker rerun reached the fresh-home fixture but could not launch Claude because this
   shell had none of `ANTHROPIC_API_KEY`, `CLAUDE_EVAL_API_KEY`, or `~/.anthropic`; the test failed hard
   as designed and no skip was added. A separate Docker process-scan probe then proved the new teardown
@@ -342,6 +351,28 @@ than merely mentioning it.
   duplicated diagnostics and generic hint belong to #91 rather than a new issue. Four independent
   auditors ultimately agreed exactly on the terminal census and mapping. No genuinely untracked defect
   remained, so no duplicate issue was created.
+
+### 2026-08-05 — task-only agent-autonomy follow-up
+
+- Replaced the scripted bootstrap task with a user-outcome-only prompt. Contract coverage rejects the
+  strings `devrig`, `steroid_`, `mcp-steroid://`, `ClassInheritorsSearch`, and
+  `Observation.awaitConfiguration` from the task itself.
+- Two fresh Claude containers passed in 7m53s and 5m16s. The final run used no window, screenshot, or
+  input tool, imported all 136 Maven modules, and completed the hierarchy in one successful semantic query.
+- A fresh Codex container passed in 5m26s (6m15s including the Gradle rebuild) through an approved local
+  OpenAI gateway. MCP initialization completed before its first call; it discovered the empty state, the
+  download catalog, IU `2026.2.0.1`, on-demand `steroid_open_project`, Maven readiness, and the hierarchy
+  recipe without those steps appearing in the task prompt.
+- Both agents observed 74 raw inheritors: 70 named implementing classes, two named sub-interfaces, and two
+  anonymous/local implementations without FQNs. Final answers contained the intended 70 class markers;
+  an independent `FilenameIndex`/`InheritanceUtil` scan matched Codex's 70-class set exactly.
+- Backend mode, managed plugin, trust/noninteractive flags, route liveness, agent-credential isolation,
+  stop, and process cleanup all passed. The final adversarial review returned GO.
+- The harness still intentionally uses a 70-FQN lower bound plus known indirect implementors. Pinning the
+  exact full oracle and deterministically gating the first task turn on MCP initialization remain separate
+  non-gating TODOs.
+- Detailed prompt findings and the maintained validation plan live in
+  [`headless-agent-guidance.md`](headless-agent-guidance.md).
 
 ## Review log
 

--- a/docs/guides/AGENT-STEROID-GUIDE.md
+++ b/docs/guides/AGENT-STEROID-GUIDE.md
@@ -136,7 +136,9 @@ Provide feedback on execution results. Use after `steroid_execute_code` to rate 
 ### `steroid_open_project`
 Open a project in the IDE. This tool initiates the project opening process and returns quickly.
 
-**IMPORTANT**: Project opening is **ASYNCHRONOUS**. This tool returns immediately after initiating the open operation. You **MUST poll** `steroid_list_windows` to verify the project is fully ready.
+**IMPORTANT**: Project opening is **ASYNCHRONOUS**. A project route, an attended frontend window, and
+Maven/Gradle configuration are separate readiness signals. A Remote Development backend can be fully useful
+without any frontend window, so `steroid_list_windows` is never the universal completion gate.
 
 Parameters:
 - `project_path` (required): Absolute path to the project directory to open
@@ -146,16 +148,20 @@ Parameters:
 
 **Verification Workflow (Required):**
 1. Call `steroid_open_project` with the project path
-2. Poll `steroid_list_windows` every 2-3 seconds until:
-   - The project appears in the windows list
-   - `modalDialogShowing` is `false` (no dialogs blocking)
-   - `indexingInProgress` is `false` (indexing complete)
-   - `projectInitialized` is `true`
-3. If `modalDialogShowing` is `true`:
+2. Poll `steroid_list_projects` until the requested normalized path appears. Retain that entry's opaque
+   `project_name`; use it for subsequent project-scoped tools.
+3. If that backend has an attended frontend window, use `steroid_list_windows` to wait until
+   `modalDialogShowing=false`, `indexingInProgress=false`, and `projectInitialized=true`. If no window exists,
+   continue: that is normal for a frontendless Remote Development backend.
+4. If a visible window reports `modalDialogShowing=true`:
    - Call `steroid_take_screenshot` to see the dialog
    - Use `steroid_input` to interact with the dialog
-4. Use `steroid_take_screenshot` to visually confirm the project is loaded
-5. Verify with `steroid_list_projects` that the project appears
+5. Before compilation, inspections, refactoring, or indexed semantic queries, trigger and await the
+   project's Maven/Gradle import using `mcp-steroid://skill/execute-code-maven` or
+   `mcp-steroid://skill/execute-code-gradle`. IDE reachability alone does not prove the external model is
+   configured.
+
+Screenshots are diagnostics for a real frontend, not a required proof of project readiness.
 
 #### Choosing a backend (`backend_name`)
 
@@ -206,7 +212,8 @@ explicitly run backends, call the `devrig` CLI directly:
 
 - `devrig backend` — show three groups: running MCP Steroid IDEs /
   other running IDEs (no plugin) / installed managed IDEs not running.
-- `devrig backend download <id>` — fetch an IDE.
+- `devrig backend download --json` — on a clean machine, list the downloadable product/version catalog.
+- `devrig backend download <id>` — fetch an IDE selected from that catalog.
 - `devrig backend start <id>` / `devrig backend stop <id>` — explicit
   lifecycle control (not needed for `open_project`, which starts managed
   backends automatically).
@@ -215,6 +222,13 @@ explicitly run backends, call the `devrig` CLI directly:
 
 Run `devrig` — the stable launcher the devrig binary keeps current on
 your `PATH` (under `~/.mcp-steroid/bin`) — e.g. `devrig backend ...`.
+
+For unattended Java semantic work, IDEA Ultimate `2026.2.x` (baseline 262) uses the supported native
+Remote Development backend with the managed MCP Steroid plugin included. It is frontendless; the validated
+native IU-262 run logged `headless=false`. More generally, Remote Development product mode takes precedence
+over the raw AWT-headless flag, while only plain non-backend headless mode is unsupported. Do not wait for a
+window or invoke screenshot/input tools unless an attended frontend is actually present. Other
+products/build lines may use their standard managed launcher.
 
 See also: `mcp-steroid://open-project/managing-backends`.
 

--- a/docs/headless-agent-guidance.md
+++ b/docs/headless-agent-guidance.md
@@ -1,4 +1,4 @@
-# Headless IDE agent guidance
+# Frontendless Remote Development agent guidance
 
 ## Goal
 
@@ -24,13 +24,14 @@ From a fresh container with devrig registered but no IDE installed or running, e
 7. Leave evidence that the live IDE is the trusted, unattended IU-262 Remote Development backend with
    MCP Steroid installed and no agent credentials in its process environment.
 
-## Evidence from the merged scenario
+## Baseline before the autonomy follow-up
 
-The merged E2E proves the Remote Development launcher, plugin installation, process marker, trusted
-environment, project route, and semantic hierarchy query. It does not prove autonomous discovery: its
-prompt currently supplies the exact download/start commands, every MCP step, and the hierarchy recipe.
+PR #411 proved the Remote Development launcher, plugin installation, process marker, trusted environment,
+project route, and semantic hierarchy query. Its original scripted prompt supplied the exact download/start
+commands, every MCP step, and the hierarchy recipe, so that baseline alone did not prove autonomous
+discovery. PR #441 replaced it with the task-only workflow described below.
 
-Three independent audits found the same agent-facing gaps:
+Three independent audits of that baseline found the same agent-facing gaps:
 
 - The baseline `devrig backend` said only `No backends detected.` on a clean machine although initialization
   guidance claimed it listed available products. Bare `devrig backend download --json` is the real discovery path.
@@ -58,7 +59,7 @@ Three independent audits found the same agent-facing gaps:
 - [x] Run focused unit, prompt-generation, Kotlin-fence, and experimental harness contracts.
 - [x] Run two Claude scenarios in fresh containers, review their `<<<IMPROVEMENTS>>>` artifacts, and
   iterate on the observed frontendless-readiness and hierarchy-classification gaps.
-- [x] Run the Codex scenario in a fresh container through the local jb-central OpenAI route and review its
+- [x] Run the Codex scenario in a fresh container through an approved local OpenAI gateway and review its
   raw NDJSON plus `<<<IMPROVEMENTS>>>` artifact. The credential entered only the Codex CLI process; the
   backend-environment assertion proved it did not reach IntelliJ.
 - [x] Run the final adversarial artifact review and close its runtime gate. The reviewer returned GO after
@@ -98,8 +99,8 @@ Three independent audits found the same agent-facing gaps:
   set exactly, and the final answer emitted 70 unique class markers. Backend mode, managed plugin, trust and
   noninteractive flags, API-credential isolation, the current Bearer/`_ijt` marker-credential invariant,
   route liveness, stop, and process cleanup all passed. Artifact review found an expired Remote Development
-  `#jt` join fragment outside that sanitizer's coverage; `TODO.md` now tracks making preserved backend logs
-  generally publication-safe.
+  `#jt` join fragment outside that sanitizer's coverage; [#448](https://github.com/jonnyzzz/mcp-steroid/issues/448)
+  now tracks making preserved backend logs generally publication-safe.
 - Independent reviews completed with the repository subagent quorum, `run-agent.sh` Codex, Claude Opus 5,
   and Claude Fable 5. Their findings were iterated into the current wording and assertions.
 - The final adversarial artifact review returned GO for the full Claude-and-Codex goal. It kept the separate
@@ -112,8 +113,8 @@ Three independent audits found the same agent-facing gaps:
   edited Kotlin contract test is also clean under every enabled file-scoped inspection with no failed tools.
 - The final read-only review returned GO after verifying the conditional null-SDK behavior, module-aware
   selection, canonical home validation, post-write read action, contract coverage, and KtBlock results.
-- PR #441 is mergeable; compile, Linux PowerShell Docker, and Windows PowerShell checks passed after the
-  final rebase and prompt iteration.
+- PR #441 merged via rebase-and-merge; compile, Linux PowerShell Docker, and Windows PowerShell checks
+  passed on the final zero-behind head.
 - File-scoped IDE inspections ran on every changed production Kotlin file. They found no actionable
   changed-line diagnostic, but the `OpenProjectTool.kt` check is not called clean: two Kotlin/UAST
   inspections crashed on `KtFakeSourceElementKind.PluginGenerated`, so `failedTools` correctly made it
@@ -161,6 +162,26 @@ or diagnostics show it is absent, after inspecting module SDKs instead of blindl
 The executable repair recipe canonicalizes and validates an explicit home through IntelliJ APIs, refuses
 ambiguous candidates, and performs every project/module SDK model read under a read action.
 
+## Durable operational lessons
+
+- Treat readiness as three separate gates: MCP/backend reachability, the requested path appearing in
+  `steroid_list_projects`, and external-system configuration/indexing. A visible IDE window is optional;
+  a frontendless Remote Development backend normally has none.
+- A null project-level SDK is a capability warning, not proof that project-local PSI is incomplete. Repair
+  only when the requested work needs JDK symbols, compilation, inspections, or refactoring and the required
+  SDK is unambiguous. Prefer a consistent module SDK, then an exact validated environment/project path;
+  never apply the first global SDK registration.
+- Score agent behavior from raw NDJSON tool events and bound the first successful semantic result. Decoded
+  prose can echo fetched recipes and create false positives for tool-use assertions.
+- Keep API credentials in the agent CLI process only. Local gateways integrate through the standard
+  `*_API_KEY` plus `*_BASE_URL` variables; their private credential/bootstrap helpers stay outside this
+  repository. The E2E must continue proving those values do not enter the IntelliJ backend environment.
+- Preserved logs are diagnostic artifacts, not automatically publishable evidence. The current sanitizer
+  still needs the `#jt` join-fragment coverage tracked by [#448](https://github.com/jonnyzzz/mcp-steroid/issues/448)
+  before raw managed-backend logs may be shared.
+- The reproducible commands, artifacts, and one-Docker-test-at-a-time rules live in
+  `test-experiments/CLAUDE.md`; this file records conclusions rather than duplicating the runner playbook.
+
 ## Experiment discipline
 
 The Claude and Codex cases each use a new container; backend state is never shared. Assertions use raw
@@ -175,7 +196,7 @@ known sub-interfaces do not contribute to that count. It detects the observed st
 shallow searches, but it does not pin the entire upstream class set. The agent task still requires the full,
 untruncated named hierarchy; this E2E primarily gates autonomous backend discovery and IDE use.
 
-Docker agent runs are sequential. Local OpenAI access may come from direct credentials or the jb-central
-proxy wrapper used for this run; either way, credentials are injected only into the agent CLI process. If
-credentials are unavailable, the tests continue to fail hard as designed; no runtime skip or weakened
-assertion is permitted.
+Docker agent runs are sequential. Local OpenAI access may come from direct credentials or an approved
+gateway exposed through the standard API-key/base-URL variables; either way, credentials are injected only
+into the agent CLI process. If credentials are unavailable, the tests continue to fail hard as designed;
+no runtime skip or weakened assertion is permitted.

--- a/docs/superpowers/plans/2026-06-09-backend-name-open-project.md
+++ b/docs/superpowers/plans/2026-06-09-backend-name-open-project.md
@@ -1,5 +1,11 @@
 # `backend_name` Routing Parameter for `steroid_open_project` — Implementation Plan
 
+> **Historical plan.** The implementation shipped and its readiness wording was later superseded by the
+> frontendless Remote Development flow. The current contract is in
+> [`docs/guides/AGENT-STEROID-GUIDE.md`](../../guides/AGENT-STEROID-GUIDE.md): poll
+> `steroid_list_projects` for the requested path, treat windows as optional, and await Maven/Gradle
+> configuration separately. Do not copy the mandatory-window recipe from this plan.
+
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
 **Goal:** Let an agent talking to **devrig** choose *which discovered IDE backend* a project opens in, by passing an optional `backend_name` to `steroid_open_project`, where `backend_name` is the same stable backend identifier already surfaced by `steroid_list_projects` and `devrig backend/project --json`.

--- a/docs/superpowers/plans/2026-06-22-startable-backends.md
+++ b/docs/superpowers/plans/2026-06-22-startable-backends.md
@@ -1,5 +1,11 @@
 # Startable backends + backend-listing simplification — Implementation Plan
 
+> **Historical plan.** Startable managed backends shipped; the later IU-262 Remote Development work added
+> a frontendless launcher and separated backend reachability, project-path routing, and build-system import.
+> Use [`docs/guides/AGENT-STEROID-GUIDE.md`](../../guides/AGENT-STEROID-GUIDE.md) and
+> [`docs/devrig-remote-development-backend-e2e.md`](../../devrig-remote-development-backend-e2e.md) for the
+> current behavior.
+
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
 **Goal:** Let `steroid_open_project` start a not-yet-running devrig-managed IDE (blocking until reachable) then open the project, and simplify the backend model around `ideHome` identity — deleting `BackendRow`, `BackendInfo`, `ListedBackendInfo`, and the `backends[]` array on the list tools.

--- a/prompts/src/main/prompts/open-project/managing-backends.md
+++ b/prompts/src/main/prompts/open-project/managing-backends.md
@@ -22,7 +22,8 @@ version, build, and license tier; pass `--version <version>` to pin another rele
 version. For unattended Java/JVM work on the supported 2026.2 line, choose
 `devrig backend download idea-ultimate --version <version>`. IDEA Ultimate
 262 is launched as a **frontendless Remote Development backend** with MCP
-Steroid included; plain AWT headless mode is a different, unsupported mode.
+Steroid included. Plain non-backend headless mode is unsupported; Remote Development product mode takes
+precedence over the raw AWT-headless flag, so that flag alone is not a support detector.
 
 After the download, call `steroid_open_project` with the project path. When
 the installed backend is the sole candidate, omit `backend_name`: devrig

--- a/prompts/src/main/prompts/skill/debug-remote-ide-skill.md
+++ b/prompts/src/main/prompts/skill/debug-remote-ide-skill.md
@@ -17,7 +17,7 @@ Guide for AI agents on debugging IntelliJ-based IDEs (CLion, Rider, etc.) using 
 This guide explains how an AI agent can debug an IntelliJ-based IDE (like CLion) by:
 1. Launching the IDE in debug mode from IntelliJ IDEA
 2. Using MCP Steroid to interact with the debugged IDE
-3. Taking screenshots to observe UI state
+3. Taking screenshots when an attended frontend exists
 4. Using the debugger to inject code and inspect runtime state
 5. Testing plugin functionality programmatically
 
@@ -46,7 +46,8 @@ This guide explains how an AI agent can debug an IntelliJ-based IDE (like CLion)
 │                                     │
 │  - Running with -agentlib:jdwp      │
 │  - Plugin under test loaded         │
-│  - UI may be visible or headless    │
+│  - Frontend may be attached/absent  │
+│  - Run mode confirmed from idea.log │
 │  - Fully controllable via debugger  │
 │  - State inspectable                │
 └─────────────────────────────────────┘
@@ -262,7 +263,9 @@ val checkWindows = ProcessBuilder(listOf(
 val windowCount = checkWindows.inputStream.bufferedReader().readText().trim()
 checkWindows.waitFor()
 println("Window count: $windowCount")
-// Output: 0 = headless mode
+// Output 0 only means that no frontend window is visible.
+// It does not distinguish a supported Remote Development backend from
+// unsupported plain non-backend headless mode.
 ```
 
 ---
@@ -358,10 +361,29 @@ throw RuntimeException("Debug marker")
 
 ### No Visible Window
 
-Target IDE may be running headless. Use programmatic approaches:
+First distinguish the two modes:
+
+- A supported Remote Development backend can be **frontendless**: no client window is attached. Backend
+  product mode takes precedence over the raw AWT-headless flag, so commands such as `rdserver-headless`
+  remain supported backends.
+- Plain non-backend headless mode is best-effort and unsupported because platform UI assumptions can cause
+  long waits and deadlocks.
+
+Check the target `idea.log`: a managed IU-262 backend reports Remote Development backend mode (the validated
+native run logged `headless=false`). The explicit `MCP Steroid is running in a headless IDE` warning is
+emitted only for plain non-backend headless mode; restart that IDE with a real display or Xvfb. Do not use
+the raw `headless=` flag by itself as the mode detector.
+
+For a supported frontendless backend, prove readiness through MCP instead of a window: wait until the
+requested path appears in `steroid_list_projects`, retain its opaque `project_name`, then trigger and await
+Maven/Gradle configuration before indexed semantic work. `steroid_list_windows` and screenshots are optional
+diagnostics only when an attended frontend actually exists.
+
+Use programmatic approaches:
 - Monitor logs
-- Use state file manipulation
 - Query via debugger code injection
+- Query the target backend through MCP Steroid when it is installed
+- Use state file manipulation when appropriate
 
 ---
 
@@ -371,7 +393,8 @@ Target IDE may be running headless. Use programmatic approaches:
 2. **Wait for initialization** - Monitor logs for "Loaded bundled plugins"
 3. **Check logs first** - Before UI automation, verify IDE started correctly
 4. **Use multiple evidence sources** - Process status + debug connection + logs + state files
-5. **Document everything** - PID, debug port, log excerpts, screenshots
+5. **Document everything** - PID, debug port, log excerpts, MCP readiness evidence, and screenshots when a
+   frontend exists
 
 ### Evidence Checklist
 
@@ -394,7 +417,7 @@ State files updated
 2. Use MCP Steroid to execute code in the host IDE
 3. Inject code into target IDE via debugger "Evaluate Expression"
 4. Set breakpoints and inspect runtime state
-5. Take screenshots for visual verification
+5. Take screenshots for visual verification when a frontend exists
 6. Monitor logs in real-time
 7. Test plugins without UI automation
 8. Modify behavior during debugging
@@ -408,7 +431,7 @@ Monitor logs -> Collect evidence -> Document results
 
 **Remember:**
 - Debugging is async - wait for readiness
-- Headless mode is common - adapt your approach
+- Frontendless Remote Development is supported; only plain non-backend headless mode is unsupported
 - Logs are your best friend
 - Multiple evidence sources = high confidence
 - Document everything for reproducibility

--- a/test-experiments/CLAUDE.md
+++ b/test-experiments/CLAUDE.md
@@ -44,6 +44,58 @@ the 1-minute rule and stuck-test debugging.
 invocation still works. Depends on `:test-integration` for the shared infrastructure (`IdeContainer`,
 `ConsoleDriver`, `XcvbDriver`, `AiAgentDriver`, `ConsolePumpingContainerDriver`).
 
+## Frontendless Remote Development Keycloak agent E2E
+
+`DevrigRemoteDevelopmentKeycloakTypeHierarchyTest` is the task-only clean-machine proof for Claude and
+Codex. Each method gets a fresh container, agent home, and `~/.mcp-steroid`; do not combine or parallelize
+them:
+
+```bash
+./gradlew :test-experiments:test \
+  --tests '*DevrigRemoteDevelopmentKeycloakTypeHierarchyTest.claude*' --rerun-tasks
+
+./gradlew :test-experiments:test \
+  --tests '*DevrigRemoteDevelopmentKeycloakTypeHierarchyTest.codex*' --rerun-tasks
+```
+
+The task prompt deliberately names only the Keycloak outcome. It must not reveal devrig, `steroid_*`, an
+`mcp-steroid://` URI, `ClassInheritorsSearch`, or the Maven readiness recipe; contract coverage pins that
+purity. The agent must discover the empty state, downloadable catalog, IU 2026.2 backend, on-demand project
+open, external-system readiness, and deep hierarchy itself.
+
+Readiness is frontendless: poll the requested path through `steroid_list_projects`, retain its opaque
+`project_name`, then trigger/await Maven configuration. Do not require `steroid_list_windows`, screenshots,
+or input; the native Remote Development backend normally has no window. The semantic result currently gates
+at least 70 named implementing-class FQNs plus known indirect implementations; sub-interfaces and unnamed
+implementations are classified separately. Exact full-oracle pinning remains in `TODO.md`.
+
+### Local credentials and gateways
+
+The agent drivers accept the normal vendor variables (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`) and the
+corresponding `ANTHROPIC_BASE_URL` / `OPENAI_BASE_URL`. Loopback gateway URLs are rewritten for container
+reachability by the shared test helper. Private helpers that obtain or rotate gateway credentials must stay
+outside this public repository: invoke the helper around the Gradle command, never copy it into a Dockerfile,
+test, or checked-in script, and never print the token value.
+
+Credentials belong only to the external agent CLI process. The E2E must keep asserting that API keys/base
+URLs do not enter the managed IntelliJ backend environment. Missing Claude/OpenAI credentials fail hard;
+do not add a runtime skip or weaken the scenario.
+
+### Evidence and iteration
+
+- Raw tool evidence: `test-experiments/build/test-logs/test/run-*/agent-*-raw.ndjson`.
+- Decoded transcript: sibling `agent-*-decoded.txt` (useful to read, never authoritative for tool calls).
+- Agent reflection: `test-experiments/build/improvements/IMPROVEMENTS-headless-backend-<agent>.md`.
+- Backend/launcher/IDE logs remain private artifacts until the `#jt` join-fragment sanitizer gap tracked by
+  [#448](https://github.com/jonnyzzz/mcp-steroid/issues/448) is fixed; existing Bearer, `_ijt`, and `x-ijt`
+  sanitization is not sufficient for publication.
+
+Parse raw NDJSON to assert ordered download/open/list/execute calls and score the first successful semantic
+query. A decoded transcript can echo fetched prompt text and create false positives. If a run crosses the
+one-minute rule, collect the available process/thread/log evidence before stopping it; the absence of a
+frontend screenshot is expected here. Read `docs/headless-agent-guidance.md` for the measured Claude/Codex
+iterations and `docs/devrig-remote-development-backend-e2e.md` for the launcher contract.
+
 ## Remote-debugging (shared with :test-integration)
 
 Because the infra is shared, every `:test-experiments` Docker IDE also starts with a JDWP agent on

--- a/test-integration/AGENTS.md
+++ b/test-integration/AGENTS.md
@@ -797,6 +797,23 @@ Credentials stored as `credentialsJSON:*` on the TC server, referenced via `Toke
 **Missing:** `GEMINI_API_KEY` — no `credentialsJSON` ref exists yet. `CliGeminiIntegrationTest` opts
 into `skipTestWhenKeyMissing` (see root CLAUDE.md → BANNED → Gemini exception).
 
+### Local agent credentials and LLM gateways
+
+Local Docker agent tests use the same standard environment contract as TeamCity. In addition to the API
+key, the session drivers honor `ANTHROPIC_BASE_URL`, `OPENAI_BASE_URL` (fallback
+`OPENAI_API_BASE`), and Gemini's base-URL variants. `resolveContainerAgentBaseUrl` rewrites a loopback
+host to `host.docker.internal`, so a gateway bound on the host remains reachable from the agent container.
+
+An internal credential/gateway bootstrap helper may wrap the Gradle invocation, but that helper must remain
+outside this public repository. Do not copy it into production code, tests, Dockerfiles, or checked-in shell
+scripts; the test infrastructure stays vendor-neutral and sees only the standard environment variables.
+Before a long run, verify authentication and gateway liveness without printing the returned key.
+
+Forward credentials only to the external agent CLI process. They must not appear in the Docker IDE's launch
+environment, managed backend marker, or preserved logs; the frontendless Remote Development E2E asserts that
+isolation. Missing Claude/OpenAI credentials still fail hard. An unresolved TeamCity credential reference is
+also a configuration failure, not a reason to skip.
+
 ## Agent output filters & NDJSON quirks
 
 Each agent is invoked with specific flags to produce NDJSON output piped through `agent-output-filter`:

--- a/website/content/docs/devrig.md
+++ b/website/content/docs/devrig.md
@@ -167,6 +167,29 @@ devrig backend stop idea-community
 `devrig backend start <id>` / `devrig backend stop <id>` still exist for
 explicit lifecycle control when you prefer it.
 
+### Frontendless IntelliJ IDEA Ultimate 2026.2
+
+For unattended Java semantic work, devrig can run IntelliJ IDEA Ultimate 2026.2 (baseline 262) as a
+native Remote Development backend with MCP Steroid installed:
+
+```bash
+devrig backend download idea-ultimate --version 2026.2.0.1
+```
+
+After the download, call `steroid_open_project` normally. It starts the backend on demand, waits until MCP
+Steroid is reachable, and routes the requested project. No separate `devrig backend start` command and no
+Remote Development client window are required.
+
+This mode is **frontendless**. The validated native IU-262 run logged Remote Development backend mode with
+`headless=false`; more generally, backend product mode takes precedence over the raw AWT-headless flag, and
+only plain non-backend headless mode is unsupported. A window or screenshot is therefore not a readiness
+requirement: wait until the requested path appears in `steroid_list_projects`, keep its returned
+`project_name`, then trigger and await Maven/Gradle import before indexed semantic work. If an attended
+frontend exists, `steroid_list_windows` remains useful for dialogs and indexing progress.
+
+The native frontendless launcher is intentionally limited to IDEA Ultimate baseline 262. Other managed
+products/build lines currently use their standard launcher and may still need a display/Xvfb.
+
 ## Next Steps
 
 - [Getting Started](/docs/getting-started/) — install the MCP Steroid plugin and connect your AI Agent

--- a/website/content/docs/getting-started.md
+++ b/website/content/docs/getting-started.md
@@ -40,13 +40,18 @@ Codex, or Gemini. The agent must be one of `claude`, `codex`, or `gemini`. See t
 In your JetBrains IDE, install **MCP Steroid** from the
 [JetBrains Marketplace](https://plugins.jetbrains.com/plugin/30019-mcp-steroid).
 
+This manual plugin step is for an IDE you already manage. When devrig downloads and starts a managed
+backend, it installs the matching MCP Steroid plugin into that isolated backend automatically.
+
 ### Requirements
 
 - A JetBrains IDE — IntelliJ IDEA, PyCharm, GoLand, WebStorm, Rider, CLion, or Android Studio
-- The IDE runs with a real display: the normal GUI on macOS/Windows, or under Xvfb (a virtual
-  X display) on Linux/CI. True headless launches (`-Djava.awt.headless=true`) are unsupported
-  (best-effort, see [#177](https://github.com/jonnyzzz/mcp-steroid/issues/177)) — see
-  [Running devrig in CI](/docs/running-on-ci/)
+- A standard desktop IDE runs with a real display: the normal GUI on macOS/Windows, or under Xvfb (a
+  virtual X display) on Linux/CI. A devrig-managed IntelliJ IDEA Ultimate 2026.2 backend may instead run
+  as a supported frontendless Remote Development backend. Only plain non-backend headless mode is
+  unsupported (best-effort, see [#177](https://github.com/jonnyzzz/mcp-steroid/issues/177)); Remote
+  Development product mode takes precedence over the raw AWT-headless flag. See
+  [Running devrig in CI](/docs/running-on-ci/).
 - An MCP-compatible AI agent (Claude Code, Codex, Gemini, or any MCP client)
 
 ## Verify the connection
@@ -63,6 +68,9 @@ gemini "List all open projects using steroid_list_projects"
 If you see your open IntelliJ projects, the connection works and your agent can now use all
 MCP Steroid capabilities. We recommend asking your agent to use IntelliJ APIs and the IDE
 while it works.
+
+An empty project list is valid when no IDE/project is open yet. The agent can discover downloadable
+backends, download one, and call `steroid_open_project`; managed backends start on demand.
 
 ## Troubleshooting
 
@@ -82,14 +90,19 @@ If port 6315 is in use, change it:
 4. Restart IntelliJ
 5. Update your MCP client with the new URL from `.idea/mcp-steroid.md`
 
-**Headless IDE (unsupported)**
+**Plain headless IDE (unsupported)**
 
 If `idea.log` contains the WARN `MCP Steroid is running in a headless IDE`, the IDE was
-launched without a UI (e.g. `-Djava.awt.headless=true`). Headless mode is unsupported
+classified as plain non-backend headless mode. That mode is unsupported
 (best-effort): long blocking waits and deadlocks in platform code have been observed — see
 [#177](https://github.com/jonnyzzz/mcp-steroid/issues/177). Run the normal desktop GUI on
 macOS/Windows, or, on Linux/CI, start the IDE under Xvfb (a virtual X display) — see
 [Running devrig in CI](/docs/running-on-ci/).
+
+A frontendless Remote Development backend is different: it has no attached client window but is classified
+by Remote Development product mode before the raw AWT-headless flag is considered. It is supported for the
+managed IU-262 path documented in the [devrig CLI guide](/docs/devrig/); agents should wait for the project
+path and build-system import, not for a screenshot.
 
 ## Next Steps
 

--- a/website/content/docs/how-to-debug-ide.md
+++ b/website/content/docs/how-to-debug-ide.md
@@ -21,7 +21,7 @@ group: "Examples"
 This guide explains how an AI agent can debug an IntelliJ-based IDE (like CLion) by:
 1. Launching the IDE in debug mode from IntelliJ IDEA
 2. Using the MCP Steroid to interact with the debugged IDE
-3. Taking screenshots to observe UI state
+3. Taking screenshots when an attended frontend exists
 4. Using the debugger to inject code and inspect runtime state
 5. Testing plugin functionality programmatically
 
@@ -52,7 +52,8 @@ This guide explains how an AI agent can debug an IntelliJ-based IDE (like CLion)
 │                                     │
 │  - Running with -agentlib:jdwp      │
 │  - Plugin under test loaded         │
-│  - UI may be visible or headless    │
+│  - Frontend may be attached/absent  │
+│  - Run mode confirmed from idea.log │
 │  - Fully controllable via debugger  │
 │  - State inspectable                │
 └─────────────────────────────────────┘
@@ -328,7 +329,7 @@ tell application "System Events"
         end repeat
         return "Found " & winCount & " windows"
     else
-        return "No visible windows (headless mode)"
+        return "No visible windows"
     end if
 end tell
 EOF
@@ -336,7 +337,8 @@ EOF
 
 **Result tells you:**
 - Visible: Can use UI automation
-- Headless: Must use programmatic approaches only
+- Not visible: Use programmatic approaches. This does not identify the IDE run mode; check the
+  `IDE run mode: ...` log line because a supported Remote Development backend may have no window.
 
 ---
 
@@ -716,15 +718,16 @@ throw RuntimeException("Debug marker")
 
 ### No Visible Window
 
-**Reason:** Target IDE running headless (no GUI)
+**Reason:** Either a supported frontendless Remote Development backend or unsupported plain non-backend
+headless mode.
 
-**Support status:** headless IDEs are unsupported (best-effort) for MCP Steroid. The platform
-behaves differently without a UI and long blocking waits/deadlocks in platform code have been
-observed — see [#177](https://github.com/jonnyzzz/mcp-steroid/issues/177). On startup the plugin
-logs an `IDE run mode: ...` INFO line and, for a plain headless IDE, a
-`MCP Steroid is running in a headless IDE` WARN in `idea.log`. Give the IDE a real display instead: the normal GUI on
-macOS/Windows, or a virtual one via Xvfb on Linux/CI (see [Running devrig in CI](/docs/running-on-ci/)). The workarounds
-below are best-effort only.
+**Determine which mode first.** On startup the plugin logs `IDE run mode: ...`. A managed IU-262 backend
+reports remote development (backend) and may legitimately have no window; the validated native run also
+logged `headless=false`. The `MCP Steroid is running in a headless IDE` WARN is emitted only for plain
+non-backend headless mode; that mode is best-effort/unsupported because platform UI assumptions can cause
+long waits and deadlocks ([#177](https://github.com/jonnyzzz/mcp-steroid/issues/177)). Give the latter a real
+GUI/Xvfb instead. Remote Development product mode takes precedence over the raw AWT-headless flag, so do not
+use that flag alone as the mode detector. See [Running devrig in CI](/docs/running-on-ci/).
 
 **Approach:**
 - Don't rely on UI automation
@@ -732,11 +735,17 @@ below are best-effort only.
 - Monitor logs
 - Use state file manipulation
 
-**Verify headless:**
+For a supported frontendless backend, prove readiness through MCP instead of a window: wait until the
+requested path appears in `steroid_list_projects`, retain its opaque `project_name`, then trigger and await
+Maven/Gradle configuration before indexed semantic work. `steroid_list_windows` and screenshots are optional
+diagnostics only when an attended frontend exists.
+
+**Check for a visible macOS window (not a mode detector):**
 
 ```bash
 osascript -e 'tell application "System Events" to get count of windows of (first process whose name is "java")'
-# Output: 0 = headless
+# Output 0 can mean supported Remote Development OR unsupported plain headless mode.
+# Use the idea.log run-mode/WARN lines above to distinguish them.
 ```
 
 ### Plugin Classes Not Found
@@ -851,7 +860,7 @@ Monitor logs -> Collect evidence -> Document results
 
 **Remember:**
 - Debugging is async - wait for readiness
-- Headless mode is common - adapt your approach
+- Frontendless Remote Development is supported; only plain non-backend headless mode is unsupported
 - Logs are your best friend
 - Multiple evidence sources = high confidence
 - Document everything for reproducibility

--- a/website/content/docs/running-on-ci.md
+++ b/website/content/docs/running-on-ci.md
@@ -1,17 +1,22 @@
 ---
 title: "Running devrig in CI"
-description: "Run devrig and a real JetBrains IDE on CI — under Xvfb (a virtual X display) on Linux, or the normal GUI on macOS/Windows"
+description: "Run devrig with an attended IDE under Xvfb/GUI, or with the supported frontendless IDEA Ultimate Remote Development backend"
 weight: 55
 group: "Reference"
 ---
 
-devrig drives a **real** JetBrains IDE, and a JetBrains IDE is a GUI application: it needs a
-display to attach to. That is true in CI as well. There is no true headless mode — launching
-the IDE with `-Djava.awt.headless=true` is unsupported (best-effort only; long blocking waits
-and deadlocks in platform code have been observed — see
-[#177](https://github.com/jonnyzzz/mcp-steroid/issues/177)).
+devrig drives a **real** JetBrains IDE. There are two supported CI shapes:
 
-So "running in CI" does not mean "running headless". It means giving the IDE a display:
+- **Attended desktop IDE** — use the normal GUI on macOS/Windows or Xvfb on Linux.
+- **Frontendless Remote Development backend** — devrig-managed IntelliJ IDEA Ultimate 2026.2
+  (baseline 262) can run without an attached Remote Development client window.
+
+Support follows IntelliJ product mode, not the presence of a client window or the raw AWT-headless flag
+alone. Remote Development backends are supported even when a backend command sets that flag. Plain
+non-backend headless mode remains unsupported (best-effort only; long blocking waits and deadlocks in
+platform code have been observed — see [#177](https://github.com/jonnyzzz/mcp-steroid/issues/177)).
+
+For an attended IDE, provide a display:
 
 - **macOS / Windows CI** — the runner already has a real GUI session. Install and run devrig
   exactly as you would locally; the IDE renders to the normal desktop.
@@ -19,6 +24,27 @@ So "running in CI" does not mean "running headless". It means giving the IDE a d
   with **Xvfb** (the X virtual framebuffer). The IDE renders into the virtual display and
   behaves as if a screen were attached. This is the approach the project's own integration
   tests use.
+
+## Frontendless Remote Development backend
+
+For an unattended Java semantic task, download the verified IDEA Ultimate build:
+
+```bash
+devrig backend download idea-ultimate --version 2026.2.0.1
+```
+
+The agent can then call `steroid_open_project`. devrig starts the native Remote Development backend on
+demand with MCP Steroid installed and opens the requested path. No separate `devrig backend start` and no
+client window are required.
+
+Wait for the path through `steroid_list_projects`, retain its `project_name`, and then trigger/await the
+Maven or Gradle import before semantic work. Do not make `steroid_list_windows` or a screenshot mandatory;
+use them only when an attended frontend actually exists.
+
+The verified path is frontendless IU baseline 262. The native run logged Remote Development backend mode
+with `headless=false`; the Docker E2E proves operation without a Remote Development client. This does not
+make arbitrary plain headless desktop launches supported. On Linux, retain the normal Xvfb test environment
+unless your exact IDE build and runner have separately proved a supported backend launch without it.
 
 ## Linux: run under Xvfb
 
@@ -43,7 +69,8 @@ devrig backend download idea-community
 
 With `DISPLAY` set, the managed backend (whether started explicitly with
 `devrig backend start`, or automatically by `steroid_open_project`) launches against the
-virtual display. Do **not** pass `-Djava.awt.headless=true` — headless mode is unsupported.
+virtual display. Do not use `-Djava.awt.headless=true` to force a standard desktop IDE into plain headless
+mode; use a supported Remote Development backend when no client window is wanted.
 
 ## macOS / Windows: use the real GUI
 
@@ -61,13 +88,13 @@ Install devrig and provision or connect to an IDE exactly as on a developer mach
   manager — see the post linked below.
 - Everything else is unchanged from a local run: `devrig install <agent>` registration, the
   `devrig mcp` bridge, and `devrig backend download|start|stop` all work identically once a
-  display is available.
+  backend is reachable.
 
 ## Related
 
 - [Getting Started](/docs/getting-started/) — install devrig and connect your agent
 - [devrig CLI](/docs/devrig/) — the full command set, including managed backends
-- [#177](https://github.com/jonnyzzz/mcp-steroid/issues/177) — why true headless launches are unsupported
+- [#177](https://github.com/jonnyzzz/mcp-steroid/issues/177) — why plain non-backend headless mode is unsupported
 
 ## Further reading
 

--- a/website/content/docs/skill-factory.md
+++ b/website/content/docs/skill-factory.md
@@ -70,7 +70,7 @@ You don't need to be an IntelliJ platform expert. The agent does the API explora
 
 The immediate focus is skill coverage -- more documented API patterns, more worked examples, more pre-built skills. The goal is to shrink the research phase for common tasks until it's nearly zero.
 
-Running in Docker and in CI already works today: the IDE runs against a real display -- the normal GUI on macOS/Windows, or a virtual one via Xvfb on Linux and CI (see [Running devrig in CI](/docs/running-on-ci/)). A true headless launch with no display (`-Djava.awt.headless=true`) is unsupported ([#177](https://github.com/jonnyzzz/mcp-steroid/issues/177)). Longer term: event-driven skills (reacting to commits, test failures, inspection results).
+Running in Docker and CI already works today: use the normal GUI on macOS/Windows, Xvfb for an attended Linux IDE, or the supported frontendless IDEA Ultimate 2026.2 Remote Development backend (see [Running devrig in CI](/docs/running-on-ci/)). Remote Development product mode takes precedence over the raw AWT-headless flag; only plain non-backend headless mode is unsupported ([#177](https://github.com/jonnyzzz/mcp-steroid/issues/177)). Longer term: event-driven skills (reacting to commits, test failures, inspection results).
 
 ---
 

--- a/website/content/docs/strategy.md
+++ b/website/content/docs/strategy.md
@@ -53,9 +53,11 @@ This validation loop is described in [Learning Methodology](/docs/learning-metho
 ### Phase 3: Scale -- self-contained runtime, SaaS, B2B
 
 The long-term target is a self-contained runtime, available both as SaaS and as an end-user product, that runs the IDE for
-AI agents without a developer's desktop session. That runtime still gives the IDE a real display -- the normal GUI on
-macOS/Windows, or a virtual one via Xvfb on Linux and CI; a true headless launch (`-Djava.awt.headless=true`) is
-unsupported (see [#177](https://github.com/jonnyzzz/mcp-steroid/issues/177) and [Running devrig in CI](/docs/running-on-ci/)).
+AI agents without a developer's desktop session. Today an attended IDE uses the normal GUI on macOS/Windows or Xvfb on
+Linux/CI; devrig also supports a frontendless IDEA Ultimate 2026.2 Remote Development backend. Remote Development
+product mode is supported regardless of whether a client window is attached and takes precedence over the raw AWT-headless
+flag; only plain non-backend headless mode is unsupported (see
+[#177](https://github.com/jonnyzzz/mcp-steroid/issues/177) and [Running devrig in CI](/docs/running-on-ci/)).
 
 ## Easy experimentation
 


### PR DESCRIPTION
## Summary

- document the clean-machine Claude/Codex workflow for provisioning and using the IU-262 Remote Development backend
- make project-path routing and Maven/Gradle import the readiness gates, with windows and screenshots optional
- distinguish supported Remote Development backend product mode from unsupported plain HEADLESS classification
- preserve raw-NDJSON evidence, agent-only credential isolation, and log-publication safeguards
- supersede stale historical window-gating guidance and update public website copy

## Evidence

- PR #411 shipped the native Remote Development backend scenario
- PR #441 shipped the task-only Claude/Codex autonomy validation
- #448 tracks the discovered Remote Development join-fragment sanitizer gap; raw backend logs remain private

## Validation

- prompts MarkdownArticleContract: passed
- DebugRemoteIdeSkill block 007 compatibility matrix: 8 tests, 0 skipped, 0 failures, 0 errors across stable/EAP IDEA, Rider, CLion, and PyCharm
- Hugo 0.142.0 extended render: passed, 35 pages
- git diff --check: passed
- independent final documentation/security audit: GO