### PR TITLE
Test servers bind port 0, so a lost port race can no longer poison a later test

### DIFF
--- a/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/BackendCommandPortDiscoveryTest.kt
+++ b/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/BackendCommandPortDiscoveryTest.kt
@@ -6,10 +6,7 @@ import io.ktor.client.HttpClient
 import io.ktor.client.engine.cio.CIO
 import io.ktor.client.plugins.HttpTimeout
 import io.ktor.http.ContentType
-import io.ktor.server.application.ApplicationStarted
-import io.ktor.server.cio.CIO as ServerCIO
 import io.ktor.server.engine.EmbeddedServer
-import io.ktor.server.engine.embeddedServer
 import io.ktor.server.response.respondText
 import io.ktor.server.routing.get
 import io.ktor.server.routing.routing
@@ -54,15 +51,15 @@ class BackendCommandPortDiscoveryTest {
 
     @BeforeEach
     fun setUp() {
-        port = ServerSocket(0).use { it.localPort }
-        server = embeddedServer(ServerCIO, port = port, host = "127.0.0.1") {
+        val started = startTestHttpServer {
             routing {
                 get("/api/about") {
                     call.respondText(aboutBody, ContentType.Application.Json)
                 }
             }
-        }.also { it.start(wait = false) }
-        runBlocking { server.monitor.subscribe(ApplicationStarted) {} }
+        }
+        server = started.server
+        port = started.port
 
         httpClient = HttpClient(CIO) {
             install(HttpTimeout) {

--- a/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/BackendProvisionTest.kt
+++ b/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/BackendProvisionTest.kt
@@ -11,16 +11,12 @@ import io.ktor.client.HttpClient
 import io.ktor.client.engine.cio.CIO
 import io.ktor.client.plugins.HttpTimeout
 import io.ktor.http.ContentType
-import io.ktor.server.application.ApplicationStarted
-import io.ktor.server.cio.CIO as ServerCIO
 import io.ktor.server.engine.EmbeddedServer
-import io.ktor.server.engine.embeddedServer
 import io.ktor.server.response.respondText
 import io.ktor.server.routing.get
 import io.ktor.server.routing.routing
 import java.io.ByteArrayOutputStream
 import java.io.PrintStream
-import java.net.ServerSocket
 import java.nio.file.Files
 import java.nio.file.Path
 import kotlin.io.path.notExists
@@ -278,10 +274,8 @@ class BackendProvisionTest {
     fun `provision resolves port id and computes manual instruction paths without installing plugin`(@TempDir tempDir: Path) = runBlocking {
         val sourcePlugin = tempDir.resolve("source-plugin.zip")
         Files.writeString(sourcePlugin, "fake plugin zip")
-        val port = ServerSocket(0).use { it.localPort }
         val installPluginCalls = mutableListOf<Unit>()
-        val server = ideServer(
-            port = port,
+        val started = ideServer(
             aboutBody = """
                 {
                   "name": "IntelliJ IDEA 2026.1.1",
@@ -293,7 +287,8 @@ class BackendProvisionTest {
             """.trimIndent(),
             installPluginCalls = installPluginCalls,
         )
-        servers += server
+        servers += started.server
+        val port = started.port
         val httpClient = httpClient()
         clients += httpClient
 
@@ -476,11 +471,10 @@ class BackendProvisionTest {
     }
 
     private fun ideServer(
-        port: Int,
         aboutBody: String,
         installPluginCalls: MutableList<Unit>,
-    ): EmbeddedServer<*, *> {
-        val server = embeddedServer(ServerCIO, port = port, host = "127.0.0.1") {
+    ): TestHttpServer {
+        return startTestHttpServer {
             routing {
                 get("/api/about") {
                     call.respondText(aboutBody, ContentType.Application.Json)
@@ -490,9 +484,7 @@ class BackendProvisionTest {
                     call.respondText("{}", ContentType.Application.Json)
                 }
             }
-        }.also { it.start(wait = false) }
-        runBlocking { server.monitor.subscribe(ApplicationStarted) {} }
-        return server
+        }
     }
 
     private class FixedBundledPluginResolver(private val zip: Path) : BundledPluginResolver {

--- a/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/DevrigUpdateCheckerTest.kt
+++ b/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/DevrigUpdateCheckerTest.kt
@@ -7,9 +7,23 @@ import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
 
 class DevrigUpdateCheckerTest {
+    /**
+     * Hits the LIVE `https://devrig.dev/version.json`, so it belongs in the opt-in lane
+     * (`./gradlew :npx-kt:liveNetworkTest`) that the root CLAUDE.md reserves for vendor-feed coverage:
+     * "a Google/JetBrains/GitHub outage can never redden a normal build". It was in the default unit
+     * suite instead, where `fetchVersionInfo()`'s catch-all — it returns null for a DNS blip, a >10 s
+     * response, a Pages deploy mid-flight, anything — turned any of those into
+     * `checkForUpdates fetches ... It should have base version ==> expected: not <null>` on an unrelated
+     * build. Reproduced locally in 1 of 2 full-suite runs while hunting #477.
+     *
+     * The assertion itself is unchanged and still runs, just in the lane built for it. The offline half
+     * of this contract (version parsing and the update gate) is covered by the other tests here.
+     */
+    @Tag("live-network")
     @Test
     fun `checkForUpdates fetches`() = runTest {
         val info = fetchVersionInfo()

--- a/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/InstallPluginCommandTest.kt
+++ b/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/InstallPluginCommandTest.kt
@@ -9,16 +9,13 @@ import io.ktor.client.HttpClient
 import io.ktor.client.engine.cio.CIO
 import io.ktor.client.plugins.HttpTimeout
 import io.ktor.http.ContentType
-import io.ktor.server.cio.CIO as ServerCIO
 import io.ktor.server.engine.EmbeddedServer
-import io.ktor.server.engine.embeddedServer
 import io.ktor.server.request.uri
 import io.ktor.server.response.respondText
 import io.ktor.server.routing.get
 import io.ktor.server.routing.routing
 import java.io.ByteArrayOutputStream
 import java.io.PrintStream
-import java.net.ServerSocket
 import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -41,8 +38,9 @@ class InstallPluginCommandTest {
 
     @Test
     fun `checkCompatibility parses the single-id compatible=true form`() = runBlocking {
-        val port = freePort()
-        servers += installPluginServer(port, compatibleBody = """{"compatible": true}""")
+        val started = installPluginServer(compatibleBody = """{"compatible": true}""")
+        servers += started.server
+        val port = started.port
         val client = KtorPluginRestClient(httpClient())
 
         assertEquals(true, client.checkCompatibility("http://127.0.0.1:$port", MCP_STEROID_PLUGIN_ID))
@@ -50,8 +48,9 @@ class InstallPluginCommandTest {
 
     @Test
     fun `checkCompatibility parses compatible=false`() = runBlocking {
-        val port = freePort()
-        servers += installPluginServer(port, compatibleBody = """{"compatible": false}""")
+        val started = installPluginServer(compatibleBody = """{"compatible": false}""")
+        servers += started.server
+        val port = started.port
         val client = KtorPluginRestClient(httpClient())
 
         assertEquals(false, client.checkCompatibility("http://127.0.0.1:$port", MCP_STEROID_PLUGIN_ID))
@@ -61,14 +60,15 @@ class InstallPluginCommandTest {
     fun `checkCompatibility returns null when the IDE is unreachable`() = runBlocking {
         val client = KtorPluginRestClient(httpClient())
         // Nothing is bound on this port — a refused connection must surface as null, not an exception.
-        assertNull(client.checkCompatibility("http://127.0.0.1:${freePort()}", MCP_STEROID_PLUGIN_ID))
+        assertNull(client.checkCompatibility("http://127.0.0.1:${unboundPort()}", MCP_STEROID_PLUGIN_ID))
     }
 
     @Test
     fun `requestInstall hits action=install with a localhost Origin and returns true on 200`() = runBlocking {
-        val port = freePort()
         val recorded = RecordedRequests()
-        servers += installPluginServer(port, compatibleBody = """{"compatible": true}""", recorded = recorded)
+        val started = installPluginServer(compatibleBody = """{"compatible": true}""", recorded = recorded)
+        servers += started.server
+        val port = started.port
         val client = KtorPluginRestClient(httpClient())
 
         assertTrue(client.requestInstall("http://127.0.0.1:$port", MCP_STEROID_PLUGIN_ID))
@@ -219,7 +219,7 @@ class InstallPluginCommandTest {
         backendName = "mock-backend-name-$pid",
     )
 
-    private fun freePort(): Int = ServerSocket(0).use { it.localPort }
+
 
     private fun httpClient(): HttpClient = HttpClient(CIO) {
         install(HttpTimeout) {
@@ -236,10 +236,9 @@ class InstallPluginCommandTest {
     }
 
     private fun installPluginServer(
-        port: Int,
         compatibleBody: String,
         recorded: RecordedRequests = RecordedRequests(),
-    ): EmbeddedServer<*, *> = embeddedServer(ServerCIO, port = port, host = "127.0.0.1") {
+    ): TestHttpServer = startTestHttpServer {
         routing {
             get("/api/installPlugin") {
                 val action = call.request.queryParameters["action"]
@@ -252,7 +251,7 @@ class InstallPluginCommandTest {
                 }
             }
         }
-    }.also { it.start(wait = false) }
+    }
 
     private class FakePluginRestClient(
         private val compatibility: (String) -> Boolean?,

--- a/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/TestHttpServer.kt
+++ b/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/TestHttpServer.kt
@@ -1,0 +1,51 @@
+/* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
+package com.jonnyzzz.mcpSteroid.devrig
+
+import io.ktor.server.application.Application
+import io.ktor.server.cio.CIO as ServerCIO
+import io.ktor.server.engine.EmbeddedServer
+import io.ktor.server.engine.embeddedServer
+import kotlinx.coroutines.runBlocking
+
+/** A started fake HTTP server bound to [port] on 127.0.0.1. */
+class TestHttpServer(val server: EmbeddedServer<*, *>, val port: Int)
+
+/**
+ * Starts [module] on an **ephemeral** port and returns the port it actually bound.
+ *
+ * This is the fixture shape for every fake-IDE / fake-backend server in `:npx-kt:test`. It replaces
+ * `port = ServerSocket(0).use { it.localPort }` followed by `embeddedServer(port = port)`, which had two
+ * defects that together produced jonnyzzz/mcp-steroid#477 — a flake reproduced 2 times in 14 loaded runs:
+ *
+ *  1. **Probe-then-bind race.** Closing the probe socket and binding that number later leaves a window in
+ *     which anything (another test, an ephemeral client port) can take it. Binding port 0 has no window.
+ *  2. **Nobody observed startup.** `start(wait = false)` publishes failures into the server's lazily
+ *     started coroutine, and `runBlocking { server.monitor.subscribe(ApplicationStarted) {} }` was not the
+ *     barrier it looked like — `subscribe` only registers a handler, it never waits. (Production does wait
+ *     correctly: `SteroidsMcpServer` pairs subscribe/unlock with a blocking `lock()`.) So a
+ *     `BindException: Address already in use` stayed invisible, cancelled the coroutine's parent, and hit
+ *     whichever test later touched the server as
+ *     `JobCancellationException: LazyStandaloneCoroutine is cancelling` — a message naming neither the
+ *     port nor the bind.
+ *
+ * `resolvedConnectors()` suspends until the socket is really listening and yields the bound port, so a
+ * startup failure is thrown HERE, from the fixture, with its own stack trace.
+ *
+ * The server is started at top level on purpose: called inside `runBlocking`, `embeddedServer` resolves to
+ * the `CoroutineScope` extension, the server becomes a child of the calling coroutine, and the caller then
+ * waits for it forever (so `@AfterEach` never runs).
+ */
+fun startTestHttpServer(module: Application.() -> Unit): TestHttpServer {
+    val server = embeddedServer(ServerCIO, port = 0, host = "127.0.0.1", module = module)
+    server.start(wait = false)
+    val port = runBlocking { server.engine.resolvedConnectors().first().port }
+    return TestHttpServer(server, port)
+}
+
+/**
+ * A port with nothing listening on it, for the "connection refused" cases.
+ *
+ * Probe-then-close is correct HERE — the point is that the port is unbound. Never use this to pick a port
+ * to bind later: use [startTestHttpServer], which binds port 0 and reports what it got (#477).
+ */
+fun unboundPort(): Int = java.net.ServerSocket(0).use { it.localPort }

--- a/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/monitor/IdeProjectMonitorServiceTest.kt
+++ b/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/monitor/IdeProjectMonitorServiceTest.kt
@@ -14,10 +14,8 @@ import io.ktor.client.engine.cio.CIO
 import io.ktor.client.plugins.HttpTimeout
 import io.ktor.client.plugins.HttpTimeoutConfig
 import io.ktor.http.ContentType
-import io.ktor.server.application.ApplicationStarted
-import io.ktor.server.cio.CIO as ServerCIO
 import io.ktor.server.engine.EmbeddedServer
-import io.ktor.server.engine.embeddedServer
+import com.jonnyzzz.mcpSteroid.devrig.startTestHttpServer
 import io.ktor.server.response.respondText
 import io.ktor.server.routing.get
 import io.ktor.server.routing.routing
@@ -31,7 +29,6 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
 import java.io.File
-import java.net.ServerSocket
 import java.nio.file.Files
 import java.nio.file.Path
 import kotlin.test.assertEquals
@@ -62,16 +59,16 @@ class IdeProjectMonitorServiceTest {
 
     @BeforeEach
     fun setUp() {
-        port = freePort()
-        server = embeddedServer(ServerCIO, port = port, host = "127.0.0.1") {
+        val started = startTestHttpServer {
             routing {
                 get("$DEVRIG_RPC_PATH_PREFIX/projects") {
                     receivedAuthHeaders += call.request.headers["Authorization"]
                     call.respondText(projectsJson.toString(), ContentType.Application.Json)
                 }
             }
-        }.also { it.start(wait = false) }
-        runBlocking { server.monitor.subscribe(ApplicationStarted) {} }
+        }
+        server = started.server
+        port = started.port
 
         httpClient = HttpClient(CIO) {
             install(HttpTimeout) {
@@ -153,5 +150,5 @@ class IdeProjectMonitorServiceTest {
     private fun projectsResponse(projects: List<String>): String =
         """{"projects":[${projects.joinToString(",")}]}"""
 
-    private fun freePort(): Int = ServerSocket(0).use { it.localPort }
+
 }

--- a/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/server/DevrigListToolHandlersTest.kt
+++ b/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/server/DevrigListToolHandlersTest.kt
@@ -7,6 +7,7 @@ import com.jonnyzzz.mcpSteroid.devrig.monitor.DiscoveredIde
 import com.jonnyzzz.mcpSteroid.devrig.monitor.IdeMonitorState
 import com.jonnyzzz.mcpSteroid.devrig.monitor.IdeProjectState
 import com.jonnyzzz.mcpSteroid.devrig.testDevrigEndpoint
+import com.jonnyzzz.mcpSteroid.devrig.startTestHttpServer
 import com.jonnyzzz.mcpSteroid.mcp.McpJson
 import com.jonnyzzz.mcpSteroid.server.NpxBridgeWindowsResponse
 import com.jonnyzzz.mcpSteroid.server.ProgressTaskInfo
@@ -17,13 +18,10 @@ import io.ktor.client.HttpClient
 import io.ktor.client.engine.cio.CIO
 import io.ktor.client.plugins.HttpTimeout
 import io.ktor.http.ContentType
-import io.ktor.server.cio.CIO as ServerCIO
 import io.ktor.server.engine.EmbeddedServer
-import io.ktor.server.engine.embeddedServer
 import io.ktor.server.response.respondText
 import io.ktor.server.routing.get
 import io.ktor.server.routing.routing
-import java.net.ServerSocket
 import java.nio.file.Files
 import java.nio.file.Path
 import kotlin.test.Test
@@ -148,12 +146,10 @@ class DevrigListToolHandlersTest {
     fun `list_windows binds every window and background task to its source pid backend_name`(
         @TempDir tempDir: Path,
     ) {
-        val port = freePort()
-        // The server is deliberately created OUTSIDE runBlocking: inside it, `embeddedServer` resolves
-        // to the CoroutineScope extension, the server becomes a child of the test coroutine, and
-        // runBlocking then waits forever for it (the AfterEach stop can never run). Top-level call ==
-        // standalone server lifecycle, stopped in tearDown.
-        server = embeddedServer(ServerCIO, port = port, host = "127.0.0.1") {
+        // startTestHttpServer binds port 0 and reports what it bound: no probe-then-bind window, and a
+        // startup failure surfaces here instead of as a cancelled coroutine later (#477). It also keeps
+        // the standalone (non-child) server lifecycle this test needs — see its KDoc.
+        val started = startTestHttpServer {
             routing {
                 get("/api/jonnyzzz/mcp-steroid/v1/windows") {
                     // One embedded server plays both IDEs — the bearer token tells which pid is asked.
@@ -165,7 +161,9 @@ class DevrigListToolHandlersTest {
                     call.respondText(windowsResponseJson(pid), ContentType.Application.Json)
                 }
             }
-        }.also { it.start(wait = false) }
+        }
+        server = started.server
+        val port = started.port
 
         val homeA = Files.createDirectories(tempDir.resolve("a"))
         val homeB = Files.createDirectories(tempDir.resolve("b"))
@@ -270,4 +268,4 @@ class DevrigListToolHandlersTest {
     )
 }
 
-private fun freePort(): Int = ServerSocket(0).use { it.localPort }
+

--- a/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/server/DevrigToolBridgeClientTest.kt
+++ b/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/server/DevrigToolBridgeClientTest.kt
@@ -12,6 +12,7 @@ import com.jonnyzzz.mcpSteroid.devrig.InstalledBackend
 import com.jonnyzzz.mcpSteroid.server.backendNameForMarker
 import com.jonnyzzz.mcpSteroid.devrig.monitor.DiscoveredIde
 import com.jonnyzzz.mcpSteroid.devrig.startableBackendName
+import com.jonnyzzz.mcpSteroid.devrig.startTestHttpServer
 import com.jonnyzzz.mcpSteroid.devrig.testDevrigEndpoint
 import com.jonnyzzz.mcpSteroid.testHelper.CloseableStackHost
 import com.jonnyzzz.mcpSteroid.devrig.monitor.IdeMonitorState
@@ -32,16 +33,12 @@ import io.ktor.client.plugins.HttpTimeout
 import io.ktor.client.plugins.HttpTimeoutConfig
 import io.ktor.http.ContentType
 import io.ktor.http.HttpStatusCode
-import io.ktor.server.application.ApplicationStarted
-import io.ktor.server.cio.CIO as ServerCIO
 import io.ktor.server.engine.EmbeddedServer
-import io.ktor.server.engine.embeddedServer
 import io.ktor.server.request.receiveText
 import io.ktor.server.response.respondText
 import io.ktor.server.response.respondTextWriter
 import io.ktor.server.routing.post
 import io.ktor.server.routing.routing
-import java.net.ServerSocket
 import java.nio.file.Files
 import java.nio.file.Path
 import kotlin.coroutines.cancellation.CancellationException
@@ -82,8 +79,7 @@ class DevrigToolBridgeClientTest {
 
     @BeforeEach
     fun setUp() {
-        port = freePort()
-        server = embeddedServer(ServerCIO, port = port, host = "127.0.0.1") {
+        val started = startTestHttpServer {
             routing {
                 post("/api/jonnyzzz/mcp-steroid/v1/tools/call/stream") {
                     receivedAuth = call.request.headers["Authorization"]
@@ -122,8 +118,9 @@ class DevrigToolBridgeClientTest {
                     }
                 }
             }
-        }.also { it.start(wait = false) }
-        runBlocking { server.monitor.subscribe(ApplicationStarted) {} }
+        }
+        server = started.server
+        port = started.port
 
         httpClient = HttpClient(CIO) {
             install(HttpTimeout) {
@@ -143,8 +140,10 @@ class DevrigToolBridgeClientTest {
         holdStreamRelease = null
         httpStatus = HttpStatusCode.OK
         httpBody = ""
-        httpClient.close()
-        server.stop(0L, 0L)
+        // Guarded: when setUp fails these were never assigned, and an
+        // UninitializedPropertyAccessException from teardown would bury the real cause (#477).
+        if (::httpClient.isInitialized) httpClient.close()
+        if (::server.isInitialized) server.stop(0L, 0L)
     }
 
     @Test
@@ -990,7 +989,7 @@ class DevrigToolBridgeClientTest {
         )
 }
 
-private fun freePort(): Int = ServerSocket(0).use { it.localPort }
+
 
 private fun ToolCallResult.errorText(): String =
     (content.single() as ContentItem.Text).text


### PR DESCRIPTION
Fixes #477.

## The flake, and what it actually was

`DevrigToolBridgeClientTest` failed intermittently with a message naming neither a port nor a bind:

```
kotlinx.coroutines.JobCancellationException: LazyStandaloneCoroutine is cancelling
```

Reproduced **2 times in 14 runs** of the class under 12-way CPU load — each time against a *different*
test (`ignores heartbeat and unknown NDJSON messages before result`, then `open project bridge handler
lists candidates when no backend_name and zero discovered`). That was the tell: it is not any one test's
bug. The cause was buried three levels down in the saved XML:

```
Caused by: java.net.BindException: Address already in use
    at io.ktor.network.sockets.TcpSocketBuilder.bind
```

Two fixture defects compounded:

1. **Probe-then-bind.** `freePort()` opened `ServerSocket(0)`, read the number and **closed it**;
   `embeddedServer(port = port)` bound that number later. Under load, something takes it in between —
   another fixture, or an ephemeral client port.
2. **Nobody observed startup.** `start(wait = false)` leaves the failure in the server's lazily started
   coroutine (hence `LazyStandaloneCoroutine`), and
   `runBlocking { server.monitor.subscribe(ApplicationStarted) {} }` was **not** the barrier it looked
   like — `subscribe` only registers a handler, it never waits. Production does it correctly:
   `SteroidsMcpServer` pairs subscribe/unlock with a blocking `lock()`. So the `BindException` stayed
   invisible, cancelled its parent, and struck whichever test next touched the server.

A third defect hid the evidence: `tearDown` closed a `lateinit httpClient` unguarded, so a failed `setUp`
reported `UninitializedPropertyAccessException` *on top of* the real cause.

Two plausible-sounding hypotheses were **refuted by probe** before this one was confirmed, rather than
shipped as a guess: a request to an unbound port throws `ConnectException: Connection refused`, and a
client closed under an in-flight request throws `ClosedSelectorCancellationException` — neither matches.

## The fix

`startTestHttpServer` (new, npx-kt test sources) binds **port 0** — no window to lose — and returns the
port `resolvedConnectors()` reports, which suspends until the socket is really listening. A startup
failure is therefore thrown *from the fixture*, with its own stack trace, instead of poisoning a later
request.

All six fixtures carrying the old pattern move to it — `DevrigToolBridgeClientTest`,
`DevrigListToolHandlersTest`, `InstallPluginCommandTest`, `BackendProvisionTest`,
`BackendCommandPortDiscoveryTest`, `IdeProjectMonitorServiceTest`. Fixing only the one that happened to
fail would have left the identical flake live in the other five. The one legitimate probe — a
deliberately **unbound** port for the connection-refused case — stays, under the honest name
`unboundPort()`, so the two intents can't be confused again. Teardown is guarded so it can no longer mask
a setup failure.

## Verification

| | before | after |
|---|---|---|
| 14 iterations of the class under 12-way CPU load | **2 failures** | — |
| 14 iterations under the same load, across all 6 migrated fixtures | — | **0 failures** |
| full `:npx-kt:test` | — | 1753 tests, 0 failures (green on the rebased tree) |

## Second flake, same hunt

`DevrigUpdateCheckerTest.checkForUpdates fetches` reproduced in 1 of 2 full-suite runs while I was hunting
#477. It asserts `assertNotNull(fetchVersionInfo())`, which fetches the LIVE
`https://devrig.dev/version.json` — and `fetchVersionInfo()` returns `null` for a DNS blip, a >10 s
response, or a Pages deploy mid-flight. That is a vendor-feed assertion sitting in the default unit suite,
which the root CLAUDE.md forbids outright: *"a Google/JetBrains/GitHub outage can never redden a normal
build."*

It moves to the existing opt-in lane with `@Tag("live-network")` — the assertion is unchanged and still
runs, now under `:npx-kt:liveNetworkTest`, where it passes. Verified routing: `:npx-kt:test` runs the 2
offline tests in that class, `:npx-kt:liveNetworkTest` runs this one. It was the **only** live-network
test in the default suite; every other `https://` in the test sources is a fixture string with no HTTP
call.

Also removes 17 imports the migration orphaned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
