### PR TITLE
De-count README tool/resource headings, gate the philosophy tool list (#457)

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ better recipes are. The full canonical statement lives in
 [`docs/PHILOSOPHY.md`](docs/PHILOSOPHY.md) and is mirrored at runtime
 as `mcp-steroid://skill/design-philosophy`.
 
-### 8 MCP Tools
+### MCP Tools
 
 | Tool | Description |
 |------|-------------|
@@ -205,17 +205,20 @@ as `mcp-steroid://skill/design-philosophy`.
 | **List Windows** (`steroid_list_windows`) | Enumerate IDE windows and components |
 | **Open Project** (`steroid_open_project`) | Open projects programmatically |
 
-### 58 MCP Resources
+### MCP Resources
 
 Comprehensive guides and examples covering:
 
-- **LSP Operations** (11) — Go to definition, find references, hover, completion
-- **IDE Power Operations** (22) — Refactorings, code generation, project analysis
-- **Debugger Integration** (7) — Breakpoints, thread control, debugging workflows
-- **Test Runner** (10) — Run tests, inspect results, navigate test trees
-- **VCS Operations** (3) — Git annotations, file history
-- **Project Workflows** (4) — Open projects with trust levels
-- **Skill Guides** (3) — IntelliJ API, debugger, and test runner guides
+- **LSP Operations** — Go to definition, find references, hover, completion
+- **IDE Power Operations** — Refactorings, code generation, project analysis
+- **Debugger Integration** — Breakpoints, thread control, debugging workflows
+- **Test Runner** — Run tests, inspect results, navigate test trees
+- **VCS Operations** — Git annotations, file history
+- **Project Workflows** — Open projects with trust levels
+- **Skill Guides** — IntelliJ API, debugger, and test runner guides
+
+The always-current index is served at runtime: fetch `mcp-steroid://prompt/skill`
+via `steroid_fetch_resource`.
 
 ---
 

--- a/TODO.md
+++ b/TODO.md
@@ -62,13 +62,11 @@
     flake it (observed once during the quorum review). Make the runner's temp-file parent
     injectable and point the test at `@TempDir` for an isolated scan.
 
-- [ ] **Tool/resource counts drift across surfaces** (found during the 2026-07-31 plugin-description
-  rewrite review). The MCP tool surface is **8** (`docs/PHILOSOPHY.md` Tenet 1, canonical; confirmed
-  against live registrations), but root `CLAUDE.md` and `ij-plugin/CLAUDE.md` say "10 today", and
-  `README.md` still carries "### 8 MCP Tools" plus a stale "### 58 MCP Resources" heading with
-  per-category counts summing to 60 while there are 106 prompt articles. Reconcile the CLAUDE.md
-  numbers with PHILOSOPHY.md and de-count the README sections (headings without volatile numbers),
-  the way the Marketplace description now does.
+- [x] **Tool/resource counts drift across surfaces** (found during the 2026-07-31 plugin-description
+  rewrite review; issue #457). The CLAUDE.md numbers were reconciled with PHILOSOPHY.md ("8 today")
+  earlier; the README headings and the stale per-category resource counts (summing to 60 vs 106
+  prompt articles) are now de-counted the way the Marketplace description is, with a pointer to the
+  runtime index (`mcp-steroid://prompt/skill`) as the always-current source.
 
 - [ ] **KtBlock matrix ignores the production kotlinc language/api pin (drift).**
   `CodeEvalManager` compiles every `steroid_execute_code` script with the

--- a/mcp-steroid-server/src/test/kotlin/com/jonnyzzz/mcpSteroid/server/ToolSurfacePhilosophyContractTest.kt
+++ b/mcp-steroid-server/src/test/kotlin/com/jonnyzzz/mcpSteroid/server/ToolSurfacePhilosophyContractTest.kt
@@ -1,0 +1,45 @@
+/* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
+package com.jonnyzzz.mcpSteroid.server
+
+import com.jonnyzzz.mcpSteroid.prompts.Generic
+import com.jonnyzzz.mcpSteroid.prompts.PromptsContext
+import com.jonnyzzz.mcpSteroid.prompts.generated.skill.DesignPhilosophyPromptArticle
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+/**
+ * Pins the tool list in the canonical design-philosophy resource
+ * (`mcp-steroid://skill/design-philosophy`, Tenet 1) to the live tool
+ * registrations in [McpSteroidTools], so the two can never drift apart
+ * again (issue #457: contributor guides claimed "10 today" while the
+ * server exposed 8).
+ *
+ * When this test fails after a deliberate tool-surface change, update the
+ * article AND every count-bearing doc: `docs/PHILOSOPHY.md`, root
+ * `CLAUDE.md`, `ij-plugin/CLAUDE.md`, and
+ * `website/content/docs/how-it-works.md`.
+ */
+class ToolSurfacePhilosophyContractTest {
+
+    private val tools = object : McpSteroidTools() {
+        override fun <T> handler(type: Class<T>): T = unreachableHandler()
+    }
+
+    @Test
+    fun `design-philosophy article lists exactly the registered tool surface`() {
+        val registered = tools.devrigToolSpecs().map { it.name }.sorted()
+
+        val payload = DesignPhilosophyPromptArticle().readPayload(PromptsContext.Generic)
+        val listed = Regex("(?m)^- `(steroid_[a-z_]+)`$")
+            .findAll(payload)
+            .map { it.groupValues[1] }
+            .toList()
+            .sorted()
+
+        assertEquals(registered, listed) {
+            "The tool list in mcp-steroid://skill/design-philosophy must match the live " +
+                "registrations in McpSteroidTools. Update the article (and the count-bearing " +
+                "docs named in this test's KDoc) together with any tool-surface change."
+        }
+    }
+}


### PR DESCRIPTION
Fixes #457.

The issue's headline claim — contributor guides saying "10 today" while the server exposes 8 — was already reconciled on main (root `CLAUDE.md` and `ij-plugin/CLAUDE.md` now say "8 today"). This PR finishes the remaining part tracked in TODO.md and implements the issue's "Expected" (avoid separately maintained counts / gate with a toolset contract test):

- **README**: the `### 8 MCP Tools` heading and the stale `### 58 MCP Resources` section (per-category counts summing to 60 vs 106 actual prompt articles) are de-counted the way the Marketplace description already is; a pointer to the runtime index (`mcp-steroid://prompt/skill` via `steroid_fetch_resource`) names the always-current source.
- **New contract test** `ToolSurfacePhilosophyContractTest` (`:mcp-steroid-server`): pins the `steroid_*` tool list in the canonical `mcp-steroid://skill/design-philosophy` article to the live `McpSteroidTools.devrigToolSpecs()` registrations. Any tool-surface change now fails the test instead of drifting silently; the test's KDoc lists the remaining count-bearing docs to update (`docs/PHILOSOPHY.md`, both CLAUDE.md files, `website/content/docs/how-it-works.md`).
- **TODO.md**: the drift entry is checked off with what was done.

Deliberately untouched: historical release notes (`release/notes/0.95.0.md`, website release pages) that say "10 tools" — accurate at release time.

Verified: `./gradlew :mcp-steroid-server:test --tests 'com.jonnyzzz.mcpSteroid.server.ToolSurfacePhilosophyContractTest'` passes. The test cannot pass vacuously — an empty regex match would fail the equality against the 8 registered names.