### PR TITLE
Successful compiles no longer forward kotlinc's verbose chatter as agent-visible progress (#463 part 2)

### DIFF
--- a/ij-plugin/src/main/kotlin/com/jonnyzzz/mcpSteroid/execution/CodeEvalManager.kt
+++ b/ij-plugin/src/main/kotlin/com/jonnyzzz/mcpSteroid/execution/CodeEvalManager.kt
@@ -159,7 +159,13 @@ class CodeEvalManager(
                     ?.let { line -> "\n    $line" }
                     .orEmpty()
                 when(it.severity) {
-                    CompilerMessageRenderer.Severity.DEBUG,
+                    // kotlinc LOGGING chatter (BTA DEBUG): environment boot lines
+                    // ("Using Kotlin home directory", the 45-entry "Loading modules:
+                    // […]" dump) that plain kotlinc prints only under -verbose, and
+                    // that repeat on EVERY compile. Not forwarded to the agent
+                    // (#463) — persistCompilerMessages below records every message
+                    // with its severity in the execution folder's kotlin.txt.
+                    CompilerMessageRenderer.Severity.DEBUG -> Unit
                     CompilerMessageRenderer.Severity.INFO -> resultBuilder
                         .logProgress("Compiler output: $message$where")
                     CompilerMessageRenderer.Severity.WARNING -> resultBuilder

--- a/ij-plugin/src/test/kotlin/com/jonnyzzz/mcpSteroid/execution/CodeEvalManagerTest.kt
+++ b/ij-plugin/src/test/kotlin/com/jonnyzzz/mcpSteroid/execution/CodeEvalManagerTest.kt
@@ -8,6 +8,8 @@ import com.jonnyzzz.mcpSteroid.TestResultBuilder
 import com.jonnyzzz.mcpSteroid.storage.executionStorage
 import com.jonnyzzz.mcpSteroid.testExecParams
 import org.junit.Assert
+import kotlin.io.path.exists
+import kotlin.io.path.readText
 import kotlin.time.Duration.Companion.minutes
 
 class CodeEvalManagerTest: BasePlatformTestCase()  {
@@ -73,6 +75,35 @@ class CodeEvalManagerTest: BasePlatformTestCase()  {
         Assert.assertTrue(
             "Compiler output must not carry the scripting-plugin probe noise, got: $probeLines",
             probeLines.isEmpty(),
+        )
+    }
+
+    fun testDefaultCompileForwardsNoDebugCompilerChatter(): Unit = timeoutRunBlocking(5.minutes) {
+        // #463 part 2: kotlinc emits LOGGING-severity (BTA DEBUG) environment boot
+        // chatter on every compile — "Using Kotlin home directory", "Configuring the
+        // compilation environment", the 45-entry "Loading modules: […]" dump — lines
+        // plain kotlinc prints only under -verbose. Forwarding them as agent-visible
+        // progress costs tokens on every call and reads like diagnostics of THIS run.
+        // A successful compile must forward no compiler chatter at all; the complete
+        // per-severity record stays in the execution folder's kotlin.txt.
+        val code = """
+            println("quiet happy path expected")
+        """.trimIndent()
+        val execId = project.executionStorage.writeNewExecution(testExecParams(code))
+        val result = TestResultBuilder()
+        val data = project.codeEvalManager.evalCode(execId, code, result)
+        Assert.assertNotNull("Trivial script must compile. Result: $result", data)
+        val chatter = result.progressMessages.filter { it.startsWith("Compiler output:") }
+        Assert.assertTrue(
+            "A successful compile must not forward compiler chatter as progress, got: $chatter",
+            chatter.isEmpty(),
+        )
+        // Preservation half: the dropped DEBUG lines are still on disk for diagnosis.
+        val kotlinTxt = project.executionStorage.resolveExecutionPath(execId, "kotlin.txt")
+        Assert.assertTrue("kotlin.txt must exist for a compile that produced messages", kotlinTxt.exists())
+        Assert.assertTrue(
+            "kotlin.txt must preserve the DEBUG-severity compiler messages",
+            kotlinTxt.readText().contains("DEBUG: "),
         )
     }
 


### PR DESCRIPTION
## Problem

Part 2 of #463 (part 1 — the scripting-plugin probe — merged as `4575e93c7` / #475). Even after the probe fix, every `execute_code` still streams kotlinc's environment boot chatter to the agent:

```text
Compiler output: Using Kotlin home directory <no_path>
Compiler output: Configuring the compilation environment
Compiler output: Using JDK home inferred from java.home: …
Compiler output: Loading modules: [java.se, gluegen.rt, … 40+ more …]
```

These are kotlinc **LOGGING**-severity messages (BTA `Severity.DEBUG`) — plain `kotlinc` prints them only under `-verbose` — but `CodeEvalManager`'s severity `when` mapped `DEBUG` and `INFO` alike to `logProgress("Compiler output: …")`, so agents paid ~1 KB of stderr tokens per call for diagnostics that describe the compiler environment, not their run.

## Fix

`Severity.DEBUG` is no longer forwarded as user-visible progress. Nothing is lost: `persistCompilerMessages` already records **every** message with its severity in the execution folder's `kotlin.txt` (that file is how the severities were diagnosed in #463 in the first place). `INFO` / `WARNING` / `ERROR` forwarding is unchanged.

## Tests (written first, red → green)

- `CodeEvalManagerTest.testDefaultCompileForwardsNoDebugCompilerChatter` — a successful default-settings compile must forward **zero** `Compiler output:` progress lines, and `kotlin.txt` must still preserve the `DEBUG:` record. Failed before the change, passes after.
- Part 1's `testDefaultCompileEmitsNoScriptingPluginProbeNoise`, the `-Werror` wiring canary, and the rest of `CodeEvalManagerTest` + `KotlincRegistryDefaultsTest` all stay green (7/7, verified via the report XML).

Fixes #463.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
