### PR TITLE
--debug prints again: logging is configured before anything can reach SLF4J

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -338,18 +338,15 @@
   receiver). Folding changes marker discovery under explicit test homes (today it escapes the sandbox
   on purpose — see `GeneratedToolRuntimeTestSupport`), so it is a design decision, not a cleanup.
 
-- [ ] **`devrig mcp` log files all collapse onto `devrig-session.log`, and every line reads `[pid:?]`**
-  (spotted while fixing #461, pre-existing and unrelated to it). `configureLoggingAndLogStarted` sets
-  `devrig.log.dir` / `devrig.log.session` / `devrig.pid` before the first *intended* SLF4J call, but
-  logback has already initialised by then — the appender resolves the `${devrig.log.session:-session}`
-  and `${devrig.pid:-?}` defaults and pins them. Consequence: concurrent devrig processes share one
-  `~/.mcp-steroid/logs/devrig-session.log` (the per-pid file a log monitor is supposed to detect never
-  appears) and no log line is attributable to a process. Evidence: that file locally spans 10:34
-  `[Test worker]` lines through a 17:25 `devrig mcp` WARN, all `[pid:?]`. Find whoever touches SLF4J
-  before `configureLoggingAndLogStarted` (Clikt parsing / `resolveHomePathsOrDie` / a static
-  initialiser) and either set the properties earlier or reconfigure logback explicitly afterwards.
-  Note the same file shows Gradle test JVMs logging into the developer's REAL `~/.mcp-steroid/logs` —
-  worth checking separately.
+- [x] **`devrig mcp` log files all collapse onto `devrig-session.log`, and every line reads `[pid:?]`**
+  — FIXED as #462: `configureLoggingSystemProperties` now publishes the properties as the first
+  statement of `runDevrigMain`, before command-tree construction can reach SLF4J (the first getLogger
+  came from `FetchResourceToolHandler`'s logger field, confirmed by class-load order).
+- [ ] **Gradle test JVMs log into the developer's REAL `~/.mcp-steroid/logs`** (spotted while fixing
+  #462, still open). `~/.mcp-steroid/logs/devrig-session.log` locally carries `[Test worker]` lines from
+  Ktor/`:npx-kt:test` runs — unit tests should never write into the real devrig home. Find which test
+  path initialises logback without redirecting `devrig.log.dir` (a `systemProperty` on the test task
+  pointing at `build/` would do it) and pin it with a test.
 
 - [ ] **stdio framing follow-ups noticed while fixing #461** (both pre-existing, neither blocking).
   (a) `FramingBuffer.append` grows without bound: a peer that never sends a newline (binary dump, a
@@ -359,3 +356,12 @@
   mid-frame") rather than dispatched. That is spec-faithful (newlines delimit frames) and beats the
   old silence, but a tolerant reading would dispatch parseable EOF residue instead. Deliberate choice,
   worth revisiting only if a real client trips on it.
+
+- [ ] **`--debug` inside a Clikt `@argfile` still does not enable logging** (residual after the #462 fix).
+  Logging verbosity is now read straight off argv (`Array<String>.debugRequested()`) before Clikt runs,
+  because logback pins its configuration during command-tree construction. Clikt's `expandArgumentFiles`
+  defaults to on, so `devrig backend @args.txt` with `--debug` in the file parses to
+  `DevrigCliInvocation.debug = true` while the argv scan sees only `@args.txt` — verified: 0 bytes on
+  stderr. Left as is deliberately: the parsed flag has no other consumer, `@argfile` is not a documented
+  devrig invocation form, and the alternative is a logback `reset()` + `JoranConfigurator` re-read after
+  parsing. Pick that up only if a real client trips on it.

--- a/npx-kt/src/integrationTest/kotlin/com/jonnyzzz/mcpSteroid/devrig/cli/CliOptionsIntegrationTest.kt
+++ b/npx-kt/src/integrationTest/kotlin/com/jonnyzzz/mcpSteroid/devrig/cli/CliOptionsIntegrationTest.kt
@@ -2,7 +2,9 @@
 package com.jonnyzzz.mcpSteroid.devrig.cli
 
 import com.jonnyzzz.mcpSteroid.testHelper.CloseableStackHost
+import com.jonnyzzz.mcpSteroid.testHelper.docker.startProcessInContainer
 import com.jonnyzzz.mcpSteroid.testHelper.process.ProcessResult
+import com.jonnyzzz.mcpSteroid.testHelper.process.assertExitCode
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -391,6 +393,43 @@ class CliOptionsIntegrationTest {
         assertTrue(download.stdout.contains("--version"), download.stdout)
         assertTrue(download.stdout.contains("--json"), download.stdout)
     }
+
+    // -------------------------------- --debug -------------------------------
+
+    @Test
+    fun `--debug logs to stderr and gives this process its own pid-named log file`() {
+        // jonnyzzz/mcp-steroid#462: logback pins every logback.xml substitution at its first getLogger
+        // call, which happens while the command tree is built — so the properties set after parsing set
+        // nothing. `--debug` printed zero bytes, every process wrote the shared devrig-session.log, and
+        // every line read `[pid:?]`. All three promises are asserted here against the packaged launcher.
+        val r = runLauncher("backend", "--debug")
+        assertEquals(0, r.exitCode, "backend --debug must exit 0; stdout=\n${r.stdout}\nstderr=\n${r.stderr}")
+
+        assertTrue(
+            r.stderr.contains("Starting Devrig"),
+            "--debug must put the startup line on stderr; got:\n${r.stderr}",
+        )
+        val pid = Regex("""\[pid:(\d+)]""").find(r.stderr)?.groupValues?.get(1)
+            ?: error("log lines must carry this process's pid, not `[pid:?]`; got:\n${r.stderr}")
+
+        // The pid from the log line ties both halves together: the file this very run wrote must be the
+        // per-pid one Log.kt promises, and the shared fallback name must not appear at all.
+        val logs = shellInContainer("ls /home/agent/.mcp-steroid/logs")
+        assertTrue(
+            Regex("""devrig-\d{4}-\d{2}-\d{2}-\d{6}-pid$pid\.log""").containsMatchIn(logs),
+            "run with pid $pid must own a <timestamp>-pid$pid log file so a log monitor sees it; got:\n$logs",
+        )
+        assertTrue(
+            "devrig-session.log" !in logs,
+            "devrig-session.log means the session property was unset at logback init; got:\n$logs",
+        )
+    }
+
+    /** Runs a plain shell command inside the CLI container (not the launcher) and returns its stdout. */
+    private fun shellInContainer(script: String): String =
+        cli.container.startProcessInContainer {
+            args("sh", "-c", script).description(script).quietly()
+        }.awaitForProcessFinish().assertExitCode(0) { "in-container `$script` failed: $stderr" }.stdout
 
     private fun String.removeOptionalHeadliner(): String =
         if (startsWith("devrig v")) substringAfter("\n\n", this).trimStart('\n') else this

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/Cli.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/Cli.kt
@@ -160,7 +160,12 @@ private fun UsageError.withCuratedMissingHints(command: SchemaToolCliCommand): U
     return UsageError(hint, paramName = name).also { it.context = context }
 }
 
-private fun Array<String>.debugRequested(): Boolean = devrigDebugEnvEnabled() || any { it == "--debug" }
+/**
+ * Was diagnostics asked for? Read straight off argv (and the env) so logging can be configured before
+ * Clikt runs — logback pins its configuration on the first getLogger call, which happens during
+ * command-tree construction (#462). [configureLoggingSystemProperties] is the caller with that need.
+ */
+fun Array<String>.debugRequested(): Boolean = devrigDebugEnvEnabled() || any { it == "--debug" }
 
 /** Exact framework flag only, before the conventional end-of-options marker. Values such as
  * `--reason=--json` are data, not a presentation request. */

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/Log.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/Log.kt
@@ -26,16 +26,47 @@ fun applyDebugLogging(debug: Boolean) {
 
 private class DevrigLog
 
-fun configureLoggingAndLogStarted(homePaths: HomePaths, rawArgs: List<String>, debug: Boolean) {
-    //configure loggers ASAP — these properties are read at logback init (the first SLF4J call below).
+/**
+ * Publish every substitution `logback.xml` reads — and do it before ANYTHING can touch SLF4J.
+ *
+ * logback configures itself on the first `LoggerFactory.getLogger` call and pins each `${...}` at that
+ * moment. Command-tree construction makes that call long before a home is resolved: building the
+ * schema-driven tool commands constructs `FetchResourceToolHandler`, which holds a logger field. Setting
+ * the properties after parsing therefore set nothing at all — `--debug` printed no stderr, every process
+ * shared one `devrig-session.log`, and every line read `[pid:?]` (jonnyzzz/mcp-steroid#462).
+ *
+ * Everything here is derived from argv and this process alone: pure path math, no validation, no I/O,
+ * nothing that can fail or print. devrig's home is hardcoded and [resolveHomePaths] is the same pure
+ * path math `resolveHomePathsOrDie` runs later, so the directory published here is exactly the one that
+ * gets validated — the two cannot drift apart.
+ *
+ * Must stay the first statement of [runDevrigMain]. The regression nets are
+ * `LoggingConfigurationOrderTest`, which snapshots these properties at parse time, and
+ * `CliOptionsIntegrationTest`, which asserts `--debug` output and the per-pid file from the packaged CLI.
+ */
+fun configureLoggingSystemProperties(rawArgs: Array<String>) {
     val pid = ProcessHandle.current().pid()
-    System.setProperty("devrig.log.dir", homePaths.logsDir.toString())
+    System.setProperty("devrig.log.dir", resolveHomePaths().logsDir.toString())
     // The PID is in BOTH the session (so every devrig process writes its OWN file — a log monitor detects
     // each as a new file) and the log-line pattern (so interleaved output is attributable to a process).
     System.setProperty("devrig.log.session", "${LocalDateTime.now().format(ofPattern("yyyy-MM-dd-HHmmss"))}-pid$pid")
     System.setProperty("devrig.pid", pid.toString())
-    applyDebugLogging(debug)
+    applyDebugLogging(rawArgs.debugRequested())
+}
 
+/**
+ * Record the startup line, once a validated home exists.
+ *
+ * Deliberately takes no `debug`: [configureLoggingSystemProperties] already configured the level from
+ * argv before logback initialised, and logback has long since pinned it — accepting a flag here and
+ * "applying" it would be a no-op that lies. `--debug` on argv (and `DEVRIG_DEBUG`) is the one source of
+ * truth for logging verbosity; `DevrigCliInvocation.debug` records the same request for the parser's own
+ * consumers.
+ */
+fun configureLoggingAndLogStarted(homePaths: HomePaths, rawArgs: List<String>) {
     val log = logger<DevrigLog>()
-    log.info("Starting Devrig ${DevrigVersionMetadata.getDevrigVersion()} (pid=$pid) with home paths: $homePaths and args: ${rawArgs.joinToString(" ")}")
+    val pid = ProcessHandle.current().pid()
+    // homePaths.home, not homePaths: the class has no toString(), so the line used to record
+    // "HomePaths@1b8a29df" where the operator needs the actual directory.
+    log.info("Starting Devrig ${DevrigVersionMetadata.getDevrigVersion()} (pid=$pid) with home: ${homePaths.home} and args: ${rawArgs.joinToString(" ")}")
 }

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/Main.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/Main.kt
@@ -31,6 +31,11 @@ fun runDevrigMain(
     terminal: Terminal = Terminal(),
     parseCommand: (Array<String>, Terminal) -> DevrigCliInvocation = ::parseDevrigCommand,
 ): Int {
+    // FIRST, before anything can reach SLF4J: logback pins every logback.xml substitution at its first
+    // getLogger call, and command-tree construction below makes that call (a tool handler holds a logger
+    // field). Publishing these after parsing published nothing at all — see #462.
+    configureLoggingSystemProperties(rawArgs)
+
     // Construct the terminal while stdout still points at the user's destination. Parsing happens
     // after stdout is guarded for MCP purity, but color auto-detection must follow stdout, not stderr.
     // Replace stdout immediately. MCP stdio reserves the original stdout for
@@ -53,8 +58,9 @@ fun runDevrigMain(
 
         val homePaths = resolveHomePathsOrDie()
 
-        // Setup logging. That is essential to avoid logger usages before this statement.
-        configureLoggingAndLogStarted(homePaths, rawArgs.toList(), command.debug)
+        // Logging itself was configured at the top of this function; this only records the startup line,
+        // which needs a validated home.
+        configureLoggingAndLogStarted(homePaths, rawArgs.toList())
 
         val lifetime = CloseableStackHost()
         try {

--- a/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/LoggingConfigurationOrderTest.kt
+++ b/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/LoggingConfigurationOrderTest.kt
@@ -1,0 +1,102 @@
+/* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
+package com.jonnyzzz.mcpSteroid.devrig
+
+import java.io.ByteArrayOutputStream
+import java.io.PrintStream
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+import kotlin.test.fail
+
+/**
+ * jonnyzzz/mcp-steroid#462 — logback configures itself on the FIRST `LoggerFactory.getLogger` call and
+ * pins every `${...}` substitution in `logback.xml` at that moment. Command-tree construction makes
+ * that call: building the schema-driven tool commands constructs `FetchResourceToolHandler`, which
+ * holds a logger field (confirmed by class-load order — it is the last devrig class loaded before
+ * `org.slf4j.LoggerFactory`).
+ *
+ * So every property `logback.xml` reads MUST be published before the parser runs. Setting them after
+ * it, as `configureLoggingAndLogStarted` did, pinned all four at their fallbacks: `--debug` printed
+ * nothing to stderr, every process shared one `devrig-session.log` instead of its own per-pid file,
+ * and every line read `[pid:?]`.
+ *
+ * The tests drive [runDevrigMain] with an injected parser — the seam [LastResortCrashHandlerTest]
+ * uses — which snapshots the properties exactly where the real parser would run, then aborts so the
+ * command never executes and the developer's real `~/.mcp-steroid` is never touched.
+ *
+ * Property names are spelled literally here on purpose: they are a contract with `logback.xml`, which
+ * cannot import a constant. `logback-xml reads exactly the properties devrig publishes` pins both ends.
+ */
+class LoggingConfigurationOrderTest {
+
+    private val logProperties = listOf("devrig.log.dir", "devrig.log.session", "devrig.pid", "devrig.log.level")
+
+    /**
+     * Runs [runDevrigMain] far enough to parse, and returns what the four properties looked like at
+     * that instant. Restores them afterwards — they are JVM-global and this JVM runs other tests.
+     */
+    private fun propertiesAtParseTime(vararg rawArgs: String): Map<String, String?> {
+        var snapshot: Map<String, String?>? = null
+        val original = logProperties.associateWith { System.getProperty(it) }
+        val originalErr = System.err
+        try {
+            // The deliberate abort below prints its trace; keep it out of the test log.
+            System.setErr(PrintStream(ByteArrayOutputStream(), true, Charsets.UTF_8))
+            val exit = runDevrigMain(arrayOf(*rawArgs)) { _, _ ->
+                snapshot = logProperties.associateWith { System.getProperty(it) }
+                error("abort before the command runs")
+            }
+            assertEquals(CliExit.SOFTWARE, exit)
+        } finally {
+            System.setErr(originalErr)
+            original.forEach { (name, value) ->
+                if (value == null) System.clearProperty(name) else System.setProperty(name, value)
+            }
+        }
+        return snapshot ?: fail("the injected parser was never called")
+    }
+
+    @Test
+    fun `the log directory, session and pid are published before the command tree is parsed`() {
+        val properties = propertiesAtParseTime("backend")
+        val pid = ProcessHandle.current().pid()
+
+        assertEquals(resolveHomePaths().logsDir.toString(), properties["devrig.log.dir"])
+        assertEquals(pid.toString(), properties["devrig.pid"], "log lines must be attributable to a process")
+
+        val session = properties["devrig.log.session"]
+        assertNotNull(session, "without a session every devrig process writes the same devrig-session.log")
+        assertTrue(
+            Regex("""^\d{4}-\d{2}-\d{2}-\d{6}-pid$pid$""").matches(session),
+            "session must be <timestamp>-pid<pid> so a log monitor sees each process as a new file: $session",
+        )
+    }
+
+    @Test
+    fun `--debug raises the stderr level before the command tree is parsed`() {
+        assertEquals("DEBUG", propertiesAtParseTime("backend", "--debug")["devrig.log.level"])
+    }
+
+    @Test
+    fun `--debug is honoured wherever it sits in argv`() {
+        assertEquals("DEBUG", propertiesAtParseTime("--debug", "backend", "list")["devrig.log.level"])
+    }
+
+    @Test
+    fun `the level stays unset without a debug request so an external -D still wins`() {
+        // DEVRIG_DEBUG is a documented way to ask for diagnostics, so honour it if this env has it set
+        // rather than assuming a clean environment.
+        val expected = if (System.getenv("DEVRIG_DEBUG").isNullOrBlank()) null else "DEBUG"
+        assertEquals(expected, propertiesAtParseTime("backend")["devrig.log.level"])
+    }
+
+    @Test
+    fun `logback-xml reads exactly the properties devrig publishes`() {
+        val xml = javaClass.getResource("/logback.xml")?.readText()
+            ?: fail("the bundled logback.xml is missing from the devrig resources")
+        for (name in logProperties) {
+            assertTrue("\${$name" in xml, "logback.xml must read $name — otherwise publishing it is dead code")
+        }
+    }
+}


### PR DESCRIPTION
Fixes #462.

## The bug

`--debug` promised verbose stderr logging and delivered zero bytes:

```console
$ devrig backend --debug 2>err.txt; wc -c err.txt
0 err.txt        # not even the "Starting Devrig" line
```

Two more broken promises from the same cause: every process wrote the shared
`~/.mcp-steroid/logs/devrig-session.log` instead of the per-pid file `Log.kt` documents ("so a log
monitor detects each as a new file"), and every line read `[pid:?]`, making interleaved output from
concurrent devrig processes unattributable.

## Root cause — measured, not guessed

logback configures itself on the first `LoggerFactory.getLogger` call and pins every `${...}`
substitution in `logback.xml` at that moment. `-verbose:class` shows what makes that call first:

```
[0.114s] com.jonnyzzz.mcpSteroid.server.FetchResourceToolHandler   ← holds `private val log = thisLogger()`
[0.114s] com.jonnyzzz.mcpSteroid.server.PromptsContextHandler
[0.114s] com.jonnyzzz.mcpSteroid.server.McpSteroidTools$$Lambda
[0.114s] org.slf4j.LoggerFactory                                    ← logback initialises HERE
```

That is command-tree construction: building the schema-driven tool commands constructs
`FetchResourceToolHandler` (`FetchResourceToolHandler.kt:40`), whose logger field is the first SLF4J
touch. `configureLoggingAndLogStarted` ran *after* parsing (`Main.kt:57`), so all four properties were
already pinned at their fallbacks and setting them did nothing at all.

The issue's prime suspect (`InstalledBackends.kt:13`) was not it — worth stating, since the fix would
have been whack-a-mole if driven off that guess.

## The fix

`configureLoggingSystemProperties(rawArgs)` is now the **first statement** of `runDevrigMain`. It derives
everything from argv and this process alone — pure path math, no validation, no I/O, nothing that can
fail or print — and reuses the `debugRequested()` argv scan that already existed for exactly this "before
Clikt runs" need. devrig's home is hardcoded and `resolveHomePaths()` is the same path math
`resolveHomePathsOrDie()` validates later, so the published directory cannot drift from the validated one.

`configureLoggingAndLogStarted` keeps only the startup line and **no longer takes `debug`**: logback has
long since pinned the level, so accepting the flag and "applying" it would be a no-op that lies. argv
(plus `DEVRIG_DEBUG`) is the single source of truth for verbosity; `DevrigCliInvocation.debug` still
records the request for the parser's own consumers and `DevrigCommandTest` still pins it.

Verified on the rebuilt launcher — all three symptoms gone:

```
17:48:34.181 [pid:93313] [main] INFO … Starting Devrig … (pid=93313) with home: /Users/jonnyzzz/.mcp-steroid and args: backend --debug
```
| | before | after |
|---|---|---|
| stderr with `--debug` | 0 bytes | 224 bytes, startup line present |
| log file | `devrig-session.log` (shared) | `devrig-2026-08-07-174834-pid93313.log` |
| line attribution | `[pid:?]` | `[pid:93313]` |

## Regression tests, both watched failing first

- **`LoggingConfigurationOrderTest`** (`:npx-kt:test`) drives `runDevrigMain` through the injected-parser
  seam `LastResortCrashHandlerTest` already uses, snapshotting the properties exactly where the real
  parser runs, then aborting so the developer's real `~/.mcp-steroid` is never touched. Red before the
  fix with all four properties `null`. Covers the per-pid session shape, `--debug` anywhere in argv, the
  level staying unset without a debug request (so an external `-Ddevrig.log.level` still wins), and the
  `logback.xml` ↔ `Log.kt` property-name contract — a rename on either side now fails the build.
- **`CliOptionsIntegrationTest`** (`:npx-kt:integrationTest`, Docker) asserts the packaged launcher end to
  end, exactly as the issue asked: startup line on stderr, a `[pid:<n>]` naming this process, a
  `devrig-<stamp>-pid<n>.log` written by that very pid (the pid from the log line ties both halves
  together, so leftovers in the shared container can't fake a pass), and no `devrig-session.log`. Red
  against a rebuilt pre-fix dist: *"--debug must put the startup line on stderr; got: <empty>"*.

`:npx-kt:test` (1759 tests) and the Docker options suite (23) are green on the rebased tree.

## Also here

- The startup line logged `HomePaths@1b8a29df` — the class has no `toString()` — where the operator needs
  the directory. It now records `homePaths.home`.
- `TODO.md`: closes the entry #461 opened for this bug; keeps the separate, still-open finding that Gradle
  test JVMs log into the developer's REAL `~/.mcp-steroid/logs`.

## One residual, deliberately not fixed

`--debug` inside a Clikt `@argfile` still does not enable logging (verified: 0 bytes). Clikt's
`expandArgumentFiles` defaults on, so `devrig backend @args.txt` parses to `debug = true` while the argv
scan sees only `@args.txt`. Left as is: the parsed flag has no other consumer, `@argfile` is not a
documented devrig invocation form, and the alternative is a logback `reset()` + `JoranConfigurator`
re-read after parsing — machinery for an undocumented form. Recorded in `TODO.md`; happy to add it if you
would rather the parsed flag always win.

Unrelated flake met on the way, reported rather than dodged with `--tests`: #477.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
