### PR TITLE
Stop the script wrapper from rewriting the contents of multi-line raw strings

### DIFF
--- a/kotlin-cli/src/main/kotlin/com/jonnyzzz/mcpSteroid/koltinc/CodeWrapperForCompilation.kt
+++ b/kotlin-cli/src/main/kotlin/com/jonnyzzz/mcpSteroid/koltinc/CodeWrapperForCompilation.kt
@@ -150,8 +150,8 @@ object CodeWrapperForCompilation {
             out.emit("  }")
             out.emit("  suspend fun $scriptContextFqn.${methodName}_code() {")
             out.emit("    //the rest of submitted code")
-            otherLines.forEachIndexed { i, line ->
-                out.emit("    $line")
+            indentOutsideRawStrings(otherLines).forEachIndexed { i, line ->
+                out.emit(line)
                 mapping[out.line] = extracted.otherLineNumbers[i]
             }
             out.emit("  }")
@@ -162,6 +162,38 @@ object CodeWrapperForCompilation {
         val lineMapping = LineMapping(mapping)
 
         return WrapResult(classFqn = clazzName, methodName = methodName, code = wrappedCode, lineMapping = lineMapping)
+    }
+
+
+    /**
+     * Indent body lines for readability of the generated file — but never a line that starts INSIDE a
+     * multi-line raw string, because there the indentation is not cosmetic, it is string CONTENT.
+     *
+     * Indenting unconditionally silently rewrote every `"""…"""` an agent submitted: continuation lines
+     * gained four leading spaces. Two consequences, both invisible at the call site. An anchor built from
+     * real file text stopped matching that file, so the multi-site edit recipe reported
+     * `anchor occurs 0 times` for text that was demonstrably there and threw away the whole batch. And a
+     * multi-line string written to a new file landed on disk misindented, which the project's own
+     * formatter then rewrote on the next build.
+     *
+     * Line count is preserved exactly — one input line stays one output line — so [LineMapping] is
+     * unaffected either way.
+     */
+    fun indentOutsideRawStrings(lines: List<String>): List<String> {
+        var insideRawString = false
+        return lines.map { line ->
+            val startsInsideRawString = insideRawString
+            var idx = 0
+            while (idx <= line.length - 3) {
+                if (line.startsWith("\"\"\"", idx)) {
+                    insideRawString = !insideRawString
+                    idx += 3
+                } else {
+                    idx++
+                }
+            }
+            if (startsInsideRawString) line else "    $line"
+        }
     }
 
     /**

--- a/kotlin-cli/src/test/kotlin/com/jonnyzzz/mcpSteroid/koltinc/CodeWrapperForCompilationTest.kt
+++ b/kotlin-cli/src/test/kotlin/com/jonnyzzz/mcpSteroid/koltinc/CodeWrapperForCompilationTest.kt
@@ -43,6 +43,39 @@ class CodeWrapperForCompilationTest {
     }
 
     @Test
+    fun `a multi-line raw string keeps its exact content`() {
+        // The wrapper used to indent every body line by four spaces for cosmetics, which rewrote the
+        // CONTENT of any multi-line raw string: continuation lines gained four leading spaces. An agent
+        // that built an anchor out of real file text then searched for text that no longer existed, and
+        // `content.split(anchor)` found nothing. In the arena that discarded whole 36 KB edit batches on
+        // a `check(occurrences == 1)` whose anchor was, in the submitted code, perfectly correct.
+        val tripleQuote = "\"\"\""
+        val code = listOf(
+            "val anchor = $tripleQuote",
+            "    @Column(name = \"released_at\")",
+            "    private Instant releasedAt;",
+            tripleQuote,
+            "println(anchor.length)",
+        ).joinToString("\n")
+
+        val wrapped = CodeWrapperForCompilation.wrap(className = "Test", code = code).code
+        val lines = wrapped.lines()
+
+        assertTrue(
+            "the raw string's continuation line must stay at its original indentation:\n$wrapped",
+            lines.any { it == "    private Instant releasedAt;" },
+        )
+        assertTrue(
+            "no line inside the raw string may gain indentation:\n$wrapped",
+            lines.none { it == "        private Instant releasedAt;" },
+        )
+        assertTrue(
+            "code outside the raw string is still indented for readability:\n$wrapped",
+            lines.any { it == "    println(anchor.length)" },
+        )
+    }
+
+    @Test
     fun `line mapping maps import lines back to original positions`() {
         val code = """
             import foo.Bar


### PR DESCRIPTION
## The bug

`CodeWrapperForCompilation.wrap()` indents every body line by four spaces for readability of the generated file:

```kotlin
otherLines.forEachIndexed { i, line ->
    out.emit("    $line")
```

Inside a `"""…"""` literal that indentation is not cosmetic — it is string **content**. Every continuation line of every raw string an agent submits comes out four spaces wider than it was written.

## Why it matters

An agent reads a file, builds an anchor out of the real text, and asks `steroid_execute_code` to replace it. The anchor it typed is correct; the anchor the compiled script searches for is not. `content.split(anchor)` finds nothing, and the multi-site edit recipe fails its `check(occurrences == 1)` and discards the entire batch — including the parts of the script that had no anchors at all.

Measured on six arena runs of one scenario: the same 17–36 KB edit script died in all six, and those six scripts account for **96 % of all the Kotlin those runs threw away**.

A second consequence is quieter. A multi-line string written to a new file lands on disk with four extra spaces per line. Java still compiles, so nothing complains until the project's own formatter rewrites the file on the next build.

## Evidence

Reproduced three independent ways before the fix:

1. **Build artifact.** `script.kts` (what the plugin received) is byte-identical to what the model sent, while `compiled/input.kt` has all 846 body lines indented — including lines inside anchors.
2. **Live IDE, five lines.** A two-line anchor sent at indent 4 came back at indent 8 and matched **0 times** in a file that demonstrably contains it.
3. **Replay.** Running the recipe's own loop against the real file content: both anchors match exactly once, so the submitted script was correct.

Two competing hypotheses were tested and ruled out by experiment: the VFS does not go stale (a disk write while the IDE runs is visible immediately), and a charset mismatch breaks the *disk* read rather than the VFS one.

## The fix

`indentOutsideRawStrings()` indents only lines that start outside a raw string, tracking `"""` parity the same way the import extractor in this file already does. One input line still maps to one output line, so `LineMapping` is untouched.

## Verification

- New test `a multi-line raw string keeps its exact content` — fails without the fix, passes with it (verified in both directions).
- `:kotlin-cli:test` — 61 tests, 0 failures.
- Re-checked on a live IDE after `deployPlugin`: continuation indents `[0, 0]`, anchor matches `1`.