### PR TITLE
A malformed stdin line no longer bricks the devrig mcp session

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -337,3 +337,25 @@
   "everything through HomePaths" reading would fold it in as `home.resolve("markers")` over the
   receiver). Folding changes marker discovery under explicit test homes (today it escapes the sandbox
   on purpose — see `GeneratedToolRuntimeTestSupport`), so it is a design decision, not a cleanup.
+
+- [ ] **`devrig mcp` log files all collapse onto `devrig-session.log`, and every line reads `[pid:?]`**
+  (spotted while fixing #461, pre-existing and unrelated to it). `configureLoggingAndLogStarted` sets
+  `devrig.log.dir` / `devrig.log.session` / `devrig.pid` before the first *intended* SLF4J call, but
+  logback has already initialised by then — the appender resolves the `${devrig.log.session:-session}`
+  and `${devrig.pid:-?}` defaults and pins them. Consequence: concurrent devrig processes share one
+  `~/.mcp-steroid/logs/devrig-session.log` (the per-pid file a log monitor is supposed to detect never
+  appears) and no log line is attributable to a process. Evidence: that file locally spans 10:34
+  `[Test worker]` lines through a 17:25 `devrig mcp` WARN, all `[pid:?]`. Find whoever touches SLF4J
+  before `configureLoggingAndLogStarted` (Clikt parsing / `resolveHomePathsOrDie` / a static
+  initialiser) and either set the properties earlier or reconfigure logback explicitly afterwards.
+  Note the same file shows Gradle test JVMs logging into the developer's REAL `~/.mcp-steroid/logs` —
+  worth checking separately.
+
+- [ ] **stdio framing follow-ups noticed while fixing #461** (both pre-existing, neither blocking).
+  (a) `FramingBuffer.append` grows without bound: a peer that never sends a newline (binary dump, a
+  huge single line) makes devrig buffer it all. A cap — discard-and-report past N MiB, reusing the
+  new `readNextUnparsableChunk` reporting path — would bound it.
+  (b) A final NDJSON message with no trailing newline is now answered with `-32700` ("stdin ended
+  mid-frame") rather than dispatched. That is spec-faithful (newlines delimit frames) and beats the
+  old silence, but a tolerant reading would dispatch parseable EOF residue instead. Deliberate choice,
+  worth revisiting only if a real client trips on it.

--- a/docs/devrig-cli-contract.md
+++ b/docs/devrig-cli-contract.md
@@ -107,6 +107,14 @@ The default presentation is for people: headings, tables, hints, and terminal co
 Diagnostics and progress go to stderr. Stdout is reserved for the requested result, and `devrig mcp`
 writes no presentation bytes to stdout before the JSON-RPC stdio server takes over.
 
+`devrig mcp` never lets bad input from the client end the session. Bytes on stdin that cannot begin a
+JSON-RPC frame — a stray log line, a BOM, a header block with no usable `Content-Length` — are
+discarded a run at a time; each one draws a JSON-RPC 2.0 §4.2 parse error (`code: -32700`, `id: null`)
+on stdout and a WARN naming the offending text (truncated) on stderr and in the log file. Frames that
+follow are still parsed and answered. Residue left when stdin ends mid-frame is reported the same way.
+A session that only saw garbage still exits 0: stdin reaching EOF is a normal shutdown, and the
+evidence is in the parse errors and the log.
+
 Commands that advertise `--json` emit one ANSI-free JSON document. Every schema-generated MCP-tool
 command uses this envelope:
 

--- a/mcp-stdio/src/main/kotlin/com/jonnyzzz/mcpSteroid/mcp/McpStdioFraming.kt
+++ b/mcp-stdio/src/main/kotlin/com/jonnyzzz/mcpSteroid/mcp/McpStdioFraming.kt
@@ -30,6 +30,36 @@ class FramingBuffer {
         return frame
     }
 
+    /**
+     * Consumes a leading byte run that can never begin a frame — a line that is neither
+     * JSON nor a frame header, or a completed header block with no usable
+     * `Content-Length` — and returns it (trimmed) so the caller can report it.
+     *
+     * Returns null when the buffer is empty, holds a frame ([readNextFrame] takes those),
+     * or could still grow into one. A non-null result always consumed at least one byte,
+     * so a caller may loop on it. Blank text means the discarded run was only line breaks.
+     *
+     * jonnyzzz/mcp-steroid#461: without this, the first stray line on stdin sat at the head
+     * of the buffer forever and every frame queued behind it was silently never parsed.
+     */
+    fun readNextUnparsableChunk(): String? {
+        val length = unparsableChunkLength(data) ?: return null
+        val text = data.copyOfRange(0, length).toString(Charsets.UTF_8).trim()
+        data = data.copyOfRange(length, data.size)
+        return text
+    }
+
+    /**
+     * Consumes everything still buffered and returns it verbatim — the residue at EOF,
+     * i.e. an unterminated line or a frame the peer never finished sending. Untrimmed on
+     * purpose: this text is diagnostic evidence.
+     */
+    fun drain(): String {
+        val text = data.toString(Charsets.UTF_8)
+        data = ByteArray(0)
+        return text
+    }
+
     fun isEmpty(): Boolean = data.isEmpty()
 }
 
@@ -60,6 +90,80 @@ private fun ByteArray.indexOf(target: ByteArray, fromIndex: Int = 0): Int {
         return i
     }
     return -1
+}
+
+/**
+ * A completed header block: [headerEnd] is where the headers stop, [consumed] where the
+ * body begins (i.e. past the blank-line delimiter).
+ */
+private class HeaderBlock(val headerEnd: Int, val consumed: Int)
+
+/**
+ * Locates the blank line that ends a header block, or null while none is buffered.
+ * CRLFCRLF wins over LFLF at the same precedence [tryParseNextFrame] uses, so both
+ * agree on where a frame's headers stop.
+ */
+private fun findHeaderBlock(data: ByteArray): HeaderBlock? {
+    val crlf = data.indexOf("\r\n\r\n".toByteArray())
+    if (crlf >= 0) return HeaderBlock(headerEnd = crlf, consumed = crlf + 4)
+    val lf = data.indexOf("\n\n".toByteArray())
+    if (lf >= 0) return HeaderBlock(headerEnd = lf, consumed = lf + 2)
+    return null
+}
+
+/**
+ * True when [line] can be the FIRST line of a Content-Length header block.
+ *
+ * LSP-style framing defines exactly two header fields, and only `Content-Length` makes a
+ * frame decodable — so the check stays deliberately narrow: a line that isn't one of them
+ * is garbage to be reported now, not a header to keep waiting on. That is what lets an
+ * interleaved wrapper log line ("2026-08-07 INFO: started") be answered with -32700 and
+ * skipped instead of jamming the stream (jonnyzzz/mcp-steroid#461).
+ *
+ * Only the first line is judged, so exotic headers deeper in a block still pass through
+ * (`decodeContentLength` skips what it doesn't know). A client that leads with one loses
+ * no frames either — its header line draws a spurious parse error and the frame behind it
+ * parses normally.
+ */
+private fun couldBeFrameHeaderLine(line: String): Boolean {
+    val colon = line.indexOf(':')
+    if (colon <= 0) return false
+    return when (line.substring(0, colon).trim().lowercase()) {
+        "content-length", "content-type" -> true
+        else -> false
+    }
+}
+
+/**
+ * Byte count of the leading run that can never begin a valid frame, or null when the
+ * buffer is empty, starts a frame, or may still grow into one.
+ *
+ * The complement of [tryParseNextFrame]'s grammar: a frame starts either with a JSON
+ * payload (NDJSON) or with a header block carrying a usable `Content-Length`. Anything
+ * else is unparsable the moment its line — or its header block — is complete. Never
+ * claims bytes [tryParseNextFrame] would accept, and always reports at least one byte
+ * when it reports anything.
+ */
+private fun unparsableChunkLength(data: ByteArray): Int? {
+    if (data.isEmpty()) return null
+    // An NDJSON frame, complete or still arriving — readNextFrame owns it either way.
+    if (startsLikeJsonPayload(data)) return null
+
+    val headerBlock = findHeaderBlock(data)
+    if (headerBlock != null) {
+        val headersText = data.copyOfRange(0, headerBlock.headerEnd).toString(Charsets.UTF_8)
+        // A usable Content-Length makes this a real frame, pending only on its body.
+        if (decodeContentLength(headersText) != null) return null
+        return headerBlock.consumed
+    }
+
+    // No blank line yet, so the header block is either still arriving or was never one.
+    // A first line that cannot be a header line proves it never will be.
+    val newlineIdx = data.indexOf(byteArrayOf(0x0a))
+    if (newlineIdx < 0) return null  // the line itself is still arriving
+    val firstLine = data.copyOfRange(0, newlineIdx).toString(Charsets.UTF_8).trimEnd('\r')
+    if (couldBeFrameHeaderLine(firstLine)) return null
+    return newlineIdx + 1
 }
 
 private fun tryParseNextFrame(data: ByteArray): FrameResult? {

--- a/mcp-stdio/src/main/kotlin/com/jonnyzzz/mcpSteroid/mcp/McpStdioServer.kt
+++ b/mcp-stdio/src/main/kotlin/com/jonnyzzz/mcpSteroid/mcp/McpStdioServer.kt
@@ -52,9 +52,14 @@ import java.io.OutputStream
  *      client's response while the handler is parked.
  *   3. The output framing mode is locked on the **first inbound frame** ("framed" or
  *      "ndjson"); subsequent writes match that mode.
- *   4. On EOF (or [IOException]) the reader exits and the session is closed (which
- *      drains its channels). The surrounding `coroutineScope` waits for all in-flight
- *      dispatch coroutines and pump coroutines to finish before returning.
+ *   4. Bytes that can never begin a frame (a stray log line, a BOM, a header block with no
+ *      usable `Content-Length`) are discarded a run at a time, each answered with a
+ *      `-32700` parse error and logged at WARN. The session keeps serving — the frames
+ *      queued behind the garbage still get answered (jonnyzzz/mcp-steroid#461).
+ *   5. On EOF (or [IOException]) the reader exits, any unparsed residue is reported the
+ *      same way, and the session is closed (which drains its channels). The surrounding
+ *      `coroutineScope` waits for all in-flight dispatch coroutines and pump coroutines to
+ *      finish before returning.
  */
 class McpStdioServer(
     private val server: McpServerCore,
@@ -156,7 +161,15 @@ class McpStdioServer(
             if (n == 0) continue       // 0-byte read is unusual for blocking InputStream; defend against it
             buffer.append(buf, n)
             while (true) {
-                val frame = buffer.readNextFrame() ?: break
+                val frame = buffer.readNextFrame()
+                if (frame == null) {
+                    // Bytes that can never start a frame used to sit at the head of the
+                    // buffer forever, hiding every valid frame queued behind them (#461).
+                    // Discard the run, answer it, and keep reading.
+                    val unparsable = buffer.readNextUnparsableChunk() ?: break
+                    reportUnparsableInput(unparsable, "input is not a JSON-RPC message")
+                    continue
+                }
                 if (outputMode == null) outputMode = frame.mode
                 if (frame.payloadText.isBlank()) continue
                 val payload = frame.payloadText
@@ -169,6 +182,27 @@ class McpStdioServer(
                 }
             }
         }
+        // Anything left over means stdin ended mid-frame: an unterminated line, or a frame
+        // whose declared body never arrived. Reported, never swallowed — silence here is
+        // what made #461 undiagnosable. Skipped under cancellation: the streams are being
+        // torn down and a diagnostic write would only fail.
+        if (currentCoroutineContext().isActive) {
+            reportUnparsableInput(buffer.drain().trim(), "stdin ended mid-frame")
+        }
+    }
+
+    /**
+     * Answers input that never formed a frame with the JSON-RPC 2.0 §4.2 parse error
+     * (`-32700`, `id: null`) and records the offending bytes at WARN — which reaches both
+     * stderr and the log file, the two places a stuck client is debugged from. Blank
+     * [text] is stray line breaks between frames: noise, not a protocol error.
+     */
+    private suspend fun reportUnparsableInput(text: String, reason: String) {
+        if (text.isBlank()) return
+        val excerpt = text.take(MAX_REPORTED_CHARS)
+        val elision = if (text.length > MAX_REPORTED_CHARS) " ...(${text.length} chars total)" else ""
+        log.warn("[MCP stdio] $reason, discarding unparsable input: $excerpt$elision")
+        writeFrame(encodeError(JsonRpcErrorCodes.PARSE_ERROR, "Parse error: $reason: $excerpt$elision"))
     }
 
     /**
@@ -210,7 +244,7 @@ class McpStdioServer(
             throw e
         } catch (e: Exception) {
             log.warn("[MCP stdio] handler failed", e)
-            encodeInternalError(e.message ?: "Internal error")
+            encodeError(JsonRpcErrorCodes.INTERNAL_ERROR, e.message ?: "Internal error")
         }
         if (response != null) writeFrame(response)
     }
@@ -238,16 +272,24 @@ class McpStdioServer(
         }
     }
 
-    private fun encodeInternalError(message: String): String {
+    /** JSON-RPC 2.0 error response with a null id — for failures with no addressable request. */
+    private fun encodeError(code: Int, message: String): String {
         val response = JsonRpcResponse(
             id = JsonNull,
-            error = JsonRpcError(code = JsonRpcErrorCodes.INTERNAL_ERROR, message = message)
+            error = JsonRpcError(code = code, message = message)
         )
         return McpJson.encodeToString(JsonRpcResponse.serializer(), response)
     }
 
     private companion object {
         private const val READ_BUFFER_SIZE = 8192
+
+        /**
+         * How much of an unparsable input run is echoed into the WARN and the `-32700`
+         * message. Enough to recognise a BOM, a CRLF, or a stray log line; short enough
+         * that a megabyte of garbage can't blow up the log or the response.
+         */
+        private const val MAX_REPORTED_CHARS = 200
     }
 }
 

--- a/mcp-stdio/src/test/kotlin/com/jonnyzzz/mcpSteroid/mcp/McpStdioFramingTest.kt
+++ b/mcp-stdio/src/test/kotlin/com/jonnyzzz/mcpSteroid/mcp/McpStdioFramingTest.kt
@@ -425,4 +425,119 @@ class McpStdioFramingTest {
     fun `encodeNdjsonMessage empty payload is just a newline`() {
         assertEquals("\n", encodeNdjsonMessage(""))
     }
+
+    // -------------------------------------------------------------------------
+    // readNextUnparsableChunk — jonnyzzz/mcp-steroid#461
+    //
+    // A leading byte run that can never begin a frame used to jam the buffer
+    // forever: `readNextFrame` kept returning null, so every valid frame queued
+    // behind the garbage was never seen. These tests pin the discard contract
+    // that lets the transport report the garbage and carry on.
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `garbage line is discarded so the frame behind it can be read`() {
+        val buf = FramingBuffer()
+        buf.append("this is not json\n{\"id\":\"1\"}\n".toByteArray(Charsets.UTF_8))
+        assertNull(buf.readNextFrame(), "a non-JSON prefix is not a frame")
+        assertEquals("this is not json", buf.readNextUnparsableChunk())
+        val frame = buf.readNextFrame()
+        assertNotNull(frame)
+        assertEquals("""{"id":"1"}""", frame.payloadText)
+        assertEquals("ndjson", frame.mode)
+    }
+
+    @Test
+    fun `garbage line with CRLF ending is discarded without the line break`() {
+        val buf = FramingBuffer()
+        buf.append("this is not json\r\n{\"id\":\"1\"}\n".toByteArray(Charsets.UTF_8))
+        assertEquals("this is not json", buf.readNextUnparsableChunk())
+        assertEquals("""{"id":"1"}""", buf.readNextFrame()?.payloadText)
+    }
+
+    @Test
+    fun `a BOM before the payload is discarded as one garbage line`() {
+        val buf = FramingBuffer()
+        buf.append("\uFEFF{\"id\":\"1\"}\n{\"id\":\"2\"}\n".toByteArray(Charsets.UTF_8))
+        assertNull(buf.readNextFrame(), "a BOM-prefixed line does not start like JSON")
+        assertEquals("\uFEFF{\"id\":\"1\"}", buf.readNextUnparsableChunk())
+        assertEquals("""{"id":"2"}""", buf.readNextFrame()?.payloadText)
+    }
+
+    @Test
+    fun `empty buffer has nothing to discard`() {
+        assertNull(FramingBuffer().readNextUnparsableChunk())
+    }
+
+    @Test
+    fun `a partial ndjson line is never discarded`() {
+        val buf = FramingBuffer()
+        buf.append("{\"id\":\"1\",".toByteArray(Charsets.UTF_8))
+        assertNull(buf.readNextUnparsableChunk(), "the rest of the line may still arrive")
+    }
+
+    @Test
+    fun `partial framed headers are never discarded`() {
+        val buf = FramingBuffer()
+        buf.append("Content-Length: 10\r\n".toByteArray(Charsets.UTF_8))
+        assertNull(buf.readNextUnparsableChunk(), "the header block is still arriving")
+    }
+
+    @Test
+    fun `a framed message whose body is still arriving is never discarded`() {
+        val buf = FramingBuffer()
+        buf.append("Content-Length: 20\r\n\r\npartial".toByteArray(Charsets.UTF_8))
+        assertNull(buf.readNextUnparsableChunk(), "the declared body is still arriving")
+    }
+
+    @Test
+    fun `a leading Content-Type header is never discarded`() {
+        val buf = FramingBuffer()
+        buf.append("Content-Type: application/vscode-jsonrpc; charset=utf-8\r\n".toByteArray(Charsets.UTF_8))
+        assertNull(buf.readNextUnparsableChunk(), "Content-Type may precede Content-Length")
+    }
+
+    @Test
+    fun `a header block without a usable content-length is discarded whole`() {
+        val buf = FramingBuffer()
+        buf.append("Content-Length: xyz\r\n\r\n{}\n".toByteArray(Charsets.UTF_8))
+        assertNull(buf.readNextFrame())
+        assertEquals("Content-Length: xyz", buf.readNextUnparsableChunk())
+        assertEquals("{}", buf.readNextFrame()?.payloadText)
+    }
+
+    @Test
+    fun `a blank leading line is discarded as empty text`() {
+        val buf = FramingBuffer()
+        buf.append("\nthis is not json\n".toByteArray(Charsets.UTF_8))
+        assertEquals("", buf.readNextUnparsableChunk(), "a stray blank line is noise, not a protocol error")
+        assertEquals("this is not json", buf.readNextUnparsableChunk())
+        assertTrue(buf.isEmpty())
+    }
+
+    // -------------------------------------------------------------------------
+    // drain — residue diagnostics at EOF (jonnyzzz/mcp-steroid#461)
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `an unterminated garbage line is only surfaced by drain`() {
+        val buf = FramingBuffer()
+        buf.append("this is not json".toByteArray(Charsets.UTF_8))
+        assertNull(buf.readNextUnparsableChunk(), "an unterminated line may still grow")
+        assertEquals("this is not json", buf.drain())
+        assertTrue(buf.isEmpty())
+    }
+
+    @Test
+    fun `drain surfaces a truncated framed body`() {
+        val buf = FramingBuffer()
+        buf.append("Content-Length: 20\r\n\r\npartial".toByteArray(Charsets.UTF_8))
+        assertEquals("Content-Length: 20\r\n\r\npartial", buf.drain())
+        assertTrue(buf.isEmpty())
+    }
+
+    @Test
+    fun `drain on an empty buffer is empty text`() {
+        assertEquals("", FramingBuffer().drain())
+    }
 }

--- a/mcp-stdio/src/test/kotlin/com/jonnyzzz/mcpSteroid/mcp/McpStdioServerProtocolTest.kt
+++ b/mcp-stdio/src/test/kotlin/com/jonnyzzz/mcpSteroid/mcp/McpStdioServerProtocolTest.kt
@@ -71,6 +71,11 @@ class McpStdioServerProtocolTest {
             inputBytes.write(encodeNdjsonMessage(jsonStr).toByteArray(Charsets.UTF_8))
         }
 
+        /** Writes [text] to stdin verbatim — no framing, no trailing newline. */
+        fun sendRaw(text: String) {
+            inputBytes.write(text.toByteArray(Charsets.UTF_8))
+        }
+
         suspend fun runRaw(): ByteArray {
             val outputBuffer = ByteArrayOutputStream()
             val input = ByteArrayInputStream(inputBytes.toByteArray())
@@ -1321,6 +1326,88 @@ class McpStdioServerProtocolTest {
         // Three parse errors + one valid response.
         assertEquals(3, responses.count { it["error"] != null })
         assertEquals(1, responses.count { it["result"] != null })
+    }
+
+    // ---- Unparsable (non-JSON) input recovery — jonnyzzz/mcp-steroid#461 -----
+
+    @Test
+    fun `garbage line before initialize gets a parse error and initialize is still answered`() = runTest {
+        // #461: one non-JSON line on stdin used to jam the framing buffer forever — the
+        // `initialize` behind it was never parsed, nothing was written, and the process
+        // exited 0. The line must produce -32700 and the session must survive it.
+        val h = StdioHarness()
+        h.sendRaw("this is not json\n")
+        h.sendNdjson(init("1"))
+
+        val responses = h.runAndGetObjects()
+        assertEquals(2, responses.size, "expected a parse error plus the initialize result: $responses")
+        assertEquals(JsonRpcErrorCodes.PARSE_ERROR, (responses[0]["error"] as JsonObject)["code"]?.jsonPrimitive?.int)
+        assertEquals("1", responses[1]["id"]?.jsonPrimitive?.content)
+        assertNotNull(responses[1]["result"], "initialize must still be answered: ${responses[1]}")
+    }
+
+    @Test
+    fun `the parse error for an unframed garbage line is itself ndjson`() = runTest {
+        // Nothing has locked the output mode yet, and MCP stdio is NDJSON — the error
+        // must not go out with a Content-Length header a spec-only client can't read.
+        val h = StdioHarness()
+        h.sendRaw("this is not json\n")
+        val raw = h.runRaw().toString(Charsets.UTF_8)
+        assertTrue(raw.startsWith("{"), "parse error must be a bare NDJSON line: $raw")
+        assertTrue(raw.endsWith("\n"), "NDJSON frames are newline-terminated: $raw")
+    }
+
+    @Test
+    fun `garbage between two valid frames is reported without dropping either`() = runTest {
+        val h = StdioHarness()
+        h.sendNdjson(req("before", "ping"))
+        h.sendRaw("2026-08-07 INFO wrapper script says hello\n")
+        h.sendNdjson(req("after", "ping"))
+
+        // Dispatch of non-initialize requests is concurrent, so assert on the set of
+        // responses, not their order.
+        val responses = h.runAndGetObjects()
+        assertEquals(3, responses.size, "both pings plus one parse error: $responses")
+        assertEquals(
+            setOf("before", "after"),
+            responses.mapNotNull { it["id"]?.jsonPrimitive?.contentOrNull }.toSet(),
+            "the frames on either side of the garbage must both be answered: $responses",
+        )
+        val errors = responses.filter { it["error"] != null }
+        assertEquals(1, errors.size, "exactly one parse error: $responses")
+        assertEquals(JsonRpcErrorCodes.PARSE_ERROR, (errors[0]["error"] as JsonObject)["code"]?.jsonPrimitive?.int)
+    }
+
+    @Test
+    fun `unterminated garbage at EOF still gets a parse error`() = runTest {
+        // No trailing newline: the line can only be judged once stdin ends.
+        val h = StdioHarness()
+        h.sendRaw("this is not json")
+        val responses = h.runAndGetObjects()
+        assertEquals(1, responses.size, "EOF residue must be reported, not silently dropped: $responses")
+        assertEquals(JsonRpcErrorCodes.PARSE_ERROR, (responses[0]["error"] as JsonObject)["code"]?.jsonPrimitive?.int)
+    }
+
+    @Test
+    fun `a framed body truncated by EOF gets a parse error`() = runTest {
+        // A client that dies mid-frame leaves a legal header with a short body. That is
+        // evidence worth reporting, not a clean shutdown.
+        val h = StdioHarness()
+        h.sendRaw("Content-Length: 200\r\n\r\n{\"jsonrpc\":\"2.0\"")
+        val responses = h.runAndGetObjects()
+        assertEquals(1, responses.size, "truncated final frame must be reported: $responses")
+        assertEquals(JsonRpcErrorCodes.PARSE_ERROR, (responses[0]["error"] as JsonObject)["code"]?.jsonPrimitive?.int)
+    }
+
+    @Test
+    fun `a trailing newline after the last frame is not a parse error`() = runTest {
+        // Stray line breaks between frames are noise, not protocol errors.
+        val h = StdioHarness()
+        h.sendNdjson(req("1", "ping"))
+        h.sendRaw("\n\n")
+        val responses = h.runAndGetObjects()
+        assertEquals(1, responses.size, "blank lines must not produce parse errors: $responses")
+        assertNull(responses[0]["error"])
     }
 
     // ---- params shape -------------------------------------------------------

--- a/npx-kt/src/integrationTest/kotlin/com/jonnyzzz/mcpSteroid/devrig/cli/CliMcpStdioIntegrationTest.kt
+++ b/npx-kt/src/integrationTest/kotlin/com/jonnyzzz/mcpSteroid/devrig/cli/CliMcpStdioIntegrationTest.kt
@@ -1,13 +1,18 @@
 /* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
 package com.jonnyzzz.mcpSteroid.devrig.cli
 
+import com.jonnyzzz.mcpSteroid.mcp.JsonRpcErrorCodes
 import com.jonnyzzz.mcpSteroid.mcp.MCP_PROTOCOL_VERSION
 import com.jonnyzzz.mcpSteroid.testHelper.CloseableStackDriver
 import com.jonnyzzz.mcpSteroid.testHelper.CloseableStackHost
 import com.jonnyzzz.mcpSteroid.testHelper.StdioMcpProcess
+import com.jonnyzzz.mcpSteroid.testHelper.StdoutCleanlinessHarness
+import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonNull
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.int
 import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
@@ -182,6 +187,52 @@ class CliMcpStdioIntegrationTest {
         // alive (i.e. the server didn't crash on the notification handling).
         val pingResponse = process.request("ping", buildJsonObject {})
         assertNull(pingResponse["error"], "ping after notification must succeed: $pingResponse")
+    }
+
+    @Test
+    fun `a malformed line on stdin does not brick the session`() {
+        // jonnyzzz/mcp-steroid#461: `(echo 'this is not json'; echo '<initialize>') | devrig mcp`
+        // wrote ZERO bytes and exited 0 — the handshake queued behind the stray line was never
+        // parsed, and nothing on stderr named the cause. A client-side CRLF, BOM, or wrapper
+        // log line bricked the whole session invisibly.
+        val garbage = "this is not json"
+        val stdin = "$garbage\n".toByteArray(Charsets.UTF_8) + StdoutCleanlinessHarness.handshakeBytes
+
+        val result = cli.runMpcWithStdin(stdin)
+
+        assertEquals(
+            0,
+            result.exitCode,
+            "devrig mcp must still shut down cleanly\nstdout=\n${result.stdout}\nstderr=\n${result.stderr}",
+        )
+        // Every handshake id round-trips — i.e. the stray line cost no requests — and every
+        // stdout line is still a bare JSON-RPC envelope.
+        StdoutCleanlinessHarness.assertStdoutClean(
+            stdout = result.stdout,
+            variantLabel = "docker:linux",
+            stderrForDiagnostics = result.stderr,
+        )
+
+        val frames = result.stdout.lineSequence()
+            .filter { it.isNotBlank() }
+            .map { Json.parseToJsonElement(it).jsonObject }
+            .toList()
+        val parseErrors = frames.filter {
+            it["error"]?.jsonObject?.get("code")?.jsonPrimitive?.int == JsonRpcErrorCodes.PARSE_ERROR
+        }
+        assertEquals(
+            1,
+            parseErrors.size,
+            "the stray line must draw exactly one -32700 (JSON-RPC 2.0 §4.2)\nstdout=\n${result.stdout}",
+        )
+        assertTrue(
+            parseErrors.single()["id"] is JsonNull,
+            "a parse error has no addressable request: ${parseErrors.single()}",
+        )
+        assertTrue(
+            garbage in result.stderr,
+            "stderr must name the offending line so a hung client is diagnosable\nstderr=\n${result.stderr}",
+        )
     }
 
     companion object {


### PR DESCRIPTION
Fixes #461.

## The bug

One non-JSON line on stdin killed the whole `devrig mcp` session, silently:

```console
$ (echo 'this is not json'; echo '{"jsonrpc":"2.0","id":1,"method":"initialize",...}'; sleep 3) | devrig mcp
$ echo $?
0
```

0 bytes on stdout, nothing on stderr, exit 0 — the `initialize` behind the stray line was never answered, so the client hung forever with no evidence on either side. A single client-side CRLF, BOM, or interleaved wrapper log line was enough.

## Root cause

`tryParseNextFrame` (`McpStdioFraming.kt`) accepts exactly two frame starts: a `Content-Length` header block, or a payload beginning `{`/`[`. A leading garbage line matches neither, so `readNextFrame()` returned `null` **forever** — the run sat at the head of the buffer, every valid frame queued behind it was never parsed, and EOF exited the reader loop as a clean shutdown. That last part is why the failure had no symptoms at all.

## The fix

`FramingBuffer` gained the two operations the grammar was missing, as the exact complement of `tryParseNextFrame`:

- **`readNextUnparsableChunk()`** — consumes a leading run that can never begin a frame: a line that is neither JSON nor a `Content-Length`/`Content-Type` header, or a completed header block with no usable `Content-Length`. Never claims bytes `tryParseNextFrame` would accept, and always consumes ≥1 byte, so the caller can loop.
- **`drain()`** — surfaces the residue when stdin ends mid-frame (unterminated line, or a body the peer never finished).

`McpStdioServer` answers each with the JSON-RPC 2.0 §4.2 parse error (`code: -32700`, `id: null`) plus a WARN carrying up to 200 chars of the offending text — which reaches **stderr and the log file** — and keeps serving, so frames behind the garbage are still answered. Blank runs stay silent: stray line breaks between frames are noise, not protocol errors. This is option 1 of the issue's "Expected", with option 2's logging on top.

Behaviour on the issue's own repro, against the packaged binary:

```
{"jsonrpc":"2.0","id":null,"error":{"code":-32700,"message":"Parse error: input is not a JSON-RPC message: this is not json"}}
{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-11-25", ... }}
```
```
WARN c.j.mcpSteroid.mcp.McpStdioServer - [MCP stdio] input is not a JSON-RPC message, discarding unparsable input: this is not json
```

## Regression tests — watched failing first, at all three levels

| Level | Pre-fix | Post-fix |
|---|---|---|
| `McpStdioServerProtocolTest` (6 new) | 5 FAILED — zero responses; the interleaved case answered only the ping *before* the garbage | 192/192 green |
| `McpStdioFramingTest` (12 new) | API absent | green |
| `CliMcpStdioIntegrationTest` (Docker, packaged `bin/devrig`) | FAILED: "expected at least one JSON-RPC frame on stdout but got none" — verified against a rebuilt pre-fix dist | 8/8 green |

The framing tests pin the discard boundary **in both directions**, which is the part that could silently break real clients: garbage line, CRLF line ending, BOM prefix and unusable `Content-Length` are discarded; partial NDJSON, partial headers, a still-arriving declared body and a leading `Content-Type` are **not**. The Docker test reuses `StdoutCleanlinessHarness`, so it asserts every handshake id still round-trips — i.e. the stray line costs no requests — and that stdout stays exclusively JSON-RPC.

Covers levels 1–2 of the `docs/devrig-cli-contract.md` validation matrix; levels 3–4 (IDE-backed tool commands, live-agent command discovery) are untouched by a transport parse-error change — no command grammar, help text, or JSON envelope moved.

## Two judgement calls worth reviewing

- **A final NDJSON message with no trailing newline now draws `-32700`** ("stdin ended mid-frame") instead of being silently dropped. Spec-faithful — newlines delimit frames — and strictly better than the old silence, but a tolerant reading would dispatch parseable EOF residue instead. Logged in `TODO.md` as revisitable if a real client trips on it.
- **Only `Content-Length`/`Content-Type` count as header-block starts.** A client leading with an exotic header draws one spurious parse error but loses no frames (the frame behind it parses normally). The payoff: a colon-bearing wrapper log line like `INFO: started` recovers mid-stream instead of jamming the session until EOF.

A session that saw only garbage still exits 0 — stdin reaching EOF is a normal shutdown, and the evidence now lives in the parse errors and the log rather than in an exit code.

## Also in this PR

`docs/devrig-cli-contract.md` documents the malformed-input contract. `TODO.md` records three pre-existing findings noticed on the way, none fixed here: `FramingBuffer.append` grows unbounded for a peer that never sends a newline; the EOF-newline tolerance question above; and every `devrig mcp` run logging into one shared `devrig-session.log` with `[pid:?]` (logback initialises before `configureLoggingAndLogStarted` sets its properties — and Gradle test JVMs write into the developer's real `~/.mcp-steroid/logs`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
