### PR TITLE
#284 Phases C&D: layered `devrig help <tool>`, `prompt <uri>`, `open_project --wait`, CLI I/O hardening

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -162,17 +162,13 @@
   JSON payload as one minified line. Add a structured, colorful human renderer while preserving the
   current ANSI-free `--json` envelope for agents.
 
-- [ ] **devrig CLI must own the `--wait` polling loop (#284)**: the schema-driven-command reshape
-  removed the `out` parameter from `VisionScreenshotToolSpec` and turned `--wait` into a declared
-  `CliExtraOption` on `steroid_open_project`, because neither is a tool input, so the tool metadata
-  carries neither behavior. **`--out` is done**: it is a devrig framework flag registered only on
-  `execute_code` and `take_screenshot`, and implemented by `renderWithOut` in `CliToolSupport.kt` (verified end to end —
-  `devrig take_screenshot --out=<path>` writes the PNG and prints `Saved --out: <path>`). `--wait` is
-  **not**: it parses, and a generic guard in `GeneratedToolRuntime.kt` then refuses with exit 64
-  (`--wait is accepted by the command line but no runtime acts on it yet`). Implement it as a project-list
-  poll until the target path appears; a frontendless Remote Development backend has no window. If a
-  frontend window exists, additionally poll its modal/indexing/initialized flags. Then delete the guard
-  plus its test.
+- [ ] **`open_project --wait` never reports ready on a frontendless backend (#284)**: the poll is
+  implemented (`WaitForProjectReady.kt`, `awaitWaitOption` in `GeneratedToolRuntime.kt`) but reads
+  `steroid_list_windows` only, and a frontendless Remote Development backend has NO window — so `--wait`
+  against one burns the full 300 s and then answers `UNAVAILABLE 69` for a project that opened fine.
+  Poll the project list for the target path first, and treat the window flags (`projectInitialized` /
+  `indexingInProgress` / `modalDialogShowing`) as an additional condition only when a frontend window
+  exists. Needs a Docker case on the Remote Development fixture, not a unit test alone.
 
 - [ ] **`--json` parse-time usage errors emit nothing on stdout (#284)**: a parse failure becomes
   `DevrigCommandParseError`, which prints to stderr and answers 64 with no `--json` envelope — the KDoc

--- a/TODO.md
+++ b/TODO.md
@@ -162,14 +162,6 @@
   JSON payload as one minified line. Add a structured, colorful human renderer while preserving the
   current ANSI-free `--json` envelope for agents.
 
-- [ ] **`open_project --wait` never reports ready on a frontendless backend (#284)**: the poll is
-  implemented (`WaitForProjectReady.kt`, `awaitWaitOption` in `GeneratedToolRuntime.kt`) but reads
-  `steroid_list_windows` only, and a frontendless Remote Development backend has NO window — so `--wait`
-  against one burns the full 300 s and then answers `UNAVAILABLE 69` for a project that opened fine.
-  Poll the project list for the target path first, and treat the window flags (`projectInitialized` /
-  `indexingInProgress` / `modalDialogShowing`) as an additional condition only when a frontend window
-  exists. Needs a Docker case on the Remote Development fixture, not a unit test alone.
-
 - [ ] **`--json` parse-time usage errors emit nothing on stdout (#284)**: a parse failure becomes
   `DevrigCommandParseError`, which prints to stderr and answers 64 with no `--json` envelope — the KDoc
   argues the failure precedes the command's options so the `--json` intent is unknowable, yet the sibling

--- a/mcp-core/src/main/kotlin/com/jonnyzzz/mcpSteroid/mcp/McpRegistrars.kt
+++ b/mcp-core/src/main/kotlin/com/jonnyzzz/mcpSteroid/mcp/McpRegistrars.kt
@@ -105,6 +105,11 @@ data class CliCommandSpec(
     val producesImage: Boolean = false,
     /** Human-only output style; `--json` always uses the unified envelope. */
     val outputStyle: CliOutputStyle = CliOutputStyle.CONTENT,
+    /**
+     * `mcp-steroid://` article URIs a layered `devrig help <tool>` renders alongside this subcommand's
+     * synopsis; empty for tools that need none. Never part of the MCP wire.
+     */
+    val guideUris: List<String> = emptyList(),
 )
 
 /** Derives the default CLI subcommand name from an MCP tool [toolName] by stripping the `steroid_` prefix. */
@@ -143,6 +148,11 @@ abstract class McpToolBase : CliToolSpec {
 
     /** Human-only renderer selection; most tools print their MCP content directly. */
     protected open val cliOutputStyle: CliOutputStyle get() = CliOutputStyle.CONTENT
+    /**
+     * `mcp-steroid://` article URIs a layered `devrig help` renders for this tool's subcommand; empty by
+     * default.
+     */
+    protected open val cliGuideUris: List<String> get() = emptyList()
 
     override val cli: CliCommandSpec
         get() = CliCommandSpec(
@@ -153,6 +163,7 @@ abstract class McpToolBase : CliToolSpec {
             extraOptions = cliExtraOptions,
             producesImage = cliProducesImage,
             outputStyle = cliOutputStyle,
+            guideUris = cliGuideUris,
         )
 }
 

--- a/mcp-core/src/main/kotlin/com/jonnyzzz/mcpSteroid/mcp/McpSchema.kt
+++ b/mcp-core/src/main/kotlin/com/jonnyzzz/mcpSteroid/mcp/McpSchema.kt
@@ -37,7 +37,11 @@ data class InputSchemaParamSpec(
     /** Additional JSON keys merged into the property body (e.g. `minimum`, `maximum`, `items`). */
     val extra: JsonObjectBuilder.() -> Unit = {},
     // CLI hints are exposed by [ToolSchema.asCliParams] and are never serialized into MCP inputSchema JSON.
-    /** CLI flag for this parameter; defaults to `--<name>` (e.g. `project_name` -> `--project_name`). */
+    /**
+     * CLI flag for this parameter; defaults to `--<name>` (e.g. `project_name` -> `--project_name`).
+     * When [cliPositional] is true, help promotes the positional and this flag remains accepted as a
+     * hidden compatibility spelling for scripts written before the presentation change.
+     */
     val cliFlag: String = "--$name",
     /**
      * Short one-line flag help for the CLI. Required for every CLI-visible parameter (see
@@ -52,7 +56,7 @@ data class InputSchemaParamSpec(
      * [ToolSchema.asMcpJson], because the parameter itself is an ordinary MCP parameter either way.
      */
     val cliFileSource: CliFileSource? = null,
-    /** True when the parameter is a CLI positional argument rather than a flag (e.g. `uri`). */
+    /** True when the parameter is advertised as a CLI positional argument rather than a flag (e.g. `uri`). */
     val cliPositional: Boolean = false,
     /** True when the parameter is not exposed as a CLI flag at all. */
     val cliHidden: Boolean = false,

--- a/mcp-steroid-server/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/ExecuteCodeTool.kt
+++ b/mcp-steroid-server/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/ExecuteCodeTool.kt
@@ -82,6 +82,12 @@ data class ExecCodeParams(
     @Transient val executionBackend: ExecutionBackendProvenance? = null,
 )
 
+/** Article URIs a `devrig help execute_code` renders alongside the subcommand's synopsis. */
+val executeCodeGuideUris = listOf(
+    ExecuteCodeToolDescriptionPromptArticle().uri,
+    CodingWithIntelliJContextApiPromptArticle().uri,
+)
+
 /**
  * Handler for the steroid_execute_code MCP tool.
  */
@@ -92,6 +98,8 @@ class ExecuteCodeToolSpec(val handler: () -> ExecuteCodeToolHandler) : McpToolBa
 
     /** A script can return an image (`logImage`), and a modal-dialog failure attaches one, so `--out` applies. */
     override val cliProducesImage = true
+
+    override val cliGuideUris = executeCodeGuideUris
 
     val projectName = CommonToolParams.projectName().registerToSchema()
 

--- a/mcp-steroid-server/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/ExecuteFeedbackTool.kt
+++ b/mcp-steroid-server/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/ExecuteFeedbackTool.kt
@@ -109,11 +109,12 @@ class ExecuteFeedbackToolSpec(val handler: () -> ExecuteFeedbackToolHandler) : M
         if (explanation.isBlank()) {
             return ToolCallResult.errorResult("explanation is required (free-form: what worked, what didn't, what you'll try next)")
         }
-        // execution_id is optional — noted for context but value is not currently used
+        val executionId = context[executionId]
         val code = context[code]
 
         val params = FeedbackParams(
             taskId = taskId,
+            executionId = executionId,
             successRating = successRating,
             explanation = explanation,
             code = code,
@@ -127,6 +128,7 @@ class ExecuteFeedbackToolSpec(val handler: () -> ExecuteFeedbackToolHandler) : M
 @Serializable
 data class FeedbackParams(
     val taskId: String,
+    val executionId: String? = null,
     val successRating: Double,
     val explanation: String?,
     val code: String?,

--- a/mcp-steroid-server/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/FetchResourceToolHandler.kt
+++ b/mcp-steroid-server/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/FetchResourceToolHandler.kt
@@ -12,7 +12,6 @@ import com.jonnyzzz.mcpSteroid.mcp.get
 import com.jonnyzzz.mcpSteroid.mcp.param
 import com.jonnyzzz.mcpSteroid.mcp.required
 import com.jonnyzzz.mcpSteroid.mcp.string
-import com.jonnyzzz.mcpSteroid.prompts.generated.ResourcesIndex
 import com.jonnyzzz.mcpSteroid.prompts.generated.ide.FindDuplicatesPromptArticle
 import com.jonnyzzz.mcpSteroid.prompts.generated.ide.InspectAndFixPromptArticle
 import com.jonnyzzz.mcpSteroid.prompts.generated.ide.TypeHierarchyPromptArticle
@@ -85,10 +84,7 @@ class FetchResourceToolHandler(
         log.info("steroid_fetch_resource: $uri")
 
         val promptsContext = handler().buildPromptsContext(projectName)
-        val article = ResourcesIndex().roots.values
-            .asSequence()
-            .flatMap { it.articles.values.asSequence() }
-            .firstOrNull { it.uri == uri && it.filter.matches(promptsContext) }
+        val article = resolveResourceArticle(uri, promptsContext)
             ?: return ToolCallResult(
                 content = listOf(ContentItem.Text(text = "ERROR: Resource not found: $uri")),
                 isError = true

--- a/mcp-steroid-server/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/FetchResourceToolHandler.kt
+++ b/mcp-steroid-server/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/FetchResourceToolHandler.kt
@@ -6,6 +6,7 @@ import com.jonnyzzz.mcpSteroid.mcp.McpToolBase
 import com.jonnyzzz.mcpSteroid.mcp.ToolCallContext
 import com.jonnyzzz.mcpSteroid.mcp.ToolCallResult
 import com.jonnyzzz.mcpSteroid.mcp.cliMissingHint
+import com.jonnyzzz.mcpSteroid.mcp.cliPositional
 import com.jonnyzzz.mcpSteroid.mcp.cliSynopsis
 import com.jonnyzzz.mcpSteroid.mcp.description
 import com.jonnyzzz.mcpSteroid.mcp.get
@@ -70,7 +71,8 @@ class FetchResourceToolHandler(
         .description("The mcp-steroid:// URI to fetch (see the tool description for canonical entry points, " +
             "or fetch ${SkillPromptArticle().uri} for the index)")
         .cliSynopsis("mcp-steroid:// resource URI to fetch")
-        .cliMissingHint("missing --uri. Example:\n  devrig fetch_resource --uri=${SkillPromptArticle().uri}")
+        .cliMissingHint("missing uri. Example:\n  devrig prompt ${SkillPromptArticle().uri}")
+        .cliPositional()
         .string()
         .required()
         .registerToSchema()

--- a/mcp-steroid-server/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/OpenProjectTool.kt
+++ b/mcp-steroid-server/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/OpenProjectTool.kt
@@ -91,20 +91,20 @@ class OpenProjectToolSpec(
     } else null
 
     // Not a tool input: the tool returns as soon as opening starts, and the CLI itself polls
-    // list_windows afterwards until the project is initialized. Declared unconditionally — unlike
+    // list_projects afterwards until the project has an addressable route. Declared unconditionally — unlike
     // backend_name, this changes nothing on the MCP wire, so it needs no per-surface gate.
     override val cliExtraOptions = listOf(
         CliExtraOption(
             name = "wait",
             type = CliOptionType.BOOLEAN,
-            synopsis = "reserved, not implemented; will poll until the project is initialized",
+            synopsis = "wait up to 300s for list_projects to return the project route",
         ),
     )
 
     override suspend fun call(context: ToolCallContext): ToolCallResult {
         val projectPathStr = context[projectPath]
-        context[taskId]
-        context[reason]
+        val taskIdValue = context[taskId]
+        val reasonValue = context[reason]
         val trustProject = context[trustProject] ?: true
         val backendNameValue = backendName?.let { context[it] }
 
@@ -132,6 +132,8 @@ class OpenProjectToolSpec(
         return handler().handleOpenProject(
             OpenProjectParams(
                 projectPath = projectPath.toString(),
+                taskId = taskIdValue,
+                reason = reasonValue,
                 trustProject = trustProject,
                 backendName = backendNameValue,
             ),
@@ -183,6 +185,8 @@ See ${ManagingBackendsPromptArticle().uri}."""
 @Serializable
 data class OpenProjectParams(
     val projectPath: String,
+    val taskId: String,
+    val reason: String,
     val trustProject: Boolean,
     /**
      * Optional devrig-only routing hint: the stable backend id — the `backend_name` from

--- a/mcp-steroid-server/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/ResourceArticleResolver.kt
+++ b/mcp-steroid-server/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/ResourceArticleResolver.kt
@@ -1,0 +1,30 @@
+/* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
+package com.jonnyzzz.mcpSteroid.server
+
+import com.jonnyzzz.mcpSteroid.prompts.PromptsContext
+import com.jonnyzzz.mcpSteroid.prompts.generated.ResourcesIndex
+import com.jonnyzzz.mcpSteroid.prompts.generated.ide.FindDuplicatesPromptArticle
+import com.jonnyzzz.mcpSteroid.prompts.generated.ide.InspectAndFixPromptArticle
+import com.jonnyzzz.mcpSteroid.prompts.generated.prompt.DebuggerSkillPromptArticle
+import com.jonnyzzz.mcpSteroid.prompts.generated.prompt.SkillPromptArticle
+import com.jonnyzzz.mcpSteroid.prompts.generated.prompt.TestSkillPromptArticle
+import com.jonnyzzz.mcpSteroid.prompts.generated.skill.CodingWithIntelliJPromptArticle
+
+/**
+ * Single source for mcp-steroid:// article resolution, shared by `steroid_fetch_resource`
+ * and `devrig help`.
+ */
+fun resolveResourceArticle(uri: String, promptsContext: PromptsContext) =
+    ResourcesIndex().roots.values.asSequence()
+        .flatMap { it.articles.values.asSequence() }
+        .firstOrNull { it.uri == uri && it.filter.matches(promptsContext) }
+
+/** The curated entry-point URIs, from the generated article classes — never string literals. */
+fun canonicalResourceEntryPoints(): List<String> = listOf(
+    TestSkillPromptArticle().uri,
+    DebuggerSkillPromptArticle().uri,
+    FindDuplicatesPromptArticle().uri,
+    InspectAndFixPromptArticle().uri,
+    SkillPromptArticle().uri,
+    CodingWithIntelliJPromptArticle().uri,
+)

--- a/mcp-steroid-server/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/ResourceArticleResolver.kt
+++ b/mcp-steroid-server/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/ResourceArticleResolver.kt
@@ -3,12 +3,6 @@ package com.jonnyzzz.mcpSteroid.server
 
 import com.jonnyzzz.mcpSteroid.prompts.PromptsContext
 import com.jonnyzzz.mcpSteroid.prompts.generated.ResourcesIndex
-import com.jonnyzzz.mcpSteroid.prompts.generated.ide.FindDuplicatesPromptArticle
-import com.jonnyzzz.mcpSteroid.prompts.generated.ide.InspectAndFixPromptArticle
-import com.jonnyzzz.mcpSteroid.prompts.generated.prompt.DebuggerSkillPromptArticle
-import com.jonnyzzz.mcpSteroid.prompts.generated.prompt.SkillPromptArticle
-import com.jonnyzzz.mcpSteroid.prompts.generated.prompt.TestSkillPromptArticle
-import com.jonnyzzz.mcpSteroid.prompts.generated.skill.CodingWithIntelliJPromptArticle
 
 /**
  * Single source for mcp-steroid:// article resolution, shared by `steroid_fetch_resource`
@@ -18,13 +12,3 @@ fun resolveResourceArticle(uri: String, promptsContext: PromptsContext) =
     ResourcesIndex().roots.values.asSequence()
         .flatMap { it.articles.values.asSequence() }
         .firstOrNull { it.uri == uri && it.filter.matches(promptsContext) }
-
-/** The curated entry-point URIs, from the generated article classes — never string literals. */
-fun canonicalResourceEntryPoints(): List<String> = listOf(
-    TestSkillPromptArticle().uri,
-    DebuggerSkillPromptArticle().uri,
-    FindDuplicatesPromptArticle().uri,
-    InspectAndFixPromptArticle().uri,
-    SkillPromptArticle().uri,
-    CodingWithIntelliJPromptArticle().uri,
-)

--- a/mcp-steroid-server/src/test/kotlin/com/jonnyzzz/mcpSteroid/server/FetchResourceResolverTest.kt
+++ b/mcp-steroid-server/src/test/kotlin/com/jonnyzzz/mcpSteroid/server/FetchResourceResolverTest.kt
@@ -5,7 +5,6 @@ import com.jonnyzzz.mcpSteroid.prompts.PromptsContext
 import com.jonnyzzz.mcpSteroid.prompts.generated.prompt.SkillPromptArticle
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNull
-import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 
 class FetchResourceResolverTest {
@@ -19,14 +18,5 @@ class FetchResourceResolverTest {
     @Test
     fun `returns null for an unknown uri`() {
         assertNull(resolveResourceArticle("mcp-steroid://does/not/exist", PromptsContext.Generic))
-    }
-
-    @Test
-    fun `canonical entry points are non-empty and all resolvable`() {
-        val entryPoints = canonicalResourceEntryPoints()
-        assertTrue(entryPoints.isNotEmpty(), "there must be at least one canonical entry point")
-        for (uri in entryPoints) {
-            assertEquals(uri, resolveResourceArticle(uri, PromptsContext.Generic)?.uri, "entry point $uri must resolve")
-        }
     }
 }

--- a/mcp-steroid-server/src/test/kotlin/com/jonnyzzz/mcpSteroid/server/FetchResourceResolverTest.kt
+++ b/mcp-steroid-server/src/test/kotlin/com/jonnyzzz/mcpSteroid/server/FetchResourceResolverTest.kt
@@ -1,0 +1,32 @@
+package com.jonnyzzz.mcpSteroid.server
+
+import com.jonnyzzz.mcpSteroid.prompts.Generic
+import com.jonnyzzz.mcpSteroid.prompts.PromptsContext
+import com.jonnyzzz.mcpSteroid.prompts.generated.prompt.SkillPromptArticle
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class FetchResourceResolverTest {
+    @Test
+    fun `resolves an existing uri in a Generic context`() {
+        val uri = SkillPromptArticle().uri
+        val article = resolveResourceArticle(uri, PromptsContext.Generic)
+        assertEquals(uri, article?.uri, "the skill index article must resolve by its own uri")
+    }
+
+    @Test
+    fun `returns null for an unknown uri`() {
+        assertNull(resolveResourceArticle("mcp-steroid://does/not/exist", PromptsContext.Generic))
+    }
+
+    @Test
+    fun `canonical entry points are non-empty and all resolvable`() {
+        val entryPoints = canonicalResourceEntryPoints()
+        assertTrue(entryPoints.isNotEmpty(), "there must be at least one canonical entry point")
+        for (uri in entryPoints) {
+            assertEquals(uri, resolveResourceArticle(uri, PromptsContext.Generic)?.uri, "entry point $uri must resolve")
+        }
+    }
+}

--- a/mcp-steroid-server/src/test/kotlin/com/jonnyzzz/mcpSteroid/server/OpenProjectParamsTest.kt
+++ b/mcp-steroid-server/src/test/kotlin/com/jonnyzzz/mcpSteroid/server/OpenProjectParamsTest.kt
@@ -12,14 +12,18 @@ class OpenProjectParamsTest {
     fun `backendName defaults to null and decodes when absent`() {
         val decoded = McpJson.decodeFromString(
             OpenProjectParams.serializer(),
-            """{"projectPath":"/tmp/p","trustProject":true}""",
+            """{"projectPath":"/tmp/p","taskId":"t","reason":"r","trustProject":true}""",
         )
         assertNull(decoded.backendName)
+        assertEquals("t", decoded.taskId)
+        assertEquals("r", decoded.reason)
     }
 
     @Test
     fun `backendName round-trips when present`() {
-        val params = OpenProjectParams(projectPath = "/tmp/p", trustProject = false, backendName = "pid-1234")
+        val params = OpenProjectParams(
+            projectPath = "/tmp/p", taskId = "t", reason = "r", trustProject = false, backendName = "pid-1234",
+        )
         val json = McpJson.encodeToString(OpenProjectParams.serializer(), params)
         val decoded = McpJson.decodeFromString(OpenProjectParams.serializer(), json)
         assertEquals("pid-1234", decoded.backendName)
@@ -27,7 +31,9 @@ class OpenProjectParamsTest {
 
     @Test
     fun `backendName null round-trips (key omitted by explicitNulls=false)`() {
-        val params = OpenProjectParams(projectPath = "/tmp/p", trustProject = true, backendName = null)
+        val params = OpenProjectParams(
+            projectPath = "/tmp/p", taskId = "t", reason = "r", trustProject = true, backendName = null,
+        )
         val json = McpJson.encodeToString(OpenProjectParams.serializer(), params)
         // McpJson has explicitNulls=false, so the key is omitted, keeping the wire additive.
         assertFalse(json.contains("backendName"))

--- a/mcp-steroid-server/src/test/kotlin/com/jonnyzzz/mcpSteroid/server/ToolSpecCliMetadataTest.kt
+++ b/mcp-steroid-server/src/test/kotlin/com/jonnyzzz/mcpSteroid/server/ToolSpecCliMetadataTest.kt
@@ -271,7 +271,9 @@ class ToolSpecCliMetadataTest {
         assertEquals("wait", wait.name, "the extra option's identity is its name, not its flag")
         assertEquals(CliOptionType.BOOLEAN, wait.type, "--wait is a boolean switch")
         assertFalse(wait.synopsis.isBlank(), "--wait needs help text")
-        assertTrue("reserved" in wait.synopsis.lowercase(), "--wait help must say it is not implemented yet")
+        assertTrue("300s" in wait.synopsis, "--wait help must state its bounded timeout")
+        assertTrue("project route" in wait.synopsis, "--wait help must explain the successful outcome")
+        assertFalse("reserved" in wait.synopsis.lowercase(), "implemented --wait must not be described as reserved")
         // An extra option is not a tool input: it must not appear among the parameters.
         val params = tools.single { it.name == "steroid_open_project" }.schema.asCliParams().map { it.name }
         assertFalse(params.contains("wait"), "--wait must not be a schema parameter: $params")

--- a/mcp-steroid-server/src/test/kotlin/com/jonnyzzz/mcpSteroid/server/ToolSpecCliMetadataTest.kt
+++ b/mcp-steroid-server/src/test/kotlin/com/jonnyzzz/mcpSteroid/server/ToolSpecCliMetadataTest.kt
@@ -4,6 +4,8 @@ package com.jonnyzzz.mcpSteroid.server
 import com.jonnyzzz.mcpSteroid.mcp.CliOptionType
 import com.jonnyzzz.mcpSteroid.mcp.CliOutputStyle
 import com.jonnyzzz.mcpSteroid.mcp.CliToolSpec
+import com.jonnyzzz.mcpSteroid.prompts.Generic
+import com.jonnyzzz.mcpSteroid.prompts.PromptsContext
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.jsonArray
@@ -294,5 +296,16 @@ class ToolSpecCliMetadataTest {
             openProject.schema.asCliParams().any { it.name == "backend_name" },
             "the in-IDE open_project must still advertise no backend_name",
         )
+    }
+
+    @Test
+    fun `execute_code declares resolvable guide URIs and other tools default to none`() {
+        val specs = devrigToolSpecsForTest()
+        val executeCode = specs.single { it.name == "steroid_execute_code" }
+        assertTrue(executeCode.cli.guideUris.isNotEmpty(), "execute_code must seed guide URIs for `devrig help execute_code`")
+        for (uri in executeCode.cli.guideUris) {
+            assertEquals(uri, resolveResourceArticle(uri, PromptsContext.Generic)?.uri, "guide uri $uri must resolve")
+        }
+        assertTrue(specs.single { it.name == "steroid_list_windows" }.cli.guideUris.isEmpty(), "a tool that declares none has none")
     }
 }

--- a/mcp-steroid-server/src/test/kotlin/com/jonnyzzz/mcpSteroid/server/ToolSpecCliMetadataTest.kt
+++ b/mcp-steroid-server/src/test/kotlin/com/jonnyzzz/mcpSteroid/server/ToolSpecCliMetadataTest.kt
@@ -82,11 +82,13 @@ class ToolSpecCliMetadataTest {
     }
 
     @Test
-    fun `fetch_resource exposes the prompt alias and maps uri to the --uri flag`() {
+    fun `fetch_resource exposes the prompt alias and maps uri to a bare positional`() {
+        // bindPositional (SchemaCliBinding.kt) registers a Clikt argument, never an option, for a
+        // cliPositional parameter, so `--uri` is not part of the actual grammar here even though the
+        // spec still carries its default cliFlag value — that field is simply unused once positional.
         assertTrue(fetchResource.cli.aliases.contains("prompt"), "fetch_resource should alias 'prompt'")
         val uri = fetchResource.schema.asCliParams().single { it.name == "uri" }
-        assertFalse(uri.cliPositional, "fetch_resource uri must map to --uri, not a positional")
-        assertEquals("--uri", uri.cliFlag)
+        assertTrue(uri.cliPositional, "fetch_resource uri must be a bare positional, not a --uri flag")
     }
 
     @Test

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/Cli.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/Cli.kt
@@ -329,6 +329,28 @@ abstract class JsonDevrigCliktCommand(
     override fun localJson(): Boolean = jsonFlag
 }
 
+/**
+ * The base of the GENERATED tool commands: a [DevrigCliktCommand] that accepts `--out` when — and only
+ * when — [acceptsOut] says this tool's result can carry an image.
+ *
+ * `--out` sits here and not on [DevrigCliktCommand] because it redirects the image a tool RESULT carries
+ * (the behavior is [renderWithOut]), and no lifecycle verb — `project`, `backend`, `install`, `help`,
+ * `version` — ever produces a result at all. But not every tool command produces an image either: only
+ * `take_screenshot` (always) and `execute_code` (a script's `logImage` or a dialog-failure screenshot) do,
+ * which is what [com.jonnyzzz.mcpSteroid.mcp.CliCommandSpec.producesImage] records. So the option is
+ * registered per command, gated on that flag, rather than declared once for everything: declared for all it
+ * parsed everywhere and was read in one place, so `devrig project --out=/tmp/x.png` (and `devrig
+ * list_projects --out=x`) exited having written nothing. Accepting a flag and silently dropping it is the
+ * same failure `open_project --wait` had to avoid ([awaitWaitOption] in `GeneratedToolRuntime.kt`): no flag
+ * may be accepted and then ignored. The lever differs only because the ownership does — `--wait` is
+ * declared by a tool's own metadata that devrig cannot unilaterally withhold, so devrig can only act on it
+ * (or fail loudly) at runtime, whereas devrig owns this declaration and can simply not make it. Scoping it
+ * wins where it is available: on a command that cannot honour `--out` the refusal is Clikt's own
+ * unknown-option error at parse time, and that command's `--help` stops listing it.
+ *
+ * The cost is that `--out` must now follow its command (`devrig take_screenshot --out=x`, not
+ * `devrig --out=x take_screenshot`), which is where it reads correctly anyway.
+ */
 abstract class DevrigToolCliktCommand(
     name: String,
     selected: SelectedDevrigInvocation,

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/Cli.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/Cli.kt
@@ -357,7 +357,8 @@ abstract class DevrigToolCliktCommand(
     parent: DevrigCliktCommand?,
     help: String,
     acceptsOut: Boolean,
-) : JsonDevrigCliktCommand(name = name, help = help, selected = selected, parent = parent) {
+    epilog: String = "",
+) : JsonDevrigCliktCommand(name = name, help = help, selected = selected, parent = parent, epilog = epilog) {
     private val outFlag =
         if (acceptsOut) option("--out", help = DEVRIG_OUT_FLAG_HELP).path(canBeDir = false).also { registerOption(it) }
         else null

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/CliToolSupport.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/CliToolSupport.kt
@@ -140,8 +140,9 @@ sealed interface Presentation {
             val sink = if (result.isError) err else out
             for ((index, item) in result.content.withIndex()) {
                 when (item) {
-                    // Tool payload: printed verbatim, never name-translated.
-                    is ContentItem.Text -> sink.println(item.text)
+                    // Tool payload: content never name-translated. A JSON object/array payload is
+                    // pretty-printed for a human reader; a scalar or a parse failure prints verbatim.
+                    is ContentItem.Text -> sink.println(prettyPrintIfJsonContainer(item.text))
                     is ContentItem.Image -> {
                         // A hard image failure (undecodable payload, unwritable disk) outranks the tool's
                         // own success/failure: abort rendering immediately and report it as the exit code,
@@ -424,4 +425,17 @@ private fun unpackJsonPayload(item: JsonObject): JsonObject {
 private fun parseAsJsonContainer(text: String): JsonElement? {
     val parsed = runCatching { McpJson.parseToJsonElement(text) }.getOrNull() ?: return null
     return parsed.takeIf { it is JsonObject || it is JsonArray }
+}
+
+/**
+ * Console-only counterpart to [unpackJsonPayload]: renders [text] pretty-printed across multiple lines
+ * when it parses whole as a JSON object or array (via the same [parseAsJsonContainer] predicate the
+ * `--json` envelope uses, so console and envelope agree on what counts as JSON), otherwise returns [text]
+ * verbatim. A bare scalar or a parse failure is presentation-neutral prose, not a tool's structured
+ * payload, and is never reformatted. [CLI_ENVELOPE_JSON] is reused rather than a second `Json {
+ * prettyPrint = true }` instance: it already is this module's pretty-printing configuration.
+ */
+private fun prettyPrintIfJsonContainer(text: String): String {
+    val parsed = parseAsJsonContainer(text) ?: return text
+    return CLI_ENVELOPE_JSON.encodeToString(JsonElement.serializer(), parsed)
 }

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/GeneratedToolRuntime.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/GeneratedToolRuntime.kt
@@ -13,7 +13,9 @@ import com.jonnyzzz.mcpSteroid.server.McpSteroidTools
 import com.jonnyzzz.mcpSteroid.server.NoOpProgressReporter
 import java.io.IOException
 import java.io.InputStream
+import java.nio.ByteBuffer
 import java.nio.charset.CharacterCodingException
+import java.nio.charset.CodingErrorAction
 import java.nio.file.Files
 import java.nio.file.InvalidPathException
 import java.nio.file.Path
@@ -330,13 +332,24 @@ fun GeneratedToolInvocation.argumentsWithFileSources(spec: CliToolSpec, stdin: I
 private const val CLI_STDIN_PATH: String = "-"
 
 /**
+ * The most a file source will read from EITHER a file or standard input, in bytes, before
+ * [decodeCliSourceBytes] rejects it — 10 MB. Named so both readers enforce the identical limit and so a
+ * rejection message can quote the same number this constant defines, rather than a number hand-copied into
+ * a string.
+ */
+const val CLI_FILE_SOURCE_MAX_BYTES: Long = 10L * 1024 * 1024
+
+/**
  * The value behind one file source: standard input when [path] is [CLI_STDIN_PATH], else the content of the
  * file at [path]. [paramName] is the schema parameter being filled, named in every failure so the caller
  * knows which flag to fix when a tool declares more than one source.
  *
  * A malformed path string is the caller's typo ([CliExit.USAGE]); an absent, non-regular or unreadable file
  * is a filesystem failure ([CliExit.IO_ERROR]) — the distinction a caller acts on is "fix the command line"
- * versus "fix the disk", not whether `Files` threw.
+ * versus "fix the disk", not whether `Files` threw. Malformed UTF-8 ([CliExit.IO_ERROR]) and exceeding
+ * [CLI_FILE_SOURCE_MAX_BYTES] ([CliExit.DATA_ERROR]) are the same two content faults [readCliStdin] rejects,
+ * via the same [decodeCliSourceBytes], so the two sources behave identically instead of a file throwing on
+ * malformed bytes while stdin silently substituted them.
  */
 private fun readCliFileSource(
     paramName: String,
@@ -357,18 +370,18 @@ private fun readCliFileSource(
             "'$paramName' was to be read from '$file', which is not an existing regular file", CliExit.IO_ERROR,
         )
     }
-    val content = try {
-        Files.readString(file)
+    val bytes = try {
+        Files.newInputStream(file).use { it.readNBytes((CLI_FILE_SOURCE_MAX_BYTES + 1).toInt()) }
     } catch (e: IOException) {
         throw CliInputException("'$paramName' could not be read from '$file': ${e.message}", CliExit.IO_ERROR)
     }
     // Same contract as the stdin branch below: an empty value must fail here with a message that names
     // the cause, instead of being forwarded for the tool to answer with its own confusing complaint.
-    if (content.isEmpty()) throw CliInputException(
+    if (bytes.isEmpty()) throw CliInputException(
         "'$paramName' was to be read from '$file', which is empty; put the value in the file or pass it directly",
         CliExit.USAGE,
     )
-    return content
+    return decodeCliSourceBytes(paramName, bytes)
 }
 
 /**
@@ -381,34 +394,59 @@ private fun readCliFileSource(
  *  - reaching end of input immediately — nothing was piped — is a [CliExit.USAGE] failure naming both the
  *    parameter and the two ways to supply it, instead of handing the tool an empty value and letting it
  *    answer with its own confusing complaint about empty input.
+ *
+ * The read stops at [CLI_FILE_SOURCE_MAX_BYTES] + 1 bytes rather than draining an unbounded pipe, and the
+ * result is decoded by [decodeCliSourceBytes] — the same strict decoder [readCliFileSource] uses — so
+ * malformed UTF-8 is rejected here too, instead of `String.decodeToString()`'s silent U+FFFD substitution.
  */
 private fun readCliStdin(paramName: String, stdin: InputStream, announce: Boolean): String {
     if (announce) {
-        System.err.println(
-            "devrig: reading '$paramName' from standard input ('$CLI_STDIN_PATH' given); " +
-                "pipe the value in, or close standard input (Ctrl-D) to finish"
-        )
+    System.err.println(
+        "devrig: reading '$paramName' from standard input ('$CLI_STDIN_PATH' given); " +
+            "pipe the value in, or close standard input (Ctrl-D) to finish"
+    )
     }
-    val content = try {
-        // Strict decode: the file branch (Files.readString) throws on malformed UTF-8, and the default
-        // lenient decodeToString() would instead corrupt the value to U+FFFD silently — the same bytes
-        // must fail the same way from either source.
-        stdin.readBytes().decodeToString(throwOnInvalidSequence = true)
-    } catch (e: CharacterCodingException) {
-        // Before the IOException arm: CharacterCodingException IS an IOException, and the decode
-        // failure deserves its own wording — the bytes were read fine, they just are not text.
-        throw CliInputException(
-            "'$paramName' from standard input is not valid UTF-8 text: ${e.message}", CliExit.IO_ERROR,
-        )
+    val bytes = try {
+        stdin.readNBytes((CLI_FILE_SOURCE_MAX_BYTES + 1).toInt())
     } catch (e: IOException) {
         throw CliInputException(
             "'$paramName' could not be read from standard input: ${e.message}", CliExit.IO_ERROR,
         )
     }
-    if (content.isEmpty()) throw CliInputException(
+    if (bytes.isEmpty()) throw CliInputException(
         "'$paramName' was to be read from standard input ('$CLI_STDIN_PATH' given) but nothing was piped in; " +
             "pipe the value or pass a file path instead",
         CliExit.USAGE,
     )
-    return content
+    return decodeCliSourceBytes(paramName, bytes)
+}
+
+/**
+ * [bytes] as strict UTF-8 text — the shared content-validation [readCliFileSource] and [readCliStdin] both
+ * apply, so a file source and standard input reject the same two content faults the same way:
+ *  - more than [CLI_FILE_SOURCE_MAX_BYTES] arrived — [CliExit.DATA_ERROR], because nothing failed to be
+ *    read: the caller handed devrig more data than it accepts (both readers stop at the cap plus one byte,
+ *    so exceeding it is detected without ever buffering an unbounded source in full);
+ *  - the bytes are not valid UTF-8 — rejected via [CodingErrorAction.REPORT] rather than substituted with
+ *    U+FFFD, so a caller sees the actual encoding mistake instead of silently corrupted content reaching
+ *    the tool. Reported as [CliExit.IO_ERROR], keeping the contract the file branch has answered since
+ *    `Files.readString` did the decoding: a [CharacterCodingException] IS an [IOException], and the two
+ *    sources must agree — a `devrig` caller that pipes the same bytes it would have passed as a file must
+ *    not get a different code depending on which spelling it chose.
+ */
+private fun decodeCliSourceBytes(paramName: String, bytes: ByteArray): String {
+    if (bytes.size.toLong() > CLI_FILE_SOURCE_MAX_BYTES) {
+        throw CliInputException(
+            "'$paramName' exceeds the ${CLI_FILE_SOURCE_MAX_BYTES / (1024 * 1024)} MB limit", CliExit.DATA_ERROR,
+        )
+    }
+    return try {
+        Charsets.UTF_8.newDecoder()
+            .onMalformedInput(CodingErrorAction.REPORT)
+            .onUnmappableCharacter(CodingErrorAction.REPORT)
+            .decode(ByteBuffer.wrap(bytes))
+            .toString()
+    } catch (e: CharacterCodingException) {
+        throw CliInputException("'$paramName' is not valid UTF-8 text: ${e.message}", CliExit.IO_ERROR)
+    }
 }

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/GeneratedToolRuntime.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/GeneratedToolRuntime.kt
@@ -264,11 +264,12 @@ private suspend fun DevrigServices.awaitWaitOption(command: GeneratedToolInvocat
         )
     val projectPath = Path.of(rawProjectPath).toRealPath().toString()
     val listWindowsSpec = liveToolSpec("steroid_list_windows", tools)
+    // Created ONCE, outside the poll lambda: `stderrProgressReporter` prints "Tool call started: devrig
+    // list_windows" on construction, and a wait that polls for minutes must not repeat that line on
+    // every iteration.
+    val listWindowsProgress = if (command.json) NoOpProgressReporter else stderrProgressReporter(listWindowsSpec.name)
     val ready = awaitProjectReady(
-        pollListWindows = {
-            callToolViaSpec(listWindowsSpec, JsonObject(emptyMap()), stderrProgressReporter(listWindowsSpec.name))
-                .listWindowsJson()
-        },
+        pollListWindows = { callToolViaSpec(listWindowsSpec, JsonObject(emptyMap()), listWindowsProgress).listWindowsJson() },
         projectPath = projectPath,
         timeoutMs = WAIT_TIMEOUT_MS,
         intervalMs = WAIT_INTERVAL_MS,

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/GeneratedToolRuntime.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/GeneratedToolRuntime.kt
@@ -124,6 +124,7 @@ fun DevrigServices.runGeneratedToolCommand(
             if (!toolResult.isError && command.extraOptions[WAIT_EXTRA_OPTION_NAME] == true) {
                 awaitWaitOption(command, tools)
             }
+            command.requireNoUnhandledExtraOption()
             toolResult
         }
     } catch (e: CliInputException) {
@@ -233,6 +234,30 @@ private const val WAIT_TIMEOUT_MS: Long = 300_000
 private const val WAIT_INTERVAL_MS: Long = 1_000
 
 /**
+ * Fails when the invocation SET a [com.jonnyzzz.mcpSteroid.mcp.CliExtraOption] no runtime acts on.
+ *
+ * An extra option is by definition orchestration the CLI performs around the call — `open_project --wait`
+ * polling the IDE after the tool returns — so it reaches no tool and there is nothing to forward it to.
+ * [WAIT_EXTRA_OPTION_NAME] is the only name any runtime behavior is keyed off today; every other name that
+ * arrives set to `true` in [GeneratedToolInvocation.extraOptions] is, by construction, a flag Clikt accepted
+ * and this runtime silently ignored — the exact "accept then ignore" outcome the design this file follows
+ * exists to rule out. The check reads [GeneratedToolInvocation.extraOptions] alone, never a per-tool `when`
+ * or a lookup into the tool's own [com.jonnyzzz.mcpSteroid.mcp.CliCommandSpec.extraOptions], so a future
+ * tool that declares a second extra option needs no edit here: either the runtime grows a name-keyed
+ * handler for it (like [awaitWaitOption]) before it ships, or this guard rejects it the first time it is
+ * set — there is no silent third option.
+ */
+private fun GeneratedToolInvocation.requireNoUnhandledExtraOption() {
+    val unhandled = extraOptions.filterKeys { it != WAIT_EXTRA_OPTION_NAME }.filterValues { it }
+    // No "devrig <command>:" prefix here — the pipeline's IllegalArgumentException arm adds it, and saying
+    // it twice is what the printed message actually looked like before this comment existed.
+    require(unhandled.isEmpty()) {
+        "${unhandled.keys.joinToString(", ")} is accepted by the command line but no runtime acts on it " +
+            "yet — drop it and the command runs"
+    }
+}
+
+/**
  * Thrown by [awaitWaitOption] when its poll deadline passes before `steroid_list_windows` reports the
  * project ready. Caught in [runGeneratedToolCommand]'s own pipeline, alongside every other failure that
  * pipeline classifies, and mapped to [CliExit.UNAVAILABLE] there — a project that never finishes opening
@@ -267,8 +292,8 @@ private suspend fun DevrigServices.awaitWaitOption(command: GeneratedToolInvocat
     val projectPath = Path.of(rawProjectPath).toRealPath().toString()
     val listWindowsSpec = liveToolSpec("steroid_list_windows", tools)
     // Created ONCE, outside the poll lambda: `stderrProgressReporter` prints "Tool call started: devrig
-    // list_windows" on construction, and a wait that polls for minutes must not repeat that line on
-    // every iteration.
+    // list_windows" on its FIRST `report()` call, and a wait that polls for minutes must not repeat that
+    // line on every iteration.
     val listWindowsProgress = if (command.json) NoOpProgressReporter else stderrProgressReporter(listWindowsSpec.name)
     val ready = awaitProjectReady(
         pollListWindows = { callToolViaSpec(listWindowsSpec, JsonObject(emptyMap()), listWindowsProgress).listWindowsJson() },

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/GeneratedToolRuntime.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/GeneratedToolRuntime.kt
@@ -5,7 +5,10 @@ import com.jonnyzzz.mcpSteroid.devrig.server.ProjectRouteNotFoundException
 import com.jonnyzzz.mcpSteroid.devrig.server.StubMcpSteroidTools
 import com.jonnyzzz.mcpSteroid.devrig.server.callToolViaSpec
 import com.jonnyzzz.mcpSteroid.mcp.CliToolSpec
+import com.jonnyzzz.mcpSteroid.mcp.ContentItem
+import com.jonnyzzz.mcpSteroid.mcp.McpJson
 import com.jonnyzzz.mcpSteroid.mcp.ToolCallErrorException
+import com.jonnyzzz.mcpSteroid.mcp.ToolCallResult
 import com.jonnyzzz.mcpSteroid.server.McpSteroidTools
 import com.jonnyzzz.mcpSteroid.server.NoOpProgressReporter
 import java.io.IOException
@@ -16,11 +19,15 @@ import java.nio.file.InvalidPathException
 import java.nio.file.Path
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.SerializationException
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
 
 /**
  * The runtime half of the schema-driven CLI: what happens after Clikt has parsed a `devrig <tool>`
@@ -66,6 +73,7 @@ data class GeneratedToolInvocation(
  * | a malformed path, an empty standard input, an argument the CLI or the TOOL rejects, an unknown `project_name` | [CliExit.USAGE] 64 |
  * | unusable data from the backend (an undecodable payload, a malformed response) | [CliExit.DATA_ERROR] 65 |
  * | an [IOException] reaching the tool — no IDE running, a refused connection, a timeout | [CliExit.UNAVAILABLE] 69 |
+ * | a declared `wait` extra option's poll timed out before the project reported ready | [CliExit.UNAVAILABLE] 69 |
  * | the tool answered with `isError=true` | [CliExit.TOOL_ERROR] 1 |
  *
  * Any OTHER throwable — an internal devrig or handler fault such as an NPE or a broken invariant — is
@@ -107,12 +115,22 @@ fun DevrigServices.runGeneratedToolCommand(
         )
     }
     val result = try {
-        command.requireNoUnhandledExtraOption(spec)
         val arguments = command.argumentsWithFileSources(spec, mcpStdin)
         val progress = if (command.json) NoOpProgressReporter else stderrProgressReporter(spec.name)
-        runBlocking(Dispatchers.IO) { callToolViaSpec(spec, arguments, progress) }
+        runBlocking(Dispatchers.IO) {
+            val toolResult = callToolViaSpec(spec, arguments, progress)
+            if (!toolResult.isError && command.extraOptions[WAIT_EXTRA_OPTION_NAME] == true) {
+                awaitWaitOption(command, tools)
+            }
+            toolResult
+        }
     } catch (e: CliInputException) {
         return presentation.renderError(command.commandName, e.message.orEmpty(), e.exit, mcpStdout)
+    } catch (e: ProjectNotReadyException) {
+        // Thrown by awaitWaitOption above when a declared `wait` extra option's poll deadline passed
+        // before `steroid_list_windows` reported the project ready — the same "no usable IDE" story an
+        // IOException tells below, just discovered after open_project's own call already succeeded.
+        return presentation.renderError(command.commandName, e.message.orEmpty(), CliExit.UNAVAILABLE, mcpStdout)
     } catch (e: ProjectRouteNotFoundException) {
         // Reworded rather than appended to: the exception's own message tells an MCP client to call
         // `steroid_list_projects`, which a CLI user cannot do, and printing both instructions for the one
@@ -200,32 +218,77 @@ fun liveToolSpec(toolName: String, tools: McpSteroidTools): CliToolSpec {
     )
 }
 
+/** Identity of the generic `--wait` extra option — [com.jonnyzzz.mcpSteroid.mcp.CliExtraOption.name], not
+ * a CLI spelling. Declared today only by `open_project` (`OpenProjectTool.kt`), but [awaitWaitOption] is
+ * keyed off this NAME alone, never a per-tool `when`, so any future tool that declares another
+ * `CliExtraOption("wait", ...)` over a `project_path` argument gets the same poll for free. */
+private const val WAIT_EXTRA_OPTION_NAME: String = "wait"
+
+/** How long a declared `wait` extra option polls `steroid_list_windows` before giving up. */
+private const val WAIT_TIMEOUT_MS: Long = 300_000
+
+/** How long a declared `wait` extra option sleeps between polls of `steroid_list_windows`. */
+private const val WAIT_INTERVAL_MS: Long = 1_000
+
 /**
- * Fails when the invocation SET a [com.jonnyzzz.mcpSteroid.mcp.CliExtraOption] no runtime acts on.
- *
- * An extra option is by definition orchestration the CLI performs around the call — `open_project --wait`
- * polling the IDE after the tool returns — so it reaches no tool and there is nothing to forward it to. Until
- * that orchestration exists, honouring the flag by ignoring it would be the worst of the three options: the
- * caller asked devrig to wait, devrig said nothing, and the difference is invisible in the exit code. The
- * failure is derived from the declaration ([com.jonnyzzz.mcpSteroid.mcp.CliCommandSpec.extraOptions]) and
- * names the FLAG the user typed, so it needs no per-tool knowledge.
- *
- * **This function is temporary, and the phase that implements the first extra option must DELETE it** —
- * together with its test, `CliErrorEnvelopeTest.an extra option no runtime acts on yet fails loudly instead
- * of being ignored`. That deletion is pre-authorised here, so it does not read as removing a passing test.
- * It cannot lapse on its own: the condition below is "the declared flag was set", which says nothing about
- * whether a runtime consumes it, so once `--wait` works this guard would reject the very invocation it is
- * meant to enable. There is no version of it worth keeping — asking "does a runtime consume this option?"
- * would need exactly the per-tool registry this design exists to avoid.
+ * Thrown by [awaitWaitOption] when its poll deadline passes before `steroid_list_windows` reports the
+ * project ready. Caught in [runGeneratedToolCommand]'s own pipeline, alongside every other failure that
+ * pipeline classifies, and mapped to [CliExit.UNAVAILABLE] there — a project that never finishes opening
+ * is the same "no usable IDE" story as an unreachable backend, just discovered after the call.
  */
-private fun GeneratedToolInvocation.requireNoUnhandledExtraOption(spec: CliToolSpec) {
-    val unhandled = spec.cli.extraOptions.filter { extraOptions[it.name] == true }
-    // No "devrig <command>:" prefix here — the pipeline's IllegalArgumentException arm adds it, and saying
-    // it twice is what the printed message actually looked like before this comment existed.
-    require(unhandled.isEmpty()) {
-        "${unhandled.joinToString(", ") { it.flag }} is accepted by the command line but no runtime acts " +
-            "on it yet — drop it and the command runs"
-    }
+private class ProjectNotReadyException(projectPath: String, timeoutMs: Long) : RuntimeException(
+    "project '$projectPath' not initialized within ${timeoutMs / 1000}s"
+)
+
+/**
+ * The orchestration a declared `wait` extra option means: after [command]'s own tool call has already
+ * returned, poll [tools]' `steroid_list_windows` until [command]'s `project_path` argument reports ready
+ * ([isProjectReady]), or throw [ProjectNotReadyException] once [WAIT_TIMEOUT_MS] passes. Keyed off
+ * [WAIT_EXTRA_OPTION_NAME] alone by the one caller in [runGeneratedToolCommand] — this function itself
+ * assumes nothing about WHICH tool called it beyond "it declared a `project_path` argument", which is
+ * `wait`'s whole contract: it orchestrates opening a project, so there is always a project path to poll
+ * for.
+ *
+ * [rawProjectPath] is normalized with [Path.toRealPath] before polling: `open_project` resolves its own
+ * `project_path` input the same way (`OpenProjectTool.kt`) before opening it, and `steroid_list_windows`
+ * reports that resolved path, not the caller's original string — a relative path or an unresolved symlink
+ * would otherwise never match. Resolution can only fail here if the directory vanished between
+ * `open_project` validating it and this call, which is exotic enough to fall out through the ordinary
+ * [IOException] arm below rather than needing its own.
+ */
+private suspend fun DevrigServices.awaitWaitOption(command: GeneratedToolInvocation, tools: McpSteroidTools) {
+    val rawProjectPath = command.arguments["project_path"]?.jsonPrimitive?.contentOrNull
+        ?: error(
+            "'$WAIT_EXTRA_OPTION_NAME' extra option requires a 'project_path' argument, which " +
+                "'${command.toolName}' does not declare"
+        )
+    val projectPath = Path.of(rawProjectPath).toRealPath().toString()
+    val listWindowsSpec = liveToolSpec("steroid_list_windows", tools)
+    val ready = awaitProjectReady(
+        pollListWindows = {
+            callToolViaSpec(listWindowsSpec, JsonObject(emptyMap()), stderrProgressReporter(listWindowsSpec.name))
+                .listWindowsJson()
+        },
+        projectPath = projectPath,
+        timeoutMs = WAIT_TIMEOUT_MS,
+        intervalMs = WAIT_INTERVAL_MS,
+        now = System::currentTimeMillis,
+        sleep = ::delay,
+    )
+    if (!ready) throw ProjectNotReadyException(projectPath, WAIT_TIMEOUT_MS)
+}
+
+/**
+ * A `steroid_list_windows` call result, parsed as the [JsonObject] [isProjectReady] reads. A malformed or
+ * absent text payload is the backend's fault, not the caller's, so it is reported with [error] — an
+ * invariant violation propagating to `runCliWithLastResortHandling`, not a [CliExit] this pipeline knows
+ * how to name; a genuinely undecodable JSON body instead throws [SerializationException] here, which the
+ * pipeline's own arm already maps to [CliExit.DATA_ERROR].
+ */
+private fun ToolCallResult.listWindowsJson(): JsonObject {
+    val text = content.filterIsInstance<ContentItem.Text>().firstOrNull()?.text
+        ?: error("steroid_list_windows returned no text content to parse")
+    return McpJson.parseToJsonElement(text).jsonObject
 }
 
 /**

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/GeneratedToolRuntime.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/GeneratedToolRuntime.kt
@@ -9,6 +9,7 @@ import com.jonnyzzz.mcpSteroid.mcp.ContentItem
 import com.jonnyzzz.mcpSteroid.mcp.McpJson
 import com.jonnyzzz.mcpSteroid.mcp.ToolCallErrorException
 import com.jonnyzzz.mcpSteroid.mcp.ToolCallResult
+import com.jonnyzzz.mcpSteroid.server.ListProjectsResponse
 import com.jonnyzzz.mcpSteroid.server.McpSteroidTools
 import com.jonnyzzz.mcpSteroid.server.NoOpProgressReporter
 import java.io.IOException
@@ -23,12 +24,14 @@ import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
 import kotlinx.serialization.SerializationException
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.contentOrNull
-import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 
 /**
@@ -107,7 +110,17 @@ fun DevrigServices.runGeneratedToolCommand(
     val spec = liveToolSpec(command.toolName, tools)
     val presentation = presentationFor(command.json, spec.cli.outputStyle, homePaths::tmpDir)
     val preparedOut = try {
+        // A usage failure must win before --out preflight creates a parent directory or probe file.
+        // This also keeps unsupported orchestration flags ahead of the backend call below.
+        command.requireNoUnhandledExtraOption()
         preflightOutTarget(command.out)
+    } catch (e: IllegalArgumentException) {
+        return presentation.renderError(
+            command.commandName,
+            "devrig ${command.commandName}: ${e.message}",
+            CliExit.USAGE,
+            mcpStdout,
+        )
     } catch (e: IOException) {
         return presentation.renderError(
             command.commandName,
@@ -121,17 +134,16 @@ fun DevrigServices.runGeneratedToolCommand(
         val progress = if (command.json) NoOpProgressReporter else stderrProgressReporter(spec.name)
         runBlocking(Dispatchers.IO) {
             val toolResult = callToolViaSpec(spec, arguments, progress)
-            if (!toolResult.isError && command.extraOptions[WAIT_EXTRA_OPTION_NAME] == true) {
+            val completedResult = if (!toolResult.isError && command.extraOptions[WAIT_EXTRA_OPTION_NAME] == true) {
                 awaitWaitOption(command, tools)
-            }
-            command.requireNoUnhandledExtraOption()
-            toolResult
+            } else toolResult
+            completedResult
         }
     } catch (e: CliInputException) {
         return presentation.renderError(command.commandName, e.message.orEmpty(), e.exit, mcpStdout)
     } catch (e: ProjectNotReadyException) {
         // Thrown by awaitWaitOption above when a declared `wait` extra option's poll deadline passed
-        // before `steroid_list_windows` reported the project ready — the same "no usable IDE" story an
+        // before `steroid_list_projects` reported the project route — the same "no usable IDE" story an
         // IOException tells below, just discovered after open_project's own call already succeeded.
         return presentation.renderError(command.commandName, e.message.orEmpty(), CliExit.UNAVAILABLE, mcpStdout)
     } catch (e: ProjectRouteNotFoundException) {
@@ -227,10 +239,10 @@ fun liveToolSpec(toolName: String, tools: McpSteroidTools): CliToolSpec {
  * `CliExtraOption("wait", ...)` over a `project_path` argument gets the same poll for free. */
 private const val WAIT_EXTRA_OPTION_NAME: String = "wait"
 
-/** How long a declared `wait` extra option polls `steroid_list_windows` before giving up. */
+/** How long a declared `wait` extra option polls `steroid_list_projects` before giving up. */
 private const val WAIT_TIMEOUT_MS: Long = 300_000
 
-/** How long a declared `wait` extra option sleeps between polls of `steroid_list_windows`. */
+/** How long a declared `wait` extra option sleeps between polls of `steroid_list_projects`. */
 private const val WAIT_INTERVAL_MS: Long = 1_000
 
 /**
@@ -258,65 +270,83 @@ private fun GeneratedToolInvocation.requireNoUnhandledExtraOption() {
 }
 
 /**
- * Thrown by [awaitWaitOption] when its poll deadline passes before `steroid_list_windows` reports the
- * project ready. Caught in [runGeneratedToolCommand]'s own pipeline, alongside every other failure that
+ * Thrown by [awaitWaitOption] when its poll deadline passes before `steroid_list_projects` reports the
+ * project route. Caught in [runGeneratedToolCommand]'s own pipeline, alongside every other failure that
  * pipeline classifies, and mapped to [CliExit.UNAVAILABLE] there — a project that never finishes opening
  * is the same "no usable IDE" story as an unreachable backend, just discovered after the call.
  */
 private class ProjectNotReadyException(projectPath: String, timeoutMs: Long) : RuntimeException(
-    "project '$projectPath' not initialized within ${timeoutMs / 1000}s"
+    "project '$projectPath' was not routed by list_projects within ${timeoutMs / 1000}s"
+)
+
+/** Structured success returned by `open_project --wait`, including the routing values needed next. */
+@Serializable
+private data class AwaitedProjectResult(
+    @SerialName("project_name") val projectName: String,
+    @SerialName("backend_name") val backendName: String?,
+    val path: String,
 )
 
 /**
  * The orchestration a declared `wait` extra option means: after [command]'s own tool call has already
- * returned, poll [tools]' `steroid_list_windows` until [command]'s `project_path` argument reports ready
- * ([isProjectReady]), or throw [ProjectNotReadyException] once [WAIT_TIMEOUT_MS] passes. Keyed off
+ * returned, poll [tools]' `steroid_list_projects` until [command]'s `project_path` appears as an addressable
+ * route, or throw [ProjectNotReadyException] once [WAIT_TIMEOUT_MS] passes. Keyed off
  * [WAIT_EXTRA_OPTION_NAME] alone by the one caller in [runGeneratedToolCommand] — this function itself
  * assumes nothing about WHICH tool called it beyond "it declared a `project_path` argument", which is
  * `wait`'s whole contract: it orchestrates opening a project, so there is always a project path to poll
  * for.
  *
  * [rawProjectPath] is normalized with [Path.toRealPath] before polling: `open_project` resolves its own
- * `project_path` input the same way (`OpenProjectTool.kt`) before opening it, and `steroid_list_windows`
+ * `project_path` input the same way (`OpenProjectTool.kt`) before opening it, and `steroid_list_projects`
  * reports that resolved path, not the caller's original string — a relative path or an unresolved symlink
  * would otherwise never match. Resolution can only fail here if the directory vanished between
  * `open_project` validating it and this call, which is exotic enough to fall out through the ordinary
  * [IOException] arm below rather than needing its own.
  */
-private suspend fun DevrigServices.awaitWaitOption(command: GeneratedToolInvocation, tools: McpSteroidTools) {
+private suspend fun awaitWaitOption(
+    command: GeneratedToolInvocation,
+    tools: McpSteroidTools,
+): ToolCallResult {
     val rawProjectPath = command.arguments["project_path"]?.jsonPrimitive?.contentOrNull
         ?: error(
             "'$WAIT_EXTRA_OPTION_NAME' extra option requires a 'project_path' argument, which " +
                 "'${command.toolName}' does not declare"
         )
-    val projectPath = Path.of(rawProjectPath).toRealPath().toString()
-    val listWindowsSpec = liveToolSpec("steroid_list_windows", tools)
+    val projectPath = withContext(Dispatchers.IO) { Path.of(rawProjectPath).toRealPath().toString() }
+    val backendName = command.arguments["backend_name"]?.jsonPrimitive?.contentOrNull
+        ?.trim()?.takeIf { it.isNotEmpty() }
+    val listProjectsSpec = liveToolSpec("steroid_list_projects", tools)
     // Created ONCE, outside the poll lambda: `stderrProgressReporter` prints "Tool call started: devrig
-    // list_windows" on its FIRST `report()` call, and a wait that polls for minutes must not repeat that
+    // list_projects" on its FIRST `report()` call, and a wait that polls for minutes must not repeat that
     // line on every iteration.
-    val listWindowsProgress = if (command.json) NoOpProgressReporter else stderrProgressReporter(listWindowsSpec.name)
-    val ready = awaitProjectReady(
-        pollListWindows = { callToolViaSpec(listWindowsSpec, JsonObject(emptyMap()), listWindowsProgress).listWindowsJson() },
+    val listProjectsProgress = if (command.json) NoOpProgressReporter else stderrProgressReporter(listProjectsSpec.name)
+    val route = awaitProjectReady(
+        pollListProjects = {
+            callToolViaSpec(listProjectsSpec, JsonObject(emptyMap()), listProjectsProgress).listProjectsResponse()
+        },
         projectPath = projectPath,
+        backendName = backendName,
         timeoutMs = WAIT_TIMEOUT_MS,
         intervalMs = WAIT_INTERVAL_MS,
         now = System::currentTimeMillis,
         sleep = ::delay,
     )
-    if (!ready) throw ProjectNotReadyException(projectPath, WAIT_TIMEOUT_MS)
+        ?: throw ProjectNotReadyException(projectPath, WAIT_TIMEOUT_MS)
+    val result = AwaitedProjectResult(route.projectName, route.backendName, route.path)
+    return ToolCallResult(content = listOf(ContentItem.Text(McpJson.encodeToString(result))))
 }
 
 /**
- * A `steroid_list_windows` call result, parsed as the [JsonObject] [isProjectReady] reads. A malformed or
- * absent text payload is the backend's fault, not the caller's, so it is reported with [error] — an
+ * A `steroid_list_projects` call result, decoded to the shared response model. A malformed or absent text
+ * payload is the backend's fault, not the caller's, so it is reported with [error] — an
  * invariant violation propagating to `runCliWithLastResortHandling`, not a [CliExit] this pipeline knows
  * how to name; a genuinely undecodable JSON body instead throws [SerializationException] here, which the
  * pipeline's own arm already maps to [CliExit.DATA_ERROR].
  */
-private fun ToolCallResult.listWindowsJson(): JsonObject {
+private fun ToolCallResult.listProjectsResponse(): ListProjectsResponse {
     val text = content.filterIsInstance<ContentItem.Text>().firstOrNull()?.text
-        ?: error("steroid_list_windows returned no text content to parse")
-    return McpJson.parseToJsonElement(text).jsonObject
+        ?: error("steroid_list_projects returned no text content to parse")
+    return McpJson.decodeFromString(ListProjectsResponse.serializer(), text)
 }
 
 /**

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/GithubCommunityReleases.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/GithubCommunityReleases.kt
@@ -73,7 +73,7 @@ fun resolveGithubCommunityArchiveFromReleasesJson(
         ?: error("'${product.id}' is not a GitHub Community product")
     val wanted = version?.takeIf { it.isNotBlank() }
 
-    val releases = Json { ignoreUnknownKeys = true }.parseToJsonElement(payload).jsonArray
+    val releases = Json.parseToJsonElement(payload).jsonArray
         .filterIsInstance<JsonObject>()
         .filter { (it["prerelease"] as? JsonPrimitive)?.content != "true" }
         .mapNotNull { release ->

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/SchemaCliBinding.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/SchemaCliBinding.kt
@@ -189,10 +189,11 @@ private class BoundExtra(val option: CliExtraOption, val value: () -> Boolean)
 /**
  * Every CLI name this command will carry, mapped back to its declaring parameter, failing fast on any
  * collision: Clikt keeps one option per name, so two declarations claiming one name would let one
- * silently shadow the other. All four sources of a name take part — a parameter's own flag or positional
- * name, an optional boolean's negative spelling, a file-source flag, and an [CliExtraOption] flag — and
- * they are checked against each other, not only within their own kind. Extra options are not in the
- * returned map: an extra option is not a parameter, so nothing can map back to a spec for it.
+ * silently shadow the other. All sources of a name take part — a parameter's own flag or positional
+ * name, a positional's hidden compatibility flag, an optional boolean's negative spelling, a file-source
+ * flag, and an [CliExtraOption] flag — and they are checked against each other, not only within their own
+ * kind. Extra options are not in the returned map: an extra option is not a parameter, so nothing can map
+ * back to a spec for it.
  */
 private fun cliNames(
     params: List<InputSchemaParamSpec>,
@@ -207,6 +208,9 @@ private fun cliNames(
     }
     for (spec in params) {
         claim(spec.cliParamName, "parameter '${spec.name}'", spec)
+        if (spec.cliPositional) {
+            claim(spec.cliFlag, "the compatibility flag of positional parameter '${spec.name}'", spec)
+        }
         spec.negativeCliFlag?.let { claim(it, "the negative flag of '${spec.name}'", spec) }
         spec.cliFileSource?.let { claim(it.flag, "the file source of '${spec.name}'", spec) }
     }
@@ -224,13 +228,64 @@ private fun bindParam(command: CliktCommand, spec: InputSchemaParamSpec): BoundP
     require(!spec.cliHidden) { "cliHidden parameter '${spec.name}' must never be bound to the CLI" }
     // The parameter's own form is registered first so generated help lists it before the alternative
     // (`--code` above `--code-file`); Clikt renders options in registration order.
-    val value = if (spec.cliPositional) bindPositional(command, spec) else bindOption(command, spec)
+    val value = if (spec.cliPositional) bindPositionalWithCompatibilityFlag(command, spec) else bindOption(command, spec)
     val fileOption = spec.cliFileSource?.let { source ->
         command.option(source.flag, help = source.synopsis, metavar = "PATH").also { command.registerOption(it) }
     }
     val filePath: () -> String? = { fileOption?.value }
     registerRequirednessChecks(command, spec, value, filePath)
     return BoundParam(spec, value, filePath)
+}
+
+/**
+ * Makes the positional the only advertised form while retaining the parameter's former `--name` option
+ * as a hidden compatibility spelling. A schema migration from option to positional is presentation, not
+ * a reason to break existing shell scripts. Both forms still flow through Clikt and the same type
+ * conversion; no second parser or command implementation is involved.
+ */
+private fun bindPositionalWithCompatibilityFlag(
+    command: CliktCommand,
+    spec: InputSchemaParamSpec,
+): () -> JsonElement? {
+    val positional = bindPositional(command, spec, required = false)
+    val compatibilityFlag = bindHiddenValueOption(command, spec)
+    val value = { positional() ?: compatibilityFlag() }
+    command.registerCliParseCheck {
+        val positionalValue = positional()
+        val flagValue = compatibilityFlag()
+        if (positionalValue != null && flagValue != null) {
+            throw UsageError(
+                "give either <${spec.name}> or ${spec.cliFlag} for '${spec.name}', not both",
+                paramName = spec.name,
+            )
+        }
+        if (positionalValue == null && flagValue == null && spec.cliRequired) {
+            throw MissingCliValue(
+                "'${spec.name}' is required: pass <${spec.name}> (the former ${spec.cliFlag} spelling is also accepted)",
+                paramName = spec.name,
+            )
+        }
+    }
+    return value
+}
+
+/** A positional parameter's non-advertised former option spelling, with the same typed conversion. */
+private fun bindHiddenValueOption(command: CliktCommand, spec: InputSchemaParamSpec): () -> JsonElement? {
+    val typed = command.option(spec.cliFlag, hidden = true).typedJson(spec)
+    if (spec.type == "array") {
+        val bound = typed.multiple()
+        command.registerOption(bound)
+        return { bound.value.toJsonArrayOrNull() }
+    }
+    val bound = typed.multiple()
+    command.registerOption(bound)
+    return {
+        if (bound.value.size > 1) throw UsageError(
+            "${spec.cliFlag} was given ${bound.value.size} times but takes a single value",
+            paramName = spec.name,
+        )
+        bound.value.singleOrNull()
+    }
 }
 
 /**
@@ -368,14 +423,18 @@ private fun bindOption(command: CliktCommand, spec: InputSchemaParamSpec): () ->
     }
 }
 
-private fun bindPositional(command: CliktCommand, spec: InputSchemaParamSpec): () -> JsonElement? {
+private fun bindPositional(
+    command: CliktCommand,
+    spec: InputSchemaParamSpec,
+    required: Boolean = spec.cliRequired,
+): () -> JsonElement? {
     val typed = command.argument(spec.name, help = spec.cliSynopsis).typedJson(spec)
     if (spec.type == "array") {
-        val bound = typed.multiple(required = spec.cliRequired)
+        val bound = typed.multiple(required = required)
         command.registerArgument(bound)
         return { bound.value.toJsonArrayOrNull() }
     }
-    if (spec.cliRequired) {
+    if (required) {
         command.registerArgument(typed)
         return { typed.value }
     }

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/SchemaToolCliCommand.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/SchemaToolCliCommand.kt
@@ -64,6 +64,7 @@ class SchemaToolCliCommand(
     help = spec.cli.synopsis,
     // Only a tool whose result can carry an image gets `--out`; the rest refuse it as an unknown option.
     acceptsOut = spec.cli.producesImage,
+    epilog = renderGuideEpilog(spec),
 ) {
     private val binding = SchemaCliBinding.bind(this, spec)
 
@@ -78,7 +79,7 @@ class SchemaToolCliCommand(
         }
         rejectFlagsConsumedAsValues(buildMap {
             for (param in spec.schema.asCliParams()) {
-                if (param.cliHidden || param.cliPositional) continue
+                if (param.cliHidden) continue
                 put(param.cliFlag, param.name)
                 param.cliFileSource?.let { put(it.flag, param.name) }
             }
@@ -126,4 +127,19 @@ class SchemaToolCliCommand(
         ) { runGeneratedToolCommand(command) }
     }
 
+}
+
+/**
+ * Focused help's optional second layer. The tool owns the URI list; the generic command tree only explains
+ * how to fetch each declared article through the same CLI. Keeping article bodies out of `--help` makes
+ * the grammar scannable while leaving a direct, copyable route to the full workflow guidance.
+ */
+fun renderGuideEpilog(spec: CliToolSpec): String {
+    if (spec.cli.guideUris.isEmpty()) return ""
+    return buildString {
+        appendLine("Guides for deeper workflows:")
+        for (uri in spec.cli.guideUris) appendLine("  $uri")
+        appendLine()
+        append("Read one with `devrig prompt <uri> --project_name=<routing-key>`.")
+    }
 }

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/WaitForProjectReady.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/WaitForProjectReady.kt
@@ -1,61 +1,48 @@
 /* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
 package com.jonnyzzz.mcpSteroid.devrig
 
-import kotlinx.serialization.json.JsonObject
-import kotlinx.serialization.json.boolean
-import kotlinx.serialization.json.jsonArray
-import kotlinx.serialization.json.jsonObject
-import kotlinx.serialization.json.jsonPrimitive
+import com.jonnyzzz.mcpSteroid.server.ListProjectsResponse
+import com.jonnyzzz.mcpSteroid.server.ListedProject
 
 /**
- * True iff a parsed `steroid_list_windows` result ([listWindowsJson]) contains a window for
- * [projectPath] that has finished opening: initialized, not indexing, and with no modal dialog
- * blocking it. This is the pure decision `open_project --wait` polls on; [awaitProjectReady] is the
- * loop around it.
+ * Returns the project route whose canonical [ListedProject.path] matches [projectPath]. When
+ * [backendName] is known, the match must also belong to that backend so an already-open copy in a
+ * different IDE cannot make `open_project --wait` return early with the wrong routing key.
  *
- * Field names match `ListedWindow` in `mcp-steroid-server`'s `ListWindowsTool.kt` verbatim, confirmed
- * from that class rather than assumed: `McpJson` sets no naming strategy, so a property serializes
- * under its own name unless annotated. `projectPath` carries an explicit `@SerialName("project_path")`
- * (issue #381 — the same snake_case key `steroid_list_projects` uses), while `projectInitialized`,
- * `indexingInProgress` and `modalDialogShowing` carry no annotation and so stay camelCase on the wire.
- * `project_path` is matched against `open_project`'s OWN normalized value: that tool resolves its
- * `project_path` input through `toRealPath()` before opening, so the caller must pass the same
- * resolved path here for the two to line up.
+ * Project routing is the readiness contract deliberately: a Remote Development backend normally has
+ * no frontend window, while every project-scoped MCP call requires the opaque [ListedProject.projectName]
+ * published by `steroid_list_projects`. Window state is useful for interactive dialog handling, but it
+ * cannot be required for a project to become addressable.
  */
-fun isProjectReady(listWindowsJson: JsonObject, projectPath: String): Boolean {
-    val windows = listWindowsJson["windows"]?.jsonArray ?: return false
-    return windows.any { window ->
-        val entry = window.jsonObject
-        entry["project_path"]?.jsonPrimitive?.content == projectPath &&
-            entry["projectInitialized"]?.jsonPrimitive?.boolean == true &&
-            entry["indexingInProgress"]?.jsonPrimitive?.boolean != true &&
-            entry["modalDialogShowing"]?.jsonPrimitive?.boolean != true
-    }
+fun findProjectRoute(
+    response: ListProjectsResponse,
+    projectPath: String,
+    backendName: String? = null,
+): ListedProject? = response.projects.singleOrNull { project ->
+    project.path == projectPath && (backendName == null || project.backendName == backendName)
 }
 
 /**
- * Polls [pollListWindows] for [projectPath] to become [isProjectReady], returning `true` as soon as it
- * does and `false` once [timeoutMs] has elapsed without that happening. [now] and [sleep] are injected
- * rather than reading the wall clock or calling `kotlinx.coroutines.delay` directly, so a test drives the
- * whole loop deterministically, with no real waiting: production passes `System::currentTimeMillis` and
- * `kotlinx.coroutines.delay`.
+ * Polls [pollListProjects] until [findProjectRoute] returns the requested route, or returns `null` once
+ * [timeoutMs] has elapsed. The matched [ListedProject] is returned rather than a boolean because its
+ * opaque routing key is the primary value a caller needs after opening a project.
  *
- * Each iteration polls FIRST and only then checks the deadline, so a caller always gets at least one
- * poll even when [timeoutMs] is small — matching "ask the IDE, then decide whether to give up", not
- * "give up before ever asking".
+ * [now] and [sleep] are injected so tests drive the loop deterministically. Each iteration polls first
+ * and only then checks the deadline, so even a zero-duration wait asks the IDE once before giving up.
  */
 suspend fun awaitProjectReady(
-    pollListWindows: suspend () -> JsonObject,
+    pollListProjects: suspend () -> ListProjectsResponse,
     projectPath: String,
+    backendName: String? = null,
     timeoutMs: Long,
     intervalMs: Long,
     now: () -> Long,
     sleep: suspend (Long) -> Unit,
-): Boolean {
+): ListedProject? {
     val deadline = now() + timeoutMs
     while (true) {
-        if (isProjectReady(pollListWindows(), projectPath)) return true
-        if (now() >= deadline) return false
+        findProjectRoute(pollListProjects(), projectPath, backendName)?.let { return it }
+        if (now() >= deadline) return null
         sleep(intervalMs)
     }
 }

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/WaitForProjectReady.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/WaitForProjectReady.kt
@@ -1,0 +1,61 @@
+/* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
+package com.jonnyzzz.mcpSteroid.devrig
+
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.boolean
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+
+/**
+ * True iff a parsed `steroid_list_windows` result ([listWindowsJson]) contains a window for
+ * [projectPath] that has finished opening: initialized, not indexing, and with no modal dialog
+ * blocking it. This is the pure decision `open_project --wait` polls on; [awaitProjectReady] is the
+ * loop around it.
+ *
+ * Field names match `ListedWindow` in `mcp-steroid-server`'s `ListWindowsTool.kt` verbatim, confirmed
+ * from that class rather than assumed: `McpJson` sets no naming strategy, so a property serializes
+ * under its own name unless annotated. `projectPath` carries an explicit `@SerialName("project_path")`
+ * (issue #381 — the same snake_case key `steroid_list_projects` uses), while `projectInitialized`,
+ * `indexingInProgress` and `modalDialogShowing` carry no annotation and so stay camelCase on the wire.
+ * `project_path` is matched against `open_project`'s OWN normalized value: that tool resolves its
+ * `project_path` input through `toRealPath()` before opening, so the caller must pass the same
+ * resolved path here for the two to line up.
+ */
+fun isProjectReady(listWindowsJson: JsonObject, projectPath: String): Boolean {
+    val windows = listWindowsJson["windows"]?.jsonArray ?: return false
+    return windows.any { window ->
+        val entry = window.jsonObject
+        entry["project_path"]?.jsonPrimitive?.content == projectPath &&
+            entry["projectInitialized"]?.jsonPrimitive?.boolean == true &&
+            entry["indexingInProgress"]?.jsonPrimitive?.boolean != true &&
+            entry["modalDialogShowing"]?.jsonPrimitive?.boolean != true
+    }
+}
+
+/**
+ * Polls [pollListWindows] for [projectPath] to become [isProjectReady], returning `true` as soon as it
+ * does and `false` once [timeoutMs] has elapsed without that happening. [now] and [sleep] are injected
+ * rather than reading the wall clock or calling `kotlinx.coroutines.delay` directly, so a test drives the
+ * whole loop deterministically, with no real waiting: production passes `System::currentTimeMillis` and
+ * `kotlinx.coroutines.delay`.
+ *
+ * Each iteration polls FIRST and only then checks the deadline, so a caller always gets at least one
+ * poll even when [timeoutMs] is small — matching "ask the IDE, then decide whether to give up", not
+ * "give up before ever asking".
+ */
+suspend fun awaitProjectReady(
+    pollListWindows: suspend () -> JsonObject,
+    projectPath: String,
+    timeoutMs: Long,
+    intervalMs: Long,
+    now: () -> Long,
+    sleep: suspend (Long) -> Unit,
+): Boolean {
+    val deadline = now() + timeoutMs
+    while (true) {
+        if (isProjectReady(pollListWindows(), projectPath)) return true
+        if (now() >= deadline) return false
+        sleep(intervalMs)
+    }
+}

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/server/DevrigExecuteFeedbackToolHandler.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/server/DevrigExecuteFeedbackToolHandler.kt
@@ -15,6 +15,7 @@ class DevrigExecuteFeedbackToolHandler(
         val route = routing.requireProject(projectName)
         val result = bridge.callProjectTool(route, "steroid_execute_feedback") {
             put("task_id", params.taskId)
+            params.executionId?.let { put("execution_id", it) }
             put("success_rating", params.successRating)
             params.explanation?.let { put("explanation", it) }
             params.code?.let { put("code", it) }

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/server/DevrigOpenProjectToolHandler.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/server/DevrigOpenProjectToolHandler.kt
@@ -35,8 +35,8 @@ class DevrigOpenProjectToolHandler(
         return bridge.callTool(ide, "steroid_open_project", callProgress) {
             put("project_path", openProjectParams.projectPath)
             put("trust_project", openProjectParams.trustProject)
-            put("task_id", "open-project")
-            put("reason", "Open project through devrig")
+            put("task_id", openProjectParams.taskId)
+            put("reason", openProjectParams.reason)
         }
     }
 

--- a/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/CliErrorEnvelopeTest.kt
+++ b/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/CliErrorEnvelopeTest.kt
@@ -388,37 +388,6 @@ class CliErrorEnvelopeTest {
         }
     }
 
-    // --------------------------- an extra option nothing acts on yet ---------------------------
-
-    @Test
-    fun `an extra option no runtime acts on yet fails loudly instead of being ignored`() {
-        // `--wait` is generated from open_project's declaration and parses today, but the polling that
-        // gives it meaning does not exist yet. Ignoring it would be invisible: the caller asked devrig to
-        // wait for the project, devrig would open it, return 0, and never wait. Derived from the
-        // declaration, so it names the flag the user typed and needs no per-tool knowledge.
-        //
-        // DELETE THIS TEST, along with `requireNoUnhandledExtraOption`, in the phase that implements the
-        // first extra option. The deletion is pre-authorised — it is not a weakened test. The rule it pins
-        // fires on "the declared flag was set" and cannot tell whether a runtime consumes the option, so
-        // once `--wait` works this guard would reject the very invocation it exists to protect.
-        val command = parseRunTool(
-            "open_project", "--json", "--project_path=/tmp/p", "--backend_name=b",
-            "--task_id=t", "--reason=r", "--wait",
-        )
-
-        val run = runGeneratedToolForTest(home, command, FakeMcpSteroidTools())
-
-        assertEquals(CliExit.USAGE, run.exit, "stdout was:\n${run.stdout}")
-        run.assertIsErrorEnvelope("open_project")
-        assertEquals(
-            "devrig open_project: --wait is accepted by the command line but no runtime acts on it yet — " +
-                "drop it and the command runs",
-            run.errorMessage(),
-            "the whole message is asserted, not just the flag: the first version of this rule said " +
-                "'devrig open_project:' twice, because the pipeline already prefixes it",
-        )
-    }
-
     // ------------------------------------- console mode -------------------------------------
 
     @Test

--- a/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/CliErrorEnvelopeTest.kt
+++ b/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/CliErrorEnvelopeTest.kt
@@ -135,6 +135,27 @@ class CliErrorEnvelopeTest {
     }
 
     @Test
+    fun `an unhandled extra option fails loudly instead of being ignored`() {
+        // A synthetic extra option no runtime name-keyed handler (like the `--wait` poll) ever consumes.
+        // `list_windows` declares no extra options at all, so `SchemaCliBinding` could never produce this
+        // on a real parse — this hand-builds the RunTool to prove the RUNTIME'S OWN guard rejects it, not
+        // merely that the parser never emits it.
+        val command = GeneratedToolInvocation(
+            toolName = "steroid_list_windows",
+            commandName = "list_windows",
+            extraOptions = mapOf("phantom" to true),
+            json = true,
+        )
+        val tools = FakeMcpSteroidTools().with(ListWindowsToolHandler::class.java, CountingListWindows())
+
+        val run = runGeneratedToolForTest(home, command, tools)
+
+        assertEquals(CliExit.USAGE, run.exit, "stdout was:\n${run.stdout}")
+        run.assertIsErrorEnvelope("list_windows")
+        assertTrue("phantom" in run.errorMessage(), run.errorMessage())
+    }
+
+    @Test
     fun `an argument the tool itself rejects exits 64 and never blames the backend`() {
         // The rejection the SCHEMA layer raises — `McpSchema`'s `required()` parser for an absent required
         // parameter, and its enum parser for an unknown value. Both throw ToolCallErrorException, which

--- a/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/CliErrorEnvelopeTest.kt
+++ b/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/CliErrorEnvelopeTest.kt
@@ -71,6 +71,15 @@ class CliErrorEnvelopeTest {
         }
     }
 
+    private class CountingListWindows : ListWindowsToolHandler {
+        var called: Boolean = false
+
+        override suspend fun collectListWindowsResponse(): ListWindowsResponse {
+            called = true
+            return ListWindowsResponse(windows = emptyList(), backgroundTasks = emptyList())
+        }
+    }
+
     private fun listWindowsFailing(failure: () -> Nothing) =
         FakeMcpSteroidTools().with(ListWindowsToolHandler::class.java, ThrowingListWindows(failure))
 
@@ -357,6 +366,27 @@ class CliErrorEnvelopeTest {
         assertEquals(CliExit.TOOL_ERROR, run.exit, "stdout was:\n${run.stdout}")
         run.assertIsErrorEnvelope("execute_code")
         assertEquals("compilation failed: line 3", run.errorMessage())
+    }
+
+    @Test
+    fun `--wait never polls when open_project itself returns isError`() {
+        // OpenProjectToolSpec.call() rejects a non-existent path with its own ToolCallResult.errorResult(...)
+        // BEFORE ever reaching an OpenProjectToolHandler — so no handler double is registered here at all.
+        // If the runtime's `--wait` handling ever regressed to reach the handler anyway, FakeMcpSteroidTools
+        // would fail loudly ("no test double is registered") rather than silently passing.
+        val listWindows = CountingListWindows()
+        val tools = FakeMcpSteroidTools().with(ListWindowsToolHandler::class.java, listWindows)
+        val missingPath = home.resolve("does-not-exist")
+        val command = parseRunTool(
+            "open_project", "--json", "--project_path=$missingPath", "--task_id=t", "--reason=r", "--wait",
+        )
+
+        val run = runGeneratedToolForTest(home, command, tools)
+
+        assertEquals(CliExit.TOOL_ERROR, run.exit, "stdout was:\n${run.stdout}")
+        run.assertIsErrorEnvelope("open_project")
+        assertEquals("ERROR: Project path is not a directory: $missingPath", run.errorMessage())
+        assertFalse(listWindows.called, "a failed open_project must never trigger the --wait poll")
     }
 
     // ------------------------------------- 0 OK -------------------------------------

--- a/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/CliErrorEnvelopeTest.kt
+++ b/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/CliErrorEnvelopeTest.kt
@@ -7,6 +7,8 @@ import com.jonnyzzz.mcpSteroid.mcp.ToolCallErrorException
 import com.jonnyzzz.mcpSteroid.mcp.ToolCallResult
 import com.jonnyzzz.mcpSteroid.server.ExecCodeParams
 import com.jonnyzzz.mcpSteroid.server.ExecuteCodeToolHandler
+import com.jonnyzzz.mcpSteroid.server.ListProjectsResponse
+import com.jonnyzzz.mcpSteroid.server.ListProjectsToolHandler
 import com.jonnyzzz.mcpSteroid.server.ListWindowsResponse
 import com.jonnyzzz.mcpSteroid.server.ListWindowsToolHandler
 import com.jonnyzzz.mcpSteroid.server.McpProgressReporter
@@ -80,6 +82,15 @@ class CliErrorEnvelopeTest {
         }
     }
 
+    private class CountingListProjects : ListProjectsToolHandler {
+        var called: Boolean = false
+
+        override suspend fun collectListProjectsResponse(): ListProjectsResponse {
+            called = true
+            return ListProjectsResponse(projects = emptyList())
+        }
+    }
+
     private fun listWindowsFailing(failure: () -> Nothing) =
         FakeMcpSteroidTools().with(ListWindowsToolHandler::class.java, ThrowingListWindows(failure))
 
@@ -135,24 +146,29 @@ class CliErrorEnvelopeTest {
     }
 
     @Test
-    fun `an unhandled extra option fails loudly instead of being ignored`() {
+    fun `an unhandled extra option fails before tool and out filesystem side effects`() {
         // A synthetic extra option no runtime name-keyed handler (like the `--wait` poll) ever consumes.
-        // `list_windows` declares no extra options at all, so `SchemaCliBinding` could never produce this
-        // on a real parse — this hand-builds the RunTool to prove the RUNTIME'S OWN guard rejects it, not
-        // merely that the parser never emits it.
+        // `execute_code` declares no extra options at all, so `SchemaCliBinding` could never produce this
+        // on a real parse — this hand-builds the invocation to prove the RUNTIME'S OWN guard rejects it
+        // before either the image-producing tool or --out preflight can have an observable side effect.
+        val outParent = home.resolve("unsupported-extra-output")
         val command = GeneratedToolInvocation(
-            toolName = "steroid_list_windows",
-            commandName = "list_windows",
+            toolName = "steroid_execute_code",
+            commandName = "execute_code",
             extraOptions = mapOf("phantom" to true),
+            out = outParent.resolve("result.png"),
             json = true,
         )
-        val tools = FakeMcpSteroidTools().with(ListWindowsToolHandler::class.java, CountingListWindows())
+        val handler = CountingExecuteCode()
+        val tools = FakeMcpSteroidTools().with(ExecuteCodeToolHandler::class.java, handler)
 
         val run = runGeneratedToolForTest(home, command, tools)
 
         assertEquals(CliExit.USAGE, run.exit, "stdout was:\n${run.stdout}")
-        run.assertIsErrorEnvelope("list_windows")
+        run.assertIsErrorEnvelope("execute_code")
         assertTrue("phantom" in run.errorMessage(), run.errorMessage())
+        assertFalse(handler.called, "an unsupported orchestration flag must fail before the tool can have side effects")
+        assertFalse(Files.exists(outParent), "unsupported options must fail before --out creates its parent directory")
     }
 
     @Test
@@ -395,8 +411,8 @@ class CliErrorEnvelopeTest {
         // BEFORE ever reaching an OpenProjectToolHandler — so no handler double is registered here at all.
         // If the runtime's `--wait` handling ever regressed to reach the handler anyway, FakeMcpSteroidTools
         // would fail loudly ("no test double is registered") rather than silently passing.
-        val listWindows = CountingListWindows()
-        val tools = FakeMcpSteroidTools().with(ListWindowsToolHandler::class.java, listWindows)
+        val listProjects = CountingListProjects()
+        val tools = FakeMcpSteroidTools().with(ListProjectsToolHandler::class.java, listProjects)
         val missingPath = home.resolve("does-not-exist")
         val command = parseRunTool(
             "open_project", "--json", "--project_path=$missingPath", "--task_id=t", "--reason=r", "--wait",
@@ -407,7 +423,7 @@ class CliErrorEnvelopeTest {
         assertEquals(CliExit.TOOL_ERROR, run.exit, "stdout was:\n${run.stdout}")
         run.assertIsErrorEnvelope("open_project")
         assertEquals("ERROR: Project path is not a directory: $missingPath", run.errorMessage())
-        assertFalse(listWindows.called, "a failed open_project must never trigger the --wait poll")
+        assertFalse(listProjects.called, "a failed open_project must never trigger the --wait poll")
     }
 
     // ------------------------------------- 0 OK -------------------------------------

--- a/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/CliFileSourceReadTest.kt
+++ b/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/CliFileSourceReadTest.kt
@@ -1,0 +1,131 @@
+/* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
+package com.jonnyzzz.mcpSteroid.devrig
+
+import java.io.ByteArrayInputStream
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+import kotlinx.serialization.json.jsonPrimitive
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+
+/**
+ * A file source's two ways to read a value — standard input and a file path — must reject malformed UTF-8
+ * ([CliExit.IO_ERROR], the code the file branch has answered since `Files.readString` did the decoding) and
+ * an oversized payload ([CliExit.DATA_ERROR], nothing failed to be read) IDENTICALLY, through the same
+ * [CliInputException]. Before this test existed, the two paths diverged: `Files.readString` (the file
+ * path) threw on malformed bytes, while stdin's `decodeToString()` silently substituted U+FFFD, and
+ * neither path capped how much it would read.
+ *
+ * Driven through `execute_code`'s declared `--code-file`, via the same public
+ * [GeneratedToolInvocation.argumentsWithFileSources] entry point [CliFileSourceRuntimeTest] uses — there is no
+ * need to lift the private readers to test them.
+ */
+class CliFileSourceReadTest {
+
+    @TempDir
+    lateinit var work: Path
+
+    private val spec = devrigCliTools().single { it.name == "steroid_execute_code" }
+
+    private fun commandWith(codeFile: String) = parseRunTool(
+        "execute_code", "--project_name=demo", "--code-file=$codeFile", "--task_id=t", "--reason=r",
+    )
+
+    // ------------------------------- standard input -------------------------------
+
+    @Test
+    fun `malformed UTF-8 from stdin is rejected, not substituted`() {
+        val stdin = ByteArrayInputStream(byteArrayOf(0xFF.toByte(), 0xFE.toByte()))
+
+        val e = assertFailsWith<CliInputException> {
+            commandWith("-").argumentsWithFileSources(spec, stdin)
+        }
+
+        assertEquals(CliExit.IO_ERROR, e.exit, "message was: ${e.message}")
+        assertTrue(e.message!!.contains("not valid UTF-8"), "got: ${e.message}")
+    }
+
+    @Test
+    fun `over-cap stdin is rejected and the limit is named`() {
+        val big = ByteArray((CLI_FILE_SOURCE_MAX_BYTES + 1).toInt()) { 'a'.code.toByte() }
+
+        val e = assertFailsWith<CliInputException> {
+            commandWith("-").argumentsWithFileSources(spec, ByteArrayInputStream(big))
+        }
+
+        assertEquals(CliExit.DATA_ERROR, e.exit, "message was: ${e.message}")
+        assertTrue(e.message!!.contains("10"), "message must name the cap; got: ${e.message}")
+    }
+
+    @Test
+    fun `a small valid stdin value round-trips`() {
+        val arguments = commandWith("-").argumentsWithFileSources(
+            spec, ByteArrayInputStream("println(1)".toByteArray(Charsets.UTF_8)),
+        )
+
+        assertEquals("println(1)", arguments.getValue("code").jsonPrimitive.content)
+    }
+
+    // ------------------------------- file path -------------------------------
+
+    @Test
+    fun `malformed UTF-8 from a file is rejected, not substituted`() {
+        val file = work.resolve("bad.kts")
+        Files.write(file, byteArrayOf(0xFF.toByte(), 0xFE.toByte()))
+
+        val e = assertFailsWith<CliInputException> {
+            commandWith(file.toString()).argumentsWithFileSources(spec, ByteArrayInputStream(ByteArray(0)))
+        }
+
+        assertEquals(CliExit.IO_ERROR, e.exit, "message was: ${e.message}")
+        assertTrue(e.message!!.contains("not valid UTF-8"), "got: ${e.message}")
+    }
+
+    @Test
+    fun `an over-cap file is rejected and the limit is named`() {
+        val file = work.resolve("big.kts")
+        Files.newOutputStream(file).use { out ->
+            val chunk = ByteArray(1024 * 1024) { 'a'.code.toByte() }
+            repeat(11) { out.write(chunk) }
+        }
+
+        val e = assertFailsWith<CliInputException> {
+            commandWith(file.toString()).argumentsWithFileSources(spec, ByteArrayInputStream(ByteArray(0)))
+        }
+
+        assertEquals(CliExit.DATA_ERROR, e.exit, "message was: ${e.message}")
+        assertTrue(e.message!!.contains("10"), "message must name the cap; got: ${e.message}")
+    }
+
+    @Test
+    fun `a small valid file value round-trips`() {
+        val file = work.resolve("ok.kts")
+        Files.writeString(file, "println(2)")
+
+        val arguments = commandWith(file.toString()).argumentsWithFileSources(spec, ByteArrayInputStream(ByteArray(0)))
+
+        assertEquals("println(2)", arguments.getValue("code").jsonPrimitive.content)
+    }
+
+    // ------------------------------- consistency between the two sources -------------------------------
+
+    @Test
+    fun `stdin and file sources report the same exit code for malformed UTF-8`() {
+        val file = work.resolve("bad2.kts")
+        Files.write(file, byteArrayOf(0xFF.toByte(), 0xFE.toByte()))
+
+        val fromStdin = assertFailsWith<CliInputException> {
+            commandWith("-").argumentsWithFileSources(
+                spec, ByteArrayInputStream(byteArrayOf(0xFF.toByte(), 0xFE.toByte())),
+            )
+        }
+        val fromFile = assertFailsWith<CliInputException> {
+            commandWith(file.toString()).argumentsWithFileSources(spec, ByteArrayInputStream(ByteArray(0)))
+        }
+
+        assertEquals(fromStdin.exit, fromFile.exit)
+    }
+}

--- a/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/CliToolSupportTest.kt
+++ b/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/CliToolSupportTest.kt
@@ -53,6 +53,13 @@ class CliToolSupportTest {
     private fun countOccurrences(haystack: String, needle: String): Int =
         Regex(Regex.escape(needle)).findAll(haystack).count()
 
+    /** Runs [result] through [Presentation.Console] and returns everything written to stdout. */
+    private fun renderConsole(result: ToolCallResult): String {
+        val out = CapturedStream()
+        Presentation.Console { tempDir }.render(result, "list_windows", out.stream)
+        return out.text()
+    }
+
     // ------------------------------ presentationFor / stderrProgressReporter ------------------------------
 
     @Test
@@ -244,14 +251,45 @@ class CliToolSupportTest {
     }
 
     @Test
-    fun `console rendering of a json-shaped payload is untouched, printing the raw text verbatim`() {
+    fun `console rendering of a json-shaped payload is pretty-printed, not the raw minified text`() {
         val out = CapturedStream()
         val payload = """{"windows":[{"windowId":"w1"}]}"""
 
         val exit = Presentation.Console { tempDir }.render(textResult(payload), "list_windows", out.stream)
 
         assertEquals(CliExit.OK, exit)
-        assertEquals(payload + "\n", out.text())
+        val rendered = out.text()
+        // More than one line: println's own trailing "\n" alone must not satisfy this — a minified blob
+        // is exactly one line plus that trailing newline, so require at least two non-blank lines.
+        assertTrue(rendered.trim().lines().size > 1, "a JSON object must be pretty-printed across lines, not one minified blob: $rendered")
+        // Content-equivalent, not byte-identical: only the formatting changed.
+        assertEquals(parseJson.parseToJsonElement(payload), parseJson.parseToJsonElement(rendered))
+    }
+
+    @Test
+    fun `console pretty-prints a JSON object text payload`() {
+        val out = renderConsole(textResult("""{"windows":[{"a":1}]}"""))
+        assertTrue(out.trim().lines().size > 1, "a JSON object must be pretty-printed across lines, not one minified blob: $out")
+        assertTrue(out.contains("\"windows\""))
+    }
+
+    @Test
+    fun `console pretty-prints a JSON array text payload`() {
+        val out = renderConsole(textResult("""[1,2,3]"""))
+        assertTrue(out.trim().lines().size > 1, "a JSON array must be pretty-printed across lines, not one minified blob: $out")
+        assertEquals(listOf(1, 2, 3), parseJson.parseToJsonElement(out).jsonArray.map { it.jsonPrimitive.int })
+    }
+
+    @Test
+    fun `console leaves a prose text payload untouched`() {
+        val out = renderConsole(textResult("just some prose"))
+        assertEquals("just some prose", out.trim())
+    }
+
+    @Test
+    fun `console leaves a bare scalar untouched`() {
+        val out = renderConsole(textResult("123"))
+        assertEquals("123", out.trim())
     }
 
     // ------------------------------ console image rendering ------------------------------

--- a/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/ExecuteCodeCommandTest.kt
+++ b/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/ExecuteCodeCommandTest.kt
@@ -1,0 +1,98 @@
+/* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
+package com.jonnyzzz.mcpSteroid.devrig
+
+import com.jonnyzzz.mcpSteroid.mcp.ContentItem
+import com.jonnyzzz.mcpSteroid.mcp.ToolCallResult
+import com.jonnyzzz.mcpSteroid.server.ExecCodeParams
+import com.jonnyzzz.mcpSteroid.server.ExecuteCodeToolHandler
+import com.jonnyzzz.mcpSteroid.server.McpProgressReporter
+import com.jonnyzzz.mcpSteroid.server.ModalMode
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Path
+import kotlin.test.assertEquals
+
+/**
+ * `devrig execute_code` end to end: the generated command reaches the real
+ * [com.jonnyzzz.mcpSteroid.server.ExecuteCodeToolSpec.call], which builds [ExecCodeParams] from the parsed
+ * arguments. The parse-time shape of these flags (bounds, missing hints, code/code-file exclusivity) is
+ * already proven in `SchemaToolCliCommandTest` and `SchemaCliBindingTest`; this file is where the built
+ * [ExecCodeParams] itself — defaults included — is checked against a handler double, and where the
+ * console-mode success path (no `--json`) is proven for a tool whose result is plain text, not a listing.
+ */
+class ExecuteCodeCommandTest {
+
+    @TempDir
+    lateinit var home: Path
+
+    private class RecordingExecuteCode(private val result: ToolCallResult) : ExecuteCodeToolHandler {
+        var projectName: String? = null
+        var params: ExecCodeParams? = null
+
+        override suspend fun executeCode(
+            projectName: String,
+            execCodeParams: ExecCodeParams,
+            callProgress: McpProgressReporter,
+        ): ToolCallResult {
+            this.projectName = projectName
+            this.params = execCodeParams
+            return result
+        }
+    }
+
+    private fun toolsWith(rec: RecordingExecuteCode) =
+        FakeMcpSteroidTools().with(ExecuteCodeToolHandler::class.java, rec)
+
+    @Test
+    fun `inline code maps to ExecCodeParams with the spec's own defaults, end to end`() {
+        val rec = RecordingExecuteCode(ToolCallResult(content = listOf(ContentItem.Text("42"))))
+        val command = parseRunTool(
+            "execute_code", "--json",
+            "--project_name=demo", "--code=1+1", "--task_id=t1", "--reason=testing",
+        )
+
+        val run = runGeneratedToolForTest(home, command, toolsWith(rec))
+
+        assertEquals(CliExit.OK, run.exit, "stdout was:\n${run.stdout}")
+        assertEquals("demo", rec.projectName)
+        val params = rec.params!!
+        assertEquals("t1", params.taskId)
+        assertEquals("1+1", params.code)
+        assertEquals("testing", params.reason)
+        assertEquals(600, params.timeout, "the spec's own default timeout must reach the handler unchanged")
+        assertEquals(ModalMode.SMART_NON_MODAL, params.modal, "the spec's own default modal must reach the handler unchanged")
+    }
+
+    @Test
+    fun `all CLI flags reach the handler as the exact ExecCodeParams the spec builds`() {
+        val rec = RecordingExecuteCode(ToolCallResult(content = listOf(ContentItem.Text("ok"))))
+        val command = parseRunTool(
+            "execute_code", "--json",
+            "--project_name=demo", "--code=x", "--task_id=t2", "--reason=r2",
+            "--timeout=30", "--modal=unleashed",
+        )
+
+        val run = runGeneratedToolForTest(home, command, toolsWith(rec))
+
+        assertEquals(CliExit.OK, run.exit, "stdout was:\n${run.stdout}")
+        val params = rec.params!!
+        assertEquals("t2", params.taskId)
+        assertEquals("x", params.code)
+        assertEquals("r2", params.reason)
+        assertEquals(30, params.timeout)
+        assertEquals(ModalMode.UNLEASHED, params.modal)
+    }
+
+    @Test
+    fun `a successful result in console mode prints the tool's own text on stdout, with no envelope`() {
+        val rec = RecordingExecuteCode(ToolCallResult(content = listOf(ContentItem.Text("compilation ok"))))
+        val command = parseRunTool(
+            "execute_code", "--project_name=demo", "--code=x", "--task_id=t", "--reason=r",
+        )
+
+        val run = runGeneratedToolForTest(home, command, toolsWith(rec))
+
+        assertEquals(CliExit.OK, run.exit)
+        assertEquals("compilation ok", run.stdout.trim(), "console mode prints the tool's own text and nothing else")
+    }
+}

--- a/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/FeedbackAndInputCommandTest.kt
+++ b/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/FeedbackAndInputCommandTest.kt
@@ -52,7 +52,7 @@ class FeedbackAndInputCommandTest {
         val tools = FakeMcpSteroidTools().with(ExecuteFeedbackToolHandler::class.java, rec)
         val command = parseRunTool(
             "execute_feedback", "--json",
-            "--project_name=demo", "--task_id=t1", "--success_rating=0.75",
+            "--project_name=demo", "--task_id=t1", "--execution_id=eid_original", "--success_rating=0.75",
             "--explanation=worked", "--code=val x = 1",
         )
 
@@ -62,6 +62,7 @@ class FeedbackAndInputCommandTest {
         assertEquals("demo", rec.projectName)
         val params = rec.params!!
         assertEquals("t1", params.taskId)
+        assertEquals("eid_original", params.executionId)
         assertEquals(0.75, params.successRating)
         assertEquals("worked", params.explanation)
         assertEquals("val x = 1", params.code)

--- a/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/FeedbackAndInputCommandTest.kt
+++ b/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/FeedbackAndInputCommandTest.kt
@@ -1,0 +1,92 @@
+/* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
+package com.jonnyzzz.mcpSteroid.devrig
+
+import com.jonnyzzz.mcpSteroid.mcp.ContentItem
+import com.jonnyzzz.mcpSteroid.mcp.ToolCallResult
+import com.jonnyzzz.mcpSteroid.server.FeedbackParams
+import com.jonnyzzz.mcpSteroid.server.ExecuteFeedbackToolHandler
+import com.jonnyzzz.mcpSteroid.server.InputParams
+import com.jonnyzzz.mcpSteroid.server.VisionInputToolHandler
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Path
+import kotlin.test.assertEquals
+
+/**
+ * `devrig execute_feedback` and `devrig input` end to end: the generated command reaches the real specs
+ * ([com.jonnyzzz.mcpSteroid.server.ExecuteFeedbackToolSpec.call],
+ * [com.jonnyzzz.mcpSteroid.server.VisionInputToolSpec.call]), which build [FeedbackParams] / [InputParams]
+ * from the parsed arguments. Bounds and missing-hint SHAPE are already proven in `SchemaCliBindingTest`;
+ * this file is where the built params reach a handler double.
+ */
+class FeedbackAndInputCommandTest {
+
+    @TempDir
+    lateinit var home: Path
+
+    private class RecordingFeedback : ExecuteFeedbackToolHandler {
+        var projectName: String? = null
+        var params: FeedbackParams? = null
+
+        override suspend fun handleFeedback(projectName: String, params: FeedbackParams): ToolCallResult {
+            this.projectName = projectName
+            this.params = params
+            return ToolCallResult(content = listOf(ContentItem.Text("recorded")))
+        }
+    }
+
+    private class RecordingInput : VisionInputToolHandler {
+        var projectName: String? = null
+        var params: InputParams? = null
+
+        override suspend fun handleInputSequence(projectName: String, inputParams: InputParams): ToolCallResult {
+            this.projectName = projectName
+            this.params = inputParams
+            return ToolCallResult(content = listOf(ContentItem.Text("done")))
+        }
+    }
+
+    @Test
+    fun `feedback maps rating, explanation and inline code to FeedbackParams end to end`() {
+        val rec = RecordingFeedback()
+        val tools = FakeMcpSteroidTools().with(ExecuteFeedbackToolHandler::class.java, rec)
+        val command = parseRunTool(
+            "execute_feedback", "--json",
+            "--project_name=demo", "--task_id=t1", "--success_rating=0.75",
+            "--explanation=worked", "--code=val x = 1",
+        )
+
+        val run = runGeneratedToolForTest(home, command, tools)
+
+        assertEquals(CliExit.OK, run.exit, "stdout was:\n${run.stdout}")
+        assertEquals("demo", rec.projectName)
+        val params = rec.params!!
+        assertEquals("t1", params.taskId)
+        assertEquals(0.75, params.successRating)
+        assertEquals("worked", params.explanation)
+        assertEquals("val x = 1", params.code)
+    }
+
+    @Test
+    fun `input forwards the raw sequence verbatim to InputParams for plugin version skew`() {
+        val rec = RecordingInput()
+        val tools = FakeMcpSteroidTools().with(VisionInputToolHandler::class.java, rec)
+        val sequenceText = "press:CTRL+P, type:Main, delay:200, press:ENTER"
+        val command = parseRunTool(
+            "input", "--json",
+            "--project_name=demo", "--window_id=win-1", "--task_id=t", "--reason=r",
+            "--sequence=$sequenceText",
+        )
+
+        val run = runGeneratedToolForTest(home, command, tools)
+
+        assertEquals(CliExit.OK, run.exit, "stdout was:\n${run.stdout}")
+        assertEquals("demo", rec.projectName)
+        val params = rec.params!!
+        assertEquals("win-1", params.windowId)
+        assertEquals(
+            sequenceText, params.rawSequence,
+            "the plugin parses rawSequence using its own version, so the raw string must reach it unchanged",
+        )
+    }
+}

--- a/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/FetchResourceCommandTest.kt
+++ b/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/FetchResourceCommandTest.kt
@@ -1,0 +1,34 @@
+/* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
+package com.jonnyzzz.mcpSteroid.devrig
+
+import kotlinx.serialization.json.JsonPrimitive
+import kotlin.test.assertEquals
+import org.junit.jupiter.api.Test
+
+/**
+ * `fetch_resource`'s `uri` is a bare CLI positional (see `FetchResourceToolHandler.uri`), and `prompt` is
+ * its declared alias (issue #284). `bindPositional` (`SchemaCliBinding.kt`) registers a Clikt argument,
+ * never an option, so there is no `--uri` flag under either name — this pins the bare-positional form
+ * under both the `prompt` alias and the canonical `fetch_resource` command name.
+ */
+class FetchResourceCommandTest {
+
+    @Test
+    fun `devrig prompt uri parses as a bare positional to fetch_resource`() {
+        // project_name stays mandatory on the CLI (see ToolSpecCliMetadataTest: "project-scoped tools
+        // demand project_name on the CLI, not just MCP-required"), so it is still passed as a flag here —
+        // only `uri` moves to a bare positional.
+        val skill = com.jonnyzzz.mcpSteroid.prompts.generated.prompt.SkillPromptArticle().uri
+        val run = requireNotNull(parseDevrigCommand(arrayOf("prompt", skill, "--project_name=key")).generatedTool)
+        assertEquals("steroid_fetch_resource", run.toolName)
+        assertEquals(JsonPrimitive(skill), run.arguments["uri"])
+    }
+
+    @Test
+    fun `devrig fetch_resource uri still works as the canonical name`() {
+        val skill = com.jonnyzzz.mcpSteroid.prompts.generated.prompt.SkillPromptArticle().uri
+        val run = requireNotNull(parseDevrigCommand(arrayOf("fetch_resource", skill, "--project_name=key")).generatedTool)
+        assertEquals("steroid_fetch_resource", run.toolName)
+        assertEquals(JsonPrimitive(skill), run.arguments["uri"])
+    }
+}

--- a/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/FetchResourceCommandTest.kt
+++ b/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/FetchResourceCommandTest.kt
@@ -7,9 +7,9 @@ import org.junit.jupiter.api.Test
 
 /**
  * `fetch_resource`'s `uri` is a bare CLI positional (see `FetchResourceToolHandler.uri`), and `prompt` is
- * its declared alias (issue #284). `bindPositional` (`SchemaCliBinding.kt`) registers a Clikt argument,
- * never an option, so there is no `--uri` flag under either name — this pins the bare-positional form
- * under both the `prompt` alias and the canonical `fetch_resource` command name.
+ * its declared alias (issue #284). Help advertises that concise form under both names. The schema-driven
+ * binding also retains the former `--uri` option as a hidden compatibility spelling so existing scripts
+ * survive the presentation change without creating a second command implementation.
  */
 class FetchResourceCommandTest {
 
@@ -30,5 +30,20 @@ class FetchResourceCommandTest {
         val run = requireNotNull(parseDevrigCommand(arrayOf("fetch_resource", skill, "--project_name=key")).generatedTool)
         assertEquals("steroid_fetch_resource", run.toolName)
         assertEquals(JsonPrimitive(skill), run.arguments["uri"])
+    }
+
+    @Test
+    fun `the former uri flag remains accepted without becoming the advertised form`() {
+        val skill = com.jonnyzzz.mcpSteroid.prompts.generated.prompt.SkillPromptArticle().uri
+        for (command in listOf("fetch_resource", "prompt")) {
+            val run = requireNotNull(
+                parseDevrigCommand(arrayOf(command, "--uri=$skill", "--project_name=key")).generatedTool,
+            )
+            assertEquals("steroid_fetch_resource", run.toolName)
+            assertEquals(JsonPrimitive(skill), run.arguments["uri"])
+        }
+
+        val help = requireNotNull(parseDevrigCommand(arrayOf("fetch_resource", "--help")).informationalText)
+        assertEquals(false, "--uri" in help, help)
     }
 }

--- a/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/ListCommandsTest.kt
+++ b/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/ListCommandsTest.kt
@@ -138,12 +138,16 @@ class ListCommandsTest {
     }
 
     @Test
-    fun `list_windows without --json prints the tool result on stdout`() {
+    fun `list_windows without --json pretty-prints the tool result on stdout`() {
         val response = ListWindowsResponse(windows = emptyList(), backgroundTasks = emptyList())
         val run = runGeneratedToolForTest(home, parseRunTool("list_windows"), toolsWithWindows(response))
 
         assertEquals(CliExit.OK, run.exit)
-        assertEquals(McpJson.encodeToString(ListWindowsResponse.serializer(), response) + "\n", run.stdout)
+        assertTrue(run.stdout.trim().lines().size > 1, "expected a pretty-printed, multi-line payload; got:\n${run.stdout}")
+        assertEquals(
+            McpJson.encodeToJsonElement(ListWindowsResponse.serializer(), response),
+            McpJson.parseToJsonElement(run.stdout),
+        )
     }
 
     @Test

--- a/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/McpAsCliParseTest.kt
+++ b/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/McpAsCliParseTest.kt
@@ -1,0 +1,72 @@
+/* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
+package com.jonnyzzz.mcpSteroid.devrig
+
+import org.junit.jupiter.api.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+
+/**
+ * Parse-time shapes not already covered elsewhere: `SchemaCliBindingTest` proves the generic bounds and
+ * requiredness mechanisms directly against `BindingCommand`, and `SchemaToolCliCommandTest` proves the
+ * curated-missing-hint MECHANISM once (via `execute_code`'s `task_id`). This file is where a few
+ * tool-specific parse failures are checked through the real [parseDevrigCommand] entry point: an enum
+ * rejection whose valid-values listing must stay in sync with [com.jonnyzzz.mcpSteroid.server.ModalMode],
+ * a floating-point bound against values ordinary comparisons mishandle (`NaN`/`Infinity`), and `input`'s
+ * two hand-written, multi-line missing hints (unlike `execute_code`'s single-line one, these embed an
+ * example invocation and are worth checking survive Clikt's `MultiUsageError` aggregation intact).
+ */
+class McpAsCliParseTest {
+
+    private fun parse(vararg args: String): DevrigCommand = parseDevrigCommand(args.toList().toTypedArray())
+
+    @Test
+    fun `execute_code rejects an unknown --modal value at parse`() {
+        val error = assertIs<DevrigCommand.DevrigCommandParseError>(
+            parse(
+                "execute_code", "--project_name=demo", "--code=x", "--task_id=t", "--reason=r",
+                "--modal=bogus",
+            ),
+        )
+
+        assertTrue("--modal" in error.text, "got:\n${error.text}")
+        assertTrue("bogus" in error.text, "got:\n${error.text}")
+        for (valid in listOf("smart_non_modal", "non_modal", "unleashed")) {
+            assertTrue(valid in error.text, "expected the valid-values listing to include $valid; got:\n${error.text}")
+        }
+    }
+
+    @Test
+    fun `execute_feedback rejects NaN and Infinity success_rating at parse`() {
+        for (badValue in listOf("NaN", "Infinity", "-Infinity")) {
+            val error = assertIs<DevrigCommand.DevrigCommandParseError>(
+                parse(
+                    "execute_feedback", "--project_name=demo", "--task_id=t", "--explanation=e",
+                    "--success_rating=$badValue",
+                ),
+                "--success_rating=$badValue must be a parse error, not silently accepted",
+            )
+            assertTrue("--success_rating" in error.text, "got:\n${error.text}")
+        }
+    }
+
+    @Test
+    fun `input without --window_id and --sequence reports both curated hints in one error`() {
+        val error = assertIs<DevrigCommand.DevrigCommandParseError>(
+            parse("input", "--project_name=demo", "--task_id=t", "--reason=r"),
+        )
+
+        assertTrue(
+            "missing required --window_id (get it from" in error.text,
+            "expected input's curated window_id hint; got:\n${error.text}",
+        )
+        assertTrue(
+            "missing --sequence" in error.text && "press:CTRL+P" in error.text,
+            "expected input's curated multi-line sequence hint with its example; got:\n${error.text}",
+        )
+        assertFalse(
+            "Any string works" in error.text,
+            "task_id/reason are supplied here, so their unrelated hint must not appear; got:\n${error.text}",
+        )
+    }
+}

--- a/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/McpAsCliParseTest.kt
+++ b/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/McpAsCliParseTest.kt
@@ -2,8 +2,8 @@
 package com.jonnyzzz.mcpSteroid.devrig
 
 import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertFalse
-import kotlin.test.assertIs
 import kotlin.test.assertTrue
 
 /**
@@ -18,55 +18,52 @@ import kotlin.test.assertTrue
  */
 class McpAsCliParseTest {
 
-    private fun parse(vararg args: String): DevrigCommand = parseDevrigCommand(args.toList().toTypedArray())
+    private fun parseError(vararg args: String): String {
+        val invocation = parseDevrigCommand(args.toList().toTypedArray())
+        assertEquals("parse-error", invocation.commandPath)
+        return requireNotNull(invocation.informationalText)
+    }
 
     @Test
     fun `execute_code rejects an unknown --modal value at parse`() {
-        val error = assertIs<DevrigCommand.DevrigCommandParseError>(
-            parse(
-                "execute_code", "--project_name=demo", "--code=x", "--task_id=t", "--reason=r",
-                "--modal=bogus",
-            ),
+        val error = parseError(
+            "execute_code", "--project_name=demo", "--code=x", "--task_id=t", "--reason=r",
+            "--modal=bogus",
         )
 
-        assertTrue("--modal" in error.text, "got:\n${error.text}")
-        assertTrue("bogus" in error.text, "got:\n${error.text}")
+        assertTrue("--modal" in error, "got:\n$error")
+        assertTrue("bogus" in error, "got:\n$error")
         for (valid in listOf("smart_non_modal", "non_modal", "unleashed")) {
-            assertTrue(valid in error.text, "expected the valid-values listing to include $valid; got:\n${error.text}")
+            assertTrue(valid in error, "expected the valid-values listing to include $valid; got:\n$error")
         }
     }
 
     @Test
     fun `execute_feedback rejects NaN and Infinity success_rating at parse`() {
         for (badValue in listOf("NaN", "Infinity", "-Infinity")) {
-            val error = assertIs<DevrigCommand.DevrigCommandParseError>(
-                parse(
-                    "execute_feedback", "--project_name=demo", "--task_id=t", "--explanation=e",
-                    "--success_rating=$badValue",
-                ),
-                "--success_rating=$badValue must be a parse error, not silently accepted",
+            val error = parseError(
+                "execute_feedback", "--project_name=demo", "--task_id=t", "--explanation=e",
+                "--success_rating=$badValue",
             )
-            assertTrue("--success_rating" in error.text, "got:\n${error.text}")
+            assertTrue("--success_rating" in error, "got:\n$error")
         }
     }
 
     @Test
     fun `input without --window_id and --sequence reports both curated hints in one error`() {
-        val error = assertIs<DevrigCommand.DevrigCommandParseError>(
-            parse("input", "--project_name=demo", "--task_id=t", "--reason=r"),
-        )
+        val error = parseError("input", "--project_name=demo", "--task_id=t", "--reason=r")
 
         assertTrue(
-            "missing required --window_id (get it from" in error.text,
-            "expected input's curated window_id hint; got:\n${error.text}",
+            "missing required --window_id (get it from" in error,
+            "expected input's curated window_id hint; got:\n$error",
         )
         assertTrue(
-            "missing --sequence" in error.text && "press:CTRL+P" in error.text,
-            "expected input's curated multi-line sequence hint with its example; got:\n${error.text}",
+            "missing --sequence" in error && "press:CTRL+P" in error,
+            "expected input's curated multi-line sequence hint with its example; got:\n$error",
         )
         assertFalse(
-            "Any string works" in error.text,
-            "task_id/reason are supplied here, so their unrelated hint must not appear; got:\n${error.text}",
+            "Any string works" in error,
+            "task_id/reason are supplied here, so their unrelated hint must not appear; got:\n$error",
         )
     }
 }

--- a/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/McpToolsCliHelpTest.kt
+++ b/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/McpToolsCliHelpTest.kt
@@ -298,6 +298,21 @@ class McpToolsCliHelpTest {
     }
 
     @Test
+    fun `focused execute_code help renders every declared guide and a copyable fetch route`() {
+        val spec = visibleTools().single { it.cli.name == "execute_code" }
+        val invocation = parseDevrigCommand(arrayOf("help", "execute_code"))
+        assertEquals("help", invocation.commandPath)
+        val help = requireNotNull(invocation.informationalText)
+
+        assertTrue("Guides for deeper workflows:" in help, help)
+        for (uri in spec.cli.guideUris) assertTrue(uri in help, "focused help omitted $uri:\n$help")
+        assertTrue(
+            "devrig prompt <uri> --project_name=<routing-key>" in help,
+            "focused help must lead directly from a guide URI to an executable CLI action:\n$help",
+        )
+    }
+
+    @Test
     fun `root help comes from the executable Clikt tree rather than the old manual banner`() {
         val help = globalHelp()
         assertTrue(help.startsWith("Usage: devrig [<options>] <command> [<args>]..."), help)

--- a/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/McpToolsCliHelpTest.kt
+++ b/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/McpToolsCliHelpTest.kt
@@ -171,7 +171,7 @@ class McpToolsCliHelpTest {
             "list_projects must advertise its declared plural and legacy singular aliases:\n${section()}",
         )
         assertTrue(
-            "  devrig fetch_resource --uri=<uri> --project_name=<project_name> (alias: prompt)\n" in section(),
+            "  devrig fetch_resource <uri> --project_name=<project_name> (alias: prompt)\n" in section(),
             "fetch_resource must advertise its declared `prompt` alias:\n${section()}",
         )
     }

--- a/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/ParentDeathWatchdogTest.kt
+++ b/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/ParentDeathWatchdogTest.kt
@@ -6,17 +6,19 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 import kotlin.time.Duration.Companion.seconds
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.cancelChildren
 import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 
+@OptIn(ExperimentalCoroutinesApi::class)
 class ParentDeathWatchdogTest {
     @Test
     fun `fires once after the configured number of consecutive dead readings`() = runTest {
         val fired = AtomicInteger()
         ParentDeathWatchdog(
-            ancestorsAlive = listOf({ false }),
+            ancestorsAlive = listOf { false },
             onParentDeath = { fired.incrementAndGet() },
             pollInterval = 5.seconds,
             confirmations = 2,
@@ -71,7 +73,7 @@ class ParentDeathWatchdogTest {
         val fired = AtomicInteger()
         var alive = false
         ParentDeathWatchdog(
-            ancestorsAlive = listOf({ alive }),
+            ancestorsAlive = listOf { alive },
             onParentDeath = { fired.incrementAndGet() },
             pollInterval = 5.seconds,
             confirmations = 2,

--- a/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/SchemaCliBindingTest.kt
+++ b/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/SchemaCliBindingTest.kt
@@ -2,7 +2,6 @@
 package com.jonnyzzz.mcpSteroid.devrig
 
 import com.github.ajalt.clikt.core.CliktCommand
-import com.github.ajalt.clikt.core.MissingArgument
 import com.github.ajalt.clikt.core.MissingOption
 import com.github.ajalt.clikt.core.PrintHelpMessage
 import com.github.ajalt.clikt.core.UsageError
@@ -304,6 +303,26 @@ class SchemaCliBindingTest {
         val values = bind(listOf(uri), "mcp-steroid://skill/design-philosophy")
 
         assertEquals("mcp-steroid://skill/design-philosophy", values.arguments["uri"]?.jsonPrimitive?.content)
+    }
+
+    @Test
+    fun `a positional parameter retains its hidden flag as a compatibility spelling`() {
+        val uri = param("uri", "string", required = true).copy(cliPositional = true)
+
+        val values = bind(listOf(uri), "--uri=mcp-steroid://skill/design-philosophy")
+
+        assertEquals("mcp-steroid://skill/design-philosophy", values.arguments["uri"]?.jsonPrimitive?.content)
+    }
+
+    @Test
+    fun `a positional and its compatibility flag cannot both supply the same parameter`() {
+        val uri = param("uri", "string", required = true).copy(cliPositional = true)
+
+        val error = assertFailsWith<UsageError> {
+            BindingCommand(listOf(uri)).parse(listOf("first", "--uri=second"))
+        }
+
+        assertTrue("not both" in error.message.orEmpty(), error.message.orEmpty())
     }
 
     @Test
@@ -729,14 +748,14 @@ class SchemaCliBindingTest {
     }
 
     @Test
-    fun `the name Clikt reports for a missing positional maps back to its declaring parameter`() {
-        // The positional half of the same lookup: Clikt reports a missing argument by the name it was
-        // declared with (not the upper-cased metavar its help shows), so a positional parameter's
-        // cliMissingHint is reachable the same way an option's is.
+    fun `a missing positional with a compatibility flag maps back to its declaring parameter`() {
+        // The positional is optional at Clikt's argument layer because its hidden compatibility option can
+        // satisfy the same value. The aggregate requiredness check still reports the positional's declared
+        // name, so its cliMissingHint is reachable the same way an option's is.
         val uri = param("uri", "string", required = true).copy(cliPositional = true, cliMissingHint = "pass a uri")
 
         val command = BindingCommand(listOf(uri))
-        val error = assertFailsWith<MissingArgument> { command.parse(emptyList()) }
+        val error = assertFailsWith<MissingCliValue> { command.parse(emptyList()) }
 
         val spec = command.binding.paramFor(error.paramName!!)
         assertEquals("uri", spec?.name)

--- a/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/SchemaToolCliCommandTest.kt
+++ b/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/SchemaToolCliCommandTest.kt
@@ -175,9 +175,10 @@ class SchemaToolCliCommandTest {
         }
 
         // fetch_resource's `prompt` alias shares the canonical grammar: the alias token expands to the
-        // canonical command, so there is exactly one grammar to keep working.
+        // canonical command — including its bare positional `uri` — so there is exactly one grammar to
+        // keep working.
         val run = assertIs<GeneratedToolInvocation>(
-            parse("prompt", "--project_name=key", "--uri=mcp-steroid://prompt/skill"),
+            parse("prompt", "mcp-steroid://prompt/skill", "--project_name=key"),
         )
         assertEquals("steroid_fetch_resource", run.toolName)
         assertEquals("mcp-steroid://prompt/skill", run.arguments["uri"]?.jsonPrimitive?.content)

--- a/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/ScreenshotAndOpenProjectCommandTest.kt
+++ b/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/ScreenshotAndOpenProjectCommandTest.kt
@@ -1,0 +1,144 @@
+/* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
+package com.jonnyzzz.mcpSteroid.devrig
+
+import com.jonnyzzz.mcpSteroid.mcp.ContentItem
+import com.jonnyzzz.mcpSteroid.mcp.ToolCallResult
+import com.jonnyzzz.mcpSteroid.server.ListWindowsResponse
+import com.jonnyzzz.mcpSteroid.server.ListWindowsToolHandler
+import com.jonnyzzz.mcpSteroid.server.ListedWindow
+import com.jonnyzzz.mcpSteroid.server.McpProgressReporter
+import com.jonnyzzz.mcpSteroid.server.OpenProjectParams
+import com.jonnyzzz.mcpSteroid.server.OpenProjectToolHandler
+import com.jonnyzzz.mcpSteroid.server.ScreenshotParams
+import com.jonnyzzz.mcpSteroid.server.VisionScreenshotToolHandler
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.Base64
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * `devrig take_screenshot` and `devrig open_project` end to end: the generated command reaches the real
+ * specs, which build [ScreenshotParams] / [OpenProjectParams] from the parsed arguments and — for
+ * `take_screenshot` — whose image result flows through `--out` ([renderWithOut], unit-tested directly and
+ * exhaustively in `CliToolSupportTest`; this file proves the WIRING, not the decode/write logic itself).
+ * `open_project`'s generic `--wait` poll mechanics (deadline, interval, ready predicate) are proven with a
+ * fake clock in `WaitForProjectReadyTest`; the one polling test here proves the runtime actually invokes
+ * that mechanism for a real `--wait` invocation.
+ */
+class ScreenshotAndOpenProjectCommandTest {
+
+    @TempDir
+    lateinit var home: Path
+
+    private class RecordingScreenshot(private val result: ToolCallResult) : VisionScreenshotToolHandler {
+        override suspend fun screenshotWindow(
+            projectName: String,
+            screenshotParams: ScreenshotParams,
+            mcpProgressReporter: McpProgressReporter,
+        ): ToolCallResult = result
+    }
+
+    private class RecordingOpenProject(private val result: ToolCallResult) : OpenProjectToolHandler {
+        var params: OpenProjectParams? = null
+
+        override suspend fun handleOpenProject(
+            openProjectParams: OpenProjectParams,
+            callProgress: McpProgressReporter,
+        ): ToolCallResult {
+            this.params = openProjectParams
+            return result
+        }
+    }
+
+    private class SequencedListWindows(private val responses: List<ListWindowsResponse>) : ListWindowsToolHandler {
+        var calls: Int = 0
+
+        override suspend fun collectListWindowsResponse(): ListWindowsResponse {
+            val response = responses[calls.coerceAtMost(responses.size - 1)]
+            calls += 1
+            return response
+        }
+    }
+
+    private fun window(path: String, initialized: Boolean) = ListedWindow(
+        projectName = "k", projectPath = path, title = null, isActive = false, isVisible = true,
+        bounds = null, windowId = "w", modalDialogShowing = false, indexingInProgress = false,
+        projectInitialized = initialized,
+    )
+
+    // ------------------------------ take_screenshot ------------------------------
+
+    @Test
+    fun `--out writes the decoded image end to end via the generated command`() {
+        val raw = ByteArray(16) { it.toByte() }
+        val b64 = Base64.getEncoder().encodeToString(raw)
+        val tools = FakeMcpSteroidTools().with(
+            VisionScreenshotToolHandler::class.java,
+            RecordingScreenshot(ToolCallResult(content = listOf(ContentItem.Image(data = b64, mimeType = "image/png")))),
+        )
+        val outFile = home.resolve("shots/x.png") // parent dir does not exist yet
+        val command = parseRunTool(
+            "take_screenshot",
+            "--project_name=demo", "--task_id=t", "--reason=r", "--out=$outFile",
+        )
+
+        val run = runGeneratedToolForTest(home, command, tools)
+
+        assertEquals(CliExit.OK, run.exit, "stdout was:\n${run.stdout}")
+        assertTrue(Files.exists(outFile), "parent dirs must be created and the file written")
+        assertEquals(raw.toList(), Files.readAllBytes(outFile).toList())
+        assertTrue(
+            run.stdout.contains("Saved --out:") && run.stdout.contains(outFile.toString()),
+            "console mode must report the --out path; stdout was:\n${run.stdout}",
+        )
+    }
+
+    // ------------------------------ open_project ------------------------------
+
+    @Test
+    fun `open_project dispatches to the real spec, normalizing project_path and defaulting trust_project to true`() {
+        val open = RecordingOpenProject(ToolCallResult(content = listOf(ContentItem.Text("opening"))))
+        val tools = FakeMcpSteroidTools().with(OpenProjectToolHandler::class.java, open)
+        // No ListWindowsToolHandler double is registered: without --wait the runtime must never reach for
+        // one, so a regression that polls anyway fails loudly ("no test double is registered") instead of
+        // silently passing.
+        val command = parseRunTool(
+            "open_project", "--json",
+            "--project_path=$home", "--task_id=t", "--reason=r",
+        )
+
+        val run = runGeneratedToolForTest(home, command, tools)
+
+        assertEquals(CliExit.OK, run.exit, "stdout was:\n${run.stdout}")
+        val params = open.params!!
+        assertEquals(home.toRealPath().toString(), params.projectPath, "project_path must be resolved to a real, absolute path")
+        assertEquals(true, params.trustProject, "trust_project must default to true when omitted")
+    }
+
+    @Test
+    fun `open_project --wait polls list_windows until the project reports ready, then exits OK`() {
+        val open = RecordingOpenProject(ToolCallResult(content = listOf(ContentItem.Text("opening"))))
+        val realPath = home.toRealPath().toString()
+        val windows = SequencedListWindows(
+            listOf(
+                ListWindowsResponse(windows = listOf(window(realPath, initialized = false)), backgroundTasks = emptyList()),
+                ListWindowsResponse(windows = listOf(window(realPath, initialized = true)), backgroundTasks = emptyList()),
+            ),
+        )
+        val tools = FakeMcpSteroidTools()
+            .with(OpenProjectToolHandler::class.java, open)
+            .with(ListWindowsToolHandler::class.java, windows)
+        val command = parseRunTool(
+            "open_project", "--json",
+            "--project_path=$home", "--task_id=t", "--reason=r", "--wait",
+        )
+
+        val run = runGeneratedToolForTest(home, command, tools)
+
+        assertEquals(CliExit.OK, run.exit, "stdout was:\n${run.stdout}")
+        assertTrue(windows.calls >= 2, "must poll again after a not-ready response (polled ${windows.calls} times)")
+    }
+}

--- a/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/ScreenshotAndOpenProjectCommandTest.kt
+++ b/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/ScreenshotAndOpenProjectCommandTest.kt
@@ -3,9 +3,9 @@ package com.jonnyzzz.mcpSteroid.devrig
 
 import com.jonnyzzz.mcpSteroid.mcp.ContentItem
 import com.jonnyzzz.mcpSteroid.mcp.ToolCallResult
-import com.jonnyzzz.mcpSteroid.server.ListWindowsResponse
-import com.jonnyzzz.mcpSteroid.server.ListWindowsToolHandler
-import com.jonnyzzz.mcpSteroid.server.ListedWindow
+import com.jonnyzzz.mcpSteroid.server.ListProjectsResponse
+import com.jonnyzzz.mcpSteroid.server.ListProjectsToolHandler
+import com.jonnyzzz.mcpSteroid.server.ListedProject
 import com.jonnyzzz.mcpSteroid.server.McpProgressReporter
 import com.jonnyzzz.mcpSteroid.server.OpenProjectParams
 import com.jonnyzzz.mcpSteroid.server.OpenProjectToolHandler
@@ -18,13 +18,16 @@ import java.nio.file.Path
 import java.util.Base64
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
 
 /**
  * `devrig take_screenshot` and `devrig open_project` end to end: the generated command reaches the real
  * specs, which build [ScreenshotParams] / [OpenProjectParams] from the parsed arguments and — for
  * `take_screenshot` — whose image result flows through `--out` ([renderWithOut], unit-tested directly and
  * exhaustively in `CliToolSupportTest`; this file proves the WIRING, not the decode/write logic itself).
- * `open_project`'s generic `--wait` poll mechanics (deadline, interval, ready predicate) are proven with a
+ * `open_project`'s generic `--wait` poll mechanics (deadline, interval, route predicate) are proven with a
  * fake clock in `WaitForProjectReadyTest`; the one polling test here proves the runtime actually invokes
  * that mechanism for a real `--wait` invocation.
  */
@@ -53,20 +56,18 @@ class ScreenshotAndOpenProjectCommandTest {
         }
     }
 
-    private class SequencedListWindows(private val responses: List<ListWindowsResponse>) : ListWindowsToolHandler {
+    private class SequencedListProjects(private val responses: List<ListProjectsResponse>) : ListProjectsToolHandler {
         var calls: Int = 0
 
-        override suspend fun collectListWindowsResponse(): ListWindowsResponse {
+        override suspend fun collectListProjectsResponse(): ListProjectsResponse {
             val response = responses[calls.coerceAtMost(responses.size - 1)]
             calls += 1
             return response
         }
     }
 
-    private fun window(path: String, initialized: Boolean) = ListedWindow(
-        projectName = "k", projectPath = path, title = null, isActive = false, isVisible = true,
-        bounds = null, windowId = "w", modalDialogShowing = false, indexingInProgress = false,
-        projectInitialized = initialized,
+    private fun project(path: String) = ListedProject(
+        projectName = "opaque-project-key", name = "raw-name", path = path, backendName = "iu-backend",
     )
 
     // ------------------------------ take_screenshot ------------------------------
@@ -102,7 +103,7 @@ class ScreenshotAndOpenProjectCommandTest {
     fun `open_project dispatches to the real spec, normalizing project_path and defaulting trust_project to true`() {
         val open = RecordingOpenProject(ToolCallResult(content = listOf(ContentItem.Text("opening"))))
         val tools = FakeMcpSteroidTools().with(OpenProjectToolHandler::class.java, open)
-        // No ListWindowsToolHandler double is registered: without --wait the runtime must never reach for
+        // No ListProjectsToolHandler double is registered: without --wait the runtime must never reach for
         // one, so a regression that polls anyway fails loudly ("no test double is registered") instead of
         // silently passing.
         val command = parseRunTool(
@@ -115,22 +116,24 @@ class ScreenshotAndOpenProjectCommandTest {
         assertEquals(CliExit.OK, run.exit, "stdout was:\n${run.stdout}")
         val params = open.params!!
         assertEquals(home.toRealPath().toString(), params.projectPath, "project_path must be resolved to a real, absolute path")
+        assertEquals("t", params.taskId, "task_id must reach the open-project handler unchanged")
+        assertEquals("r", params.reason, "reason must reach the open-project handler unchanged")
         assertEquals(true, params.trustProject, "trust_project must default to true when omitted")
     }
 
     @Test
-    fun `open_project --wait polls list_windows until the project reports ready, then exits OK`() {
+    fun `open_project --wait polls list_projects and returns the opaque route once it appears`() {
         val open = RecordingOpenProject(ToolCallResult(content = listOf(ContentItem.Text("opening"))))
         val realPath = home.toRealPath().toString()
-        val windows = SequencedListWindows(
+        val projects = SequencedListProjects(
             listOf(
-                ListWindowsResponse(windows = listOf(window(realPath, initialized = false)), backgroundTasks = emptyList()),
-                ListWindowsResponse(windows = listOf(window(realPath, initialized = true)), backgroundTasks = emptyList()),
+                ListProjectsResponse(projects = emptyList()),
+                ListProjectsResponse(projects = listOf(project(realPath))),
             ),
         )
         val tools = FakeMcpSteroidTools()
             .with(OpenProjectToolHandler::class.java, open)
-            .with(ListWindowsToolHandler::class.java, windows)
+            .with(ListProjectsToolHandler::class.java, projects)
         val command = parseRunTool(
             "open_project", "--json",
             "--project_path=$home", "--task_id=t", "--reason=r", "--wait",
@@ -139,6 +142,35 @@ class ScreenshotAndOpenProjectCommandTest {
         val run = runGeneratedToolForTest(home, command, tools)
 
         assertEquals(CliExit.OK, run.exit, "stdout was:\n${run.stdout}")
-        assertTrue(windows.calls >= 2, "must poll again after a not-ready response (polled ${windows.calls} times)")
+        assertEquals(2, projects.calls, "must poll again after the path is absent")
+        val payload = run.envelope().getValue("data").jsonObject.getValue("content").jsonArray
+            .single().jsonObject.getValue("json").jsonObject
+        assertEquals("opaque-project-key", payload.getValue("project_name").jsonPrimitive.content)
+        assertEquals("iu-backend", payload.getValue("backend_name").jsonPrimitive.content)
+        assertEquals(realPath, payload.getValue("path").jsonPrimitive.content)
+    }
+
+    @Test
+    fun `open_project --wait human output identifies the route to use next`() {
+        val realPath = home.toRealPath().toString()
+        val tools = FakeMcpSteroidTools()
+            .with(
+                OpenProjectToolHandler::class.java,
+                RecordingOpenProject(ToolCallResult(content = listOf(ContentItem.Text("opening")))),
+            )
+            .with(
+                ListProjectsToolHandler::class.java,
+                SequencedListProjects(listOf(ListProjectsResponse(projects = listOf(project(realPath))))),
+            )
+        val command = parseRunTool(
+            "open_project", "--project_path=$home", "--task_id=t", "--reason=r", "--wait",
+        )
+
+        val run = runGeneratedToolForTest(home, command, tools)
+
+        assertEquals(CliExit.OK, run.exit, "stdout was:\n${run.stdout}")
+        for (expected in listOf("opaque-project-key", "iu-backend", realPath)) {
+            assertTrue(expected in run.stdout, "human output must include '$expected':\n${run.stdout}")
+        }
     }
 }

--- a/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/WaitForProjectReadyTest.kt
+++ b/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/WaitForProjectReadyTest.kt
@@ -1,0 +1,70 @@
+/* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
+package com.jonnyzzz.mcpSteroid.devrig
+
+import com.jonnyzzz.mcpSteroid.mcp.McpJson
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.jsonObject
+import org.junit.jupiter.api.Test
+
+/**
+ * `win`'s field names are NOT a guess: they are `ListedWindow`'s (`mcp-steroid-server`'s
+ * `ListWindowsTool.kt`) serialized shape verbatim. `McpJson` sets no naming strategy, so a property
+ * serializes under its declared name unless annotated — `projectPath` alone carries
+ * `@SerialName("project_path")` (#381), while the three readiness flags carry no annotation and stay
+ * camelCase.
+ */
+class WaitForProjectReadyTest {
+    private fun windows(vararg w: String) = McpJson.parseToJsonElement(
+        """{"windows":[${w.joinToString(",")}]}"""
+    ).jsonObject
+
+    private fun win(path: String, init: Boolean, indexing: Boolean, modal: Boolean) =
+        """{"project_path":"$path","projectInitialized":$init,"indexingInProgress":$indexing,""" +
+            """"modalDialogShowing":$modal}"""
+
+    @Test
+    fun `ready when initialized, not indexing, no modal`() {
+        assertTrue(isProjectReady(windows(win("/p", true, false, false)), "/p"))
+    }
+
+    @Test
+    fun `not ready while indexing`() {
+        assertFalse(isProjectReady(windows(win("/p", true, true, false)), "/p"))
+    }
+
+    @Test
+    fun `not ready with a modal`() {
+        assertFalse(isProjectReady(windows(win("/p", true, false, true)), "/p"))
+    }
+
+    @Test
+    fun `not ready when the project window is absent`() {
+        assertFalse(isProjectReady(windows(win("/other", true, false, false)), "/p"))
+    }
+
+    @Test
+    fun `awaitProjectReady returns true once ready before timeout`() = runTest {
+        var t = 0L
+        var calls = 0
+        val ok = awaitProjectReady(
+            pollListWindows = { calls++; windows(win("/p", true, calls < 3, false)) },
+            projectPath = "/p", timeoutMs = 300_000, intervalMs = 1000,
+            now = { t }, sleep = { t += it },
+        )
+        assertTrue(ok)
+        assertTrue(calls >= 3)
+    }
+
+    @Test
+    fun `awaitProjectReady returns false at timeout`() = runTest {
+        var t = 0L
+        val ok = awaitProjectReady(
+            pollListWindows = { windows(win("/p", true, true, false)) },
+            projectPath = "/p", timeoutMs = 5_000, intervalMs = 1000,
+            now = { t }, sleep = { t += it },
+        )
+        assertFalse(ok)
+    }
+}

--- a/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/WaitForProjectReadyTest.kt
+++ b/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/WaitForProjectReadyTest.kt
@@ -1,70 +1,78 @@
 /* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
 package com.jonnyzzz.mcpSteroid.devrig
 
-import com.jonnyzzz.mcpSteroid.mcp.McpJson
-import kotlin.test.assertFalse
-import kotlin.test.assertTrue
+import com.jonnyzzz.mcpSteroid.server.ListProjectsResponse
+import com.jonnyzzz.mcpSteroid.server.ListedProject
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
 import kotlinx.coroutines.test.runTest
-import kotlinx.serialization.json.jsonObject
 import org.junit.jupiter.api.Test
 
-/**
- * `win`'s field names are NOT a guess: they are `ListedWindow`'s (`mcp-steroid-server`'s
- * `ListWindowsTool.kt`) serialized shape verbatim. `McpJson` sets no naming strategy, so a property
- * serializes under its declared name unless annotated — `projectPath` alone carries
- * `@SerialName("project_path")` (#381), while the three readiness flags carry no annotation and stay
- * camelCase.
- */
 class WaitForProjectReadyTest {
-    private fun windows(vararg w: String) = McpJson.parseToJsonElement(
-        """{"windows":[${w.joinToString(",")}]}"""
-    ).jsonObject
+    private fun project(
+        path: String,
+        projectName: String = "opaque-project-key",
+        backendName: String = "iu-backend",
+    ) = ListedProject(projectName = projectName, name = "raw-name", path = path, backendName = backendName)
 
-    private fun win(path: String, init: Boolean, indexing: Boolean, modal: Boolean) =
-        """{"project_path":"$path","projectInitialized":$init,"indexingInProgress":$indexing,""" +
-            """"modalDialogShowing":$modal}"""
+    private fun projects(vararg entries: ListedProject) = ListProjectsResponse(entries.toList())
 
     @Test
-    fun `ready when initialized, not indexing, no modal`() {
-        assertTrue(isProjectReady(windows(win("/p", true, false, false)), "/p"))
+    fun `a routed frontendless project is ready without any window`() {
+        val route = project("/p")
+
+        assertEquals(route, findProjectRoute(projects(route), "/p"))
     }
 
     @Test
-    fun `not ready while indexing`() {
-        assertFalse(isProjectReady(windows(win("/p", true, true, false)), "/p"))
+    fun `an absent path is not ready`() {
+        assertNull(findProjectRoute(projects(project("/other")), "/p"))
     }
 
     @Test
-    fun `not ready with a modal`() {
-        assertFalse(isProjectReady(windows(win("/p", true, false, true)), "/p"))
+    fun `an explicit backend cannot match the same path routed by another backend`() {
+        val wrong = project("/p", projectName = "wrong-key", backendName = "iu-wrong")
+        val expected = project("/p", projectName = "right-key", backendName = "iu-right")
+
+        assertEquals(expected, findProjectRoute(projects(wrong, expected), "/p", "iu-right"))
+        assertNull(findProjectRoute(projects(wrong), "/p", "iu-right"))
     }
 
     @Test
-    fun `not ready when the project window is absent`() {
-        assertFalse(isProjectReady(windows(win("/other", true, false, false)), "/p"))
-    }
-
-    @Test
-    fun `awaitProjectReady returns true once ready before timeout`() = runTest {
-        var t = 0L
+    fun `awaitProjectReady returns the opaque route once the path appears`() = runTest {
+        var time = 0L
         var calls = 0
-        val ok = awaitProjectReady(
-            pollListWindows = { calls++; windows(win("/p", true, calls < 3, false)) },
-            projectPath = "/p", timeoutMs = 300_000, intervalMs = 1000,
-            now = { t }, sleep = { t += it },
+        val expected = project("/p", projectName = "opaque-9fk2a0xq")
+
+        val route = awaitProjectReady(
+            pollListProjects = {
+                calls += 1
+                if (calls < 3) projects() else projects(expected)
+            },
+            projectPath = "/p",
+            timeoutMs = 300_000,
+            intervalMs = 1_000,
+            now = { time },
+            sleep = { time += it },
         )
-        assertTrue(ok)
-        assertTrue(calls >= 3)
+
+        assertEquals(expected, route)
+        assertEquals(3, calls)
     }
 
     @Test
-    fun `awaitProjectReady returns false at timeout`() = runTest {
-        var t = 0L
-        val ok = awaitProjectReady(
-            pollListWindows = { windows(win("/p", true, true, false)) },
-            projectPath = "/p", timeoutMs = 5_000, intervalMs = 1000,
-            now = { t }, sleep = { t += it },
+    fun `awaitProjectReady returns null at timeout`() = runTest {
+        var time = 0L
+
+        val route = awaitProjectReady(
+            pollListProjects = { projects() },
+            projectPath = "/p",
+            timeoutMs = 5_000,
+            intervalMs = 1_000,
+            now = { time },
+            sleep = { time += it },
         )
-        assertFalse(ok)
+
+        assertNull(route)
     }
 }

--- a/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/server/DevrigToolBridgeClientTest.kt
+++ b/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/server/DevrigToolBridgeClientTest.kt
@@ -234,6 +234,7 @@ class DevrigToolBridgeClientTest {
             projectName = route.exposedProjectName,
             params = FeedbackParams(
                 taskId = "feedback-task",
+                executionId = "eid_original",
                 successRating = 0.75,
                 explanation = "worked",
                 code = "println(1)",
@@ -246,6 +247,7 @@ class DevrigToolBridgeClientTest {
         val arguments = json["arguments"]?.jsonObject ?: error("missing arguments: $json")
         assertEquals("original-project", arguments["project_name"]?.jsonPrimitive?.content)
         assertEquals("feedback-task", arguments["task_id"]?.jsonPrimitive?.content)
+        assertEquals("eid_original", arguments["execution_id"]?.jsonPrimitive?.content)
         assertEquals("0.75", arguments["success_rating"]?.jsonPrimitive?.content)
         assertEquals("worked", arguments["explanation"]?.jsonPrimitive?.content)
         assertEquals("println(1)", arguments["code"]?.jsonPrimitive?.content)
@@ -337,6 +339,8 @@ class DevrigToolBridgeClientTest {
         val result = handler.handleOpenProject(
             OpenProjectParams(
                 projectPath = tempDir.resolve("target").toString(),
+                taskId = "test-task",
+                reason = "test reason",
                 trustProject = true,
             ),
             NoOpProgressReporter,
@@ -366,6 +370,8 @@ class DevrigToolBridgeClientTest {
         val result = handler.handleOpenProject(
             OpenProjectParams(
                 projectPath = tempDir.resolve("target").toString(),
+                taskId = "test-task",
+                reason = "test reason",
                 trustProject = true,
             ),
             NoOpProgressReporter,
@@ -406,6 +412,8 @@ class DevrigToolBridgeClientTest {
         val result = handler.handleOpenProject(
             OpenProjectParams(
                 projectPath = targetProject.toString(),
+                taskId = "test-task",
+                reason = "test reason",
                 trustProject = true,
             ),
             NoOpProgressReporter,
@@ -430,6 +438,8 @@ class DevrigToolBridgeClientTest {
         val result = handler.handleOpenProject(
             OpenProjectParams(
                 projectPath = targetProject.toString(),
+                taskId = "test-task",
+                reason = "test reason",
                 trustProject = false,
             ),
             NoOpProgressReporter,
@@ -442,8 +452,8 @@ class DevrigToolBridgeClientTest {
         val arguments = json["arguments"]?.jsonObject ?: error("missing arguments: $json")
         assertEquals(targetProject.toString(), arguments["project_path"]?.jsonPrimitive?.content)
         assertEquals("false", arguments["trust_project"]?.jsonPrimitive?.content)
-        assertEquals("open-project", arguments["task_id"]?.jsonPrimitive?.content)
-        assertEquals("Open project through devrig", arguments["reason"]?.jsonPrimitive?.content)
+        assertEquals("test-task", arguments["task_id"]?.jsonPrimitive?.content)
+        assertEquals("test reason", arguments["reason"]?.jsonPrimitive?.content)
     }
 
     @Test
@@ -461,6 +471,8 @@ class DevrigToolBridgeClientTest {
         val result = handler.handleOpenProject(
             OpenProjectParams(
                 projectPath = targetProject.toString(),
+                taskId = "test-task",
+                reason = "test reason",
                 trustProject = true,
                 backendName = backendNameForMarker(42L, "IU-253.1"),
             ),
@@ -476,8 +488,8 @@ class DevrigToolBridgeClientTest {
         // backend_name is resolved locally, never forwarded.
         assertEquals(targetProject.toString(), arguments["project_path"]?.jsonPrimitive?.content)
         assertEquals("true", arguments["trust_project"]?.jsonPrimitive?.content)
-        assertEquals("open-project", arguments["task_id"]?.jsonPrimitive?.content)
-        assertEquals("Open project through devrig", arguments["reason"]?.jsonPrimitive?.content)
+        assertEquals("test-task", arguments["task_id"]?.jsonPrimitive?.content)
+        assertEquals("test reason", arguments["reason"]?.jsonPrimitive?.content)
         assertEquals(null, arguments["backend_name"])
     }
 
@@ -496,6 +508,8 @@ class DevrigToolBridgeClientTest {
         val result = handler.handleOpenProject(
             OpenProjectParams(
                 projectPath = targetProject.toString(),
+                taskId = "test-task",
+                reason = "test reason",
                 trustProject = true,
                 backendName = unknown,
             ),
@@ -801,6 +815,8 @@ class DevrigToolBridgeClientTest {
         val result = handler.handleOpenProject(
             OpenProjectParams(
                 projectPath = targetProject.toString(),
+                taskId = "caller-task",
+                reason = "caller reason",
                 trustProject = true,
                 backendName = startableBackendName(installed),
             ),
@@ -814,6 +830,8 @@ class DevrigToolBridgeClientTest {
         assertEquals("steroid_open_project", json["name"]?.jsonPrimitive?.content)
         val arguments = json["arguments"]?.jsonObject ?: error("missing arguments: $json")
         assertEquals(targetProject.toString(), arguments["project_path"]?.jsonPrimitive?.content)
+        assertEquals("caller-task", arguments["task_id"]?.jsonPrimitive?.content)
+        assertEquals("caller reason", arguments["reason"]?.jsonPrimitive?.content)
         // backend_name is never forwarded to the plugin.
         assertEquals(null, arguments["backend_name"])
     }
@@ -840,6 +858,8 @@ class DevrigToolBridgeClientTest {
         val result = handler.handleOpenProject(
             OpenProjectParams(
                 projectPath = targetProject.toString(),
+                taskId = "test-task",
+                reason = "test reason",
                 trustProject = false,
             ),
             NoOpProgressReporter,
@@ -870,6 +890,8 @@ class DevrigToolBridgeClientTest {
         val result = handler.handleOpenProject(
             OpenProjectParams(
                 projectPath = targetProject.toString(),
+                taskId = "test-task",
+                reason = "test reason",
                 trustProject = true,
                 backendName = startableBackendName(installed),
             ),
@@ -904,6 +926,8 @@ class DevrigToolBridgeClientTest {
         val result = handler.handleOpenProject(
             OpenProjectParams(
                 projectPath = targetProject.toString(),
+                taskId = "test-task",
+                reason = "test reason",
                 trustProject = true,
                 backendName = startableBackendName(installed),
             ),

--- a/test-experiments/src/test/kotlin/com/jonnyzzz/mcpSteroid/integration/tests/DevrigCliAgentUsabilityExperimentTest.kt
+++ b/test-experiments/src/test/kotlin/com/jonnyzzz/mcpSteroid/integration/tests/DevrigCliAgentUsabilityExperimentTest.kt
@@ -74,6 +74,13 @@ fun devrigCommandHasFlagValue(commandText: String, devrig: String, flag: String,
     ).containsMatchIn(normalized)
 }
 
+fun devrigCommandHasArgumentValue(commandText: String, devrig: String, value: String): Boolean {
+    val normalized = normalizeRawDevrigCommand(commandText, devrig) ?: return false
+    val escapedValue = Regex.escape(value)
+    return Regex("(?:^|\\s)(?:\"$escapedValue\"|'$escapedValue'|$escapedValue)(?:\\s|$)")
+        .containsMatchIn(normalized)
+}
+
 fun devrigCommandHasShellSafeInlineCode(commandText: String, devrig: String, code: String): Boolean {
     val normalized = normalizeRawDevrigCommand(commandText, devrig) ?: return false
     val singleQuoted = Regex(
@@ -493,11 +500,13 @@ class DevrigCliAgentUsabilityExperimentTest {
             6. `input`: read help, then target the same project/window with the safe, delay-only sequence
                `delay:25`; do not type, press, or click anything. First run it once with only `--json` and
                verify that every missing value is explained.
-            7. `fetch_resource`: read help, then fetch `mcp-steroid://prompt/skill` for the retained project.
-               First run it once with only `--json` and verify that every missing value is explained.
+            7. `fetch_resource`: read help, then pass `mcp-steroid://prompt/skill` as its positional URI for
+               the retained project.
+                First run it once with only `--json` and verify that every missing value is explained.
             8. `open_project`: read help, then safely call it for the already-open absolute project path from
-               step 1. First run it once with only `--json` and verify that every missing value is explained.
-               Do not open a different path or set optional lifecycle flags.
+               step 1 with `--wait`. Verify that the success returns the same opaque `project_name`,
+               `backend_name`, and canonical path retained in step 1. First run it once with only `--json`
+               and verify that every missing value is explained. Do not open a different path.
 
             Copy values directly into later raw commands; do not use shell variables or command substitution.
             Do not repeat an action or insert unrelated shell commands between a command's help and action.
@@ -681,7 +690,7 @@ class DevrigCliAgentUsabilityExperimentTest {
         assertCommandHelp(
             shellCalls[fetchHelpIndex],
             "fetch_resource",
-            "--uri",
+            "<uri>",
             "--project_name",
             "--json",
         )
@@ -701,6 +710,7 @@ class DevrigCliAgentUsabilityExperimentTest {
         val project = listEnvelope.firstProject()
         val projectName = project.getValue("project_name").jsonPrimitive.content
         val projectPath = project.getValue("path").jsonPrimitive.content
+        val backendName = project.getValue("backend_name").jsonPrimitive.content
         val windowsEnvelope = shellCalls[windowsActionIndex].successfulEnvelope("list_windows")
         val windowId = windowsEnvelope.windowIdFor(projectName)
         val missingEnvelope = shellCalls[missingExecuteIndex].jsonEnvelope("execute_code", expectedError = true)
@@ -770,7 +780,7 @@ class DevrigCliAgentUsabilityExperimentTest {
         assertMissingGuidance(
             shellCalls[missingFetchIndex],
             "fetch_resource",
-            "missing --uri",
+            "missing uri",
             "mcp-steroid://prompt/skill",
             "missing --project_name",
             "devrig list_projects",
@@ -827,18 +837,32 @@ class DevrigCliAgentUsabilityExperimentTest {
 
         val fetchCall = shellCalls[fetchActionIndex]
         assertFlagValue(fetchCall, "fetch_resource", "--project_name", projectName)
-        assertFlagValue(fetchCall, "fetch_resource", "--uri", "mcp-steroid://prompt/skill")
+        assertTrue(devrigCommandHasArgumentValue(fetchCall.commandText(), DEVRIG, "mcp-steroid://prompt/skill")) {
+            "fetch_resource did not pass the guide URI positionally. ${summarizeCalls(listOf(fetchCall))}"
+        }
+        assertTrue(!fetchCall.hasFlag("--uri")) {
+            "fetch_resource did not follow help's advertised positional URI form. ${summarizeCalls(listOf(fetchCall))}"
+        }
         fetchCall.successfulEnvelope("fetch_resource")
 
         val openCall = shellCalls[openActionIndex]
         assertFlagValue(openCall, "open_project", "--project_path", projectPath)
         assertFlagValue(openCall, "open_project", "--task_id", taskId)
-        for (optionalFlag in listOf("--wait", "--trust_project", "--no-trust_project", "--backend_name")) {
+        assertTrue(openCall.hasFlag("--wait")) {
+            "open_project did not exercise the wait route. ${summarizeCalls(shellCalls)}"
+        }
+        for (optionalFlag in listOf("--trust_project", "--no-trust_project")) {
             assertTrue(!openCall.hasFlag(optionalFlag)) {
                 "open_project unexpectedly used optional lifecycle flag $optionalFlag. ${summarizeCalls(shellCalls)}"
             }
         }
-        openCall.successfulEnvelope("open_project")
+        if (openCall.hasFlag("--backend_name")) {
+            assertFlagValue(openCall, "open_project", "--backend_name", backendName)
+        }
+        val opened = openCall.successfulEnvelope("open_project").toolJson()
+        assertEquals(projectName, opened.getValue("project_name").jsonPrimitive.content)
+        assertEquals(backendName, opened.getValue("backend_name").jsonPrimitive.content)
+        assertEquals(projectPath, opened.getValue("path").jsonPrimitive.content)
 
         val finalResponse = decodeAgentFinalResponse(result.rawStdout).orEmpty()
         assertExactMarkerLines(
@@ -1136,7 +1160,16 @@ class DevrigCliAgentUsabilityExperimentTest {
     }
 
     private fun AgentToolCall.jsonEnvelope(expectedCommand: String, expectedError: Boolean): JsonObject {
-        val text = resultText().trim()
+        val rawText = resultText().trim()
+        val nativeFailurePrefix = Regex("^Exit code \\d+\\r?\\n").find(rawText)
+        if (nativeFailurePrefix != null) {
+            assertTrue(expectedError) {
+                "$expectedCommand succeeded but its native tool result carried an exit-code prefix: $rawText"
+            }
+        }
+        val text = nativeFailurePrefix
+            ?.let { rawText.substring(it.range.last + 1).trim() }
+            ?: rawText
         val envelope = Json.parseToJsonElement(text).jsonObject
         assertEquals(setOf("tool", "command", "isError", "data"), envelope.keys, envelope.toString())
         val tool = envelope.getValue("tool").jsonObject

--- a/test-experiments/src/test/kotlin/com/jonnyzzz/mcpSteroid/integration/tests/DevrigCliCommandNormalizationTest.kt
+++ b/test-experiments/src/test/kotlin/com/jonnyzzz/mcpSteroid/integration/tests/DevrigCliCommandNormalizationTest.kt
@@ -48,6 +48,14 @@ class DevrigCliCommandNormalizationTest {
     }
 
     @Test
+    fun `recognizes the positional prompt URI used by focused help`() {
+        val command = "$DEVRIG fetch_resource mcp-steroid://prompt/skill --project_name=project-key --json"
+
+        assertEquals(true, devrigCommandHasArgumentValue(command, DEVRIG, "mcp-steroid://prompt/skill"))
+        assertEquals(false, devrigCommandHasFlag(command, DEVRIG, "--uri"))
+    }
+
+    @Test
     fun `recognizes shell-safe inline code inside the Codex bash transport`() {
         val wrapped = "/bin/bash -lc \"$DEVRIG execute_code --code='println(\\\"ok\\\")'\""
         assertEquals(true, devrigCommandHasShellSafeInlineCode(wrapped, DEVRIG, "println(\"ok\")"))

--- a/test-experiments/src/test/kotlin/com/jonnyzzz/mcpSteroid/integration/tests/DevrigRemoteDevelopmentKeycloakTypeHierarchyTest.kt
+++ b/test-experiments/src/test/kotlin/com/jonnyzzz/mcpSteroid/integration/tests/DevrigRemoteDevelopmentKeycloakTypeHierarchyTest.kt
@@ -41,6 +41,71 @@ import org.junit.jupiter.api.parallel.ExecutionMode
 class DevrigRemoteDevelopmentKeycloakTypeHierarchyTest {
 
     @Test
+    @Timeout(value = 45, unit = TimeUnit.MINUTES)
+    fun `CLI wait opens and routes a project on a frontendless Remote Development backend`() =
+        runWithCloseableStack { lifetime ->
+            val container = DevrigContainer.create(
+                lifetime,
+                DevrigContainerOpts(
+                    consoleTitle = "devrig-remote-backend-cli-wait",
+                    mountDependencyCaches = true,
+                ),
+            )
+            container.console.writeHeader(
+                "test-experiments — ${this::class.simpleName} — frontendless devrig open_project --wait",
+            )
+
+            container.execAndAssertWithConsoleStream(
+                description = "open an initially unrouted project with CLI --wait on IU Remote Development",
+                timeoutSeconds = 40 * 60L,
+                script = $$"""
+                    set -euo pipefail
+                    project="/home/agent/frontendless-cli-wait-project"
+                    cleanup() {
+                      "$${container.devrig}" backend stop idea-ultimate --version "$$IDE_VERSION" >/dev/null 2>&1 || true
+                    }
+                    trap cleanup EXIT
+
+                    mkdir -p "$project"
+                    printf '# frontendless CLI wait fixture\n' > "$project/README.md"
+
+                    "$${container.devrig}" list_projects --json > /tmp/projects-before.json
+                    jq -e --arg path "$project" \
+                      '[.data.content[].json.projects[] | select(.path == $path)] | length == 0' \
+                      /tmp/projects-before.json >/dev/null
+
+                    "$${container.devrig}" backend download idea-ultimate --version "$$IDE_VERSION"
+                    "$${container.devrig}" open_project \
+                      --project_path="$project" \
+                      --task_id=frontendless-cli-wait \
+                      --reason="verify list_projects readiness without a frontend window" \
+                      --wait --json > /tmp/open-project-wait.json
+                    cat /tmp/open-project-wait.json
+
+                    jq -e --arg path "$project" '
+                      .command == "open_project" and .isError == false and
+                      (.data.content | length == 1) and
+                      (.data.content[0].json.path == $path) and
+                      (.data.content[0].json.project_name | length > 0) and
+                      (.data.content[0].json.backend_name | length > 0)
+                    ' /tmp/open-project-wait.json >/dev/null
+                    project_name="$(jq -r '.data.content[0].json.project_name' /tmp/open-project-wait.json)"
+                    backend_name="$(jq -r '.data.content[0].json.backend_name' /tmp/open-project-wait.json)"
+
+                    "$${container.devrig}" list_projects --json > /tmp/projects-after.json
+                    jq -e --arg path "$project" --arg project_name "$project_name" --arg backend_name "$backend_name" '
+                      [.data.content[].json.projects[] |
+                        select(.path == $path and .project_name == $project_name and .backend_name == $backend_name)] |
+                      length == 1
+                    ' /tmp/projects-after.json >/dev/null
+
+                    printf 'FRONTENDLESS_WAIT_PROJECT_NAME=%s\n' "$project_name"
+                    printf 'FRONTENDLESS_WAIT_BACKEND_NAME=%s\n' "$backend_name"
+                """.trimIndent(),
+            )
+        }
+
+    @Test
     @Timeout(value = 75, unit = TimeUnit.MINUTES)
     fun `claude installs devrig and uses a remote development backend for keycloak hierarchy`() =
         runScenario("claude")

--- a/test-integration/src/test/kotlin/com/jonnyzzz/mcpSteroid/integration/tests/CliDevrigToolsIntegrationTest.kt
+++ b/test-integration/src/test/kotlin/com/jonnyzzz/mcpSteroid/integration/tests/CliDevrigToolsIntegrationTest.kt
@@ -107,8 +107,8 @@ class CliDevrigToolsIntegrationTest {
         val readyWindow = windows.map { it.jsonObject }.singleOrNull { it["project_path"]?.jsonPrimitive?.content == guestProjectDir }
             ?: error("expected exactly one window for $guestProjectDir; windows=$windows")
         assertEquals("true", readyWindow["projectInitialized"]?.jsonPrimitive?.content, "windows=$windows")
-        assertEquals("false", (readyWindow["indexingInProgress"]?.jsonPrimitive?.content ?: "false"), "windows=$windows")
-        assertEquals("false", (readyWindow["modalDialogShowing"]?.jsonPrimitive?.content ?: "false"), "windows=$windows")
+        assertEquals("false", readyWindow["indexingInProgress"]?.jsonPrimitive?.content, "windows=$windows")
+        assertEquals("false", readyWindow["modalDialogShowing"]?.jsonPrimitive?.content, "windows=$windows")
     }
 
     @Test

--- a/test-integration/src/test/kotlin/com/jonnyzzz/mcpSteroid/integration/tests/CliDevrigToolsIntegrationTest.kt
+++ b/test-integration/src/test/kotlin/com/jonnyzzz/mcpSteroid/integration/tests/CliDevrigToolsIntegrationTest.kt
@@ -1,0 +1,197 @@
+/* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
+package com.jonnyzzz.mcpSteroid.integration.tests
+
+import com.jonnyzzz.mcpSteroid.integration.infra.AiMode
+import com.jonnyzzz.mcpSteroid.integration.infra.DevrigSteroidDriver
+import com.jonnyzzz.mcpSteroid.integration.infra.IntelliJContainer
+import com.jonnyzzz.mcpSteroid.integration.infra.IntelliJContainerOpts
+import com.jonnyzzz.mcpSteroid.integration.infra.create
+import com.jonnyzzz.mcpSteroid.integration.infra.waitForProjectReady
+import com.jonnyzzz.mcpSteroid.testHelper.CloseableStackHost
+import com.jonnyzzz.mcpSteroid.testHelper.docker.mapGuestPathToHostPath
+import com.jonnyzzz.mcpSteroid.testHelper.docker.startProcessInContainer
+import com.jonnyzzz.mcpSteroid.testHelper.process.ProcessResult
+import com.jonnyzzz.mcpSteroid.testHelper.process.assertExitCode
+import java.util.concurrent.TimeUnit
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Timeout
+
+/**
+ * Docker smoke test for the schema-driven `devrig` CLI (#284) against a REAL, already-running IDE —
+ * exercising the three CLI tools that genuinely need one, not a fake/stub bridge:
+ *
+ *  - `list_windows --json`: the running project's window must be visible through the CLI's own JSON
+ *    envelope, with `windows[0]` reachable from the SAME parse as the envelope's `tool`/`command`/
+ *    `isError` fields — a `jq` consumer parses stdout exactly once.
+ *  - `open_project --wait`: the CLI must poll `steroid_list_windows` itself and only return once the
+ *    project reports ready (no modal, indexing settled), not merely once the open call was accepted.
+ *  - `take_screenshot --out=<path>`: the CLI must write a real PNG to disk, not merely report success.
+ *
+ * Every assertion below is on the WHOLE parsed envelope/document, never a substring: three Phase-B
+ * defects in an earlier draft of this suite survived substring assertions.
+ *
+ * Opt-in like every other Docker test in this module: `tasks.test` in `build.gradle.kts` already
+ * refuses to run outside an explicit `:test-integration:` (or `ciIntegrationTests`) invocation — the
+ * same blanket, Gradle-task-level gate `DevrigRealIdeBridgeIntegrationTest` and
+ * `CLionMcpExecutionIntegrationTest` rely on. This class needs no extra gate beyond that: unlike
+ * `testManagedBackendsTart` (which additionally requires the `tart` binary on an Apple-Silicon host),
+ * a live IDE container is the ordinary precondition for anything under `tests/`, not a special one.
+ *
+ * ```
+ * ./gradlew :test-integration:test --tests '*CliDevrigToolsIntegrationTest*'
+ * ```
+ */
+class CliDevrigToolsIntegrationTest {
+
+    @Test
+    @Timeout(value = 15, unit = TimeUnit.MINUTES)
+    fun `list_windows --json exposes the whole envelope with windows first entry reachable in one parse`() {
+        val result = devrig("list_windows", "--json").assertExitCode(0) {
+            "devrig list_windows --json\nstdout=$stdout\nstderr=$stderr"
+        }
+
+        // ONE parse for the whole assertion: a second document, a banner line, or a leaked progress
+        // line on stdout would break `devrig list_windows --json | jq` the same way it would break this.
+        val envelope = json.parseToJsonElement(result.stdout).jsonObject
+        assertEquals("devrig", envelope.getValue("tool").jsonObject.getValue("name").jsonPrimitive.content)
+        assertEquals("list_windows", envelope.getValue("command").jsonPrimitive.content)
+        assertEquals("false", envelope.getValue("isError").jsonPrimitive.content)
+
+        val payload = envelope.getValue("data").jsonObject.getValue("content").jsonArray
+            .single().jsonObject.getValue("json").jsonObject
+        val windows = payload.getValue("windows").jsonArray
+        assertTrue(windows.isNotEmpty(), "expected at least one open window in the envelope; envelope=$envelope")
+
+        val firstWindow = windows[0].jsonObject
+        assertEquals(
+            guestProjectDir,
+            firstWindow["project_path"]?.jsonPrimitive?.content,
+            "windows[0] must be the already-open project; envelope=$envelope",
+        )
+    }
+
+    @Test
+    @Timeout(value = 15, unit = TimeUnit.MINUTES)
+    fun `open_project --wait returns only after the project reports ready`() {
+        val result = devrig(
+            "open_project",
+            "--project_path=$guestProjectDir",
+            "--task_id=cli-open-project-wait",
+            "--reason=verify devrig open_project --wait polls list_windows until ready against a real IDE",
+            "--wait",
+            "--json",
+            timeoutSeconds = 360,
+        ).assertExitCode(0) { "devrig open_project --wait\nstdout=$stdout\nstderr=$stderr" }
+
+        val envelope = json.parseToJsonElement(result.stdout).jsonObject
+        assertEquals("devrig", envelope.getValue("tool").jsonObject.getValue("name").jsonPrimitive.content)
+        assertEquals("open_project", envelope.getValue("command").jsonPrimitive.content)
+        assertEquals("false", envelope.getValue("isError").jsonPrimitive.content)
+
+        // "--wait" only returns 0 once the CLI's own poll of steroid_list_windows observes readiness —
+        // assert that readiness directly, rather than trusting the exit code alone.
+        val listWindows = devrig("list_windows", "--json").assertExitCode(0) {
+            "devrig list_windows --json (post open_project --wait)\nstdout=$stdout\nstderr=$stderr"
+        }
+        val windows = json.parseToJsonElement(listWindows.stdout).jsonObject
+            .getValue("data").jsonObject.getValue("content").jsonArray
+            .single().jsonObject.getValue("json").jsonObject.getValue("windows").jsonArray
+        val readyWindow = windows.map { it.jsonObject }.singleOrNull { it["project_path"]?.jsonPrimitive?.content == guestProjectDir }
+            ?: error("expected exactly one window for $guestProjectDir; windows=$windows")
+        assertEquals("true", readyWindow["projectInitialized"]?.jsonPrimitive?.content, "windows=$windows")
+        assertEquals("false", (readyWindow["indexingInProgress"]?.jsonPrimitive?.content ?: "false"), "windows=$windows")
+        assertEquals("false", (readyWindow["modalDialogShowing"]?.jsonPrimitive?.content ?: "false"), "windows=$windows")
+    }
+
+    @Test
+    @Timeout(value = 15, unit = TimeUnit.MINUTES)
+    fun `take_screenshot --out writes a real PNG to disk`() {
+        val projectName = waitForCliProjectName()
+        val guestOut = "/mcp-run-dir/cli-take-screenshot.png"
+
+        devrig(
+            "take_screenshot",
+            "--project_name=$projectName",
+            "--task_id=cli-take-screenshot",
+            "--reason=verify devrig take_screenshot --out writes a real PNG against a real IDE",
+            "--out=$guestOut",
+            "--json",
+        ).assertExitCode(0) { "devrig take_screenshot --out\nstdout=$stdout\nstderr=$stderr" }
+
+        val hostFile = session.scope.mapGuestPathToHostPath(guestOut)
+        assertTrue(hostFile.isFile && hostFile.length() > 0, "expected a non-empty PNG at ${hostFile.absolutePath}")
+
+        val header = hostFile.inputStream().use { it.readNBytes(PNG_MAGIC.size) }
+        assertTrue(
+            header.contentEquals(PNG_MAGIC),
+            "expected PNG magic bytes at ${hostFile.absolutePath}; got ${header.joinToString(",")}",
+        )
+    }
+
+    // ------------------------------------------------------------------------------------------------
+
+    private val guestProjectDir: String get() = session.intellijDriver.getGuestProjectDir()
+
+    private fun devrig(vararg args: String, timeoutSeconds: Long = 180): ProcessResult =
+        session.scope.startProcessInContainer {
+            args(listOf(launcher) + args)
+                .timeoutSeconds(timeoutSeconds)
+                .description("devrig ${args.joinToString(" ")}")
+        }.awaitForProcessFinish()
+
+    /**
+     * `take_screenshot` addresses a project by `project_name` (the routing key), not the filesystem
+     * path used to open it — so this polls `list_projects --json` (the CLI's own routing list) rather
+     * than assuming the two coincide, mirroring [DevrigRealIdeBridgeIntegrationTest.waitForProjectName].
+     */
+    private fun waitForCliProjectName(): String {
+        repeat(80) {
+            val result = devrig("list_projects", "--json")
+            if (result.exitCode == 0) {
+                val projects = json.parseToJsonElement(result.stdout).jsonObject
+                    .getValue("data").jsonObject.getValue("content").jsonArray
+                    .single().jsonObject.getValue("json").jsonObject.getValue("projects").jsonArray
+                val first = projects.firstOrNull()?.jsonObject?.get("project_name")?.jsonPrimitive?.content
+                if (first != null) return first
+            }
+            Thread.sleep(250)
+        }
+        error("Timed out waiting for `devrig list_projects` to discover the running IDE\n${session.diagnosticsSummary()}")
+    }
+
+    companion object {
+        private val PNG_MAGIC = byteArrayOf(0x89.toByte(), 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A)
+        private val json = Json { ignoreUnknownKeys = true }
+        private val lifetime by lazy { CloseableStackHost(CliDevrigToolsIntegrationTest::class.java.simpleName) }
+        private val session by lazy {
+            IntelliJContainer.create(lifetime, IntelliJContainerOpts(
+                consoleTitle = "devrig CLI tools against a live IDE",
+                aiMode = AiMode.NONE,
+            )).waitForProjectReady()
+        }
+        private val launcher: String by lazy {
+            DevrigSteroidDriver.deploy(session.scope, session.mcpSteroid).devrigCommand.command
+        }
+
+        @BeforeAll
+        @JvmStatic
+        fun beforeAll() {
+            session.toString()
+            check(launcher.isNotBlank()) { "devrig launcher path must not be blank" }
+        }
+
+        @AfterAll
+        @JvmStatic
+        fun cleanup() {
+            lifetime.closeAllStacks()
+        }
+    }
+}

--- a/test-integration/src/test/kotlin/com/jonnyzzz/mcpSteroid/integration/tests/CliDevrigToolsIntegrationTest.kt
+++ b/test-integration/src/test/kotlin/com/jonnyzzz/mcpSteroid/integration/tests/CliDevrigToolsIntegrationTest.kt
@@ -29,10 +29,10 @@ import org.junit.jupiter.api.Timeout
  * exercising the three CLI tools that genuinely need one, not a fake/stub bridge:
  *
  *  - `list_windows --json`: the running project's window must be visible through the CLI's own JSON
- *    envelope, with `windows[0]` reachable from the SAME parse as the envelope's `tool`/`command`/
+ *    envelope, with the original project's window reachable from the SAME parse as the envelope's `tool`/`command`/
  *    `isError` fields — a `jq` consumer parses stdout exactly once.
- *  - `open_project --wait`: the CLI must poll `steroid_list_windows` itself and only return once the
- *    project reports ready (no modal, indexing settled), not merely once the open call was accepted.
+ *  - `open_project --wait`: an initially unrouted directory must appear through `steroid_list_projects`,
+ *    and the command must return its opaque project/backend routing values.
  *  - `take_screenshot --out=<path>`: the CLI must write a real PNG to disk, not merely report success.
  *
  * Every assertion below is on the WHOLE parsed envelope/document, never a substring: three Phase-B
@@ -53,7 +53,7 @@ class CliDevrigToolsIntegrationTest {
 
     @Test
     @Timeout(value = 15, unit = TimeUnit.MINUTES)
-    fun `list_windows --json exposes the whole envelope with windows first entry reachable in one parse`() {
+    fun `list_windows --json exposes the whole envelope with the original project reachable in one parse`() {
         val result = devrig("list_windows", "--json").assertExitCode(0) {
             "devrig list_windows --json\nstdout=$stdout\nstderr=$stderr"
         }
@@ -70,22 +70,43 @@ class CliDevrigToolsIntegrationTest {
         val windows = payload.getValue("windows").jsonArray
         assertTrue(windows.isNotEmpty(), "expected at least one open window in the envelope; envelope=$envelope")
 
-        val firstWindow = windows[0].jsonObject
+        val projectWindow = windows.map { it.jsonObject }.singleOrNull {
+            it["project_path"]?.jsonPrimitive?.content == guestProjectDir
+        } ?: error("expected exactly one window for $guestProjectDir; windows=$windows")
         assertEquals(
             guestProjectDir,
-            firstWindow["project_path"]?.jsonPrimitive?.content,
-            "windows[0] must be the already-open project; envelope=$envelope",
+            projectWindow["project_path"]?.jsonPrimitive?.content,
+            "the original project window must remain addressable; envelope=$envelope",
         )
     }
 
     @Test
     @Timeout(value = 15, unit = TimeUnit.MINUTES)
-    fun `open_project --wait returns only after the project reports ready`() {
+    fun `open_project --wait routes an initially unopened path and returns its opaque key`() {
+        val targetPath = "/mcp-run-dir/cli-open-project-wait-target"
+        val before = devrig("list_projects", "--json").assertExitCode(0) {
+            "devrig list_projects --json (before open_project --wait)\nstdout=$stdout\nstderr=$stderr"
+        }
+        val beforeProjects = json.parseToJsonElement(before.stdout).jsonObject
+            .getValue("data").jsonObject.getValue("content").jsonArray
+            .single().jsonObject.getValue("json").jsonObject.getValue("projects").jsonArray
+        assertTrue(
+            beforeProjects.none { it.jsonObject["path"]?.jsonPrimitive?.content == targetPath },
+            "the wait target must start unrouted; projects=$beforeProjects",
+        )
+        session.scope.startProcessInContainer {
+            args("mkdir", "-p", targetPath)
+                .timeoutSeconds(30)
+                .description("create initially unopened CLI wait target")
+        }.awaitForProcessFinish().assertExitCode(0) {
+            "create $targetPath\nstdout=$stdout\nstderr=$stderr"
+        }
+
         val result = devrig(
             "open_project",
-            "--project_path=$guestProjectDir",
+            "--project_path=$targetPath",
             "--task_id=cli-open-project-wait",
-            "--reason=verify devrig open_project --wait polls list_windows until ready against a real IDE",
+            "--reason=verify devrig open_project --wait returns the new list_projects route against a real IDE",
             "--wait",
             "--json",
             timeoutSeconds = 360,
@@ -95,20 +116,25 @@ class CliDevrigToolsIntegrationTest {
         assertEquals("devrig", envelope.getValue("tool").jsonObject.getValue("name").jsonPrimitive.content)
         assertEquals("open_project", envelope.getValue("command").jsonPrimitive.content)
         assertEquals("false", envelope.getValue("isError").jsonPrimitive.content)
+        val opened = envelope.getValue("data").jsonObject.getValue("content").jsonArray
+            .single().jsonObject.getValue("json").jsonObject
+        assertEquals(targetPath, opened.getValue("path").jsonPrimitive.content)
+        val projectName = opened.getValue("project_name").jsonPrimitive.content
+        val backendName = opened.getValue("backend_name").jsonPrimitive.content
+        assertTrue(projectName.isNotBlank(), "wait result needs the opaque project_name: $opened")
+        assertTrue(backendName.isNotBlank(), "wait result needs the owning backend_name: $opened")
 
-        // "--wait" only returns 0 once the CLI's own poll of steroid_list_windows observes readiness —
-        // assert that readiness directly, rather than trusting the exit code alone.
-        val listWindows = devrig("list_windows", "--json").assertExitCode(0) {
-            "devrig list_windows --json (post open_project --wait)\nstdout=$stdout\nstderr=$stderr"
+        val listProjects = devrig("list_projects", "--json").assertExitCode(0) {
+            "devrig list_projects --json (post open_project --wait)\nstdout=$stdout\nstderr=$stderr"
         }
-        val windows = json.parseToJsonElement(listWindows.stdout).jsonObject
+        val projects = json.parseToJsonElement(listProjects.stdout).jsonObject
             .getValue("data").jsonObject.getValue("content").jsonArray
-            .single().jsonObject.getValue("json").jsonObject.getValue("windows").jsonArray
-        val readyWindow = windows.map { it.jsonObject }.singleOrNull { it["project_path"]?.jsonPrimitive?.content == guestProjectDir }
-            ?: error("expected exactly one window for $guestProjectDir; windows=$windows")
-        assertEquals("true", readyWindow["projectInitialized"]?.jsonPrimitive?.content, "windows=$windows")
-        assertEquals("false", readyWindow["indexingInProgress"]?.jsonPrimitive?.content, "windows=$windows")
-        assertEquals("false", readyWindow["modalDialogShowing"]?.jsonPrimitive?.content, "windows=$windows")
+            .single().jsonObject.getValue("json").jsonObject.getValue("projects").jsonArray
+        val routed = projects.map { it.jsonObject }.singleOrNull {
+            it["path"]?.jsonPrimitive?.content == targetPath
+        } ?: error("expected exactly one route for $targetPath; projects=$projects")
+        assertEquals(projectName, routed.getValue("project_name").jsonPrimitive.content)
+        assertEquals(backendName, routed.getValue("backend_name").jsonPrimitive.content)
     }
 
     @Test

--- a/website/content/docs/devrig.md
+++ b/website/content/docs/devrig.md
@@ -139,8 +139,8 @@ a second command definition.
 | `devrig execute_feedback` | Rates an execution. Requires `--project_name`, `--task_id`, `--success_rating`, and `--explanation`; code can also come from `--code-file`. |
 | `devrig take_screenshot` | Captures an IDE image. Requires `--project_name`, `--task_id`, and `--reason`; accepts `--window_id` and `--out`. |
 | `devrig input` | Sends keyboard and mouse steps to a window. Requires `--project_name`, `--task_id`, `--reason`, `--window_id`, and `--sequence`. |
-| `devrig fetch_resource` | Fetches an `mcp-steroid://` guide by `--uri` and `--project_name`. `devrig prompt` is an alias. |
-| `devrig open_project` | Opens `--project_path`. When one backend already owns that path, devrig reuses it automatically; use `--backend_name` to choose among candidates for a new or multiply-open path. `--trust_project` is on by default and `--no-trust_project` disables it. The declared `--wait` option is reserved and currently fails explicitly instead of pretending to wait. |
+| `devrig fetch_resource` | Fetches an `mcp-steroid://` guide given as a positional URI plus `--project_name`. `devrig prompt` is an alias; the former `--uri` spelling remains accepted for existing scripts. |
+| `devrig open_project` | Opens `--project_path`. When one backend already owns that path, devrig reuses it automatically; use `--backend_name` to choose among candidates for a new or multiply-open path. `--trust_project` is on by default and `--no-trust_project` disables it. `--wait` polls for up to 300 seconds and returns the opened project's opaque `project_name`, `backend_name`, and canonical path. |
 
 Use command-scoped help for the authoritative grammar, for example:
 
@@ -148,7 +148,7 @@ Use command-scoped help for the authoritative grammar, for example:
 $ devrig execute_code --help
 $ devrig list_projects --json
 $ devrig execute_code --project_name <routing-key> --code='println("hello")' --task_id demo --reason 'verify IDE access' --json
-$ devrig prompt --project_name <routing-key> --uri mcp-steroid://prompt/skill --json
+$ devrig prompt mcp-steroid://prompt/skill --project_name <routing-key> --json
 ```
 
 Generated tool commands do not repair the launcher or write to `PATH`; they


### PR DESCRIPTION
Completes the schema-driven devrig CLI work from #284 on top of Phase B (#437).

## CLI contract

- Uses the schema-driven Clikt binding for MCP-tool commands.
- Keeps `list_projects` canonical, with `projects` and `project` as aliases.
- Adds layered root and focused help, including actionable missing-value guidance and the exact accepted values for typed parameters.
- Makes `devrig prompt <mcp-steroid://...>` the canonical resource route; the former `--uri` spelling remains accepted as a hidden compatibility form.
- Exposes guide URIs from `help execute_code` with a copyable `devrig prompt <uri> --project_name=<routing-key>` next step.
- Preserves colorful human output while keeping `--json` ANSI-free and machine-readable.
- Pretty-prints JSON text payloads in human mode without changing the JSON envelope.

## Runtime behavior

- `open_project --wait` polls typed `list_projects` responses, so it works for frontendless Remote Development backends as well as desktop IDEs.
- Successful waits return the route the caller needs next: `project_name`, `backend_name`, and canonical `path`.
- Caller-supplied `task_id` and `reason` survive the open-project devrig bridge.
- `execute_feedback --execution_id` is preserved through the CLI, bridge, backend, and stored feedback payload.
- Unsupported orchestration flags fail before backend calls or `--out` filesystem preflight.
- File/stdin sources enforce strict UTF-8 and a 10 MB limit with consistent exit classification.

## Validation

- `:mcp-core:test`
- `:mcp-steroid-server:test`
- `:execution-storage:test`
- full `:npx-kt:test` (1,749 tests)
- full `:npx-kt:integrationTest`
- `:test-integration:compileTestKotlin`
- `:test-experiments:compileTestKotlin`
- live desktop `CliDevrigToolsIntegrationTest`
- live frontendless Remote Development `open_project --wait` experiment
- live Claude and Codex help-first/action-first usability sessions
- packaged branch demo covering root help, focused help, human/JSON project listing, aliases, positional prompt routing, generated tools, feedback association, and `open_project --wait --json`

The website source is updated for the new command contract, but the long-lived `website` deployment branch is intentionally not advanced by this PR.
