### PR TITLE
Default kotlinc params disable the scripting-plugin probe the bundle cannot satisfy (#463)

### DIFF
--- a/ij-plugin/src/main/kotlin/com/jonnyzzz/mcpSteroid/execution/CodeEvalManager.kt
+++ b/ij-plugin/src/main/kotlin/com/jonnyzzz/mcpSteroid/execution/CodeEvalManager.kt
@@ -122,8 +122,8 @@ class CodeEvalManager(
             inputKt.writeText(wrappedCode.code)
 
             // Space-separated argv tokens (quoting-aware), e.g. the default
-            // "-language-version 2.3 -api-version 2.3" becomes 4 tokens —
-            // applyArgumentStrings rejects entries with embedded spaces.
+            // "-language-version 2.3 -api-version 2.3 -Xdisable-default-scripting-plugin"
+            // becomes 5 tokens — applyArgumentStrings rejects entries with embedded spaces.
             val extraParams = ParametersListUtil.parse(Registry.stringValue("mcp.steroid.kotlinc.parameters"))
 
             val compilerMessageRenderer = RecordingCompilerMessageRenderer()

--- a/ij-plugin/src/main/resources/META-INF/plugin.xml
+++ b/ij-plugin/src/main/resources/META-INF/plugin.xml
@@ -141,8 +141,8 @@
             description="Toggles minimalistic analytics from the plugin"/>
 
         <!-- Kotlinc configuration -->
-        <registryKey key="mcp.steroid.kotlinc.parameters" defaultValue="-language-version 2.3 -api-version 2.3"
-            description="Additional kotlinc command-line parameters (space-separated). Default: -language-version 2.3 -api-version 2.3 — the Kotlin bundled by the oldest supported IDE (2026.1 ships 2.3.20). For example: -Xskip-metadata-version-check"/>
+        <registryKey key="mcp.steroid.kotlinc.parameters" defaultValue="-language-version 2.3 -api-version 2.3 -Xdisable-default-scripting-plugin"
+            description="Additional kotlinc command-line parameters (space-separated). Default: -language-version 2.3 -api-version 2.3 — the Kotlin bundled by the oldest supported IDE (2026.1 ships 2.3.20) — plus -Xdisable-default-scripting-plugin, because the bundled kotlinc/ folder ships no kotlin-scripting-* jars and the default scripting-plugin probe would log a ClassNotFoundException on every compilation. For example: -Xskip-metadata-version-check"/>
 
         <!-- Start MCP server when a project opens (writes URL files, runs analytics) -->
         <postStartupActivity

--- a/ij-plugin/src/test/kotlin/com/jonnyzzz/mcpSteroid/execution/CodeEvalManagerTest.kt
+++ b/ij-plugin/src/test/kotlin/com/jonnyzzz/mcpSteroid/execution/CodeEvalManagerTest.kt
@@ -53,6 +53,29 @@ class CodeEvalManagerTest: BasePlatformTestCase()  {
         )
     }
 
+    fun testDefaultCompileEmitsNoScriptingPluginProbeNoise(): Unit = timeoutRunBlocking(5.minutes) {
+        // #463: kotlinc's default scripting-plugin auto-probe fails on every
+        // compilation (the plugin bundles no kotlin-scripting-* jars) and used to
+        // spam DEBUG-severity "Exception on loading scripting plugin:
+        // ClassNotFoundException" + "Scripting plugin will not be loaded" lines
+        // into the forwarded compiler progress. The registry default carries
+        // -Xdisable-default-scripting-plugin to suppress the probe; this pins the
+        // end-to-end effect on a plain compile with default settings.
+        val code = """
+            println("no scripting probe expected")
+        """.trimIndent()
+        val execId = project.executionStorage.writeNewExecution(testExecParams(code))
+        val result = TestResultBuilder()
+        val data = project.codeEvalManager.evalCode(execId, code, result)
+        Assert.assertNotNull("Trivial script must compile. Result: $result", data)
+        val probeLines = (result.progressMessages + result.messages)
+            .filter { it.contains("scripting plugin", ignoreCase = true) }
+        Assert.assertTrue(
+            "Compiler output must not carry the scripting-plugin probe noise, got: $probeLines",
+            probeLines.isEmpty(),
+        )
+    }
+
     fun testWarningCarryingScriptCompilesWithoutWerror(): Unit = timeoutRunBlocking(5.minutes) {
         // Companion to the -Werror canary: the SAME source must compile fine with
         // the default registry value — proving the canary fails on -Werror alone.

--- a/ij-plugin/src/test/kotlin/com/jonnyzzz/mcpSteroid/koltinc/KotlincRegistryDefaultsTest.kt
+++ b/ij-plugin/src/test/kotlin/com/jonnyzzz/mcpSteroid/koltinc/KotlincRegistryDefaultsTest.kt
@@ -11,8 +11,15 @@ class KotlincRegistryDefaultsTest : BasePlatformTestCase() {
         // sinceBuild: the pin must stay at the FLOOR of the supported IDE range so a
         // script compiles identically on every IDE and its metadata stays readable by
         // the oldest bundled kotlin-reflect.
+        //
+        // -Xdisable-default-scripting-plugin: the plugin's kotlinc/ distribution
+        // deliberately ships no kotlin-scripting-* jars, so kotlinc's default
+        // scripting-plugin auto-probe throws ClassNotFoundException and logs
+        // "Scripting plugin will not be loaded" on EVERY compilation (#463).
+        // Scripts compile as plain classes (CodeButcher wraps them), so the
+        // scripting plugin is never needed — disable the probe outright.
         assertEquals(
-            "-language-version 2.3 -api-version 2.3",
+            "-language-version 2.3 -api-version 2.3 -Xdisable-default-scripting-plugin",
             Registry.stringValue("mcp.steroid.kotlinc.parameters")
         )
     }


### PR DESCRIPTION
## Problem

Every `steroid_execute_code` compile — CLI and MCP alike, even a successful `println("ok")` — streams this to the agent:

```text
Compiler output: Exception on loading scripting plugin: java.lang.ClassNotFoundException: org.jetbrains.kotlin.scripting.compiler.plugin.ScriptingK2CompilerPluginRegistrar
Compiler output: Scripting plugin will not be loaded: not all required jars are present in the classpath (missing files: [./kotlin-scripting-compiler.jar, …])
```

Root cause (full diagnosis in #463): kotlinc's K2 pipeline (`AbstractConfigurationPhase`) auto-loads the *default scripting plugin* unless told not to. The plugin's `kotlinc/` distribution deliberately ships the BTA impl set with **no `kotlin-scripting-*` jars**, and BTA in-process sets no Kotlin home (`<no_path>`), so the probe fails twice — classloader (`ClassNotFoundException`), then relative `./kotlin-scripting-*.jar` paths — on **every compilation**. The probe is pure waste here: `CodeEvalManager` compiles the wrapped script as a plain `.kt` class, so the scripting plugin is never used.

## Fix

Append kotlinc's purpose-built `-Xdisable-default-scripting-plugin` to the `mcp.steroid.kotlinc.parameters` registry default (plugin.xml). Validated live on a running IU 2026.1.3 backend before landing: the flag removes exactly the two probe lines.

## Tests (written first, red → green)

- `CodeEvalManagerTest.testDefaultCompileEmitsNoScriptingPluginProbeNoise` — end-to-end pin: a default-settings compile forwards no scripting-plugin probe lines. **Failed against the old default** (the noise reproduces in the test sandbox), passes with the new one.
- `KotlincRegistryDefaultsTest` — default-string pin updated, with the rationale in the comment.
- The existing `-Werror` registry-wiring canary still passes, proving `applyArgumentStrings` accepts the extra token.

## Scope

First half of #463 (the probe). The second half — DEBUG-severity compiler chatter (`Loading modules: […]` etc.) forwarded as user-visible progress — stays open there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
