### PR TITLE
Root help stays an index; the MCP-tools reference moves to `devrig tools`

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ The command tree is discoverable from either direction:
 
 ```bash
 devrig --help
+devrig tools
 devrig help execute_code
 devrig list_projects --json
 devrig open_project --project_path="$PWD" --task_id=demo-open --reason="open current project from CLI" --wait --json

--- a/docs/devrig-cli-contract.md
+++ b/docs/devrig-cli-contract.md
@@ -39,6 +39,7 @@ devrig
 │   ├── devrig
 │   └── plugin
 ├── mcp
+├── tools
 ├── version
 └── help <command> [<subcommand> ...]
 ```
@@ -58,12 +59,17 @@ Every command and nested action has both routes:
 devrig <command> --help
 devrig help <command>
 devrig help backend download
+devrig tools
 ```
 
-Root help is an index and a usable first step. Focused help shows the actual schema-derived parameters,
-required choices, defaults, numeric ranges, enum values, aliases, file-input alternatives, and a runnable
-usage shape. When parameters are missing or invalid, devrig prints the relevant focused help and names all
-missing values in one pass. For example, an incomplete `execute_code` call identifies
+Root help is an index and a usable first step: the generated command tree, devrig's own options, the
+environment variables, and a pointer to the deeper routes — nothing else. The complete generated
+"MCP tools as CLI" reference (every tool command's usage line, per-flag synopses, aliases, and the scoped
+framework flags) is printed by `devrig tools`. That reference is written for coding agents; it used to
+ride as the root-help epilog, where it buried the index. Focused help shows the actual schema-derived
+parameters, required choices, defaults, numeric ranges, enum values, aliases, file-input alternatives,
+and a runnable usage shape. When parameters are missing or invalid, devrig prints the relevant focused
+help and names all missing values in one pass. For example, an incomplete `execute_code` call identifies
 `--project_name`, `--task_id`, `--reason`, and the `--code` / `--code-file` choice rather than failing one
 field at a time.
 

--- a/npx-kt/src/integrationTest/kotlin/com/jonnyzzz/mcpSteroid/devrig/cli/CliOptionsIntegrationTest.kt
+++ b/npx-kt/src/integrationTest/kotlin/com/jonnyzzz/mcpSteroid/devrig/cli/CliOptionsIntegrationTest.kt
@@ -287,12 +287,27 @@ class CliOptionsIntegrationTest {
     }
 
     @Test
-    fun `the global banner carries the generated MCP-tools section`() {
+    fun `the global banner points at the tools reference instead of embedding it`() {
         val r = runLauncher("--help")
 
         assertTrue(
+            r.stdout.contains("devrig tools"),
+            "the banner must point agents at `devrig tools`; got:\n${r.stdout}",
+        )
+        assertTrue(
+            !r.stdout.contains("MCP tools as CLI"),
+            "the per-tool reference lives in `devrig tools`, not the banner; got:\n${r.stdout}",
+        )
+    }
+
+    @Test
+    fun `the tools command carries the generated MCP-tools section`() {
+        val r = runLauncher("tools")
+
+        assertEquals(0, r.exitCode, "stdout=\n${r.stdout}\nstderr=\n${r.stderr}")
+        assertTrue(
             r.stdout.contains("MCP tools as CLI"),
-            "the banner must embed the generated section; got:\n${r.stdout}",
+            "`devrig tools` must print the generated section; got:\n${r.stdout}",
         )
         for (tool in listOf("devrig list_projects", "devrig execute_code", "devrig take_screenshot")) {
             assertTrue(r.stdout.contains(tool), "the generated section must advertise `$tool`; got:\n${r.stdout}")
@@ -301,6 +316,7 @@ class CliOptionsIntegrationTest {
             r.stdout.contains("devrig list_projects (aliases: projects, project)"),
             "the generated section must advertise both project aliases; got:\n${r.stdout}",
         )
+        assertTrue(r.stderr.isBlank(), "the reference must keep stderr clean; got:\n${r.stderr}")
     }
 
     @Test

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/Cli.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/Cli.kt
@@ -375,14 +375,15 @@ fun toolAliasMap(tools: List<CliToolSpec>): Map<String, List<String>> {
     return pairs.associate { (alias, name) -> alias to listOf(name) }
 }
 
-private fun rootEpilog(tools: List<CliToolSpec>): String = buildString {
+private fun rootEpilog(): String = buildString {
     appendLine("Human output uses terminal colors automatically. JSON output never contains ANSI styling.")
     appendLine()
     appendLine("Environment variables: DEVRIG_DEBUG enables diagnostics and the launcher debugger;")
     appendLine("DEVRIG_JAVA_HOME selects the devrig runtime; DEVRIG_JVM_OPTS adds JVM options,")
     appendLine("for example -Xmx512m.")
     appendLine()
-    append(renderMcpToolsCliSection(tools).trimEnd())
+    appendLine("Run `devrig tools` for the MCP-tools-as-CLI reference (written for coding agents),")
+    append("or `devrig <command> --help` for one command's full option list.")
 }.trimEnd()
 
 class DevrigRootCommand(
@@ -395,7 +396,7 @@ class DevrigRootCommand(
     selected = selected,
     parent = null,
     invokeWithoutSubcommand = true,
-    epilog = rootEpilog(tools),
+    epilog = rootEpilog(),
 ) {
     private val versionFlag by option("--version", "-v", help = "Print the devrig version and exit.").flag()
 
@@ -422,6 +423,7 @@ class DevrigRootCommand(
             backend,
             install,
             *schemaToolCliCommands(selected, this, tools).toTypedArray(),
+            ToolsCommand(selected, this, tools),
             HelpCommand(selected, this),
             VersionCommand(selected, this),
         )
@@ -587,6 +589,30 @@ private class InstallPluginCommand(
     override fun runCommand() {
         select(DevrigCliMode.INSTALL, supportsJson = false) {
             runInstallPluginCommand(checkFlag)
+        }
+    }
+}
+
+/**
+ * `devrig tools` prints the generated "MCP tools as CLI" reference ([renderMcpToolsCliSection]). The
+ * reference used to ride as the epilog of root `--help`, where its ~90 lines buried the command index it
+ * was appended to; the root banner now stays an index and points here. It is prose for an agent to read,
+ * not a result, so `--json` is refused rather than accepted-and-ignored.
+ */
+private class ToolsCommand(
+    selected: SelectedDevrigInvocation,
+    parent: DevrigCliktCommand,
+    private val tools: List<CliToolSpec>,
+) : DevrigCliktCommand(
+    name = "tools",
+    help = "Print the MCP-tools-as-CLI reference for coding agents.",
+    selected = selected,
+    parent = parent,
+) {
+    override fun runCommand() {
+        select(DevrigCliMode.INFORMATIONAL, supportsJson = false) {
+            mcpStdout.println(renderMcpToolsCliSection(tools).trimEnd())
+            0
         }
     }
 }

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/McpToolsCliHelp.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/McpToolsCliHelp.kt
@@ -23,7 +23,7 @@ const val DEVRIG_OUT_FLAG_HELP: String =
 private const val HELP_WIDTH = 100
 
 /**
- * Renders the "MCP tools as CLI" block of the global `devrig --help` banner from the tools' own
+ * Renders the "MCP tools as CLI" reference that `devrig tools` prints from the tools' own
  * declarations — [CliToolSpec.cli] and the parameters `asCliParams()` exposes — and from nothing else.
  * Adding a tool, a parameter, a file source or a tool-scoped option surfaces here with no edit to this
  * file; conversely, nothing here can describe a flag that the command line does not actually accept.

--- a/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/DevrigCliHelpTest.kt
+++ b/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/DevrigCliHelpTest.kt
@@ -29,10 +29,22 @@ class DevrigCliHelpTest {
         assertTrue(result.stdout.contains("Usage: devrig"), result.stdout)
         assertTrue(result.stdout.contains("Commands:"), result.stdout)
         val visibleTools = devrigCliTools().filterNot { it.cli.hidden }
-        for (command in listOf("backend", "install", "mcp", "help", "version") + visibleTools.map { it.cli.name }) {
+        for (command in listOf("backend", "install", "mcp", "tools", "help", "version") + visibleTools.map { it.cli.name }) {
             assertTrue(result.stdout.contains(command), "missing $command in:\n${result.stdout}")
         }
-        for (tool in visibleTools.filter { it.cli.aliases.isNotEmpty() }) {
+        assertTrue(!result.stdout.contains("mpc"), result.stdout)
+        assertTrue(result.stdout.contains("--json"), result.stdout)
+    }
+
+    @Test
+    fun `the tools reference advertises every declared command alias`() {
+        // The alias notes moved out of root help together with the MCP-tools reference; `devrig tools`
+        // is now the surface that must advertise them.
+        val result = runHelp("tools")
+
+        assertEquals(0, result.exitCode)
+        assertTrue(result.stderr.isEmpty(), result.stderr)
+        for (tool in devrigCliTools().filterNot { it.cli.hidden }.filter { it.cli.aliases.isNotEmpty() }) {
             val aliasNote = if (tool.cli.aliases.size == 1) {
                 "(alias: ${tool.cli.aliases.single()})"
             } else {
@@ -40,8 +52,6 @@ class DevrigCliHelpTest {
             }
             assertTrue(aliasNote in result.stdout, "missing $aliasNote in:\n${result.stdout}")
         }
-        assertTrue(!result.stdout.contains("mpc"), result.stdout)
-        assertTrue(result.stdout.contains("--json"), result.stdout)
     }
 
     @Test

--- a/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/McpToolsCliHelpTest.kt
+++ b/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/McpToolsCliHelpTest.kt
@@ -1,14 +1,16 @@
 /* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
 package com.jonnyzzz.mcpSteroid.devrig
 
+import java.nio.file.Path
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 
 /**
- * The "MCP tools as CLI" section of the global `devrig --help` banner is GENERATED from each tool's own
+ * The "MCP tools as CLI" reference `devrig tools` prints is GENERATED from each tool's own
  * declaration — its [com.jonnyzzz.mcpSteroid.mcp.CliCommandSpec] and the parameters `asCliParams()`
  * exposes — and never hand-written (PR #272 review r3579479002: "re-use information from the MCP tools to
  * generate these texts").
@@ -20,6 +22,8 @@ import kotlin.test.assertTrue
  *    wording that silently rots. Three defects on this branch survived substring assertions.
  */
 class McpToolsCliHelpTest {
+    @TempDir
+    lateinit var testHome: Path
 
     private fun section(): String = renderMcpToolsCliSection(devrigCliTools())
 
@@ -27,6 +31,14 @@ class McpToolsCliHelpTest {
         val invocation = parseDevrigCommand(arrayOf("--help"))
         assertEquals("help", invocation.commandPath)
         return requireNotNull(invocation.informationalText).trimEnd() + "\n"
+    }
+
+    private fun toolsCommandOutput(): String {
+        val invocation = parseDevrigCommand(arrayOf("tools"))
+        assertEquals("devrig tools", invocation.commandPath)
+        val run = runCliForToolTest(testHome, invocation)
+        assertEquals(0, run.exit, "devrig tools must succeed; stderr:\n${run.stderr}")
+        return run.stdout
     }
 
     private fun visibleTools() = devrigCliTools().filterNot { it.cli.hidden }
@@ -239,19 +251,24 @@ class McpToolsCliHelpTest {
     }
 
     @Test
-    fun `the framework flags are documented under exactly one heading`() {
-        val help = globalHelp()
-        for ((flag, expectedCount) in mapOf("--debug" to 2, "--json" to 2, "--out" to 1)) {
+    fun `the framework flags are documented under exactly one heading per surface`() {
+        // Root help documents --debug and --json once each, in its own Options list; --out is registered
+        // only on image-producing tool commands, so the root banner must not mention it at all. The
+        // `devrig tools` reference documents each of the three exactly once, in the scoped footer.
+        val documented = { text: String, flag: String ->
             // A line that *documents* the flag opens with it; the flag may carry a metavar (`--out=<path>`).
-            val documented = help.lines().filter { line ->
-                val text = line.trimStart()
-                text.startsWith(flag) && (text.length == flag.length || text[flag.length] in " =")
+            text.lines().count { line ->
+                val trimmed = line.trimStart()
+                trimmed.startsWith(flag) && (trimmed.length == flag.length || trimmed[flag.length] in " =")
             }
-            assertEquals(
-                expectedCount,
-                documented.size,
-                "$flag must appear in the root options and/or generated-tool framework section as scoped:\n$help",
-            )
+        }
+        val help = globalHelp()
+        for ((flag, expectedCount) in mapOf("--debug" to 1, "--json" to 1, "--out" to 0)) {
+            assertEquals(expectedCount, documented(help, flag), "$flag in the root banner:\n$help")
+        }
+        val reference = toolsCommandOutput()
+        for ((flag, expectedCount) in mapOf("--debug" to 1, "--json" to 1, "--out" to 1)) {
+            assertEquals(expectedCount, documented(reference, flag), "$flag in the tools reference:\n$reference")
         }
         assertFalse(
             "Options applicable to every mode:" in help,
@@ -277,23 +294,35 @@ class McpToolsCliHelpTest {
     }
 
     @Test
-    fun `printHelp embeds the generated section verbatim`() {
-        assertTrue(section() in globalHelp(), "the global banner must embed the generated section:\n${globalHelp()}")
+    fun `devrig tools prints the generated section verbatim`() {
+        assertTrue(
+            section() in toolsCommandOutput(),
+            "`devrig tools` must print the generated section:\n${toolsCommandOutput()}",
+        )
     }
 
     @Test
-    fun `the unified command tree and generated tool section coexist in root help`() {
+    fun `devrig tools rejects --json, because the reference is prose`() {
+        assertEquals("parse-error", parseDevrigCommand(arrayOf("tools", "--json")).commandPath)
+    }
+
+    @Test
+    fun `root help stays an index and points at the tools reference`() {
         val help = globalHelp()
         for (marker in listOf(
             "Usage: devrig",
             "Commands:",
             "backend",
             "install",
-            "MCP tools as CLI",
+            "devrig tools",
             "DEVRIG_JVM_OPTS",
         )) {
-            assertTrue(marker in help, "unified help lost '$marker':\n$help")
+            assertTrue(marker in help, "root help lost '$marker':\n$help")
         }
+        assertFalse(
+            "MCP tools as CLI" in help,
+            "the per-tool reference lives in `devrig tools`; embedding it buried the command index:\n$help",
+        )
         assertFalse("devrig mpc" in help, "the hidden mpc alias must stay unadvertised:\n$help")
     }
 

--- a/website/content/docs/devrig.md
+++ b/website/content/docs/devrig.md
@@ -66,7 +66,9 @@ Run `devrig --help` (or `devrig -h`) for the authoritative usage, and
 same command tree that performs the work, so every nested command has focused
 help such as `devrig install --help` and `devrig backend download --help`.
 The equivalent discoverable route is `devrig help <command>`, including nested
-paths such as `devrig help backend download`.
+paths such as `devrig help backend download`. `devrig tools` prints the full
+MCP-tools-as-CLI reference — every tool command's usage line and flags on one
+page, written for coding agents.
 
 If required values are missing, devrig prints that focused help and identifies all missing values in one
 pass, including allowed enum values and alternatives such as `--code` / `--code-file`. Human output may
@@ -96,6 +98,7 @@ devrig
 │   ├── config [--json]
 │   ├── devrig
 │   └── plugin [--check]
+├── tools
 ├── help [<command>...]
 └── version [--json]
 ```


