### PR TITLE
Index-dependent search recipes run under smartReadAction, contract-tested

### DIFF
--- a/prompts/src/main/prompts/ide/call-hierarchy.md
+++ b/prompts/src/main/prompts/ide/call-hierarchy.md
@@ -6,7 +6,9 @@ Finding callers is platform-level: resolve the PSI element at a position, then w
 `ReferencesSearch.search(element)` — it is language-agnostic and returns the references for
 Java, Kotlin, Python, Go, JavaScript, and any other language whose PSI the IDE frontend owns.
 The enclosing-declaration lookup uses `PsiNameIdentifierOwner`, which every language's named
-declarations implement.
+declarations implement. The whole recipe runs inside `smartReadAction { }` — reference
+search is index-backed, and dumb mode can re-enter at any moment after the automatic
+smart-mode wait, so a plain read action risks `IndexNotReadyException`.
 
 ```kotlin
 import com.intellij.psi.search.searches.ReferencesSearch
@@ -19,17 +21,17 @@ val column = 15   // TODO: 1-based column number
 val maxResults = 20
 
 
-val result = readAction {
+val result = smartReadAction {
     val virtualFile = findFile(filePath)
-        ?: return@readAction "File not found: $filePath"
+        ?: return@smartReadAction "File not found: $filePath"
     val psiFile = PsiManager.getInstance(project).findFile(virtualFile)
-        ?: return@readAction "Cannot parse file: $filePath"
+        ?: return@smartReadAction "Cannot parse file: $filePath"
     val document = FileDocumentManager.getInstance().getDocument(virtualFile)
-        ?: return@readAction "Cannot get document for: $filePath"
+        ?: return@smartReadAction "Cannot get document for: $filePath"
 
     val offset = document.getLineStartOffset(line - 1) + (column - 1)
     val element = psiFile.findElementAt(offset)
-        ?: return@readAction "No element at position ($line:$column)"
+        ?: return@smartReadAction "No element at position ($line:$column)"
 
     // Position on a *usage*: resolve the reference to its declaration.
     // Position on the *declaration* itself: take the enclosing named declaration.
@@ -38,7 +40,7 @@ val result = readAction {
         .firstOrNull()
         ?.resolve()
         ?: PsiTreeUtil.getParentOfType(element, PsiNameIdentifierOwner::class.java, false)
-        ?: return@readAction "No declaration or reference at position ($line:$column)"
+        ?: return@smartReadAction "No declaration or reference at position ($line:$column)"
 
     val targetName = (target as? PsiNamedElement)?.name ?: target.text.take(40)
     val refs = ReferencesSearch.search(target, projectScope()).findAll()
@@ -99,24 +101,24 @@ val column = 15   // TODO: 1-based column number
 val maxResults = 20
 
 
-val result = readAction {
+val result = smartReadAction {
     val virtualFile = findFile(filePath)
-        ?: return@readAction "File not found: $filePath"
+        ?: return@smartReadAction "File not found: $filePath"
     val psiFile = PsiManager.getInstance(project).findFile(virtualFile)
-        ?: return@readAction "Cannot parse file: $filePath"
+        ?: return@smartReadAction "Cannot parse file: $filePath"
     val document = FileDocumentManager.getInstance().getDocument(virtualFile)
-        ?: return@readAction "Cannot get document for: $filePath"
+        ?: return@smartReadAction "Cannot get document for: $filePath"
 
     val offset = document.getLineStartOffset(line - 1) + (column - 1)
     val element = psiFile.findElementAt(offset)
-        ?: return@readAction "No element at position ($line:$column)"
+        ?: return@smartReadAction "No element at position ($line:$column)"
 
     val reference = generateSequence(element) { it.parent }
         .mapNotNull { it.reference }
         .firstOrNull()
     val method = (reference?.resolve() as? PsiMethod)
         ?: PsiTreeUtil.getParentOfType(element, PsiMethod::class.java, false)
-        ?: return@readAction "No method found at position ($line:$column)"
+        ?: return@smartReadAction "No method found at position ($line:$column)"
 
     val refs = MethodReferencesSearch.search(method, projectScope(), true).findAll()
     if (refs.isEmpty()) {

--- a/prompts/src/main/prompts/ide/hierarchy-search.md
+++ b/prompts/src/main/prompts/ide/hierarchy-search.md
@@ -21,10 +21,11 @@ val classFqn = "com.example.BaseType" // TODO: Set base class/interface FQN
 val methodName = "doWork" // TODO: Set method name or leave as-is
 
 
-val hierarchyData = readAction {
+// Inheritor and override searches read indexes — the whole query runs in smartReadAction.
+val hierarchyData = smartReadAction {
     val baseClass = JavaPsiFacade.getInstance(project)
         .findClass(classFqn, GlobalSearchScope.projectScope(project))
-        ?: return@readAction null
+        ?: return@smartReadAction null
     val inheritors = ClassInheritorsSearch.search(
         baseClass,
         GlobalSearchScope.projectScope(project),

--- a/prompts/src/main/prompts/ide/push-down-members.md
+++ b/prompts/src/main/prompts/ide/push-down-members.md
@@ -21,16 +21,17 @@ data class PushDownPlan(
     val member: PsiMember
 )
 
-val (summary, plan) = readAction {
+// The plan phase runs inheritor discovery (index-backed) — smartReadAction, not readAction.
+val (summary, plan) = smartReadAction {
     val facade = JavaPsiFacade.getInstance(project)
     val scope = GlobalSearchScope.projectScope(project)
 
     val sourceClass = facade.findClass(sourceClassFqn, scope)
-        ?: return@readAction "Source class not found: $sourceClassFqn" to null
+        ?: return@smartReadAction "Source class not found: $sourceClassFqn" to null
 
     val inheritors = ClassInheritorsSearch.search(sourceClass, scope, false).findAll()
     if (inheritors.isEmpty()) {
-        return@readAction "No inheritors found for $sourceClassFqn" to null
+        return@smartReadAction "No inheritors found for $sourceClassFqn" to null
     }
 
     val member: PsiMember? =
@@ -38,7 +39,7 @@ val (summary, plan) = readAction {
             ?: sourceClass.findFieldByName(memberName, false)
 
     if (member == null) {
-        return@readAction "Member not found: $memberName in $sourceClassFqn" to null
+        return@smartReadAction "Member not found: $memberName in $sourceClassFqn" to null
     }
 
     val memberType = when (member) {

--- a/prompts/src/main/prompts/ide/safe-delete.md
+++ b/prompts/src/main/prompts/ide/safe-delete.md
@@ -44,7 +44,10 @@ if (namedElement == null) {
 }
 
 val targetName = readAction { namedElement.name ?: "<unnamed>" }
-val usages = readAction { ReferencesSearch.search(namedElement).findAll() }
+// Discovery snapshot under smartReadAction — the reference search is index-backed.
+// The write-intent SafeDeleteProcessor phase below re-finds usages itself, so only
+// this discovery step needs smart mode.
+val usages = smartReadAction { ReferencesSearch.search(namedElement).findAll() }
 if (dryRun) {
     println("Safe delete prepared for: $targetName")
     println("Usages found: ${usages.size}")

--- a/prompts/src/main/prompts/lsp/find-references.md
+++ b/prompts/src/main/prompts/lsp/find-references.md
@@ -2,6 +2,11 @@ LSP: textDocument/references - Find All References
 
 This example demonstrates how to find all references to a symbol,
 
+The whole query — element resolution, the reference search, and the result snapshot — runs
+inside `smartReadAction { }`: reference search reads indexes, and the IDE can re-enter dumb
+mode at any moment, so a plain read action can fail nondeterministically with
+`IndexNotReadyException` mid-search.
+
 ```kotlin
 import com.intellij.psi.search.searches.ReferencesSearch
 import com.intellij.psi.util.PsiTreeUtil
