### PR TITLE
printToon docs describe the ragged-keyset fallback it actually has

### DIFF
--- a/ij-plugin/src/main/kotlin/com/jonnyzzz/mcpSteroid/execution/McpScriptContext.kt
+++ b/ij-plugin/src/main/kotlin/com/jonnyzzz/mcpSteroid/execution/McpScriptContext.kt
@@ -111,6 +111,10 @@ interface McpScriptContext {
      * equivalent JSON for that case while preserving accuracy on extraction
      * tasks (https://github.com/toon-format/toon).
      *
+     * A list whose maps all share one key set gets the compact tabular
+     * encoding — a `[N]{columns}:` header followed by one comma-joined row
+     * per element, with the column order taken from the first map:
+     *
      * ```kotlin
      * printToon(listOf(
      *   mapOf("id" to 1, "name" to "Alice"),
@@ -119,6 +123,19 @@ interface McpScriptContext {
      * // [2]{id,name}:
      * //   1,Alice
      * //   2,Bob
+     * ```
+     *
+     * Heterogeneous key sets are **accepted**, not rejected: the list falls
+     * back to the less compact per-element block form, which preserves every
+     * key of every element. Callers must not pad naturally ragged records
+     * (optional quick-fix, optional enclosing symbol) into a common key set
+     * just to satisfy the tabular form — see issue #459:
+     *
+     * ```kotlin
+     * printToon(listOf(mapOf("a" to 1), mapOf("b" to 2)))
+     * // [2]:
+     * //   a: 1
+     * //   b: 2
      * ```
      */
     fun printToon(value: Any?)

--- a/ij-plugin/src/main/kotlin/com/jonnyzzz/mcpSteroid/execution/OutputFormatters.kt
+++ b/ij-plugin/src/main/kotlin/com/jonnyzzz/mcpSteroid/execution/OutputFormatters.kt
@@ -98,10 +98,15 @@ private fun csvCell(value: String): String {
  * Format [value] as TOON — Token-Oriented Object Notation. Minimal
  * implementation covering the shapes that actually show up in the
  * find-references / call-hierarchy / project-search recipes: primitives,
- * lists of primitives, lists of uniform-shape maps, single maps. Mixed /
- * non-uniform lists fall back to one indented item per line; that's
- * acceptable for the minimal ship — the dominant case is uniform array-
- * of-records (the whole reason TOON exists).
+ * lists of primitives, lists of uniform-shape maps, single maps. The
+ * dominant case is uniform array-of-records (the whole reason TOON exists)
+ * and it gets the compact `[N]{cols}:` encoding.
+ *
+ * Mixed / non-uniform lists are a **supported input**, not a rejected one:
+ * they fall back to one indented item per line, preserving every key of
+ * every element. That fallback is part of the documented contract (issue
+ * #459) — the agent-facing prompts tell callers not to normalize ragged
+ * records to reach the compact form, so this branch must keep working.
  *
  * Spec reference: [toon-format/toon on GitHub](https://github.com/toon-format/toon).
  */

--- a/ij-plugin/src/test/kotlin/com/jonnyzzz/mcpSteroid/execution/OutputFormattersTest.kt
+++ b/ij-plugin/src/test/kotlin/com/jonnyzzz/mcpSteroid/execution/OutputFormattersTest.kt
@@ -274,6 +274,47 @@ class OutputFormattersTest {
     }
 
     @Test
+    fun `formatToon renders heterogeneous keysets as the exact documented fallback`() {
+        // Issue #459: the prompt corpus used to claim heterogeneous maps are
+        // rejected. They are accepted; this pins the exact shape the corpus
+        // now documents, so a formatter change forces a docs update.
+        val out = formatToon(listOf(
+            mapOf("a" to 1),
+            mapOf("b" to 2),
+        ))
+        assertEquals(
+            """
+            [2]:
+              a: 1
+              b: 2
+            """.trimIndent(),
+            out,
+        )
+    }
+
+    @Test
+    fun `formatToon accepts a widened record that only some elements carry`() {
+        // The realistic heterogeneous case: inspection / search records where
+        // an optional field is present on some rows only. No exception, no
+        // silent data loss — every key of every element is emitted.
+        val out = formatToon(listOf(
+            linkedMapOf("path" to "/a.kt", "line" to 1),
+            linkedMapOf("path" to "/b.kt", "line" to 2, "quickFix" to "RemoveCast"),
+        ))
+        assertEquals(
+            """
+            [2]:
+              path: /a.kt
+              line: 1
+              path: /b.kt
+              line: 2
+              quickFix: RemoveCast
+            """.trimIndent(),
+            out,
+        )
+    }
+
+    @Test
     fun `formatToon emits list of primitives as single comma-joined line`() {
         assertEquals("[3]: 1,2,3", formatToon(listOf(1, 2, 3)))
         assertEquals("[2]: alpha,beta", formatToon(listOf("alpha", "beta")))

--- a/prompts/src/main/prompts/prompt/skill.md
+++ b/prompts/src/main/prompts/prompt/skill.md
@@ -278,9 +278,11 @@ printCsv(
 )
 
 // TOON — Token-Oriented Object Notation; https://github.com/toon-format/toon.
-// printToon(value: Any?) — drop-in for printJson on uniform-shape lists.
-// Pass List<Map<String, Any?>>; column order comes from the FIRST map's keys, and every
-// subsequent map must have the same key set. Do NOT pass headers / rows / dictColumns — that's printCsv.
+// printToon(value: Any?) — drop-in for printJson on any value; cheapest on uniform-shape lists.
+// Pass List<Map<String, Any?>>. Same key set in every map -> compact [N]{cols}: form, column order
+// from the FIRST map's keys. Different key sets are ACCEPTED too -> less compact per-element block
+// ([N]: plus `key: value` lines), so never normalize naturally ragged records just to get the
+// compact form. Do NOT pass headers / rows / dictColumns — that's printCsv.
 printToon(listOf(mapOf("path" to "/abs/A.kt", "line" to 17), mapOf("path" to "/abs/B.kt", "line" to 42)))
 ```
 

--- a/prompts/src/main/prompts/skill/coding-with-intellij-context-api.md
+++ b/prompts/src/main/prompts/skill/coding-with-intellij-context-api.md
@@ -67,11 +67,14 @@ printJson(mapOf("key" to "value"))       // Serialize to pretty JSON (uses Jacks
 //   printToon(value: Any?)
 //     TOON (Token-Oriented Object Notation — https://github.com/toon-format/toon).
 //     Drop-in replacement for `printJson` when the data is array-of-records
-//     shaped. Pass a `List<Map<String, Any?>>` — the COLUMN ORDER is taken
-//     from the FIRST map's key order, and every subsequent map is checked
-//     for the same key set. `printToon` does NOT take `headers` / `rows` /
-//     `dictColumns` — that's `printCsv`'s shape; `printToon` infers
-//     everything from the data.
+//     shaped. Pass a `List<Map<String, Any?>>`. When every map has the SAME
+//     key set you get the compact `[N]{cols}:` form, with COLUMN ORDER taken
+//     from the FIRST map's key order. Maps with DIFFERENT key sets are
+//     accepted too — they render as the less compact per-element block form
+//     (see "Tabular Output" below), so do NOT normalize naturally ragged
+//     records just to reach the compact form. `printToon` does NOT take
+//     `headers` / `rows` / `dictColumns` — that's `printCsv`'s shape;
+//     `printToon` infers everything from the data.
 printCsv(
     headers = listOf("idx", "path", "line"),
     rows = listOf(listOf(1, "/abs/A.kt", 17), listOf(2, "/abs/B.kt", 42)),
@@ -99,7 +102,7 @@ inventories). Same data, two formats — pick by the heuristic below.
 | Helper      | Signature                                                                                | Row shape                                             |
 |-------------|------------------------------------------------------------------------------------------|-------------------------------------------------------|
 | `printCsv`  | `printCsv(headers: List<String>, rows: Iterable<List<Any?>>, dictColumns: Set<String> = emptySet())` | `List<List<Any?>>` — **positional**, parallel to `headers` |
-| `printToon` | `printToon(value: Any?)`                                                                 | `List<Map<String, Any?>>` — **keyed**, columns inferred from first map's key order |
+| `printToon` | `printToon(value: Any?)`                                                                 | `List<Map<String, Any?>>` — **keyed**, columns inferred from first map's key order; ragged key sets allowed |
 
 **Choose by repetition shape:**
 
@@ -136,6 +139,34 @@ becomes `""`. The TOON form follows
 [toon-format/toon](https://github.com/toon-format/toon); the array-of-
 records shape (`[N]{cols}:` header + comma rows) is what `printToon`
 emits when every map in the list has the same key set.
+
+**Ragged key sets are supported — do not normalize for the formatter.**
+When the maps in the list do *not* share one key set, `printToon` does not
+fail; it falls back to a per-element block (`[N]:` followed by
+`key: value` lines for each element, every key preserved). That is the
+right output for naturally heterogeneous records — inspection results
+where only some rows carry a quick-fix, search hits with an optional
+enclosing symbol. Spending code on padding every record to a common key
+set buys nothing but the compact header:
+
+```kotlin
+// printToon(listOf(
+//   mapOf("path" to "/a.kt", "line" to 1),
+//   mapOf("path" to "/b.kt", "line" to 2, "quickFix" to "RemoveCast"),
+// ))
+//
+// emits the per-element fallback (NOT [2]{path,line}:):
+//   [2]:
+//     path: /a.kt
+//     line: 1
+//     path: /b.kt
+//     line: 2
+//     quickFix: RemoveCast
+```
+
+Reach for a uniform key set when you want the compact tabular encoding
+for its own sake (it is the cheaper form), not because a ragged list
+would be rejected.
 
 **End-to-end example** — discover `.kt` files once, emit the same record
 list both ways. `findProjectFiles` is a `suspend` resolver; it stays

--- a/prompts/src/main/prompts/skill/coding-with-intellij.md
+++ b/prompts/src/main/prompts/skill/coding-with-intellij.md
@@ -46,7 +46,7 @@ Reflection (`Class.forName`, `getDeclaredField`, `setAccessible(true)`) is fine 
 | Run Maven tests | `MavenRunConfigurationType.runConfiguration()` + `SMTRunnerEventsListener` | Structured pass/fail; Bash `./mvnw test` cold-starts ~31 s per run |
 | Run Gradle tests | `ExternalSystemUtil.runTask()` or `GradleRunConfiguration` through the IDE runner | See `mcp-steroid://skill/execute-code-gradle`; same cold-start cost applies |
 | Maven dependency sync | `MavenProjectsManager.forceUpdateAllProjectsOrFindAllAvailablePomFiles()` | No CLI equivalent |
-| **Emit tabular results** (find-references, call-hierarchy, project-search, document-symbols, file inventories) | `printCsv(headers, rows, dictColumns = setOf("path"))` for CSV with a path-dictionary preamble; `printToon(listOf(mapOf(...)))` for TOON array-of-records | Token-efficient (`dictColumns` dedupes repeated long values; TOON is a drop-in for `printJson` on uniform-shape lists). Full doc: `mcp-steroid://skill/coding-with-intellij-context-api` → "Tabular Output". |
+| **Emit tabular results** (find-references, call-hierarchy, project-search, document-symbols, file inventories) | `printCsv(headers, rows, dictColumns = setOf("path"))` for CSV with a path-dictionary preamble; `printToon(listOf(mapOf(...)))` for TOON array-of-records | Token-efficient (`dictColumns` dedupes repeated long values; TOON is a drop-in for `printJson` on any value and cheapest on uniform-shape lists — ragged key sets are accepted, just less compact). Full doc: `mcp-steroid://skill/coding-with-intellij-context-api` → "Tabular Output". |
 
 **Native tools only where MCP Steroid genuinely does not apply** — keep this list tight, and prefer the IDE whenever the operation touches the project model:
 


### PR DESCRIPTION
Fixes #459.

## The drift

`prompts/src/main/prompts/prompt/skill.md` told agents that every map in a
`printToon(List<Map<String, Any?>>)` **must** have the same key set, and
`coding-with-intellij-context-api.md` said each map after the first "is checked"
for it. `appendToonList` does neither — a uniform key set only selects the
compact `[N]{cols}:` encoding; anything else falls back to a per-element block
that preserves every key of every element. `formatToon falls back to per-element
block when list maps have different keysets` has pinned that since #34.

The cost of the wrong claim is agents normalizing naturally ragged records — an
inspection hit that only sometimes carries a quick-fix — to satisfy a runtime
restriction that does not exist.

## What changed

Documentation only; no behaviour change.

- `prompt/skill.md` and `skill/coding-with-intellij-context-api.md` now state
  the two-form contract: same key set → compact `[N]{cols}:`; different key
  sets → accepted, per-element block. The context-API article gains a worked
  ragged-record sample and an explicit "do not normalize for the formatter".
- `skill/coding-with-intellij.md`'s summary row no longer implies TOON is only
  for uniform-shape lists.
- `McpScriptContext.printToon` KDoc documents both forms at the public API.
- `formatToon`'s KDoc no longer calls the fallback "acceptable for the minimal
  ship" — it is the contract the corpus now teaches, so the branch has to keep
  working.

Uniformity is framed as buying the cheaper encoding, not admission.

## Tests

Two new cases in `OutputFormattersTest` pin the exact shapes the articles quote,
so a formatter change forces a docs update:

- the issue's `[2]: / a: 1 / b: 2` reproduction, verbatim;
- the realistic widened-record case where only the second element carries an
  extra key.

The pre-existing test asserted only the absence of `{` and the presence of
`[2]:` — it would not have caught a change to the fallback's indentation or key
handling.

## Verification

- `./gradlew :ij-plugin:test --tests '*OutputFormattersTest*'` — 26/26 green
  (the two new cases confirmed present in the XML report). Both documented
  sample outputs were run **before** they were written into the docs.
- `./gradlew :prompts:test -Pmcp.prompts.ide.filter=idea:stable` scoped to the
  changed articles — `MarkdownArticleContractTest` 8/8, article-read 8/8,
  prompt round-trip 3/3, and KtBlock compilation 20/20 on IDEA stable
  (14 blocks in the context-API article, incl. the new fence; 6 in `prompt/skill.md`).

Not run locally: the full cross-IDE KtBlock matrix (60–120 min; `ciBuildPromptsTests`
covers it). The Rider-EAP leg could not run here at all — its download failed a
SHA-256 check at 98% after the "eap" channel slid to `JetBrains.Rider-2026.2.0.2`.
That is unrelated to this change and reported separately. The residual cross-IDE
risk is nil in any case: every fence edit here is comment-only, and the one new
fence contains only comments.