### PR TITLE
Advertise Remote Development backend in PID markers

### DIFF
--- a/devrig-common/src/main/kotlin/com/jonnyzzz/mcpSteroid/PidMarker.kt
+++ b/devrig-common/src/main/kotlin/com/jonnyzzz/mcpSteroid/PidMarker.kt
@@ -16,8 +16,8 @@ import java.nio.file.Path
  * backwards-readable.
  *
  * The REQUIRED fields ([schema], [pid], [ide], [plugin], [createdAt]) have no defaults, so every writer
- * must set them and decoding rejects their omission. The OPTIONAL sub-objects default to `null`: this is
- * the backward/forward-compat hook — a marker written by an older or newer plugin that omits one of them
+ * must set them and decoding rejects their omission. OPTIONAL fields have safe defaults: this is the
+ * backward/forward-compat hook — a marker written by an older or newer plugin that omits one of them
  * still decodes (kotlinx.serialization treats a nullable field WITHOUT a default as required, which would
  * throw on absence). Writers still set them explicitly (`encodeDefaults = true` keeps them in the output).
  */
@@ -30,6 +30,8 @@ data class PidMarker(
     val createdAt: String,
     /** Absolute IDE install home (`PathManager.getHomePath()`); identifies the install across restarts. */
     val ideHome: String? = null,
+    /** True when this IDE process is a Remote Development backend. */
+    val remoteDevelopmentBackend: Boolean = false,
     // Both transports are optional and independent: the `/mcp` MCP-client endpoint and the devrig bridge
     // endpoint are split at the protocol level. A marker may advertise only one of them — e.g. only
     // [devrigEndpoint] with no [mcpSteroidServer]. devrig reads ONLY [devrigEndpoint] and never touches MCP.

--- a/devrig-common/src/test/kotlin/com/jonnyzzz/mcpSteroid/PidMarkerTest.kt
+++ b/devrig-common/src/test/kotlin/com/jonnyzzz/mcpSteroid/PidMarkerTest.kt
@@ -1,6 +1,7 @@
 package com.jonnyzzz.mcpSteroid
 
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -161,6 +162,24 @@ class PidMarkerTest {
                "plugin":{"id":"p","name":"P","version":"v"},"createdAt":"t"}""".trimIndent()
         )
         assertNull(withoutHome.ideHome)
+    }
+
+    @Test
+    fun `remote development backend marker is encoded and defaults to false when absent`() {
+        val backendMarker = samplePidMarker().copy(remoteDevelopmentBackend = true)
+        val text = PidMarkerJson.encode(backendMarker)
+
+        assertTrue(
+            text.contains("\"remoteDevelopmentBackend\": true"),
+            "remoteDevelopmentBackend field missing: $text",
+        )
+        assertTrue(PidMarkerJson.decode(text).remoteDevelopmentBackend)
+
+        val olderMarker = PidMarkerJson.decode(
+            """{"schema":1,"pid":7,"ide":{"name":"X","version":"1","build":"IU-1"},
+               "plugin":{"id":"p","name":"P","version":"v"},"createdAt":"t"}""".trimIndent()
+        )
+        assertFalse(olderMarker.remoteDevelopmentBackend)
     }
 
     @Test

--- a/ij-plugin/CLAUDE.md
+++ b/ij-plugin/CLAUDE.md
@@ -484,6 +484,11 @@ keys, nor the #155 MCP-only `backends` / `intellij` identity keys (`BackendInfo`
   `PluginDescriptorProvider`). Plumbing for the deferred "update plugin before run" step (Finding A,
   `TASKS.md` #12); no logic reads it yet.
 
+**Later additive `PidMarker` fields:**
+- `PidMarker.remoteDevelopmentBackend: Boolean = false` — written by `ServerUrlWriter` from the public
+  `IdeProductMode.isBackend` signal. It lets devrig and diagnostics identify a frontendless Remote
+  Development backend directly from the marker; older markers that omit it decode as `false`.
+
 Deferred (revisit with a baseline release): (a) a cross-version test (devrig HEAD ↔ an older plugin build);
 (b) giving devrig its **own** copy of the marker/bridge DTOs so the two version independently and only the
 JSON wire shape is shared (today devrig reuses `mcp-steroid-server`'s classes, decoding tolerantly).

--- a/ij-plugin/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/ServerUrlWriter.kt
+++ b/ij-plugin/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/ServerUrlWriter.kt
@@ -35,7 +35,11 @@ import java.time.format.DateTimeFormatter
  * separately by [IdeaDescriptionWriter].
  */
 @Service(Service.Level.APP)
-class ServerUrlWriter : Disposable {
+class ServerUrlWriter(
+    private val remoteDevelopmentBackend: Boolean,
+) : Disposable {
+    constructor() : this(isRemoteDevBackend())
+
     private val log = thisLogger()
     private var markerFile: Path? = null
 
@@ -78,6 +82,7 @@ class ServerUrlWriter : Disposable {
             plugin = PluginInfo.ofCurrentPlugin(),
             createdAt = DateTimeFormatter.ISO_INSTANT.format(Instant.now()),
             ideHome = PathManager.getHomePath(),
+            remoteDevelopmentBackend = remoteDevelopmentBackend,
             intellijWebServer = buildIntelliJWebServerInfo(),
             intellijMcpServer = IntelliJMcpServerProbe.getInstanceOrNull()?.probe(),
         )

--- a/ij-plugin/src/test/kotlin/com/jonnyzzz/mcpSteroid/server/ServerUrlWriterTest.kt
+++ b/ij-plugin/src/test/kotlin/com/jonnyzzz/mcpSteroid/server/ServerUrlWriterTest.kt
@@ -15,7 +15,7 @@ class ServerUrlWriterTest : BasePlatformTestCase() {
     override fun runInDispatchThread(): Boolean = false
 
     fun testWriteCreatesMarkerUnderManagedMarkersDirectory() = withTemporaryUserHome { userHome ->
-        val writer = ServerUrlWriter()
+        val writer = ServerUrlWriter(remoteDevelopmentBackend = true)
         try {
             writer.writeServerUrlToUserHome("http://localhost:6315/mcp")
 
@@ -24,6 +24,7 @@ class ServerUrlWriterTest : BasePlatformTestCase() {
             assertTrue("marker should be written to $markerFile", Files.isRegularFile(markerFile))
             val marker = PidMarkerJson.decode(Files.readString(markerFile))
             assertEquals(pid, marker.pid)
+            assertTrue("marker should identify a Remote Development backend", marker.remoteDevelopmentBackend)
             assertEquals("http://localhost:6315/mcp", marker.mcpSteroidServer!!.mcpUrl)
             // The devrig bridge endpoint is advertised separately from the MCP endpoint: same Ktor base,
             // the /api/jonnyzzz/mcp-steroid/v1 prefix, and the bearer headers devrig must send.


### PR DESCRIPTION
## Summary

- add the additive remoteDevelopmentBackend boolean to the PID marker JSON
- populate it from the existing public IdeProductMode.isBackend signal in ServerUrlWriter
- default missing values to false for older-marker compatibility
- document the wire field and cover true-value encoding plus absent-field decoding

## Validation

- :devrig-common:test :ij-plugin:test --rerun-tasks (307 tests, zero failures/errors; one existing opt-in demo skip)
- :npx-kt:test --rerun-tasks (1,695 tests, zero failures/errors; four expected Windows-only skips on macOS)
- focused PidMarkerTest and ServerUrlWriterTest passed
- changed production files are inspection-clean
- git diff --check