### PR TITLE
Negotiate MCP protocol version on initialize

### DIFF
--- a/mcp-core/src/main/kotlin/com/jonnyzzz/mcpSteroid/mcp/McpProtocol.kt
+++ b/mcp-core/src/main/kotlin/com/jonnyzzz/mcpSteroid/mcp/McpProtocol.kt
@@ -12,6 +12,20 @@ import kotlinx.serialization.json.*
  */
 
 const val MCP_PROTOCOL_VERSION = "2025-11-25"
+
+/**
+ * Protocol revisions this server can speak, newest first. Per the MCP spec
+ * (Lifecycle → Version Negotiation) the server MUST echo the client's requested
+ * `protocolVersion` when it is one of these, and only otherwise fall back to its
+ * own latest ([MCP_PROTOCOL_VERSION], the head of this list). Our request/response
+ * surface (initialize, tools, resources, prompts, ping, logging) is stable across
+ * these revisions, so echoing an older one is a truthful compatibility claim, not
+ * a downgrade of behavior. A client that cannot speak our latest (e.g. Junie on an
+ * older revision) tears down the transport when it receives a version it does not
+ * recognize — negotiation is what keeps it connected.
+ */
+val SUPPORTED_PROTOCOL_VERSIONS = listOf("2025-11-25", "2025-06-18", "2025-03-26")
+
 const val JSONRPC_VERSION = "2.0"
 
 // ==================== JSON-RPC Base Types ====================

--- a/mcp-core/src/main/kotlin/com/jonnyzzz/mcpSteroid/mcp/McpServerCore.kt
+++ b/mcp-core/src/main/kotlin/com/jonnyzzz/mcpSteroid/mcp/McpServerCore.kt
@@ -215,8 +215,18 @@ class McpServerCore(
             }
         }
 