### PR DESCRIPTION
## Problem

`devrig` / `devrig --help` printed two things glued together: the generated Clikt help (Usage / Options / Commands — good) followed by the entire generated "MCP tools as CLI" section as the root epilog — ~90 lines re-documenting every tool command's flags, duplicating what each command's focused `--help` already provides. The index was buried under the blob.

## Change

- New top-level `devrig tools` command prints the generated MCP-tools-as-CLI reference (usage lines, per-flag synopses, alias notes, scoped framework-flag footer) — the agentic-help surface. `--json` is refused: the reference is prose, not a result.
- Root `--help` keeps the generated index, the color/env-var facts, and gains a one-line pointer: run `devrig tools` for the reference, or `devrig <command> --help` for one command.
- The renderer (`renderMcpToolsCliSection`) and its derivation-from-specs contract are untouched — only the surface it prints on moved.
- `docs/devrig-cli-contract.md`, README's "Explore the CLI" block and `website/content/docs/devrig.md` follow the new shape (the `website` deployment branch is not advanced by this PR).

The name `tools` does not collide with the planned `native_tools` route (TODO.md / native-mcp-tools-design.md).

## Tests

- `McpToolsCliHelpTest`: the verbatim-embed pin moved from root help to the executed `devrig tools` output (via the shared `runCliForToolTest` harness); root help is now pinned to *not* embed the section and to advertise the pointer; the framework-flag heading counts are asserted per surface (root banner: --debug/--json once, no --out; tools reference: all three once, in the footer); `tools --json` is a parse error.
- `DevrigCliHelpTest`: root-help index test now expects the `tools` command; the alias-note assertions moved to a dedicated `devrig tools` test.
- `CliOptionsIntegrationTest` (packaged launcher in Docker): the banner test asserts the pointer and the absence of the blob; a new test drives `devrig tools` end-to-end (exit 0, section + aliases on stdout, clean stderr).

TDD: updated pins ran red before the implementation. Validation: full `:npx-kt:test` green; `:npx-kt:integrationTest --tests '*CliOptionsIntegrationTest*'` green in Docker.