### PR TITLE
docs(devrig): document normalized CLI and readiness contracts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -205,6 +205,15 @@ well (JetBrains Marketplace).
 - **Modules**: see `settings.gradle.kts`. Plugin code lives in `ij-plugin/`; prompt resources in `prompts/`;
   Docker IDE smoke tests in `test-integration/`; experimental/long-running tests in `test-experiments/`.
 
+### devrig CLI contributor contract
+
+[`docs/devrig-cli-contract.md`](docs/devrig-cli-contract.md) is authoritative for command grammar, help,
+human/JSON output, direct MCP-tool commands, and `open_project --wait`. Keep one Clikt parser and derive
+tool commands from their schemas. Use canonical `list_projects`; `projects` and `project` are compatibility
+aliases. Missing/invalid parameters must route to focused help with allowed values, and parse validation
+must happen before backend, file/stdin, or `--out` side effects. Agent-facing changes require the unit,
+stable Docker, and Claude/Codex experiment buckets named in that contract.
+
 ## Technology Stack
 
 Gradle 9.6.1 / Kotlin 2.3.20 / Java 25 toolchain / IntelliJ Platform 2026.1+ / Ktor 3.3.2 (CIO+SSE) / kotlinx.serialization

--- a/README.md
+++ b/README.md
@@ -62,6 +62,24 @@ your machine at once — each open on a different project — and can download a
 We continuously measure IDE-access vs plain-shell agents on real codebases. See the
 [experiment findings](https://devrig.dev/docs/experiment-findings/) for the evidence-based results.
 
+### Explore the CLI
+
+The command tree is discoverable from either direction:
+
+```bash
+devrig --help
+devrig help execute_code
+devrig list_projects --json
+devrig open_project --project_path="$PWD" --task_id=demo-open --reason="open current project from CLI" --wait --json
+devrig prompt mcp-steroid://prompt/skill --project_name="PROJECT_NAME_FROM_LIST_PROJECTS" --json
+```
+
+`list_projects` is canonical (`projects` and `project` are compatibility aliases). Human output is
+readable and may use terminal color; commands that advertise `--json` emit one ANSI-free document for
+agents and scripts. Incomplete commands print focused help with every missing value. See the
+[devrig CLI guide](https://devrig.dev/docs/devrig/) or the contributor
+[CLI contract](docs/devrig-cli-contract.md).
+
 ---
 
 ## Install

--- a/TASKS.md
+++ b/TASKS.md
@@ -81,7 +81,8 @@ the `installer-epic` memory for the full delivered list. Still open:
    vendor + in-IDE notice + trademark line, `docs/devrig.md`, release notes 0.100. Still MISSING (all
    required): (1) `README.md` has NO disclosure — and its line-1 badge currently reads as an *official
    JetBrains incubator* project, directly contradicting the requirement (fix the badge too); (2) the devrig
-   `--version`/`--help` banner (`HelpCommand.kt`); (3) the dist `npx-kt/src/main/dist/licenses/README.md`;
+   `--version`/`--help` output (`DevrigRootCommand` / help rendering in `npx-kt/.../Cli.kt`, plus
+   `printVersion`); (3) the dist `npx-kt/src/main/dist/licenses/README.md`;
    (4) a positive independence statement in EULA (it only names JetBrains as a non-party); (5) a
    release-checklist item; (6) a build-time guard/test asserting the disclosure. (Backlog; wording TBD.)
 
@@ -93,17 +94,6 @@ the `installer-epic` memory for the full delivered list. Still open:
     - (5) **devrig-owned DTOs** — give devrig its own copy of the marker + bridge request/result DTOs (today it
       reuses `mcp-steroid-server`'s classes via tolerant decode) so the two evolve independently and only the
       JSON wire shape is shared.
-
-11. **0.101 release gate — reconcile closed-but-not-on-`main` work (tracked in #102).** The 2026-06-19
-    triage found issues marked done/closed whose code was reverted (commit `30236610`, "Revert the 0.101
-    work batch") and never re-landed on `main`:
-    - **#93 / #94 / #69** — `runInspectionsDirectly` on `main` is still a bare `InspectionEngine.inspectEx`
-      (`McpScriptContextImpl.kt`): no per-tool crash isolation, no invalid-PSI tolerance, no `Project`
-      param / structured findings.
-    - **#99 / #100** — `devrig prompt` and `devrig exec-code --file` exist only on `0101-cli-commands`, not
-      `main` (`Cli.kt` has only mcp/backend/project/install/help/version).
-    Before 0.101: either re-land these onto `main` or re-open the issues so their state matches reality.
-    Release gate **#92** (same-named-project routing) is also still open/unverified.
 
 ## startable-backends follow-ups (PR #139 shipped the core)
 

--- a/TODO-NPX-BOOTSTRAPPER.md
+++ b/TODO-NPX-BOOTSTRAPPER.md
@@ -9,18 +9,19 @@
 > installer epic's `:site-gen` (branch `installer/version-json-driven`) carries the live JDK-pinning. If
 > this bootstrapper is built, revive the pattern from there rather than expecting either module to exist.
 
-## 2026-05-28 — Design phase complete; spec at v7 (commit b403efb7)
+## 2026-05-28 — Historical v7 design phase (commit b403efb7)
 
-**Authoritative design:**
-[`docs/devrig-deployment-spec.md`](docs/devrig-deployment-spec.md). The spec
+**Historical design record:**
+[`docs/devrig-deployment-spec.md`](docs/devrig-deployment-spec.md). The document
 was iterated through seven rounds, including a three-agent (claude/codex/
 gemini) quorum review via `run-agent.sh` and an MCP-spec-grounded
-verdict on mid-session restart. v7 is locked. The older roadmap below
-predates the spec and is preserved for context only — when there's a
-conflict, the spec wins.
+verdict on mid-session restart. Its wizard, `--yes`, and `upgrade` proposals were not adopted. Current
+behavior is governed by [`docs/install-scripts-contract.md`](docs/install-scripts-contract.md),
+[`docs/devrig-cli-contract.md`](docs/devrig-cli-contract.md), and
+[`docs/updates-check/devrig-auto-update.md`](docs/updates-check/devrig-auto-update.md). The v7 list and
+older roadmap below are preserved for history, not as an implementation backlog.
 
-**Key design decisions locked in v7** (everything below this line is now
-a spec section, not a TODO):
+**Key decisions recorded in v7** (historical; some shipped and others were superseded):
 
 - Wrapper at `~/.mcp-steroid/bin/devrig` (POSIX shell) +
   `~/.mcp-steroid/bin/devrig.cmd` (Windows CMD — implemented CMD-only in
@@ -51,8 +52,8 @@ a spec section, not a TODO):
   only file op that succeeds against an in-use script on Windows).
 - All wrapper output to **stderr only** — stdout is reserved for the
   JVM's MCP protocol traffic after `exec`.
-- Agent registration wizard lives in the inner Java binary (probe PATH
-  + `<agent> --version` with timeout, prompt to register/re-register).
+- The proposed inner-Java agent-registration wizard was superseded. Bare `devrig install` now lists
+  targets non-interactively; only an explicit `devrig install <agent>` changes agent configuration.
 - `./gradlew deployNpx` pre-populates the cache so dev mode never hits
   the network; signature verification deliberately disabled in dev.
 - **Native binary alternative** (Go / Rust / GraalVM native-image of
@@ -62,7 +63,7 @@ a spec section, not a TODO):
   finding: `curl` does NOT set `com.apple.quarantine` xattr on macOS,
   so a curl-installed native binary would not need notarization.
 
-**Implementation phasing** (from the spec):
+**Historical implementation phasing** (from the v7 proposal; do not use as a current backlog):
 
 | Phase | Scope | LOC |
 |---|---|---|
@@ -70,7 +71,7 @@ a spec section, not a TODO):
 | **2** (before public release) | Key generation playbook, two-key `releaseDevrig`, `devrig upgrade` Java subcommand, GH Pages publish, weekly URL-liveness GH Action, sig-verify test suite | ~400 |
 | **3** (nice) | Standalone `install.sh` / `install.ps1` shims, key-rotation docs | ~80 |
 
-**Status: design done, implementation pending user go-ahead.**
+**Status: closed as a historical plan; use the current contracts linked above.**
 
 ---
 
@@ -78,9 +79,9 @@ a spec section, not a TODO):
 
 ## Current status after devrig rename (2026-05-19)
 
-> **Contract reference.** The devrig CLI's project/backend naming,
-> JSON output schemas, and on-demand routing model are now specified
-> in [`docs/devrig-naming.md`](docs/devrig-naming.md). Any
+> **Contract reference.** The devrig CLI grammar, aliases, help/recovery, direct-tool commands, and JSON
+> envelopes are specified in [`docs/devrig-cli-contract.md`](docs/devrig-cli-contract.md); project/backend
+> identifiers and routing are specified in [`docs/devrig-naming.md`](docs/devrig-naming.md). Any
 > bootstrapper work that touches discovery, MCP routing, or the
 > public CLI surface must keep that contract intact. The on-demand
 > rebuild decision (no background scanners in the devrig process) is

--- a/TODO.md
+++ b/TODO.md
@@ -159,17 +159,8 @@
   IDE failing its `/windows` fetch errors the whole call (`coroutineScope` + `error(...)`), unlike
   `list_projects` which degrades per-backend. Return partial windows + a per-backend error marker.
 - [ ] **list_windows human presentation (#284 follow-up)**: console mode still prints the tool's
-  JSON payload as one minified line. Add a structured, colorful human renderer while preserving the
-  current ANSI-free `--json` envelope for agents.
-
-- [ ] **`--json` parse-time usage errors emit nothing on stdout (#284)**: a parse failure becomes
-  `DevrigCommandParseError`, which prints to stderr and answers 64 with no `--json` envelope — the KDoc
-  argues the failure precedes the command's options so the `--json` intent is unknowable, yet the sibling
-  help path already sniffs `--json`/`--debug` off the raw tokens (`Array<String>.jsonRequested()` in
-  `Cli.kt`). The same sniff could drive a parse-error envelope for machine consumers. Decide whether the
-  envelope is wanted; if yes, re-introduce a `commandName` recovery that survives non-boolean pre-command
-  flags (`--out` falsified the old raw-token scan — see `DevrigCommandParseError`'s KDoc), and pin the
-  contract either way (it is untested today).
+  JSON payload as pretty-printed JSON, but still lacks a purpose-built, colorful windows/tasks renderer.
+  Add that renderer while preserving the current ANSI-free `--json` envelope for agents.
 
 - [ ] **`--project_name` is not inferred from the current directory (#284)**: `resolveProjectFromCwd`
   in `npx-kt/.../devrig/server/CwdProjectResolver.kt` is fully written and unit-tested (`One` / `None` /
@@ -205,31 +196,22 @@
   implementors. Capture the canonical full set (or query it independently after the agent run) so future
   Keycloak fixture changes can distinguish exact completeness from a strong workflow regression signal.
 
-- [ ] **Harden the CLI tool-spec metadata layer (#284 follow-up)**: three review findings deferred from
-  PR #356. (1) `CliToolSpec.schema` exposes the mutable `ToolSchema` — any consumer can call
+- [ ] **Harden the CLI tool-spec metadata layer (#284 follow-up)**: remaining review findings after
+  PR #450. (1) `CliToolSpec.schema` exposes the mutable `ToolSchema` — any consumer can call
   `register()` after registration and change the advertised `inputSchema`; expose a read-only view
-  (interface with `asMcpJson()`/`asCliParams()` only). (2) No declaration-time flag-collision
-  validation: a parameter flag, its `cliFileSource` flag, and a tool-level `CliExtraOption` flag can
-  collide — builder checks are order-dependent (`.cliFileSource("--x").cliFlag("--x")` passes) and a
-  bare `--` is accepted as a flag; validate per-tool flag/alias uniqueness at registration or pin it
-  with a `devrigToolSpecs()`-wide test. (3) Wire bounds declared via the `extra {}` closure
+  (interface with `asMcpJson()`/`asCliParams()` only). (2) Collision checks now cover parameter,
+  file-source, tool-extra, framework, command-token, and alias names at command construction, but strict
+  option-name grammar still needs a declaration-time guard (for example, reject a bare `--`). (3) Wire
+  bounds declared via the `extra {}` closure
   (`success_rating` 0..1) are invisible to `asCliParams()`, while `timeout` carries a CLI-only
   `cliMinimum` — the generated CLI cannot enforce the wire bound without parsing `asMcpJson()`; also
   `cliSynopsis` hardcodes "(default 600)" where the MCP description interpolates the constant, so the
   two can silently diverge.
 
-- [ ] **Harvest test coverage from the abandoned `issue-284-schema-driven-cli-phase-b` branch (#284)**: that
-  parallel branch (superseded by `issue-284-cli-engine`, not merged) carries ~12 test classes this branch
-  lacks — MCP-as-CLI contract/parse tests, per-command tests (execute_code / fetch_resource / feedback /
-  screenshot), a layered `help execute_code` topic test, and a Docker live-IDE MCP-as-CLI smoke
-  (`CliDevrigToolsIntegrationTest`). They assert against phase-b's command-class architecture, so port the
-  INTENT into the generated-runtime structure, don't copy the files.
-
-- [ ] **The `devrig --help` banner does not list `install plugin` / `install devrig` (#284)**: the curated
-  `LIFECYCLE_COMMANDS` in `HelpCommand.kt` documents `install [claude|codex|gemini]` and `install config`
-  (pinned by `DevrigCommandOutputTest` + `McpToolsCliHelpTest`), but the `install plugin` and `install devrig`
-  subcommands have no banner entry (main did not document them either — pre-existing, not a Phase B
-  regression). Add their one-line descriptions to the curated banner and extend the pinned test head.
+- [ ] **Make agent-choice commands shell-safe in devrig output (#284 follow-up)**: `InstallCommand` and
+  `InstallConfigCommand` still render `devrig install claude|codex|gemini`, which a shell interprets as a
+  pipeline rather than as alternatives. Print separate concrete commands (or one concrete command plus
+  prose naming the replacements) and pin that no copyable command uses shell alternation as notation.
 
 - [ ] **red-code reporter false-positives on Kotlin files**: `reportProjectRedCode` (PSI reference scan,
   `mcp-steroid-import.kt`) reports Kotlin stdlib/operator references (`mutableMapOf`, `runCatching`,

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -12,11 +12,12 @@ This document is a concise architecture map. For authoritative details, see `AGE
 - OCR helper: external `ocr-tesseract` app invoked via process client.
 - Kotlin compilation: bundled Kotlin Build Tools implementation jars (`kotlinc/` in the plugin dist), driven in-process via the Build Tools API in an isolated classloader.
 - Storage: execution logs/artifacts (append-only, under `~/.mcp-steroid/runs/` by default).
-- **devrig CLI** (`npx-kt/`): stateless stdio MCP server + `backend` /
-  `project` CLI that discovers IntelliJ instances on the host and
-  routes tool calls to them. Project / IDE naming is governed by the
-  [`docs/devrig-naming.md`](devrig-naming.md) spec; on-demand routing
-  rationale lives in
+- **devrig CLI** (`npx-kt/`): stateless stdio MCP server plus one Clikt command tree for installation,
+  backend lifecycle, and schema-generated direct MCP-tool commands. `list_projects` is canonical;
+  `projects` / `project` are aliases. The CLI discovers IntelliJ instances on the host and routes tool
+  calls to them. Grammar, help, and output are governed by
+  [`docs/devrig-cli-contract.md`](devrig-cli-contract.md); project / IDE naming is governed by
+  [`docs/devrig-naming.md`](devrig-naming.md); on-demand routing rationale lives in
   [`docs/devrig-scanning-research.md`](devrig-scanning-research.md).
 
 ## Request Flow (exec_code)
@@ -55,5 +56,7 @@ This document is a concise architecture map. For authoritative details, see `AGE
 - [`devrig-naming.md`](devrig-naming.md): canonical contract for
   project and backend (IDE) names across the devrig CLI and the
   devrig stdio MCP server
+- [`devrig-cli-contract.md`](devrig-cli-contract.md): canonical command grammar, focused help,
+  generated-tool dispatch, human/JSON output, and direct-tool readiness semantics
 - [`devrig-scanning-research.md`](devrig-scanning-research.md):
   on-demand `rebuildSnapshot()` decision record

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -34,11 +34,11 @@ rather than mirroring their contents into per-folder guides):
   register it on PATH, NOTHING else — never auto-register devrig with
   agents, never auto-install the IDE plugin; those commands are only
   promoted to the user in the `devrig install devrig` info message.
-- [`devrig-deployment-spec.md`](devrig-deployment-spec.md) — locked v7
-  design for `~/.mcp-steroid/` install layout: wrapper-driven
-  content-addressed cache, bundled Corretto JDK, two-key signed
-  self-update, auto-GC, agent registration wizard, dev-mode
-  pre-population, and a native-binary alternative appendix.
+- [`devrig-deployment-spec.md`](devrig-deployment-spec.md) — historical v7
+  design record for `~/.mcp-steroid/` layout, wrapper ownership, the bundled runtime,
+  cache/GC ideas, and a native-binary alternative. Its wizard and `upgrade` proposals are
+  superseded; current install behavior lives in `install-scripts-contract.md`, current commands in
+  `devrig-cli-contract.md`, and current updates in `updates-check/devrig-auto-update.md`.
 - [`devrig-remote-development-backend-e2e.md`](devrig-remote-development-backend-e2e.md) —
   shipped IU-262 native Remote Development backend contract, Docker fixture, lifecycle evidence,
   and follow-up risks.

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -21,6 +21,8 @@ Long-form contract documents owned by `docs/` (read these directly
 rather than mirroring their contents into per-folder guides):
 
 - [`PHILOSOPHY.md`](PHILOSOPHY.md) — the four design tenets.
+- [`devrig-cli-contract.md`](devrig-cli-contract.md) — canonical devrig command grammar, generated-tool
+  CLI, help/recovery, human and JSON output, `open_project --wait`, and agent-validation contract.
 - [`devrig-naming.md`](devrig-naming.md) — devrig CLI + stdio MCP
   project/backend naming contract (slug rule, `bootHash`,
   `archiveSha256`, `actions[].argv`, on-demand routing).

--- a/docs/TESTING-STRATEGY.md
+++ b/docs/TESTING-STRATEGY.md
@@ -1,22 +1,34 @@
 # Testing Strategy
 
-This document summarizes the testing approach. For exact commands and test lists, see `README.md`.
+This document summarizes the testing approach. Module guides own the exact commands and operational rules.
 
 ## Principles
 - Tests must assert real behavior, not just output formatting.
 - Integration tests should verify actual MCP tool calls.
 - Avoid test-only branches in production code.
+- Never run `:test-integration` and `:test-experiments` Docker tests concurrently.
 
 ## Test Layers
-- Unit tests: core protocol, session management, execution helpers.
-- Integration tests: MCP HTTP transport, tool invocation, and session behavior.
-- CLI tests: Docker-based Codex/Claude flows to validate real MCP usage.
+- Unit tests: core protocol, session management, execution helpers, and devrig schema/help/runtime contracts.
+- Process integration tests: packaged devrig behavior, stdout/stderr separation, and stdio MCP transport.
+- Stable Docker integration tests: real IDE routing and direct CLI tool calls.
+- Experimental Docker tests: Claude/Codex discovery and long-running frontendless backend scenarios.
 - OCR tests: run the bundled `ocr-tesseract` helper app against test images.
 
 ## Key Coverage
 - `ScriptExecutionAvailabilityTest` catches broken script engine quickly.
-- CLI tests include multi-step exec flows and MCP list validation.
+- `CliDevrigToolsIntegrationTest` validates `list_windows --json`, `open_project --wait`,
+  `list_projects --json`, and screenshot `--out` against a real IDE.
+- `DevrigCliCommandNormalizationTest` validates safe Claude/Codex shell-command recognition and rejection.
+- `DevrigCliAgentUsabilityExperimentTest` validates task-first, help-first, outcome-only, and lifecycle
+  discovery with both live agents.
+- `DevrigRemoteDevelopmentKeycloakTypeHierarchyTest` proves routing and semantic work without a frontend;
+  project routing and Maven/Gradle readiness are separate gates.
 - Session handling tests cover unknown-session recovery.
 
+The full CLI behavior and layer ownership are specified in
+[`devrig-cli-contract.md`](devrig-cli-contract.md).
+
 ## Running Tests
-See `README.md` for the recommended test commands and CI notes.
+Use the narrowest owning module and test class. See root `CLAUDE.md`, `test-integration/AGENTS.md`, and
+`test-experiments/CLAUDE.md`; never run unscoped root `./gradlew test`.

--- a/docs/devrig-cli-contract.md
+++ b/docs/devrig-cli-contract.md
@@ -1,0 +1,173 @@
+# devrig CLI contract
+
+Status: current since [PR #450](https://github.com/jonnyzzz/mcp-steroid/pull/450), which completed
+the command normalization work tracked by issue #284.
+
+This document is the durable contract for devrig's command-line grammar, help, human output, machine
+output, direct MCP-tool commands, and agent discovery flows. Project/backend identifier semantics remain
+in [`devrig-naming.md`](devrig-naming.md); managed Remote Development lifecycle details remain in
+[`devrig-remote-development-backend-e2e.md`](devrig-remote-development-backend-e2e.md).
+
+## One command model
+
+Clikt is the only CLI parser. MCP tool schemas generate the direct-tool commands and their parameters;
+there is no parallel hand-written parser for those commands. A schema change must therefore update the
+direct CLI grammar, focused help, validation, and MCP invocation together.
+
+The top-level command families are:
+
+```text
+devrig
+├── list_projects                 aliases: projects, project
+├── list_windows
+├── execute_code
+├── execute_feedback
+├── take_screenshot
+├── input
+├── fetch_resource               alias: prompt
+├── open_project
+├── backend
+│   ├── download
+│   ├── start
+│   ├── stop
+│   └── provision
+├── install
+│   ├── claude
+│   ├── codex
+│   ├── gemini
+│   ├── config
+│   ├── devrig
+│   └── plugin
+├── mcp
+├── version
+└── help <command> [<subcommand> ...]
+```
+
+`list_projects` is canonical. `projects` and the older singular `project` spelling are compatibility
+aliases for the same generated leaf; they have identical behavior and output, and JSON still reports
+canonical `command: "list_projects"`. New documentation and scripts use `list_projects`.
+
+`devrig prompt <uri>` is the short, positional route to `fetch_resource`. The hidden `--uri` form remains
+accepted for compatibility, but help and examples advertise the positional URI.
+
+## Help and recovery
+
+Every command and nested action has both routes:
+
+```console
+devrig <command> --help
+devrig help <command>
+devrig help backend download
+```
+
+Root help is an index and a usable first step. Focused help shows the actual schema-derived parameters,
+required choices, defaults, numeric ranges, enum values, aliases, file-input alternatives, and a runnable
+usage shape. When parameters are missing or invalid, devrig prints the relevant focused help and names all
+missing values in one pass. For example, an incomplete `execute_code` call identifies
+`--project_name`, `--task_id`, `--reason`, and the `--code` / `--code-file` choice rather than failing one
+field at a time.
+
+Unknown commands fail during parsing. Unsupported orchestration flags fail in the runtime guard before
+dispatch or preflight. Neither path may contact a backend, read a file/stdin source, or create an `--out`
+target before validation succeeds.
+
+## Direct MCP-tool commands
+
+The schema-generated commands call the same handlers exposed through `devrig mcp`:
+
+| Command | Required input | Important optional input |
+|---|---|---|
+| `list_projects` | none | `--json` |
+| `list_windows` | none | `--json` |
+| `execute_code` | `--project_name`, `--task_id`, `--reason`, one of `--code` / `--code-file` | `--modal`, `--timeout`, `--out`, `--json` |
+| `execute_feedback` | `--project_name`, `--task_id`, `--success_rating`, `--explanation` | `--execution_id`, `--code` / `--code-file`, `--json` |
+| `take_screenshot` | `--project_name`, `--task_id`, `--reason` | `--window_id`, `--out`, `--json` |
+| `input` | `--project_name`, `--task_id`, `--reason`, `--window_id`, `--sequence` | `--json` |
+| `fetch_resource` / `prompt` | positional URI, `--project_name` | hidden compatibility `--uri`, `--json` |
+| `open_project` | `--project_path`, `--task_id`, `--reason` | `--backend_name`, `--trust_project` / `--no-trust_project`, `--wait`, `--json` |
+
+Use the exact focused help as the authority when the tool schema evolves. `task_id` and `reason` are
+forwarded unchanged through `open_project`; `execute_feedback` forwards an optional `execution_id`, so a
+CLI session can rate the exact execution it observed.
+
+For a schema-declared file source, `--<name>-file=<path>` reads that parameter from a file and
+`--<name>-file=-` reads stdin. File and stdin input must be non-empty, strict UTF-8, and no larger than
+10 MiB. Human mode announces a stdin read on stderr so a waiting process is understandable; JSON stdout
+remains clean.
+
+## Human and machine output
+
+The default presentation is for people: headings, tables, hints, and terminal color where supported.
+Diagnostics and progress go to stderr. Stdout is reserved for the requested result, and `devrig mcp`
+writes no presentation bytes to stdout before the JSON-RPC stdio server takes over.
+
+Commands that advertise `--json` emit one ANSI-free JSON document. Every schema-generated MCP-tool
+command uses this envelope:
+
+```json
+{
+  "tool": { "name": "devrig", "version": "..." },
+  "command": "list_projects",
+  "isError": false,
+  "data": { "content": [] }
+}
+```
+
+Structured MCP content is unpacked below `data.content[].json`; it is not left as an escaped JSON string.
+Tool failures preserve the envelope and set `isError`. Lifecycle and installation commands keep their
+documented command-specific JSON data models, but still emit exactly one ANSI-free document on stdout.
+
+When `--out=<path>` is supported, the file is written only after parsing and input validation succeed.
+The normal result still reports what was written. Unsupported flags must fail before either backend calls
+or output-file side effects.
+
+## `open_project --wait`
+
+`--wait` is a routing wait, not a claim that the IDE is fully configured. It polls until the requested
+canonical path appears through the `list_projects` route, for at most 300 seconds. A successful result
+contains:
+
+- `project_name`: the fresh opaque routing key for subsequent project-scoped calls;
+- `backend_name`: the backend that owns the route;
+- `path`: the canonical project path.
+
+This contract deliberately does not require `list_windows`. A frontendless Remote Development backend can
+have no client window, while the project route and all semantic APIs are usable. When an attended frontend
+exists, `list_windows` is still useful for modal dialogs and visible indexing/background-task state.
+
+Maven/Gradle configuration is a separate readiness gate. After the route appears, trigger or await the
+external-system import before relying on indexed semantic results. The complete sequence is:
+
+1. establish backend/MCP reachability;
+2. wait for the requested path and retain its `project_name`;
+3. await Maven/Gradle configuration and required indexing;
+4. execute the semantic action.
+
+## Validation matrix
+
+The contract is protected at four levels:
+
+1. `:npx-kt:test` covers schema binding, aliases, help and missing-value recovery, enum/range validation,
+   file/stdin limits, JSON envelopes, ANSI separation, side-effect ordering, and tool-argument forwarding.
+2. `:npx-kt:integrationTest` covers packaged process behavior and stdout/stderr boundaries.
+3. `CliDevrigToolsIntegrationTest` in `:test-integration` exercises `list_windows --json`,
+   `open_project --wait`, `list_projects --json`, and screenshot `--out` against a real Docker IDE.
+4. `DevrigCliCommandNormalizationTest` and `DevrigCliAgentUsabilityExperimentTest` in
+   `:test-experiments` cover shell/agent command normalization plus live Claude and Codex task-first,
+   help-first, outcome-only, and backend-lifecycle discovery. The separate frontendless Remote Development
+   experiment proves that project routing does not depend on a window.
+
+The live agent experiments validated both discovery directions: agents can start from an outcome and find
+the right command, or start from root/focused help and reach a successful action. They recovered from
+missing values, used the canonical aliases and positional prompt URI, called generated tool commands and
+lifecycle commands, and recovered from an empty `execute_code` response by adding an explicit `println`.
+Those sessions deliberately had no MCP registration; assertions over raw native-shell events prove the
+packaged CLI performed each IDE action rather than taking a direct MCP-tool shortcut.
+
+## Known follow-ups
+
+- `list_windows` human mode pretty-prints the structured payload but still lacks a purpose-built,
+  colorful windows/tasks renderer.
+
+Record new CLI-contract gaps in `TODO.md` and add the smallest realistic regression at the corresponding
+level above. Do not create a second parser or hand-maintained copy of a tool schema.

--- a/docs/devrig-deployment-spec.md
+++ b/docs/devrig-deployment-spec.md
@@ -1,6 +1,15 @@
 # devrig deployment & update spec (v7 — Properties manifest, native-binary appendix)
 
-Author: Eugene Petrenko · Status: design ready for implementation
+Author: Eugene Petrenko · Status: historical v7 design record; parts are superseded
+
+> **Current-contract note (2026-08):** this document preserves the v7 design history and remains useful
+> for install-layout and wrapper rationale, but it is not the authority for today's commands. The
+> bootstrap installers only install devrig and register its launcher on `PATH`; they never register
+> agents or install the IDE plugin. Bare `devrig install` is a non-interactive target inventory, while
+> agent registration is explicit through `devrig install <agent>` (`claude`, `codex`, or `gemini`). There is no `--yes`
+> wizard mode or `devrig upgrade` command. See [`install-scripts-contract.md`](install-scripts-contract.md),
+> [`devrig-cli-contract.md`](devrig-cli-contract.md), and
+> [`updates-check/devrig-auto-update.md`](updates-check/devrig-auto-update.md) for the current contracts.
 
 > **Implementation note (2026-06, PR #117):** the Windows user launcher is
 > **CMD-only** (`~/.mcp-steroid/bin/devrig.cmd`); PowerShell is used only by the
@@ -17,17 +26,16 @@ Author: Eugene Petrenko · Status: design ready for implementation
 > verbatim unpack (no strip), Properties-format manifest, native-binary
 > alternative analyzed.
 
-## What the user gets
+## What the user gets now
 
 ```sh
-curl -fsSL https://devrig.dev/install.sh | sh -s install
+curl -fsSL https://devrig.dev/install.sh | sh
 ```
 
-A self-updating launcher at `~/.mcp-steroid/bin/devrig` (or `devrig.cmd`
-on Windows) registered with whichever of Claude / Codex / Gemini are on
-PATH. The mcp-steroid Java binary + a matching Amazon Corretto JDK are
-cached under `~/.mcp-steroid/binaries/`. After install, **zero network
-calls** unless `devrig upgrade` is run or a cache directory is missing.
+A stable launcher at `~/.mcp-steroid/bin/devrig` (or `devrig.cmd` on Windows), plus the devrig Java
+distribution and bundled runtime cached under `~/.mcp-steroid/binaries/`. Installation does not change
+agent configuration. Users register an agent explicitly with `devrig install <agent>`; long-lived
+`devrig mcp` sessions apply promoted updates through the official install scripts.
 
 > **Implementation note (PR #117/#124, revised for #398):** the install script
 > no longer writes `bin/devrig` itself (the "bootstrap mode → write the script's
@@ -300,11 +308,12 @@ Same script doubles as installer. When invoked NOT from
 6. exec  ~/.mcp-steroid/binaries/devrig-<os>-<cpu>-<sha>/<binSubpath>  install ${@:2}
 ```
 
-The exec'd inner devrig runs the agent wizard (next section).
+The v7 proposal had the inner devrig run the wizard described below. That wizard was not implemented;
+the current installer delegates only to non-interactive `devrig install devrig`.
 
-## Agent registration wizard (inner Java)
+## Historical v7 agent-registration wizard (superseded)
 
-`devrig install` (no args) — interactive:
+The v7 proposal made `devrig install` interactive:
 
 ```
 For each agent in [claude, codex, gemini]:
@@ -321,8 +330,9 @@ For each agent in [claude, codex, gemini]:
      stderr "  ✓ claude — registered (user scope)"
 ```
 
-`devrig install <agent>` — direct non-interactive (current behavior).
-`devrig install --yes` — wizard with no prompts; registers every available agent.
+Current behavior is different: `devrig install` lists install targets without prompting (and supports
+`--json`), while `devrig install <agent>` performs one explicit non-interactive registration. The proposed
+`devrig install --yes` mode does not exist.
 
 ## Agent config shape
 
@@ -342,7 +352,10 @@ Windows:
 
 **No JAVA_HOME** — wrapper sets it from `version.properties` on each launch.
 
-## `devrig upgrade` (inner Java)
+## Historical v7 `devrig upgrade` proposal (superseded)
+
+This command was not implemented; the current updater uses the install-script flow linked in the
+current-contract note above. The algorithm below is retained only as design history.
 
 ```
 1. GET https://devrig.dev/version.properties
@@ -409,11 +422,12 @@ Dev mode pre-populates the cache so the wrapper does no network at all:
      - real Corretto URL for JDK (or local file:// if pre-downloaded)
 7. Write wrapper scripts to ~/.mcp-steroid/bin/
 8. NO version.properties.signatures.  NO allowed_signers.
-9. Stderr hint: run `~/.mcp-steroid/bin/devrig install` for the agent wizard.
+9. Stderr hint: show the copyable explicit `devrig install <agent>` next steps; never run a wizard.
 ```
 
-`devrig upgrade` detects missing `allowed_signers` → exits with
-"upgrade not available in dev mode."
+The proposed `devrig upgrade` command does not exist. Current release builds update through the
+install-script flow documented in `updates-check/devrig-auto-update.md`; dev/SNAPSHOT builds skip that
+automatic updater.
 
 Auto-GC (above) sweeps old dev shas, keeping the most-recent previous one.
 
@@ -434,7 +448,7 @@ multi-process race scenarios + cross-OS smoke). Switch parser tests from
 JSON to Properties. Add auto-GC tests to inner-Java suite (in addition to
 the now-removed prune suite).
 
-## Phasing
+## Historical v7 phasing
 
 | Phase | Scope | LOC |
 |---|---|---|

--- a/docs/devrig-naming.md
+++ b/docs/devrig-naming.md
@@ -4,6 +4,10 @@ This is the canonical spec for how the **devrig** binary names projects
 and IDEs in every output it produces (CLI text, CLI JSON, devrig stdio
 MCP).
 
+The command grammar, aliases, focused-help behavior, JSON envelope, and direct-tool readiness contract
+live in [`devrig-cli-contract.md`](devrig-cli-contract.md). This document owns only the identifiers and
+routing data carried by those surfaces.
+
 ## Scope
 
 devrig is an **independent binary**. Its output is consumed by:
@@ -1048,4 +1052,5 @@ The invariants above are pinned by:
 
 - `docs/PHILOSOPHY.md` — the design tenets that gate every change in
   this repo.
+- `docs/devrig-cli-contract.md` — the command/help/output contract that carries these names.
 - `docs/ARCHITECTURE.md` — the broader request-flow picture.

--- a/docs/devrig-remote-development-backend-e2e.md
+++ b/docs/devrig-remote-development-backend-e2e.md
@@ -159,6 +159,18 @@ Managed backend startup remains project-agnostic:
 
 This keeps the existing agent-facing contract and avoids duplicate project-open requests.
 
+### Direct CLI wait contract
+
+The normalized direct-tool CLI from PR #450 exposes the same route as
+`devrig open_project --project_path="PROJECT_PATH" --task_id="TASK_ID" --reason="REASON" --wait --json`.
+`--wait` succeeds when the canonical requested path appears through `list_projects`; its result carries
+the fresh `project_name`, `backend_name`, and canonical `path`. `task_id` and `reason` survive forwarding.
+
+That result proves routing only. It does not promise a frontend window, completed indexing, or configured
+Maven/Gradle models. A frontendless Remote Development backend normally has no window, so `list_windows`
+remains optional; external-system configuration remains the next explicit readiness gate. See
+[`devrig-cli-contract.md`](devrig-cli-contract.md) for the full CLI/output contract.
+
 ### Docker fixture
 
 The scenario uses Keycloak 26.6.4 at commit `dc1bfc54bf1462f7e79822adb4c59aba7e25d50f`

--- a/docs/guides/AGENT-STEROID-GUIDE.md
+++ b/docs/guides/AGENT-STEROID-GUIDE.md
@@ -26,7 +26,8 @@ The IDE has indexed everything. It knows the code better than any file search. *
 > stick to its naming.
 
 ### `steroid_list_projects`
-List all open projects in the IDE. Use this to get project names for `steroid_execute_code`.
+List all open projects in the IDE. Use the opaque `project_name` routing key for
+`steroid_execute_code`; the separate `name` field is human-readable information only.
 
 There is **no top-level `ide`/`plugin`/`pid` header** in the response.
 Every `projects[]` entry carries a `backend_name` that identifies which
@@ -49,7 +50,7 @@ entry names its owning backend via `backend_name`.
 | `windowId` | Unique window identifier for screenshot/input targeting |
 | `modalDialogShowing` | **True if any modal dialog is showing in IDE** |
 | `indexingInProgress` | **True if project is indexing (dumb mode)** |
-| `projectInitialized` | **True if project is fully initialized** |
+| `projectInitialized` | **True if the IDE project is initialized; does not prove Maven/Gradle model readiness** |
 | `isActive` | Whether window is currently focused |
 | `isVisible` | Whether window is visible |
 | `backend_name` | The backend (IDE) this window belongs to |
@@ -64,7 +65,9 @@ entry names its owning backend via `backend_name`.
 | `project_name` | Routing key of the associated project |
 | `backend_name` | The backend (IDE) this task runs in |
 
-Use the modality/indexing fields and `backgroundTasks` to poll for project readiness after `steroid_open_project`.
+For an attended frontend, use the modality/indexing fields and `backgroundTasks` as UI-readiness signals
+after `steroid_open_project`. Establish routing through `steroid_list_projects`; Maven/Gradle model
+configuration remains a separate readiness gate.
 
 ### `steroid_take_screenshot`
 Capture a screenshot of the IDE frame and return image content.
@@ -134,7 +137,9 @@ The sub-agent pattern prevents context rot from failed code attempts and allows 
 Provide feedback on execution results. Use after `steroid_execute_code` to rate success.
 
 ### `steroid_open_project`
-Open a project in the IDE. This tool initiates the project opening process and returns quickly.
+Open a project in the IDE. The project-open request is asynchronous. If devrig must start a managed
+backend first, the call can block until that backend's MCP endpoint becomes reachable before forwarding
+the request.
 
 **IMPORTANT**: Project opening is **ASYNCHRONOUS**. A project route, an attended frontend window, and
 Maven/Gradle configuration are separate readiness signals. A Remote Development backend can be fully useful
@@ -691,7 +696,7 @@ println("Created src/Example.cs")
 
 ### Further Reading
 
-- [C# Examples for Rider](../rider-integration/CSHARP-EXAMPLES.md)
+- [Working with Rider and C# projects](#working-with-rider-and-c-projects)
 - [Rider Plugin Development](https://plugins.jetbrains.com/docs/intellij/rider.html)
 
 ## Error Handling

--- a/docs/headless-agent-guidance.md
+++ b/docs/headless-agent-guidance.md
@@ -162,6 +162,22 @@ or diagnostics show it is absent, after inspecting module SDKs instead of blindl
 The executable repair recipe canonicalizes and validates an explicit home through IntelliJ APIs, refuses
 ambiguous candidates, and performs every project/module SDK model read under a read action.
 
+## Normalized CLI usability findings
+
+PR #442 introduced direct schema-generated MCP-tool commands; PR #450 completed their normalization and
+tested the command surface independently with Claude and Codex. Both agents completed task-first and
+help-first routes: they discovered commands from an outcome, followed root help into focused help,
+recovered from missing required values, used
+`list_projects` and its aliases correctly, called the positional `devrig prompt <uri>` route, and drove
+safe backend lifecycle actions. Outcome-only runs also recovered from a Kotlin script that printed nothing
+by adding explicit `println`, matching the `steroid_execute_code` output contract.
+
+These experiments reinforce the frontendless lesson rather than changing it. The CLI can make a project
+routable and return `project_name`, `backend_name`, and canonical `path`; it cannot collapse external-system
+configuration into that routing result. Human color and structured agent output are separate presentation
+modes, with `--json` kept ANSI-free. Exact commands and regression buckets live in
+[`devrig-cli-contract.md`](devrig-cli-contract.md).
+
 ## Durable operational lessons
 
 - Treat readiness as three separate gates: MCP/backend reachability, the requested path appearing in

--- a/docs/install-scripts-contract.md
+++ b/docs/install-scripts-contract.md
@@ -34,9 +34,15 @@ If 'devrig' is not found, add ~/.mcp-steroid/bin to PATH.
 
 Next steps:
   devrig install plugin                 install the MCP Steroid plugin into your running JetBrains IDEs
-  devrig install claude|codex|gemini    connect devrig to your AI agent
+  devrig install claude                 connect devrig to Claude Code
+  devrig install codex                  connect devrig to Codex
+  devrig install gemini                 connect devrig to Gemini
   devrig install config                 print the mcp.json snippet for any other MCP client
 ```
+
+Each displayed command must be directly copyable. Do not compress mutually exclusive choices with `|` in
+a shell-looking line: POSIX shells interpret it as a pipeline. The production-output alignment is tracked
+in `TODO.md`.
 
 The scripts print no next-steps block of their own — devrig's message is the single source, so the
 guidance can never drift between the script and the binary.

--- a/docs/integration-tests-catalog.md
+++ b/docs/integration-tests-catalog.md
@@ -19,6 +19,11 @@
 | MavenRunnerAdoptionTest | Agent uses exec_code for tests (not Bash) | Created, untested |
 | ResourceReadingTest | Agent reads mcp-steroid:// resources | Created, untested |
 
+### devrig direct CLI validation
+| Test | What it validates | Status |
+|------|------------------|--------|
+| CliDevrigToolsIntegrationTest | Packaged direct CLI: full `list_windows --json` envelope, `open_project --wait` route verified through `list_projects`, and real screenshot `--out` PNG | PASS (3/3) |
+
 ### Known Issues
 - **dialog_killer too aggressive**: Kills Maven runner's `JobProviderWithOwnerContext` progress dialog, cancelling the Maven execution. Needs whitelist for build runner progress tasks.
 - **"Resolving SDKs" false positive**: `UnknownSdkTracker` fires during build, causing `Build errors: true` when compilation actually succeeded. Partially fixed by `mcpResolveUnknownSdks()` step.
@@ -37,7 +42,16 @@
 |------|------------------|--------|
 | FetchResourceToolTest | steroid_fetch_resource returns resource content | Created |
 
-## test-experiments (DPAIA arena)
+## test-experiments
+
+### devrig CLI and frontendless agent validation
+| Test | What it validates | Status |
+|------|------------------|--------|
+| DevrigCliCommandNormalizationTest | 16 safe raw/Codex transport normalization and rejection cases | PASS |
+| DevrigCliAgentUsabilityExperimentTest | Claude + Codex task-first, help-to-missing-values-to-action, outcome-only, and lifecycle-help routes without MCP registration | PASS |
+| DevrigRemoteDevelopmentKeycloakTypeHierarchyTest | Frontendless backend discovery, project routing, Maven readiness, and semantic hierarchy result | PASS |
+
+### DPAIA arena
 
 17 scenarios × 3 agents (claude, codex, gemini) × 2 modes (mcp, none).
 See `docs/arena-3pass-results.md` for full comparison table.

--- a/docs/startable-backends-design.md
+++ b/docs/startable-backends-design.md
@@ -162,9 +162,12 @@ sources — no `BackendRow`:
 4. **footer** — how to download/install more (`devrig backend download …`); group 4 is advertised
    here, never enumerated.
 
-`backend --json` / `project --json` reshape from one `backends[]` (of `BackendInfo`) to the three
-explicit groups. **No back-compat shape needed** (no external consumers; output just has to be
-valid JSON).
+`backend --json` reshapes the old single `backends[]` inventory (of `BackendInfo`) into the three
+explicit lifecycle groups. **No back-compat shape was needed** for that backend inventory.
+
+**Superseded CLI route (#450):** `project` and `projects` now alias the schema-generated
+`list_projects` leaf; they do not share the backend-inventory shape. Their JSON uses the generated
+`{tool, command, isError, data}` envelope and reports canonical `command: "list_projects"`.
 
 Each backend entry in `--json` output carries a `"compatible": <bool>` field:
 - `mcpSteroidBackends` entries: always `"compatible": true` (only S1 markers with `ideHome` reach here).

--- a/mcp-steroid-server/src/test/kotlin/com/jonnyzzz/mcpSteroid/server/ToolSpecCliMetadataTest.kt
+++ b/mcp-steroid-server/src/test/kotlin/com/jonnyzzz/mcpSteroid/server/ToolSpecCliMetadataTest.kt
@@ -83,12 +83,12 @@ class ToolSpecCliMetadataTest {
 
     @Test
     fun `fetch_resource exposes the prompt alias and maps uri to a bare positional`() {
-        // bindPositional (SchemaCliBinding.kt) registers a Clikt argument, never an option, for a
-        // cliPositional parameter, so `--uri` is not part of the actual grammar here even though the
-        // spec still carries its default cliFlag value — that field is simply unused once positional.
+        // bindPositional (SchemaCliBinding.kt) makes the bare URI canonical and visible in help.
+        // The generated command separately retains hidden `--uri` compatibility for existing scripts;
+        // this metadata test pins only the advertised positional form.
         assertTrue(fetchResource.cli.aliases.contains("prompt"), "fetch_resource should alias 'prompt'")
         val uri = fetchResource.schema.asCliParams().single { it.name == "uri" }
-        assertTrue(uri.cliPositional, "fetch_resource uri must be a bare positional, not a --uri flag")
+        assertTrue(uri.cliPositional, "fetch_resource must advertise its uri as a bare positional")
     }
 
     @Test

--- a/npx/README.md
+++ b/npx/README.md
@@ -13,8 +13,10 @@ npx devrig --help
 
 devrig is a stateless stdio MCP server + CLI that discovers running
 IntelliJ instances on the host and routes MCP tool calls to them.
-The project / backend naming contract, the on-demand routing model,
-and the JSON output schemas are specified in
-[`docs/devrig-naming.md`](../docs/devrig-naming.md) (with the
-rationale for on-demand vs background scanning in
-[`docs/devrig-scanning-research.md`](../docs/devrig-scanning-research.md)).
+The command grammar, aliases, schema-generated direct-tool help, recovery behavior,
+and human/JSON output contracts are specified in
+[`docs/devrig-cli-contract.md`](../docs/devrig-cli-contract.md). Project/backend
+identifiers and routing are specified separately in
+[`docs/devrig-naming.md`](../docs/devrig-naming.md), with the rationale for
+on-demand rather than background scanning in
+[`docs/devrig-scanning-research.md`](../docs/devrig-scanning-research.md).

--- a/prompts/src/main/prompts/open-project/managing-backends.md
+++ b/prompts/src/main/prompts/open-project/managing-backends.md
@@ -154,14 +154,21 @@ Download `<id>` values appear in `devrig backend download --json`.
 
 ## After opening — polling for readiness
 
-`steroid_open_project` has two distinct readiness phases:
+`steroid_open_project` participates in three distinct readiness gates:
 
 1. **Backend reachability.** For a startable backend, the call blocks until
    devrig observes its MCP marker. A frontendless Remote Development backend
    does not need a window or screenshot.
-2. **Project/model readiness.** The IDE accepts the open request
+2. **Project routing.** The IDE accepts the open request
    asynchronously. Poll `steroid_list_projects` until the target path appears
    and keep the returned opaque `project_name`.
+3. **External-system configuration.** Route availability does not prove Maven
+   or Gradle import. Before an indexed semantic query, fetch the matching
+   `mcp-steroid://skill/execute-code-maven` or
+   `mcp-steroid://skill/execute-code-gradle` recipe, trigger and await sync exactly
+   as it shows (the Maven recipe uses `Observation.awaitConfiguration(project)`),
+   and run index-dependent work in `smartReadAction`. Treat an unexpectedly tiny first result as incomplete
+   project configuration, not as an exhaustive semantic answer.
 
 If a frontend window exists, `steroid_list_windows` is an additional signal:
 
@@ -173,14 +180,8 @@ If a frontend window exists, `steroid_list_windows` is an additional signal:
 2. If `modalDialogShowing` is `true`, call `steroid_take_screenshot`
    to see the dialog and `steroid_input` to interact.
 
-These four flags describe IDE/window state, **not Maven or Gradle model
-import**. On a first open, they can become ready before external-system
-configuration begins. Before an indexed semantic query, fetch the matching
-`mcp-steroid://skill/execute-code-maven` or
-`mcp-steroid://skill/execute-code-gradle` recipe, trigger and await sync exactly
-as it shows (the Maven recipe uses `Observation.awaitConfiguration(project)`),
-and run index-dependent work in `smartReadAction`. Treat an unexpectedly tiny first result as incomplete
-project configuration, not as an exhaustive semantic answer.
+These four flags describe optional IDE/window state, **not Maven or Gradle model import**. On a first
+open, they can become ready before external-system configuration begins and cannot replace gate 3.
 
 When several IDEs are running, each `windows[]` / `backgroundTasks[]`
 entry carries a `backend_name` — use it to track the right IDE.

--- a/prompts/src/main/prompts/open-project/managing-backends.md
+++ b/prompts/src/main/prompts/open-project/managing-backends.md
@@ -14,13 +14,13 @@ If no IDE is installed or reachable, use the devrig binary on your PATH:
 
 ```
 devrig backend download --json
-devrig backend download <product-id> --version <version>
+devrig backend download idea-ultimate --version 2026.2.0.1
 ```
 
 The first command lists downloadable product ids with each product's latest stable
-version, build, and license tier; pass `--version <version>` to pin another released
+version, build, and license tier; pass a listed product id and `--version <version>` to pin another released
 version. For unattended Java/JVM work on the supported 2026.2 line, choose
-`devrig backend download idea-ultimate --version <version>`. IDEA Ultimate
+`devrig backend download idea-ultimate --version 2026.2.0.1`. IDEA Ultimate
 262 is launched as a **frontendless Remote Development backend** with MCP
 Steroid included. Plain non-backend headless mode is unsupported; Remote Development product mode takes
 precedence over the raw AWT-headless flag, so that flag alone is not a support detector.

--- a/prompts/src/main/prompts/open-project/open-trusted.md
+++ b/prompts/src/main/prompts/open-project/open-trusted.md
@@ -29,22 +29,24 @@ println(openProjectJson)
 
 The tool will:
 1. Mark the project path as trusted (skips trust dialog)
-2. Initiate project opening in the background
-3. Return immediately with next steps
+2. If needed, start a managed backend and wait until its MCP endpoint is reachable
+3. Initiate project opening in the background and return next steps; a cold managed-backend start can
+   therefore make the call block even though project opening itself remains asynchronous
 
-### Step 2: Wait for Project to Load
+### Step 2: Wait for the Project Route
 
-Poll `steroid_list_projects` until the target path appears. Backend startup, first open, and indexing can
-take minutes; a fixed sleep is not a readiness check. The time depends on:
+Poll `steroid_list_projects` until the target path appears. Backend startup and first project creation can
+take minutes; a fixed sleep is not a readiness check. Route appearance is not proof that indexing or the
+Maven/Gradle model is ready. The time depends on:
 - Project size
-- Number of files to index
+- Backend cold-start work
 - Installed plugins
 
 Keep the fresh opaque `project_name` returned for that path. If a frontend exists, `steroid_list_windows`
 can additionally report IDE indexing and modal state. A frontendless Remote Development backend needs no
 window or screenshot.
 
-### Step 3: Verify Project is Open
+### Step 3: Verify the Project Route
 
 Call `steroid_list_projects` to verify:
 

--- a/release/notes/0.102.md
+++ b/release/notes/0.102.md
@@ -1,11 +1,30 @@
 ## 0.102
 
-0.102 is a contract-cleanup release for the MCP surface, driven by real automation built on top of
-it: tool results are machine-parseable again, the host IDE's identity is back in the list tools,
-field naming is consistent, and version numbers finally compare the way the IDE expects.
+0.102 is a contract-cleanup release for the MCP and devrig CLI surfaces, driven by real automation built
+on top of them: direct commands are discoverable, tool results are machine-parseable again, the host IDE's
+identity is back in the list tools, field naming is consistent, and version numbers finally compare the
+way the IDE expects.
 
 > **Independent project.** MCP Steroid / Devrig is an independent open-source project. It is
 > **not affiliated with, sponsored by, or endorsed by JetBrains.**
+
+### devrig has one discoverable CLI
+
+Direct MCP-tool commands now come from the same schemas devrig serves over stdio, through one Clikt
+command tree ([#284](https://github.com/jonnyzzz/mcp-steroid/issues/284)). `list_projects` is canonical;
+`projects` and the older `project` spelling are aliases. Root help discovers commands; focused help and
+incomplete-command errors name all missing values, enum choices, and file-input alternatives, while
+`devrig help <command>` provides the same route for agents that start from discovery.
+
+Human output remains readable and can use terminal color. `--json` emits one ANSI-free document, and
+generated tools share `{tool, command, isError, data}`. `devrig prompt <uri>` is the canonical resource
+shortcut (the older `--uri` input remains compatible), and direct `execute_code` supports strict UTF-8
+file/stdin input up to 10 MiB. `open_project --wait` returns the fresh `project_name`, `backend_name`, and
+canonical path when the route appears; Maven/Gradle configuration remains a separate readiness step.
+
+The generated commands and finite safe lifecycle routes were exercised through unit/process tests, a
+stable real-IDE Docker flow, and live Claude/Codex task-first, help-first, outcome-only, and lifecycle
+experiments.
 
 ### `steroid_execute_code` output is machine-parseable again
 
@@ -38,7 +57,7 @@ IDE it was talking to without a heavyweight `execute_code` call. Both list tools
 by `project_name`, and a direct in-IDE server always includes its own entry — so a fresh IDE with
 zero open projects is still identifiable with one cheap tool call. **Migration:** parsers that read
 the old top-level `ide.*` should switch to `backends[0].intellij` (a direct per-IDE server always
-has exactly one element). The `devrig project` / `devrig backend` CLI output (text and `--json`)
+has exactly one element). The `devrig list_projects` / `devrig backend` CLI output (text and `--json`)
 now lists the same identity keys in the same order as the MCP responses.
 
 ### `steroid_list_windows` uses `project_name` / `project_path`

--- a/test-experiments/CLAUDE.md
+++ b/test-experiments/CLAUDE.md
@@ -44,6 +44,31 @@ the 1-minute rule and stuck-test debugging.
 invocation still works. Depends on `:test-integration` for the shared infrastructure (`IdeContainer`,
 `ConsoleDriver`, `XcvbDriver`, `AiAgentDriver`, `ConsolePumpingContainerDriver`).
 
+## devrig CLI normalization experiments
+
+`DevrigCliCommandNormalizationTest` pins how raw Claude/Codex shell calls are recognized: global/trailing
+`--json`, positional prompt URIs, inline code quoting, and supported Codex bash transports are accepted;
+control syntax, expansion, appended commands, and unrelated wrappers are rejected. It is the narrow
+normalization bucket and does not need a live agent.
+
+`DevrigCliAgentUsabilityExperimentTest` launches real Claude and Codex sessions for four routes per agent:
+task-first discovery, help → missing values → action, outcome-only discovery, and lifecycle help → every
+safe action. Keep all eight cases explicit. The experiment must verify the raw shell/tool events, aliases,
+focused help, generated-tool calls, positional `prompt`, and no-output recovery; prose summaries alone are
+not evidence. The agent sessions intentionally receive no MCP registration, so every IDE action proves the
+packaged CLI route rather than a direct MCP-tool shortcut. The long-lived `devrig mcp` action remains in
+protocol integration tests; the usability experiment exercises only its help.
+
+Run one method at a time, never alongside another Docker integration/experiment test:
+
+```bash
+./gradlew :test-experiments:test \
+  --tests '*DevrigCliAgentUsabilityExperimentTest.codex follows help through missing values to an action*' \
+  --rerun-tasks
+```
+
+The canonical expected behavior is [`docs/devrig-cli-contract.md`](../docs/devrig-cli-contract.md).
+
 ## Frontendless Remote Development Keycloak agent E2E
 
 `DevrigRemoteDevelopmentKeycloakTypeHierarchyTest` is the task-only clean-machine proof for Claude and

--- a/test-integration/AGENTS.md
+++ b/test-integration/AGENTS.md
@@ -29,6 +29,17 @@ Read [`docs/PHILOSOPHY.md`](../docs/PHILOSOPHY.md) before proposing
 changes that would expand the tool surface or the script-context
 surface.
 
+## Stable devrig direct-tool CLI smoke
+
+`CliDevrigToolsIntegrationTest` is the stable Docker proof for the schema-generated CLI against a real
+IDE. It covers the full `list_windows --json` envelope, opens an initially unopened path through
+`open_project --wait`, verifies that path through `list_projects --json`, and writes a real PNG through
+`take_screenshot --out`. The open assertion locates the project by canonical path, never by array order.
+
+Keep this class deterministic and product-facing. Parser/help normalization and live Claude/Codex
+discovery belong in `:test-experiments`; frontendless Remote Development has its own experiment there.
+The durable command and readiness contract is [`docs/devrig-cli-contract.md`](../docs/devrig-cli-contract.md).
+
 ## Researching IntelliJ APIs — Use MCP Steroid + Debugger
 
 **The IntelliJ project is open in the IDE (`~/Work/intellij`).** Use `steroid_execute_code`

--- a/website/content/docs/devrig.md
+++ b/website/content/docs/devrig.md
@@ -24,7 +24,8 @@ It does three jobs:
    IntelliJ-based IDEs running on your machine — across projects — and routes the
    agent's MCP Steroid calls to any of them through a single connection. One
    bridge, every IDE.
-3. **Provisions an IDE.** `devrig backend download|start|stop` downloads and runs
+3. **Provisions an IDE.** `devrig backend download`, `devrig backend start`, and
+   `devrig backend stop` download and run
    a managed IntelliJ backend under devrig's home directory, so an agent can spin
    up an IDE with no manual setup.
 
@@ -67,6 +68,11 @@ help such as `devrig install --help` and `devrig backend download --help`.
 The equivalent discoverable route is `devrig help <command>`, including nested
 paths such as `devrig help backend download`.
 
+If required values are missing, devrig prints that focused help and identifies all missing values in one
+pass, including allowed enum values and alternatives such as `--code` / `--code-file`. Human output may
+use terminal color. Commands that advertise `--json` emit one ANSI-free JSON document for agents and
+scripts.
+
 ```text
 devrig
 ├── mcp
@@ -84,7 +90,9 @@ devrig
 │   ├── stop [<id>] [--version <v>] [--json]
 │   └── provision [<id>] [--json]
 ├── install [--json]
-│   ├── claude|codex|gemini [--check]
+│   ├── claude [--check]
+│   ├── codex [--check]
+│   ├── gemini [--check]
 │   ├── config [--json]
 │   ├── devrig
 │   └── plugin [--check]
@@ -136,19 +144,20 @@ a second command definition.
 | `devrig list_projects` | Lists open projects and the routing keys accepted by `--project_name`. |
 | `devrig list_windows` | Lists IDE windows, readiness, and background tasks. |
 | `devrig execute_code` | Runs Kotlin in an IDE. Requires `--project_name`, `--task_id`, `--reason`, and either `--code` or `--code-file`; accepts `--modal`, `--timeout`, and `--out`. Quote inline Kotlin for the shell, for example `--code='println("hello")'`, or prefer `--code-file`; use `--code-file=-` for stdin. |
-| `devrig execute_feedback` | Rates an execution. Requires `--project_name`, `--task_id`, `--success_rating`, and `--explanation`; code can also come from `--code-file`. |
+| `devrig execute_feedback` | Rates an execution. Requires `--project_name`, `--task_id`, `--success_rating`, and `--explanation`; accepts the exact optional `--execution_id`, and code can also come from `--code-file`. |
 | `devrig take_screenshot` | Captures an IDE image. Requires `--project_name`, `--task_id`, and `--reason`; accepts `--window_id` and `--out`. |
 | `devrig input` | Sends keyboard and mouse steps to a window. Requires `--project_name`, `--task_id`, `--reason`, `--window_id`, and `--sequence`. |
 | `devrig fetch_resource` | Fetches an `mcp-steroid://` guide given as a positional URI plus `--project_name`. `devrig prompt` is an alias; the former `--uri` spelling remains accepted for existing scripts. |
-| `devrig open_project` | Opens `--project_path`. When one backend already owns that path, devrig reuses it automatically; use `--backend_name` to choose among candidates for a new or multiply-open path. `--trust_project` is on by default and `--no-trust_project` disables it. `--wait` polls for up to 300 seconds and returns the opened project's opaque `project_name`, `backend_name`, and canonical path. |
+| `devrig open_project` | Opens `--project_path`. When one backend already owns that path, devrig reuses it automatically; use `--backend_name` to choose among candidates for a new or multiply-open path. `--trust_project` is on by default and `--no-trust_project` disables it. `--wait` polls for up to 300 seconds and returns the opened project's opaque `project_name`, `backend_name`, and canonical path. This proves routing, not window or Maven/Gradle readiness. |
 
 Use command-scoped help for the authoritative grammar, for example:
 
 ```console
 $ devrig execute_code --help
 $ devrig list_projects --json
-$ devrig execute_code --project_name <routing-key> --code='println("hello")' --task_id demo --reason 'verify IDE access' --json
-$ devrig prompt mcp-steroid://prompt/skill --project_name <routing-key> --json
+$ devrig open_project --project_path="$PWD" --task_id=demo-open --reason="open current project from CLI" --wait --json
+$ devrig execute_code --project_name="PROJECT_NAME_FROM_LIST_PROJECTS" --code='println("hello")' --task_id demo --reason 'verify IDE access' --json
+$ devrig prompt mcp-steroid://prompt/skill --project_name="PROJECT_NAME_FROM_LIST_PROJECTS" --json
 ```
 
 Generated tool commands do not repair the launcher or write to `PATH`; they
@@ -160,7 +169,7 @@ while stdout remains human output or one clean JSON envelope.
 With no target, lists every install target and detects which agent CLIs are on
 `PATH`. `--json` emits the same inventory as a `targets` array.
 
-### `devrig install claude|codex|gemini [--check]`
+### `devrig install <agent> [--check]`
 
 Registers this devrig binary as the `mcp-steroid` stdio MCP server in the
 selected agent. `--check` is read-only: it reports registration drift and IDE
@@ -239,7 +248,8 @@ Options:
   `list_projects` (also `projects` and legacy `project`), `install`, `install config`, `version`, backend lifecycle commands,
   and every schema-generated MCP tool command.
 - `--help`, `-h` prints command-scoped help and exits.
-- `--version`, `-v` prints the devrig version and exits.
+- Root `devrig --version` / `devrig -v` prints the devrig version and exits. Backend lifecycle
+  `--version <v>` options select an IDE version instead.
 
 Environment variables:
 

--- a/website/content/docs/devrig.md
+++ b/website/content/docs/devrig.md
@@ -142,7 +142,7 @@ a second command definition.
 | Command | Purpose and important inputs |
 |---|---|
 | `devrig list_projects` | Lists open projects and the routing keys accepted by `--project_name`. |
-| `devrig list_windows` | Lists IDE windows, readiness, and background tasks. |
+| `devrig list_windows` | Lists attended IDE windows, modal/indexing/initialization state, and background tasks; it is not a project-routing or Maven/Gradle readiness gate. |
 | `devrig execute_code` | Runs Kotlin in an IDE. Requires `--project_name`, `--task_id`, `--reason`, and either `--code` or `--code-file`; accepts `--modal`, `--timeout`, and `--out`. Quote inline Kotlin for the shell, for example `--code='println("hello")'`, or prefer `--code-file`; use `--code-file=-` for stdin. |
 | `devrig execute_feedback` | Rates an execution. Requires `--project_name`, `--task_id`, `--success_rating`, and `--explanation`; accepts the exact optional `--execution_id`, and code can also come from `--code-file`. |
 | `devrig take_screenshot` | Captures an IDE image. Requires `--project_name`, `--task_id`, and `--reason`; accepts `--window_id` and `--out`. |

--- a/website/content/docs/running-on-ci.md
+++ b/website/content/docs/running-on-ci.md
@@ -87,7 +87,8 @@ Install devrig and provision or connect to an IDE exactly as on a developer mach
   integration tests the IDE runs inside a Docker container on Linux under Xvfb with a window
   manager — see the post linked below.
 - Everything else is unchanged from a local run: `devrig install <agent>` registration, the
-  `devrig mcp` bridge, and `devrig backend download|start|stop` all work identically once a
+  `devrig mcp` bridge, plus `devrig backend download`, `devrig backend start`, and
+  `devrig backend stop` all work identically once a
   backend is reachable.
 
 ## Related

--- a/website/layouts/partials/install-cta.html
+++ b/website/layouts/partials/install-cta.html
@@ -31,7 +31,7 @@
         <code class="install-cmd-text">irm https://devrig.dev/install.ps1 | iex</code>
         <button type="button" class="install-copy" aria-label="Copy the Windows install command">Copy</button>
     </div>
-    <p class="install-cta-sub">Then register your agent: <code>devrig install claude|codex|gemini</code>. <a href="{{ "/docs/devrig/" | relURL }}">Read the devrig guide &rarr;</a></p>
+    <p class="install-cta-sub">Then register your agent: <code>devrig install claude</code> (or replace <code>claude</code> with <code>codex</code> or <code>gemini</code>). <a href="{{ "/docs/devrig/" | relURL }}">Read the devrig guide &rarr;</a></p>
     {{ if .marketplace }}
     <p class="install-cta-sub">In your JetBrains IDE, also install the <strong>MCP&nbsp;Steroid</strong> plugin &rarr; <a href="https://plugins.jetbrains.com/plugin/30019-mcp-steroid" target="_blank" rel="noopener">JetBrains Marketplace</a>.</p>
     {{ end }}


### PR DESCRIPTION
## Summary

- establish `docs/devrig-cli-contract.md` as the canonical command/help/human/JSON contract
- document `list_projects` plus its `projects`/`project` aliases and schema-generated direct MCP-tool commands
- separate backend reachability, project routing, attended-window state, and Maven/Gradle readiness
- record Claude/Codex task-first and help-first experiment coverage
- mark superseded install-wizard, `--yes`, `upgrade`, and old `project --json` descriptions as historical

## Validation

- `./gradlew :prompts:test --tests '*MarkdownArticleContract*' -Pmcp.prompts.ide.filter=clion:eap`
- local-link audit across all 25 changed Markdown files
- repository-wide stale-command/readiness sweep
- two independent documentation audit/review passes