+        // Version negotiation (MCP Lifecycle → Version Negotiation): echo the client's
+        // requested revision when we support it; otherwise reply with our own latest and
+        // let the client decide whether it can proceed.
+        val negotiatedVersion = if (initParams.protocolVersion in SUPPORTED_PROTOCOL_VERSIONS) {
+            initParams.protocolVersion
+        } else {
+            MCP_PROTOCOL_VERSION
+        }
+        session.markProtocolVersion(negotiatedVersion)
+
         val result = InitializeResult(
-            protocolVersion = MCP_PROTOCOL_VERSION,
+            protocolVersion = negotiatedVersion,
             capabilities = capabilities,
             serverInfo = serverInfo,
             instructions = instructions

--- a/mcp-core/src/main/kotlin/com/jonnyzzz/mcpSteroid/mcp/McpSession.kt
+++ b/mcp-core/src/main/kotlin/com/jonnyzzz/mcpSteroid/mcp/McpSession.kt
@@ -39,6 +39,16 @@ class McpSession(
         private set
 
     /**
+     * The protocol revision negotiated during `initialize` — the client's requested
+     * version when we support it, otherwise our latest. Defaults to [MCP_PROTOCOL_VERSION]
+     * until negotiation completes. The HTTP transport reports this in the
+     * `MCP-Protocol-Version` response header so it matches the initialize result.
+     */
+    @Volatile
+    var negotiatedProtocolVersion: String = MCP_PROTOCOL_VERSION
+        private set
+
+    /**
      * Guards the once-per-session `mcp_session_initialized` beacon so a duplicate
      * `initialize` request does not double-fire the analytics event.
      */
@@ -59,6 +69,13 @@ class McpSession(
         clientInfo = info
         clientCapabilities = capabilities
         initialized = true
+    }
+
+    /**
+     * Record the protocol version negotiated during `initialize`.
+     */
+    fun markProtocolVersion(version: String) {
+        negotiatedProtocolVersion = version
     }
 
     /**

--- a/mcp-core/src/test/kotlin/com/jonnyzzz/mcpSteroid/mcp/McpServerCoreTest.kt
+++ b/mcp-core/src/test/kotlin/com/jonnyzzz/mcpSteroid/mcp/McpServerCoreTest.kt
@@ -60,6 +60,52 @@ class McpServerCoreTest {
     }
 
     @Test
+    fun `test initialize echoes a supported older protocol version back`() = runBlocking {
+        val request = initializeRequest(protocolVersion = "2025-06-18")
+
+        val responseJson = server.handleMessage(request, session)
+        val response = McpJson.decodeFromString<JsonRpcResponse>(responseJson!!)
+        val result = McpJson.decodeFromJsonElement<InitializeResult>(response.result!!)
+
+        assertEquals("2025-06-18", result.protocolVersion,
+            "Server must echo the client's requested version when it is supported")
+    }
+
+    @Test
+    fun `test initialize falls back to latest for an unsupported protocol version`() = runBlocking {
+        val request = initializeRequest(protocolVersion = "1999-01-01")
+
+        val responseJson = server.handleMessage(request, session)
+        val response = McpJson.decodeFromString<JsonRpcResponse>(responseJson!!)
+        val result = McpJson.decodeFromJsonElement<InitializeResult>(response.result!!)
+
+        assertEquals(MCP_PROTOCOL_VERSION, result.protocolVersion,
+            "Server must reply with its own latest version when the client's is not supported")
+    }
+
+    @Test
+    fun `test initialize stores the negotiated protocol version on the session`() = runBlocking {
+        server.handleMessage(initializeRequest(protocolVersion = "2025-06-18"), session)
+
+        assertEquals("2025-06-18", session.negotiatedProtocolVersion,
+            "Session must carry the negotiated version so the transport can report it")
+    }
+
+    private fun initializeRequest(protocolVersion: String): String = buildJsonObject {
+        put("jsonrpc", "2.0")
+        put("id", 1)
+        put("method", "initialize")
+        putJsonObject("params") {
+            put("protocolVersion", protocolVersion)
+            putJsonObject("capabilities") {}
+            putJsonObject("clientInfo") {
+                put("name", "test-client")
+                put("version", "1.0.0")
+            }
+        }
+    }.toString()
+
+    @Test
     fun `test ping request returns empty object`() = runBlocking {
         val request = """{"jsonrpc":"2.0","id":1,"method":"ping"}"""
 

--- a/mcp-http/src/main/kotlin/com/jonnyzzz/mcpSteroid/mcp/McpHttpTransport.kt
+++ b/mcp-http/src/main/kotlin/com/jonnyzzz/mcpSteroid/mcp/McpHttpTransport.kt
@@ -82,6 +82,7 @@ object McpHttpTransport {
         val remoteHost = call.request.local.remoteHost
         log.info("[MCP] OPTIONS request from $remoteHost - returning CORS headers")
         addCorsHeaders(call)
+        setProtocolVersionHeader(call, MCP_PROTOCOL_VERSION)
         call.respond(HttpStatusCode.NoContent)
     }
 
@@ -96,8 +97,18 @@ object McpHttpTransport {
             "Content-Type, Accept, $SESSION_HEADER, $SESSION_NOTICE_HEADER, $PROTOCOL_VERSION_HEADER"
         )
         call.response.header("Access-Control-Expose-Headers", "$SESSION_HEADER, $SESSION_NOTICE_HEADER, $PROTOCOL_VERSION_HEADER")
-        // Per MCP 2025-11-25 spec: Include protocol version in all responses
-        call.response.header(PROTOCOL_VERSION_HEADER, MCP_PROTOCOL_VERSION)
+    }
+
+    /**
+     * Set the `MCP-Protocol-Version` response header. Per the MCP spec every response
+     * carries it; on a message exchange it MUST be the version negotiated for the
+     * session (so it matches the `initialize` result body), and on preflight / health /
+     * teardown responses with no session it is our latest. `ktor`'s [call.response.header]
+     * appends rather than replaces, so this must be the only place a value is set — never
+     * in [addCorsHeaders], which runs first for every verb.
+     */
+    private fun setProtocolVersionHeader(call: ApplicationCall, version: String) {
+        call.response.header(PROTOCOL_VERSION_HEADER, version)
     }
 
     private suspend fun handlePost(call: ApplicationCall, server: McpServerCore) {
@@ -197,6 +208,11 @@ object McpHttpTransport {
         try {
             val response = server.handleMessage(body, session)
 
+            // Set AFTER handleMessage: an `initialize` negotiates the version inside it,
+            // so the session carries the negotiated value only now. This makes the header
+            // match the version in the initialize result body.
+            setProtocolVersionHeader(call, session.negotiatedProtocolVersion)
+
             if (response != null) {
                 val truncatedResponse = if (response.length > 500) response.take(500) + "...[truncated]" else response
                 log.info("[MCP] Response: $truncatedResponse")
@@ -215,6 +231,7 @@ object McpHttpTransport {
                 message = "Internal error: ${t.message ?: t.javaClass.simpleName}",
             )
             try {
+                setProtocolVersionHeader(call, session.negotiatedProtocolVersion)
                 call.respondText(errorResponse, ContentType.Application.Json)
             } catch (e: CancellationException) {
                 throw e
@@ -261,6 +278,8 @@ object McpHttpTransport {
         val remoteHost = call.request.local.remoteHost
         val userAgent = call.request.userAgent() ?: "unknown"
         log.info("[MCP] GET request from $remoteHost (User-Agent: $userAgent)")
+
+        setProtocolVersionHeader(call, MCP_PROTOCOL_VERSION)
 
         val acceptHeader = call.request.accept()
 
@@ -316,6 +335,7 @@ object McpHttpTransport {
     }
 
     private suspend fun handleDelete(call: ApplicationCall, server: McpServerCore) {
+        setProtocolVersionHeader(call, MCP_PROTOCOL_VERSION)
         val sessionId = call.request.header(SESSION_HEADER)
         if (sessionId != null) {
             log.info("[MCP] Terminating session: $sessionId")

--- a/mcp-http/src/test/kotlin/com/jonnyzzz/mcpSteroid/mcp/McpHttpTransportTest.kt
+++ b/mcp-http/src/test/kotlin/com/jonnyzzz/mcpSteroid/mcp/McpHttpTransportTest.kt
@@ -1027,6 +1027,40 @@ class McpHttpTransportTest {
     }
 
     @Test
+    fun `test POST initialize with a supported older version negotiates it in body and header`() = runBlocking {
+        val request = buildJsonObject {
+            put("jsonrpc", "2.0")
+            put("id", 1)
+            put("method", "initialize")
+            putJsonObject("params") {
+                put("protocolVersion", "2025-06-18")
+                putJsonObject("capabilities") {}
+                putJsonObject("clientInfo") {
+                    put("name", "test-client")
+                    put("version", "1.0.0")
+                }
+            }
+        }
+
+        val response = client.post("http://localhost:$port/mcp") {
+            contentType(ContentType.Application.Json)
+            accept(ContentType.Application.Json)
+            setBody(request.toString())
+        }
+
+        assertEquals(HttpStatusCode.OK, response.status)
+
+        // The MCP-Protocol-Version header MUST match the negotiated version in the body,
+        // and both must be the client's requested version since we support it.
+        assertEquals("2025-06-18", response.headers[McpHttpTransport.PROTOCOL_VERSION_HEADER])
+
+        val result = McpJson.decodeFromJsonElement<InitializeResult>(
+            McpJson.decodeFromString<JsonRpcResponse>(response.bodyAsText()).result!!
+        )
+        assertEquals("2025-06-18", result.protocolVersion)
+    }
+
+    @Test
     fun `test GET response includes MCP-Protocol-Version header`() = runBlocking {
         val response = client.get("http://localhost:$port/mcp") {
             header(HttpHeaders.Accept, "application/json")

--- a/mcp-stdio/src/test/kotlin/com/jonnyzzz/mcpSteroid/mcp/McpStdioServerProtocolTest.kt
+++ b/mcp-stdio/src/test/kotlin/com/jonnyzzz/mcpSteroid/mcp/McpStdioServerProtocolTest.kt
@@ -174,8 +174,10 @@ class McpStdioServerProtocolTest {
     // Helpers
     // =========================================================================
 
-    private fun init(id: String = "1") =
-        """{"jsonrpc":"2.0","id":"$id","method":"initialize","params":{"protocolVersion":"$MCP_PROTOCOL_VERSION","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}"""
+    private fun init(id: String = "1") = initWithVersion(id, MCP_PROTOCOL_VERSION)
+
+    private fun initWithVersion(id: String, protocolVersion: String) =
+        """{"jsonrpc":"2.0","id":"$id","method":"initialize","params":{"protocolVersion":"$protocolVersion","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}"""
 
     private fun req(id: String, method: String, params: String = "{}") =
         """{"jsonrpc":"2.0","id":"$id","method":"$method","params":$params}"""
@@ -212,6 +214,17 @@ class McpStdioServerProtocolTest {
         h.sendFramed(init())
         val result = h.runAndGetObjects()[0]["result"] as JsonObject
         assertEquals(MCP_PROTOCOL_VERSION, result["protocolVersion"]?.jsonPrimitive?.content)
+    }
+
+    @Test
+    fun `initialize echoes a supported older protocol version over stdio`() = runTest {
+        // Regression for the Junie stdio client (issue #482): a client on an older
+        // supported revision must get that same revision back, not the server's latest,
+        // or it tears down the transport and no tools become available.
+        val h = StdioHarness()
+        h.sendFramed(initWithVersion("req-1", "2025-06-18"))
+        val result = h.runAndGetObjects()[0]["result"] as JsonObject
+        assertEquals("2025-06-18", result["protocolVersion"]?.jsonPrimitive?.content)
     }
 
     @Test


### PR DESCRIPTION
Fixes #482.

## Problem

`McpServerCore.handleInitialize` always answered with `MCP_PROTOCOL_VERSION`
(`2025-11-25`) and ignored the client's requested `protocolVersion`. A client on
an older but still-supported revision (Junie's stdio MCP client) received a
version it did not recognize and tore down the transport before any `steroid_*`
tool became available. Claude/Codex were unaffected because they already speak
the latest revision.

The MCP spec (Lifecycle → Version Negotiation) requires the server to echo the
client's requested version when it supports it, and only otherwise reply with
its own latest.

## Change

- Add `SUPPORTED_PROTOCOL_VERSIONS` (`2025-11-25`, `2025-06-18`, `2025-03-26`).
  Our request/response surface (initialize, tools, resources, prompts, ping,
  logging) is stable across these revisions, so echoing an older one is a
  truthful compatibility claim, not a behavior downgrade.
- `handleInitialize` negotiates the version, returns it in the `InitializeResult`
  body, and records it on the session (`McpSession.negotiatedProtocolVersion`).
- HTTP transport reports the negotiated version in the `MCP-Protocol-Version`
  response header so it matches the initialize body. The value is now set once
  per handler (ktor appends rather than replaces): negotiated for POST, latest
  for OPTIONS/GET/DELETE.

Shared core logic means the stdio, HTTP, and plugin transports are all fixed.

## Tests

Downgrade and unsupported-version paths covered at the core, stdio, and HTTP
layers. Existing clients that request the latest version are unaffected (all
prior version assertions pass unchanged).

- `:mcp-core:test`, `:mcp-stdio:test`, `:mcp-http:test` — green.