@@ -12,30 +17,30 @@ val line = 10      // TODO: 1-based line number where symbol is defined
 val column = 15    // TODO: 1-based column number
 
 
-val result = readAction {
+val result = smartReadAction {
     // Find the virtual file
     val virtualFile = findFile(filePath)
-        ?: return@readAction "File not found: $filePath"
+        ?: return@smartReadAction "File not found: $filePath"
 
     // Get PSI file
     val psiFile = PsiManager.getInstance(project).findFile(virtualFile)
-        ?: return@readAction "Cannot parse file: $filePath"
+        ?: return@smartReadAction "Cannot parse file: $filePath"
 
     // Get document to convert line/column to offset
     val document = FileDocumentManager.getInstance().getDocument(virtualFile)
-        ?: return@readAction "Cannot get document for: $filePath"
+        ?: return@smartReadAction "Cannot get document for: $filePath"
 
     // Convert line/column to offset
     val offset = document.getLineStartOffset(line - 1) + (column - 1)
 
     // Find element at position
     val element = psiFile.findElementAt(offset)
-        ?: return@readAction "No element at position ($line:$column)"
+        ?: return@smartReadAction "No element at position ($line:$column)"
 
     // Find the named element (declaration) at or around this position
     val namedElement = PsiTreeUtil.getParentOfType(element, PsiNamedElement::class.java, false)
         ?: element.reference?.resolve() as? PsiNamedElement
-        ?: return@readAction "No named element found at position"
+        ?: return@smartReadAction "No named element found at position"
 
     // Search for all references
     val references = ReferencesSearch.search(namedElement, projectScope()).findAll()

--- a/prompts/src/main/prompts/skill/coding-with-intellij-patterns.md
+++ b/prompts/src/main/prompts/skill/coding-with-intellij-patterns.md
@@ -232,7 +232,8 @@ import com.intellij.psi.search.GlobalSearchScope
 val scope = GlobalSearchScope.projectScope(project)
 val matchingFiles = mutableListOf<String>()
 val startMs = System.currentTimeMillis()
-readAction {
+// PsiSearchHelper reads the word index — smartReadAction, not plain readAction
+smartReadAction {
     PsiSearchHelper.getInstance(project).processAllFilesWithWord(
         "thisLogger", scope,
         { psiFile -> matchingFiles.add(psiFile.virtualFile.path); true },
@@ -250,7 +251,7 @@ import com.intellij.psi.search.GlobalSearchScope
 import com.intellij.psi.search.FilenameIndex
 val scope = GlobalSearchScope.projectScope(project)
 val matchingFiles = mutableListOf<String>()
-readAction {
+smartReadAction {
     PsiSearchHelper.getInstance(project).processAllFilesWithWord("/api/", scope, { psiFile ->
         matchingFiles.add(psiFile.virtualFile.path)
         true  // continue searching

--- a/prompts/src/main/prompts/skill/coding-with-intellij-psi.md
+++ b/prompts/src/main/prompts/skill/coding-with-intellij-psi.md
@@ -155,30 +155,36 @@ if (psiFile != null) {
 import com.intellij.psi.search.searches.ReferencesSearch
 import com.intellij.psi.search.GlobalSearchScope
 
-val cls = readAction {
-    JavaPsiFacade.getInstance(project).findClass(
+// Class lookup and reference search both read indexes — keep the whole query
+// and its result snapshot inside one smartReadAction block.
+smartReadAction {
+    val cls = JavaPsiFacade.getInstance(project).findClass(
         "com.example.domain.FeatureService",
         GlobalSearchScope.projectScope(project)
     )
-}
-ReferencesSearch.search(cls!!, projectScope()).findAll().forEach { ref ->
-    val snippet = ref.element.parent.text.take(80)
-    println("${ref.element.containingFile.name} → $snippet")
+    if (cls == null) {
+        println("class not found")
+        return@smartReadAction
+    }
+    ReferencesSearch.search(cls, projectScope()).findAll().forEach { ref ->
+        val snippet = ref.element.parent.text.take(80)
+        println("${ref.element.containingFile.name} → $snippet")
+    }
 }
 ```
 
 **CRITICAL when adding new fields to command/DTO objects** — find every call site first so you can update all constructors:
 ```kotlin[IU]
 import com.intellij.psi.search.searches.ReferencesSearch
-val cmdClass = readAction {
-    JavaPsiFacade.getInstance(project).findClass("com.example.CreateReleaseCommand", projectScope())
+smartReadAction {
+    val cmdClass = JavaPsiFacade.getInstance(project).findClass("com.example.CreateReleaseCommand", projectScope())
+    if (cmdClass != null) {
+        ReferencesSearch.search(cmdClass, projectScope()).findAll().forEach { ref ->
+            val file = ref.element.containingFile.virtualFile.path.substringAfterLast('/')
+            println("$file → " + ref.element.parent.text.take(100))
+        }
+    } else println("class not found")
 }
-if (cmdClass != null) {
-    ReferencesSearch.search(cmdClass, projectScope()).findAll().forEach { ref ->
-        val file = ref.element.containingFile.virtualFile.path.substringAfterLast('/')
-        println("$file → " + ref.element.parent.text.take(100))
-    }
-} else println("class not found")
 ```
 
 ### Find Usages — Kotlin
@@ -212,7 +218,7 @@ import com.intellij.psi.JavaPsiFacade
 import com.intellij.psi.search.GlobalSearchScope
 import com.intellij.psi.search.searches.ClassInheritorsSearch
 
-readAction {
+smartReadAction {
     val baseClass = JavaPsiFacade.getInstance(project)
         .findClass("java.util.List", GlobalSearchScope.allScope(project))
 
@@ -238,11 +244,12 @@ readAction {
 ### Find All @Entity Classes
 ```kotlin[IU]
 import com.intellij.psi.search.searches.AnnotatedElementsSearch
-val entityAnnotation = readAction {
-    JavaPsiFacade.getInstance(project).findClass("jakarta.persistence.Entity", allScope())
+smartReadAction {
+    val entityAnnotation = JavaPsiFacade.getInstance(project).findClass("jakarta.persistence.Entity", allScope())
+        ?: error("jakarta.persistence.Entity not on the project classpath")
+    AnnotatedElementsSearch.searchPsiClasses(entityAnnotation, projectScope()).findAll()
+        .forEach { println(it.qualifiedName) }
 }
-AnnotatedElementsSearch.searchPsiClasses(entityAnnotation!!, projectScope()).findAll()
-    .forEach { println(it.qualifiedName) }
 ```
 
 ### Find @Repository Methods with @Query
@@ -312,12 +319,12 @@ val scope = GlobalSearchScope.moduleWithDependenciesScope(module)  // module + t
 val files = readAction { FilenameIndex.getVirtualFilesByName("PaymentService.java", scope) }
 println("Found ${files.size} files in module scope")
 
-// Step 3: Scope PSI/reference searches
-val targetClass = readAction {
-    JavaPsiFacade.getInstance(project).findClass("com.example.PaymentService", scope)
-}
-val usages = readAction {
-    ReferencesSearch.search(targetClass!!, scope).toList()
+// Step 3: Scope PSI/reference searches — index-backed, so one smartReadAction owns
+// the class lookup, the search, and the result snapshot
+val usages = smartReadAction {
+    val targetClass = JavaPsiFacade.getInstance(project).findClass("com.example.PaymentService", scope)
+        ?: error("class not found in module scope")
+    ReferencesSearch.search(targetClass, scope).toList()
 }
 println("${usages.size} usages in module")
 ```

--- a/prompts/src/main/prompts/skill/coding-with-intellij-refactoring.md
+++ b/prompts/src/main/prompts/skill/coding-with-intellij-refactoring.md
@@ -535,22 +535,21 @@ import com.intellij.psi.JavaPsiFacade
 import com.intellij.psi.search.GlobalSearchScope
 import com.intellij.psi.search.searches.ReferencesSearch
 
-// Before adding a field to CreateReleaseCommand — find every constructor call site first
-val cmdClass = readAction {
-    JavaPsiFacade.getInstance(project).findClass(
+// Before adding a field to CreateReleaseCommand — find every constructor call site first.
+// The class lookup and the reference search both read indexes, so one smartReadAction
+// owns the whole query and its printed snapshot.
+smartReadAction {
+    val cmdClass = JavaPsiFacade.getInstance(project).findClass(
         "com.example.commands.CreateReleaseCommand",
         GlobalSearchScope.projectScope(project)
     )
+    if (cmdClass != null) {
+        ReferencesSearch.search(cmdClass, GlobalSearchScope.projectScope(project)).findAll().forEach { ref ->
+            val file = ref.element.containingFile.virtualFile.path.substringAfterLast('/')
+            println("$file:${ref.element.textOffset} → " + ref.element.parent.text.take(120))
+        }
+    } else println("class not found — check FQN")
 }
-if (cmdClass != null) {
-    val usages = readAction {
-        ReferencesSearch.search(cmdClass, GlobalSearchScope.projectScope(project)).findAll()
-    }
-    usages.forEach { ref ->
-        val file = ref.element.containingFile.virtualFile.path.substringAfterLast('/')
-        println("$file:${ref.element.textOffset} → " + ref.element.parent.text.take(120))
-    }
-} else println("class not found — check FQN")
 // Fix every listed call site BEFORE running the compiler.
 // This 1 call replaces reading 3-5 files just to find constructors.
 ```

--- a/prompts/src/main/prompts/skill/coding-with-intellij-spring.md
+++ b/prompts/src/main/prompts/skill/coding-with-intellij-spring.md
@@ -38,20 +38,21 @@ queries instead of reading file contents. **1 PSI call replaces 5-10 VfsUtil.loa
 import com.intellij.psi.search.GlobalSearchScope
 import com.intellij.psi.search.searches.ReferencesSearch
 
-// Inspect class structure — no file read needed:
-val cls = readAction {
-    JavaPsiFacade.getInstance(project).findClass(
+// Class lookup + reference search are index-backed — one smartReadAction owns the whole query:
+smartReadAction {
+    val cls = JavaPsiFacade.getInstance(project).findClass(
         "com.example.domain.FeatureService",
         GlobalSearchScope.projectScope(project)
-    )
-}
-cls?.methods?.forEach { m ->
-    val params = m.parameterList.parameters.joinToString { "${it.name}: ${it.type.presentableText}" }
-    println("${m.name}($params): ${m.returnType?.presentableText}")
-}
-// Find all callers (replaces grepping source files):
-ReferencesSearch.search(cls!!, projectScope()).findAll().forEach { ref ->
-    println("${ref.element.containingFile.name} → ${ref.element.parent.text.take(80)}")
+    ) ?: error("class not found")
+    // Inspect class structure — no file read needed:
+    cls.methods.forEach { m ->
+        val params = m.parameterList.parameters.joinToString { "${it.name}: ${it.type.presentableText}" }
+        println("${m.name}($params): ${m.returnType?.presentableText}")
+    }
+    // Find all callers (replaces grepping source files):
+    ReferencesSearch.search(cls, projectScope()).findAll().forEach { ref ->
+        println("${ref.element.containingFile.name} → ${ref.element.parent.text.take(80)}")
+    }
 }
 ```
 
@@ -238,33 +239,35 @@ println("Maven IDE runner: passed=$mvnPassed")
 import com.intellij.psi.JavaPsiFacade
 import com.intellij.psi.search.searches.AnnotatedElementsSearch
 
+// AnnotatedElementsSearch reads indexes — each query runs whole inside smartReadAction.
+
 // Find all JPA @Entity classes
-val entityClass = readAction {
-    JavaPsiFacade.getInstance(project).findClass("jakarta.persistence.Entity", allScope())
+smartReadAction {
+    val entityClass = JavaPsiFacade.getInstance(project).findClass("jakarta.persistence.Entity", allScope())
         ?: JavaPsiFacade.getInstance(project).findClass("javax.persistence.Entity", allScope())
-}
-if (entityClass != null) {
-    val entities = AnnotatedElementsSearch.searchPsiClasses(entityClass, projectScope()).findAll()
-    println("@Entity classes (${entities.size}):")
-    entities.forEach { println("  ${it.qualifiedName} in ${it.containingFile.virtualFile.path}") }
+    if (entityClass != null) {
+        val entities = AnnotatedElementsSearch.searchPsiClasses(entityClass, projectScope()).findAll()
+        println("@Entity classes (${entities.size}):")
+        entities.forEach { println("  ${it.qualifiedName} in ${it.containingFile.virtualFile.path}") }
+    }
 }
 
 // Find all Spring @Service classes
-val serviceClass = readAction {
-    JavaPsiFacade.getInstance(project).findClass("org.springframework.stereotype.Service", allScope())
-}
-if (serviceClass != null) {
-    AnnotatedElementsSearch.searchPsiClasses(serviceClass, projectScope()).findAll()
-        .forEach { println("@Service: ${it.qualifiedName}") }
+smartReadAction {
+    val serviceClass = JavaPsiFacade.getInstance(project).findClass("org.springframework.stereotype.Service", allScope())
+    if (serviceClass != null) {
+        AnnotatedElementsSearch.searchPsiClasses(serviceClass, projectScope()).findAll()
+            .forEach { println("@Service: ${it.qualifiedName}") }
+    }
 }
 
 // Find all @RestController classes
-val rcClass = readAction {
-    JavaPsiFacade.getInstance(project).findClass("org.springframework.web.bind.annotation.RestController", allScope())
-}
-if (rcClass != null) {
-    AnnotatedElementsSearch.searchPsiClasses(rcClass, projectScope()).findAll()
-        .forEach { println("@RestController: ${it.qualifiedName}") }
+smartReadAction {
+    val rcClass = JavaPsiFacade.getInstance(project).findClass("org.springframework.web.bind.annotation.RestController", allScope())
+    if (rcClass != null) {
+        AnnotatedElementsSearch.searchPsiClasses(rcClass, projectScope()).findAll()
+            .forEach { println("@RestController: ${it.qualifiedName}") }
+    }
 }
 ```
 
@@ -361,22 +364,23 @@ println("Use: ${persistencePrefix}.persistence.Entity")
 import com.intellij.psi.search.searches.ReferencesSearch
 import com.intellij.psi.search.GlobalSearchScope
 
-// Find every place that constructs or references CreateReleaseCommand
-val cmdClass = readAction {
-    JavaPsiFacade.getInstance(project).findClass(
+// Find every place that constructs or references CreateReleaseCommand.
+// Lookup + reference search read indexes — the whole query runs in one smartReadAction.
+smartReadAction {
+    val cmdClass = JavaPsiFacade.getInstance(project).findClass(
         "com.example.CreateReleaseCommand",
         GlobalSearchScope.projectScope(project)
     )
+    if (cmdClass != null) {
+        val refs = ReferencesSearch.search(cmdClass, projectScope()).findAll()
+        println("Found ${refs.size} usages:")
+        refs.forEach { ref ->
+            val file = ref.element.containingFile.virtualFile.path.substringAfterLast('/')
+            val snippet = ref.element.parent.text.take(100)
+            println("  $file → $snippet")
+        }
+    } else println("Class not found")
 }
-if (cmdClass != null) {
-    val refs = ReferencesSearch.search(cmdClass, projectScope()).findAll()
-    println("Found ${refs.size} usages:")
-    refs.forEach { ref ->
-        val file = ref.element.containingFile.virtualFile.path.substringAfterLast('/')
-        val snippet = ref.element.parent.text.take(100)
-        println("  $file → $snippet")
-    }
-} else println("Class not found")
 ```
 
 ### Add a Component to a Java Record via PSI (Whitespace-Safe)
@@ -397,19 +401,20 @@ import com.intellij.psi.search.FilenameIndex
 import com.intellij.psi.search.GlobalSearchScope
 import com.intellij.psi.search.searches.ReferencesSearch
 
-// Step 1: Find all call sites BEFORE modifying the record
-val cmdClass = readAction {
-    JavaPsiFacade.getInstance(project).findClass(
+// Step 1: Find all call sites BEFORE modifying the record — discovery is an index-backed
+// search, so it runs as a smartReadAction snapshot before the write phase below
+smartReadAction {
+    val cmdClass = JavaPsiFacade.getInstance(project).findClass(
         "com.example.CreateReleaseCommand",   // ← actual FQN
         GlobalSearchScope.projectScope(project)
     )
-}
-if (cmdClass != null) {
-    val refs = readAction { ReferencesSearch.search(cmdClass, projectScope()).findAll() }
-    println("Call sites to update (${refs.size}):")
-    refs.forEach { ref ->
-        println("  ${ref.element.containingFile.virtualFile.path.substringAfterLast('/')} → " +
-            ref.element.parent.text.take(120))
+    if (cmdClass != null) {
+        val refs = ReferencesSearch.search(cmdClass, projectScope()).findAll()
+        println("Call sites to update (${refs.size}):")
+        refs.forEach { ref ->
+            println("  ${ref.element.containingFile.virtualFile.path.substringAfterLast('/')} → " +
+                ref.element.parent.text.take(120))
+        }
     }
 }
 // ↑ Read this output, then update each call site — then proceed to add the record component below
@@ -516,34 +521,35 @@ import com.intellij.psi.search.searches.AnnotatedElementsSearch
 
 val scope = GlobalSearchScope.projectScope(project)
 
-// Step 1: Locate the advice annotation class (handles both @ControllerAdvice and @RestControllerAdvice)
-val adviceAnnotation = readAction {
-    JavaPsiFacade.getInstance(project).findClass(
+// Step 1: Locate the advice annotation class (handles both @ControllerAdvice and
+// @RestControllerAdvice) and collect the annotated classes. The annotation search reads
+// indexes, so the whole discovery runs in one smartReadAction; a null result means
+// Spring Web itself is missing from the classpath.
+val adviceClasses = smartReadAction {
+    val adviceAnnotation = JavaPsiFacade.getInstance(project).findClass(
         "org.springframework.web.bind.annotation.RestControllerAdvice", allScope()
     ) ?: JavaPsiFacade.getInstance(project).findClass(
         "org.springframework.web.bind.annotation.ControllerAdvice", allScope()
-    )
+    ) ?: return@smartReadAction null
+    AnnotatedElementsSearch.searchPsiClasses(adviceAnnotation, scope).findAll().toList()
 }
 
-if (adviceAnnotation == null) {
+if (adviceClasses == null) {
     println("ERROR: Spring Web not found on classpath — check pom.xml")
+} else if (adviceClasses.isEmpty()) {
+    println("WARNING: No @ControllerAdvice/@RestControllerAdvice found in project.")
+    println("Controllers throwing custom exceptions will return HTTP 500. Create a @RestControllerAdvice.")
 } else {
-    val adviceClasses = AnnotatedElementsSearch.searchPsiClasses(adviceAnnotation, scope).findAll().toList()
-    if (adviceClasses.isEmpty()) {
-        println("WARNING: No @ControllerAdvice/@RestControllerAdvice found in project.")
-        println("Controllers throwing custom exceptions will return HTTP 500. Create a @RestControllerAdvice.")
-    } else {
-        adviceClasses.forEach { cls ->
-            println("Found advice: ${cls.qualifiedName}")
-            readAction {
-                cls.methods.forEach { m ->
-                    val handler = m.annotations.firstOrNull { it.qualifiedName?.endsWith("ExceptionHandler") == true }
-                    if (handler != null) {
-                        val exTypes = handler.findAttributeValue("value")?.text ?: "(all)"
-                        val status = m.annotations.firstOrNull { it.qualifiedName?.endsWith("ResponseStatus") == true }
-                            ?.findAttributeValue("code")?.text ?: "?"
-                        println("  ${m.name} handles: $exTypes → HTTP $status")
-                    }
+    adviceClasses.forEach { cls ->
+        println("Found advice: ${cls.qualifiedName}")
+        readAction {
+            cls.methods.forEach { m ->
+                val handler = m.annotations.firstOrNull { it.qualifiedName?.endsWith("ExceptionHandler") == true }
+                if (handler != null) {
+                    val exTypes = handler.findAttributeValue("value")?.text ?: "(all)"
+                    val status = m.annotations.firstOrNull { it.qualifiedName?.endsWith("ResponseStatus") == true }
+                        ?.findAttributeValue("code")?.text ?: "?"
+                    println("  ${m.name} handles: $exTypes → HTTP $status")
                 }
             }
         }
@@ -700,7 +706,8 @@ println(if (generatedClass != null) "Found: " + generatedClass.containingFile?.v
 import com.intellij.psi.search.PsiSearchHelper
 val scope = GlobalSearchScope.projectScope(project)
 val usageFiles = mutableListOf<String>()
-readAction {
+// PsiSearchHelper reads the word index — smartReadAction, not plain readAction
+smartReadAction {
     PsiSearchHelper.getInstance(project).processAllFilesWithWord("UserDto", scope, { psiFile ->
         usageFiles.add(psiFile.virtualFile.path); true
     }, true)
@@ -728,7 +735,8 @@ import com.intellij.psi.search.FilenameIndex
 // Use this for plain identifiers, class names, annotation names, etc.
 val scope = GlobalSearchScope.projectScope(project)
 val matchingFiles = mutableListOf<String>()
-readAction {
+// PsiSearchHelper reads the word index — smartReadAction, not plain readAction
+smartReadAction {
     PsiSearchHelper.getInstance(project).processAllFilesWithWord("api", scope, { psiFile ->
         // Further filter if needed (e.g., only files that contain "/api/")
         if (psiFile.text.contains("/api/")) matchingFiles.add(psiFile.virtualFile.path)

--- a/prompts/src/main/prompts/skill/coding-with-intellij-threading.md
+++ b/prompts/src/main/prompts/skill/coding-with-intellij-threading.md
@@ -38,7 +38,7 @@ If you are about to write any of these in a `steroid_execute_code` script, you o
 | `JavaPsiFacade.getInstance(project).findClass(...)` / `findClasses(...)` / `findPackage(...)` | `readAction { }` (or `smartReadAction { }`) |
 | `PsiManager.getInstance(project).findFile(vf)` / `findDirectory(vf)` | `readAction { }` |
 | `psiFile.text` / `psiFile.firstChild` / `psiFile.children` / `psiFile.containingFile` | `readAction { }` |
-| `PsiSearchHelper.*`, `ReferencesSearch.*`, `ClassInheritorsSearch.*`, `MethodReferencesSearch.*` | `readAction { }` (or `smartReadAction { }` for index-dependent searches) |
+| `PsiSearchHelper.*`, `ReferencesSearch.*`, `ClassInheritorsSearch.*`, `MethodReferencesSearch.*` | `smartReadAction { }` — these searches read indexes; under a plain read action they fail with `IndexNotReadyException` when dumb mode re-enters |
 | `vf.children` / `vf.parent` / `vf.findChild(name)` / recursive `walk { }` over a `VirtualFile` | `readAction { }` |
 | `FileDocumentManager.getInstance().getDocument(vf)` and reading `document.text` / `lineCount` | `readAction { }` |
 | `ProjectRootManager.getInstance(project).contentRoots` / `contentSourceRoots` / `projectSdk` | `readAction { }` |

--- a/prompts/src/main/prompts/skill/execute-code-tool-description.md
+++ b/prompts/src/main/prompts/skill/execute-code-tool-description.md
@@ -46,7 +46,7 @@ literal anchors keep failing): the IDE's tolerance-matching patch engine — fet
 | **One literal-text edit, single file** | `val vf = findProjectFile(p) ?: error("not found: $p"); writeAction { VfsUtil.saveText(vf, String(vf.contentsToByteArray(), vf.charset).replace(OLD, NEW)) }; println("saved: $p")` |
 | **Find files by extension** | `readAction { FilenameIndex.getAllFilesByExt(project, "java", projectScope()) }` — not `Bash find … -name "*.java"` |
 | **Find files by exact name** | `readAction { FilenameIndex.getVirtualFilesByName("UserService.java", projectScope()) }` |
-| **Find all references to a symbol** | `readAction { ReferencesSearch.search(psiElement, projectScope()).findAll() }` — type-aware; Grep over source text is a fallback |
+| **Find all references to a symbol** | `smartReadAction { ReferencesSearch.search(psiElement, projectScope()).findAll() }` — type-aware; index-backed, so smart read (a plain read action risks `IndexNotReadyException`); Grep over source text is a fallback |
 | **Read file content (any size)** | `String((findProjectFile(p) ?: error("not found: $p")).contentsToByteArray(), charset)` — accepts relative or absolute paths, always re-reads from disk when called at the script top level; the next semantic query sees what you read |
 | **Grep content inside project files** | `readAction { FilenameIndex.getAllFilesByExt(project, ext, scope).flatMap { vf -> Regex(pat).findAll(String(vf.contentsToByteArray(), vf.charset)) … } }` in ONE call |
 | **Run Maven / Gradle tests** | IDE runner — see `mcp-steroid://skill/execute-code-maven` and `mcp-steroid://skill/execute-code-gradle`; Bash is only for shell-level final verification or IDE-runner fallback |
@@ -156,7 +156,7 @@ The wrap is required on EVERY new script — the IDE forgets the previous script
 |---|---|
 | Read any PSI element / walk a PSI tree / navigate references | `readAction { }` |
 | Use `FilenameIndex.*` (`getAllFilesByExt`, `getVirtualFilesByName`, `processAllFileNames`) | `readAction { }` |
-| Use `PsiSearchHelper.*`, `ReferencesSearch.*`, `ClassInheritorsSearch.*` | `readAction { }` |
+| Use `PsiSearchHelper.*`, `ReferencesSearch.*`, `ClassInheritorsSearch.*` | `smartReadAction { }` — index-backed searches; a plain read action can throw `IndexNotReadyException` when dumb mode re-enters |
 | Walk a VFS tree — `vf.children`, `vf.parent`, `vf.findChild(name)`, recursive `walk { }` | `readAction { }` |
 | Resolve `PsiManager.getInstance(project).findFile(vf)` / `findDirectory(vf)` and read `psiFile.text` / `firstChild` / `name` | `readAction { }` |
 | Get a `Document` from a `VirtualFile` via `FileDocumentManager.getInstance().getDocument(vf)` and read its text | `readAction { }` |

--- a/prompts/src/main/prompts/test/overview.md
+++ b/prompts/src/main/prompts/test/overview.md
@@ -478,13 +478,14 @@ CRITICAL before writing controllers that throw custom exceptions — if no globa
 import com.intellij.psi.search.GlobalSearchScope
 import com.intellij.psi.search.searches.AnnotatedElementsSearch
 val scope = GlobalSearchScope.projectScope(project)
-val adviceAnnotation = readAction {
-    JavaPsiFacade.getInstance(project).findClass("org.springframework.web.bind.annotation.ControllerAdvice", allScope())
+// Annotation lookup + search are index-backed — one smartReadAction owns the whole query
+val adviceClasses = smartReadAction {
+    val adviceAnnotation = JavaPsiFacade.getInstance(project).findClass("org.springframework.web.bind.annotation.ControllerAdvice", allScope())
         ?: JavaPsiFacade.getInstance(project).findClass("org.springframework.web.bind.annotation.RestControllerAdvice", allScope())
+    if (adviceAnnotation != null) {
+        AnnotatedElementsSearch.searchPsiClasses(adviceAnnotation, scope).findAll().toList()
+    } else emptyList()
 }
-val adviceClasses = if (adviceAnnotation != null) {
-    AnnotatedElementsSearch.searchPsiClasses(adviceAnnotation, scope).findAll().toList()
-} else emptyList()
 println("@ControllerAdvice classes: " + adviceClasses.map { it.qualifiedName })
 // Find which exceptions each @ExceptionHandler covers:
 adviceClasses.forEach { cls ->

--- a/prompts/src/test/kotlin/com/jonnyzzz/mcpSteroid/prompts/IndexDependentSearchContractTest.kt
+++ b/prompts/src/test/kotlin/com/jonnyzzz/mcpSteroid/prompts/IndexDependentSearchContractTest.kt
@@ -1,0 +1,174 @@
+/* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
+package com.jonnyzzz.mcpSteroid.prompts
+
+import com.jonnyzzz.mcpSteroid.testHelper.ProjectHomeDirectory
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.stream.Collectors
+
+/**
+ * Regression contract for issue #464: index-dependent PSI search recipes must not run
+ * under a plain `readAction { }`.
+ *
+ * The runtime guidance (execute-code tool description, threading skill) is explicit that the
+ * automatic smart-mode wait is only a point-in-time check — IntelliJ can re-enter dumb mode
+ * at any moment afterwards, so an index-backed query inside `readAction { }` fails
+ * nondeterministically with `IndexNotReadyException` (the race issue #29 fixed at the
+ * runtime level). Every prompt example that runs an index-backed search must wrap the whole
+ * query and its result snapshot in `smartReadAction { }`.
+ *
+ * Two rules, both over `prompts/src/main/prompts/{@literal **}/{@literal *}.md`:
+ * 1. Inside ` ```kotlin ``` ` fences, an index-dependent search call must be lexically
+ *    enclosed in a `smartReadAction { }` block (at any nesting depth).
+ * 2. Outside kotlin fences (prose, decision tables, bare fences), a line must not recommend
+ *    a plain `readAction {` together with an index-dependent search API.
+ */
+class IndexDependentSearchContractTest {
+
+    /** Search entry points that read stub/reference indexes and throw `IndexNotReadyException` in dumb mode. */
+    private val indexDependentSearches = listOf(
+        "ReferencesSearch",
+        "MethodReferencesSearch",
+        "ClassInheritorsSearch",
+        "OverridingMethodsSearch",
+        "AnnotatedElementsSearch",
+        "DefinitionsScopedSearch",
+        "PsiSearchHelper",
+    )
+
+    /** A member access on one of the search classes, e.g. `ReferencesSearch.search(...)` or `ReferencesSearch.*` in a table. */
+    private val searchCallPattern = Regex("""\b(${indexDependentSearches.joinToString("|")})\s*\.""")
+
+    /** A plain `readAction {` (optionally with call args) — not `smartReadAction {`, not `return@readAction`. */
+    private val plainReadActionPattern = Regex("""(?<![A-Za-z@$])readAction\s*(?:\([^()]*\)\s*)?\{""")
+
+    /** `identifier [(args)] {` — associates a `{` with the call that owns the block. */
+    private val blockOpenerPattern = Regex("""([A-Za-z_][A-Za-z0-9_]*)\s*(?:\([^()]*\)\s*)?\{""")
+
+    private val promptsRoot: Path =
+        ProjectHomeDirectory.requireProjectHomeDirectory().resolve("prompts/src/main/prompts")
+
+    private fun promptFiles(): List<Path> {
+        check(Files.isDirectory(promptsRoot)) { "prompts root not found: $promptsRoot" }
+        return Files.walk(promptsRoot).use { stream ->
+            stream.filter { Files.isRegularFile(it) && it.fileName.toString().endsWith(".md") }
+                .collect(Collectors.toList())
+        }
+    }
+
+    @Test
+    fun testKotlinFenceSearchCallsRunUnderSmartReadAction() {
+        val violations = mutableListOf<String>()
+
+        for (file in promptFiles()) {
+            val lines = Files.readAllLines(file)
+            val relPath = promptsRoot.relativize(file)
+            var inKotlinFence = false
+            var inOtherFence = false
+            // One entry per currently-open `{`; the value is the identifier owning the block (null = anonymous).
+            val blockStack = ArrayDeque<String?>()
+
+            lines.forEachIndexed { index, line ->
+                val trimmed = line.trimStart()
+                if (trimmed.startsWith("```")) {
+                    when {
+                        inKotlinFence -> inKotlinFence = false
+                        inOtherFence -> inOtherFence = false
+                        trimmed.startsWith("```kotlin") -> {
+                            inKotlinFence = true
+                            blockStack.clear()
+                        }
+                        else -> inOtherFence = true
+                    }
+                    return@forEachIndexed
+                }
+                if (!inKotlinFence) return@forEachIndexed
+                if (trimmed.startsWith("import ")) return@forEachIndexed
+
+                scanFenceLine(line, blockStack) { searchName ->
+                    if (blockStack.none { it == "smartReadAction" }) {
+                        violations.add(
+                            "$relPath:${index + 1}: $searchName runs outside smartReadAction { } — " +
+                                "wrap the whole query and its result snapshot in smartReadAction { } " +
+                                "(plain readAction races dumb-mode re-entry: IndexNotReadyException, issue #464)"
+                        )
+                    }
+                }
+            }
+        }
+
+        assertTrue(
+            violations.isEmpty(),
+            "Index-dependent search calls outside smartReadAction in prompt kotlin fences:\n" +
+                violations.joinToString("\n"),
+        )
+    }
+
+    @Test
+    fun testProseNeverPairsPlainReadActionWithIndexDependentSearch() {
+        val violations = mutableListOf<String>()
+
+        for (file in promptFiles()) {
+            val lines = Files.readAllLines(file)
+            val relPath = promptsRoot.relativize(file)
+            var inKotlinFence = false
+            var inOtherFence = false
+
+            lines.forEachIndexed { index, line ->
+                val trimmed = line.trimStart()
+                if (trimmed.startsWith("```")) {
+                    when {
+                        inKotlinFence -> inKotlinFence = false
+                        inOtherFence -> inOtherFence = false
+                        trimmed.startsWith("```kotlin") -> inKotlinFence = true
+                        else -> inOtherFence = true
+                    }
+                    return@forEachIndexed
+                }
+                // Kotlin fences are covered (with block-structure awareness) by the fence test above.
+                if (inKotlinFence) return@forEachIndexed
+
+                if (plainReadActionPattern.containsMatchIn(line) && searchCallPattern.containsMatchIn(line)) {
+                    violations.add(
+                        "$relPath:${index + 1}: recommends plain readAction { } together with an index-dependent " +
+                            "search API — recommend smartReadAction { } instead (issue #464): $trimmed"
+                    )
+                }
+            }
+        }
+
+        assertTrue(
+            violations.isEmpty(),
+            "Prose/table lines pairing plain readAction with index-dependent searches:\n" +
+                violations.joinToString("\n"),
+        )
+    }
+
+    /**
+     * Walks one fence line character by character, keeping [blockStack] in sync with `{`/`}`
+     * nesting, and reports every index-dependent search call at the stack state where it occurs.
+     *
+     * Braces inside string templates (`${'$'}{...}`) are balanced, so they do not corrupt the
+     * depth tracking; the identifier-ownership heuristic only needs to recognize the
+     * `smartReadAction {` / `smartReadAction(project) {` openers.
+     */
+    private fun scanFenceLine(line: String, blockStack: ArrayDeque<String?>, onSearchCall: (String) -> Unit) {
+        val openerAtBrace = mutableMapOf<Int, String>()
+        for (match in blockOpenerPattern.findAll(line)) {
+            openerAtBrace[match.range.last] = match.groupValues[1]
+        }
+        val searchAt = mutableMapOf<Int, String>()
+        for (match in searchCallPattern.findAll(line)) {
+            searchAt[match.range.first] = match.groupValues[1]
+        }
+        for (i in line.indices) {
+            searchAt[i]?.let(onSearchCall)
+            when (line[i]) {
+                '{' -> blockStack.addLast(openerAtBrace[i])
+                '}' -> if (blockStack.isNotEmpty()) blockStack.removeLast()
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes #464.

## Problem

The prompt corpus still taught index-backed searches (`ReferencesSearch`, `MethodReferencesSearch`, `ClassInheritorsSearch`, `OverridingMethodsSearch`, `AnnotatedElementsSearch`, `PsiSearchHelper`) inside plain `readAction { }` — or with no read action at all — re-introducing the dumb-mode race fixed at the runtime level by #29. The automatic smart-mode wait is only a point-in-time check; when the IDE re-enters dumb mode after preflight, the search fails nondeterministically with `IndexNotReadyException`. The most prominent canonical snippets (the `mcp-steroid://lsp/find-references` recipe and the execute-code tool-description decision table) both taught the unsafe form.

## Fix

- Every index-dependent search example now wraps the **whole query and its result snapshot** in `smartReadAction { }` (12 articles). Where the search feeds a write-intent refactoring phase (`ide/safe-delete`, the record-component recipe in `coding-with-intellij-spring`), discovery stays a smart-read snapshot before the write phase, with the split documented in place — exactly the shape #464 asks for.
- The `execute-code-tool-description` and `coding-with-intellij-threading` decision tables now route those search APIs to `smartReadAction { }` and explain the `IndexNotReadyException` hazard.

## Regression test

New `IndexDependentSearchContractTest` (`:prompts:test`, seconds) pins the contract over the whole corpus:

1. **Kotlin fences** — a brace-aware scanner requires every index-dependent search call to be lexically enclosed in a `smartReadAction { }` block (any nesting depth), so a new plain-`readAction` (or bare) search recipe fails the build with a `file:line` violation list.
2. **Prose/tables** — no line outside kotlin fences may pair plain `readAction {` with one of those search APIs, which is what guards the decision tables.

Run red-first, the scanner reproduced the issue's audit exactly and found **four additional offenders** the issue missed (`PsiSearchHelper` blocks in `coding-with-intellij-patterns.md` and `coding-with-intellij-spring.md`).

## Verification

- `IndexDependentSearchContractTest` red on the old corpus (25 fence + 3 prose violations), green after the fixes.
- All 564 non-KtBlock `:prompts:test` tests green (payload, format, routing, indexing-guidance contracts).
- KtBlock IDEA-leg compilation green for all 141 blocks of every changed article; the no-arg `smartReadAction` context helper already compiles on all IDE legs (precedent: unannotated `ide/type-hierarchy.md`), and TC's prompts matrix covers the rest.
- `LspExamplesExecutionTest` (`:ij-plugin:test`, 10/10 green) executes the rewritten `lsp/find-references` recipe end-to-end against a real IDE fixture — the integration-level proof the fixed recipe still runs.

Follow-up candidate (not this PR): the same treatment for `JavaPsiFacade.findClass` / `FilenameIndex` examples, which are also index-backed but were outside #464's scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)