### PR TITLE
list_windows output contract documented truthfully everywhere (#456)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -365,3 +365,14 @@
   stderr. Left as is deliberately: the parsed flag has no other consumer, `@argfile` is not a documented
   devrig invocation form, and the alternative is a logback `reset()` + `JoranConfigurator` re-read after
   parsing. Pick that up only if a real client trips on it.
+
+- [ ] **Accept `windowId` as an input alias for `window_id` (#456 follow-up).** `steroid_list_windows`
+  emits camelCase `windowId`; `steroid_input` / `steroid_take_screenshot` take snake_case `window_id`.
+  Six doc surfaces now state the translation, which is the documentation fix, not the removal of the
+  problem — agents copy an output key into the next call. Renaming either side is breaking (the output
+  rename is #381-shaped; see `docs/devrig-naming.md` -> "Spelling decision (#456)"), but widening the
+  INPUT to accept both spellings is purely additive: it emits no new key and breaks no reader.
+  Blocked on `InputSchemaElement` having no parameter-alias mechanism — `parseParameter` resolves a
+  single name and `asCliParams()` derives one CLI flag from it, so this needs an `alias(name)` builder
+  threaded through both the MCP schema (`asMcpJson`, accept either key) and the devrig CLI parser.
+  Once it lands, the six doc mentions of the translation collapse to one sentence.

--- a/docs/devrig-naming.md
+++ b/docs/devrig-naming.md
@@ -490,11 +490,13 @@ snapshot is malformed; see the routing-service invariant below.
 
 `ListedProject.project_name` returned by `steroid_list_projects` is always the exposed routing key;
 `ListedProject.name` remains the raw IntelliJ project name for display only. Implementation:
-`DevrigListProjectsToolHandler` in `StubMcpSteroidTools.kt` (line numbers may shift with refactors).
+`DevrigListProjectsToolHandler` (its own file under `npx-kt/.../devrig/server/`; line numbers may
+shift with refactors).
 
-For `steroid_list_windows`, `DevrigProjectRoutingService.rewriteWindow`
-rewrites **only** `WindowInfo.projectName` to the exposed project name
-(or leaves it `null` when the window has no project context).
+For `steroid_list_windows`, devrig rewrites **only** the project name to
+the exposed routing key (or leaves it `null` when the window has no
+project context, or on a transient route-lookup miss):
+`DevrigListWindowsToolHandler.exposedProjectName()` + `WindowInfo.listed()`.
 
 `WindowInfo.windowId` is left **unchanged**. A `window_id` is never a
 standalone argument — it always travels together with a `project_name`.
@@ -502,6 +504,23 @@ Follow-up `steroid_input` / `steroid_take_screenshot` calls resolve the
 owning IDE via `project_name` and forward the original `window_id`
 verbatim (it is unique within that IDE). There is no window-id rewriting
 and no reverse map.
+
+**Spelling decision (#456):** on `steroid_list_windows` OUTPUT entries the
+key is camelCase `windowId` — deliberately. The #381 snake_case rename
+covers only the routing keys (`project_name`, `project_path`,
+`backend_name`); every other entry field (`isActive`,
+`modalDialogShowing`, `windowId`, …) is camelCase, so `windowId` is the
+consistent spelling. The #456-suggested alias is not free either:
+`@SerialName("window_id")` changes the EMITTED key (breaking for every
+reader of `windowId`, exactly like #381 was for the project keys) and
+`@JsonNames` only widens decoding — kotlinx has no dual-emit. A
+deliberate #381-style breaking rename remains open; until then the
+translation (output `windowId` → input `window_id` of
+`steroid_input`/`steroid_take_screenshot`) must be stated explicitly
+wherever the tools are described, and docs must never claim
+`list_windows` returns `window_id`. Pinned by
+`ListWindowsToolSpecSchemaTest` (serializer + tool description) and
+`ListWindowsMarkdownArticleContractTest` (skill article).
 
 ## Lifecycle subcommand JSON outputs
 

--- a/docs/devrig-naming.md
+++ b/docs/devrig-naming.md
@@ -507,14 +507,21 @@ and no reverse map.
 
 **Spelling decision (#456):** on `steroid_list_windows` OUTPUT entries the
 key is camelCase `windowId` — deliberately. The #381 snake_case rename
-covers only the routing keys (`project_name`, `project_path`,
-`backend_name`); every other entry field (`isActive`,
+covers only that set — the `project_name` routing key plus the two
+fields renamed alongside it (`project_path`, `backend_name`); every other entry field (`isActive`,
 `modalDialogShowing`, `windowId`, …) is camelCase, so `windowId` is the
 consistent spelling. The #456-suggested alias is not free either:
 `@SerialName("window_id")` changes the EMITTED key (breaking for every
 reader of `windowId`, exactly like #381 was for the project keys) and
-`@JsonNames` only widens decoding — kotlinx has no dual-emit. A
-deliberate #381-style breaking rename remains open; until then the
+`@JsonNames` only widens decoding — kotlinx has no dual-emit. The
+third option is additive and sits on the OTHER side: widen the INPUT so
+`steroid_input` / `steroid_take_screenshot` accept `windowId` as well as
+`window_id`. That emits no new key, breaks no reader, and removes the
+translation instead of documenting it — but `InputSchemaElement` has no
+parameter-alias mechanism today (`parseParameter` resolves one name, and
+`asCliParams()` derives one flag from it), so it is a real feature, not a
+doc fix. Logged in `TODO.md`; a deliberate #381-style breaking rename of
+the output key remains open too. Until either lands, the
 translation (output `windowId` → input `window_id` of
 `steroid_input`/`steroid_take_screenshot`) must be stated explicitly
 wherever the tools are described, and docs must never claim

--- a/docs/guides/AGENT-STEROID-GUIDE.md
+++ b/docs/guides/AGENT-STEROID-GUIDE.md
@@ -36,7 +36,7 @@ IDE owns it. Backend discovery lives in `steroid_open_project` (see
 
 ### `steroid_list_windows`
 List open IDE windows and their associated projects. Some windows may not be tied to a project and a project can have multiple windows.
-Use this in multi-window setups to pick the right `project_name` and `window_id` for screenshot/input tools.
+Use this in multi-window setups to pick the right window: each entry's `project_name` is the routing key, and its `windowId` value is what you pass as the `window_id` input of the screenshot/input tools.
 
 Like `steroid_list_projects`, the response has **no top-level
 `ide`/`plugin`/`pid` header**. Every `windows[]` and `backgroundTasks[]`
@@ -45,7 +45,7 @@ entry names its owning backend via `backend_name`.
 **Response Fields (per window):**
 | Field | Description |
 |-------|-------------|
-| `project_name` | Project routing key — the same `project_name` as `steroid_list_projects` (null if not a project window) |
+| `project_name` | Project routing key — the same `project_name` as `steroid_list_projects` (omitted, not null, if not a project window) |
 | `project_path` | Project base path |
 | `windowId` | Unique window identifier for screenshot/input targeting |
 | `modalDialogShowing` | **True if any modal dialog is showing in IDE** |
@@ -78,14 +78,14 @@ Parameters:
 - `project_name` (required): Target project from `steroid_list_projects`
 - `task_id` (required): Task identifier for logging
 - `reason` (required): Why the screenshot is needed
-- `window_id` (optional): Window id from `steroid_list_windows` to target a specific window
+- `window_id` (optional): the `windowId` value from a `steroid_list_windows` entry, to target a specific window
 
 Artifacts saved under the execution folder:
 - `screenshot.png`
 - `screenshot-tree.md`
 - `screenshot-meta.json`
 
-The response includes `window_id` (also from `steroid_list_windows`); pass it to `steroid_input` to target the same window.
+The response includes `window_id` (the same id `steroid_list_windows` reports as `windowId`); pass it to `steroid_input` to target the same window.
 
 ### `steroid_input`
 Send input events (keyboard + mouse) using a sequence string.
@@ -96,7 +96,7 @@ Parameters:
 - `project_name` (required): Target project from `steroid_list_projects`
 - `task_id` (required): Task identifier for logging
 - `reason` (required): Why the input is needed
-- `window_id` (required): Window id from `steroid_list_windows` (also returned by `steroid_take_screenshot`)
+- `window_id` (required): the `windowId` value from a `steroid_list_windows` entry (the screenshot response echoes it as `window_id`)
 - `sequence` (required): Comma-separated or newline-separated input sequence (commas inside values are allowed unless they look like `, <step>:`; commas are optional when using newlines)
 
 Sequence examples:

--- a/docs/guides/AGENT-STEROID-GUIDE.md
+++ b/docs/guides/AGENT-STEROID-GUIDE.md
@@ -46,7 +46,7 @@ entry names its owning backend via `backend_name`.
 | Field | Description |
 |-------|-------------|
 | `project_name` | Project routing key — the same `project_name` as `steroid_list_projects` (omitted, not null, if not a project window) |
-| `project_path` | Project base path |
+| `project_path` | Project base path — on the entry itself, no `steroid_list_projects` call needed (omitted, not null, when unknown) |
 | `windowId` | Unique window identifier for screenshot/input targeting |
 | `modalDialogShowing` | **True if any modal dialog is showing in IDE** |
 | `indexingInProgress` | **True if project is indexing (dumb mode)** |

--- a/mcp-steroid-server/build.gradle.kts
+++ b/mcp-steroid-server/build.gradle.kts
@@ -38,4 +38,7 @@ dependencies {
 
 tasks.test {
     useJUnitPlatform()
+    // ListWindowsGuideDriftTest reads docs/guides/AGENT-STEROID-GUIDE.md straight from the working
+    // tree, so it needs the repo root rather than the module dir.
+    systemProperty("mcp.repo.root", rootProject.layout.projectDirectory.asFile.absolutePath)
 }

--- a/mcp-steroid-server/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/CommonToolParams.kt
+++ b/mcp-steroid-server/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/CommonToolParams.kt
@@ -54,6 +54,7 @@ object CommonToolParams {
         InputSchemaElement.param("window_id")
             .description("Window id identifying the target IDE window — the `windowId` value from a steroid_list_windows entry.")
             .cliSynopsis("window id from `devrig list_windows` to target")
+            .cliMissingHint("missing --window_id. Use an entry's `windowId` value from `devrig list_windows` (camelCase on output, snake_case as this flag).")
             .string()
 
     /** Required `reason` string with the audit-log convention: `Reason for $action. Required for audit logs.` */

--- a/mcp-steroid-server/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/CommonToolParams.kt
+++ b/mcp-steroid-server/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/CommonToolParams.kt
@@ -45,13 +45,14 @@ object CommonToolParams {
             .required()
 
     /**
-     * `window_id` identifying a specific IDE window (from steroid_list_windows).
+     * `window_id` identifying a specific IDE window — the `windowId` value from a
+     * steroid_list_windows entry (#456: camelCase on output, snake_case as this input).
      * Returned un-required: callers chain `.required()` when mandatory (steroid_input)
      * or `.registerToSchema()` directly when optional (steroid_take_screenshot).
      */
     fun windowId() =
         InputSchemaElement.param("window_id")
-            .description("Window id from steroid_list_windows identifying the target IDE window.")
+            .description("Window id identifying the target IDE window — the `windowId` value from a steroid_list_windows entry.")
             .cliSynopsis("window id from `devrig list_windows` to target")
             .string()
 

--- a/mcp-steroid-server/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/ListWindowsTool.kt
+++ b/mcp-steroid-server/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/ListWindowsTool.kt
@@ -13,7 +13,7 @@ import kotlinx.serialization.Serializable
  */
 class ListWindowsToolSpec(val handler: () -> ListWindowsToolHandler) : McpToolBase() {
     override val name = "steroid_list_windows"
-    override val description = "List open IDE windows and their background tasks, with per-window readiness (modal/indexing/initialized) and a `window_id` for screenshot/input targeting in multi-window setups. Each window and background-task entry references its project by `project_name` — the single routing key for the project-scoped tools; look up that project's human-readable `name` and `path` via steroid_list_projects by the key (they are not duplicated here). `project_name` is null for windows not tied to a project. Resolve an entry's `backend_name` to the owning IDE's identity (`intellij` = `{name, version, build}`) via the `backends` lookup in the same response."
+    override val description = "List open IDE windows and their background tasks, with per-window readiness (modal/indexing/initialized) and a `windowId` for screenshot/input targeting in multi-window setups — pass its value as the `window_id` input of the screenshot/input tools. Each window and background-task entry references its project by `project_name` — the single routing key for the project-scoped tools — and windows also carry the project's `project_path`; the project's human-readable display `name` lives in steroid_list_projects (not duplicated here). Any field whose value is unknown is omitted from the JSON entirely, never serialized as null — e.g. a standalone dialog window carries no `project_name`/`project_path` keys at all. Resolve an entry's `backend_name` to the owning IDE's identity (`intellij` = `{name, version, build}`) via the `backends` lookup in the same response."
     override val cliSynopsis = "list IDE windows, readiness, and background tasks"
 
     override suspend fun call(context: ToolCallContext): ToolCallResult {
@@ -65,6 +65,10 @@ data class ListedWindow(
      *
      * Serialized as snake_case `project_name`/`project_path` (#381) — one spelling of the routing key
      * across `steroid_list_projects` and `steroid_list_windows`, matching the sibling `backend_name`.
+     * Like every nullable field on this entry, a null is omitted from the JSON entirely (McpJson
+     * `explicitNulls = false`, #456) — consumers must treat an absent key and an explicit null the
+     * same way, and must not assume the name/path pair is always present or absent together (each
+     * side can be null independently: nullable `basePath` in-IDE, nullable exposed name via devrig).
      */
     @SerialName("project_name") val projectName: String?,
     @SerialName("project_path") val projectPath: String?,

--- a/mcp-steroid-server/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/ListWindowsTool.kt
+++ b/mcp-steroid-server/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/ListWindowsTool.kt
@@ -60,8 +60,10 @@ data class ListedWindow(
     /**
      * The window's project routing KEY — the opaque, within-IDE-unique id you pass to the project-scoped
      * tools (`steroid_execute_code`, `steroid_take_screenshot`, `steroid_input`, …). The SAME `project_name`
-     * `steroid_list_projects` reports; look up the project's `name`/`path` there by this key. Null for
-     * windows not tied to a project. Treat it as opaque.
+     * `steroid_list_projects` reports; look up the project's display `name` there by this key (the
+     * `path` is already on this entry as `project_path`). Null in Kotlin for windows not tied to a
+     * project — on the wire the key is then ABSENT, never an explicit `null` (see below). Treat it
+     * as opaque.
      *
      * Serialized as snake_case `project_name`/`project_path` (#381) — one spelling of the routing key
      * across `steroid_list_projects` and `steroid_list_windows`, matching the sibling `backend_name`.

--- a/mcp-steroid-server/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/VisionInputTool.kt
+++ b/mcp-steroid-server/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/VisionInputTool.kt
@@ -42,7 +42,7 @@ class VisionInputToolSpec(val handler: () -> VisionInputToolHandler) : McpToolBa
 
         All keys are released at the end of the sequence.
 
-        The input is delivered to the window identified by window_id (from steroid_list_windows) and the focus is forced to that window.
+        The input is delivered to the window identified by window_id (a steroid_list_windows entry's windowId value) and the focus is forced to that window.
         Click coordinates with the screenshot target (e.g. @120,200) are interpreted relative to the window as reported by steroid_list_windows / steroid_take_screenshot.
     """.trimIndent()
     override val cliSynopsis = "send keyboard/mouse input to the IDE"

--- a/mcp-steroid-server/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/VisionScreenshotTool.kt
+++ b/mcp-steroid-server/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/VisionScreenshotTool.kt
@@ -19,7 +19,7 @@ class VisionScreenshotToolSpec(val handler: () -> VisionScreenshotToolHandler) :
         HEAVY ENDPOINT: This is intended for debugging and tricky configuration only.
         Prefer steroid_execute_code for regular automation.
 
-        Use steroid_list_windows when multiple IDE windows are open and pass window_id to target a specific window.
+        Use steroid_list_windows when multiple IDE windows are open and pass an entry's windowId value as window_id to target a specific window.
 
         The screenshot and component tree are saved under the execution folder:
         - screenshot.png

--- a/mcp-steroid-server/src/test/kotlin/com/jonnyzzz/mcpSteroid/server/ListWindowsGuideDriftTest.kt
+++ b/mcp-steroid-server/src/test/kotlin/com/jonnyzzz/mcpSteroid/server/ListWindowsGuideDriftTest.kt
@@ -1,0 +1,130 @@
+/* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
+package com.jonnyzzz.mcpSteroid.server
+
+import com.jonnyzzz.mcpSteroid.IdeInfo
+import com.jonnyzzz.mcpSteroid.mcp.McpJson
+import java.io.File
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * #456: `docs/guides/AGENT-STEROID-GUIDE.md` restates the `steroid_list_windows` output contract in
+ * prose and in a field table. It was the most-edited surface of the fix and the only one with no
+ * regression pin — the prompt articles are covered by `ListWindowsMarkdownArticleContractTest`, the
+ * tool description by `ListWindowsToolSpecSchemaTest`, this file by nothing.
+ *
+ * Both guards are derived from the serializer rather than from a list of past phrasings: every field
+ * the table names must be a key `ListWindowsResponse` really emits, and the spelling conflations the
+ * issue reported must not come back in any form the article ever carried.
+ */
+class ListWindowsGuideDriftTest {
+
+    private val forbiddenConflations = listOf(
+        "`window_id` is also returned by `steroid_list_windows`",
+        "`window_id` for screenshot/input tools",
+        "window_id` for screenshot/input targeting",
+        "Window id from `steroid_list_windows`",
+        "null if not a project window",
+        "is null for windows",
+        "not duplicated on window/task entries",
+        "also stored in `screenshot-meta.json`",
+    )
+
+    @Test
+    fun `every field the per-window table names is a key the serializer emits`() {
+        val table = guideSection("**Response Fields (per window):**")
+        val named = Regex("""^\|\s*`([A-Za-z_][A-Za-z0-9_]*)`""", RegexOption.MULTILINE)
+            .findAll(table).map { it.groupValues[1] }.toSet()
+        assertTrue(named.isNotEmpty(), "no `field` rows found in the per-window table:\n$table")
+        assertEquals(
+            emptySet<String>(),
+            named - liveResponseKeys(),
+            "the guide's per-window table names fields no ListedWindow emits (live keys: ${liveResponseKeys()})",
+        )
+        assertTrue(named.contains("windowId"), "the table must name the live output key windowId: $table")
+        assertTrue(named.contains("project_path"), "the table must name project_path: $table")
+    }
+
+    @Test
+    fun `the guide never re-conflates the windowId output key with the window_id input`() {
+        val text = guideFile().readText()
+        for (phrase in forbiddenConflations) {
+            assertTrue(!text.contains(phrase), "old #456 conflation is back in the guide: '$phrase'")
+        }
+        assertTrue(
+            text.contains("`windowId` value is what you pass as the `window_id` input"),
+            "the guide must state the output->input key translation explicitly",
+        )
+    }
+
+    /** The markdown between [heading] and the following blank line that ends its table. */
+    private fun guideSection(heading: String): String {
+        val text = guideFile().readText()
+        val start = text.indexOf(heading)
+        assertTrue(start >= 0, "'$heading' not found in ${guideFile()} — the field table is the pinned surface")
+        val end = text.indexOf("\n\n", start).let { if (it < 0) text.length else it }
+        return text.substring(start, end)
+    }
+
+    /**
+     * Hard requirement, not an assumption: `:mcp-steroid-server:test` always sets `mcp.repo.root`
+     * (see the module's build.gradle.kts), and a missing guide is exactly the drift this catches.
+     */
+    private fun guideFile(): File {
+        val root = System.getProperty("mcp.repo.root")
+            ?: error("mcp.repo.root is not set — the :mcp-steroid-server:test Gradle task always sets it")
+        val file = File(File(root), "docs/guides/AGENT-STEROID-GUIDE.md")
+        assertTrue(file.isFile, "$file not found — the guide drift gate must see the published guide")
+        return file
+    }
+
+    /** Every JSON key a fully-populated [ListWindowsResponse] emits, at any depth. */
+    private fun liveResponseKeys(): Set<String> {
+        val response = ListWindowsResponse(
+            windows = listOf(
+                ListedWindow(
+                    projectName = "p",
+                    projectPath = "/p",
+                    title = "t",
+                    isActive = true,
+                    isVisible = true,
+                    bounds = WindowBounds(0, 0, 1, 1),
+                    windowId = "w1",
+                    modalDialogShowing = true,
+                    indexingInProgress = false,
+                    projectInitialized = true,
+                    backendName = "b1",
+                ),
+            ),
+            backgroundTasks = listOf(
+                ListedBackgroundTask(
+                    title = "t",
+                    text = "x",
+                    text2 = "y",
+                    fraction = 0.5,
+                    isIndeterminate = false,
+                    isCancellable = true,
+                    projectName = "p",
+                    backendName = "b1",
+                ),
+            ),
+            backends = listOf(
+                BackendRef("b1", IdeInfo(name = "IntelliJ IDEA", version = "2026.1", build = "IU-261").toIntelliJInfo()),
+            ),
+        )
+        val keys = mutableSetOf<String>()
+        fun walk(element: JsonElement) {
+            when (element) {
+                is JsonObject -> element.forEach { (k, v) -> keys += k; walk(v) }
+                is JsonArray -> element.forEach { walk(it) }
+                else -> Unit
+            }
+        }
+        walk(McpJson.parseToJsonElement(McpJson.encodeToString(ListWindowsResponse.serializer(), response)))
+        return keys
+    }
+}

--- a/mcp-steroid-server/src/test/kotlin/com/jonnyzzz/mcpSteroid/server/ListWindowsToolSpecSchemaTest.kt
+++ b/mcp-steroid-server/src/test/kotlin/com/jonnyzzz/mcpSteroid/server/ListWindowsToolSpecSchemaTest.kt
@@ -1,6 +1,7 @@
 /* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
 package com.jonnyzzz.mcpSteroid.server
 
+import com.jonnyzzz.mcpSteroid.IdeInfo
 import com.jonnyzzz.mcpSteroid.mcp.McpJson
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonElement
@@ -8,6 +9,7 @@ import kotlinx.serialization.json.JsonNull
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -37,15 +39,18 @@ class ListWindowsToolSpecSchemaTest {
             backendName = "iu-9fk2a0xQ",
         )
         val json = McpJson.encodeToString(ListedWindow.serializer(), listed)
-        assertTrue(json.contains("\"project_name\":\"proj-9fk2a0xQ\""), json)
-        assertTrue(json.contains("\"project_path\":\"/p\""), json)
-        assertTrue(json.contains("\"backend_name\":\"iu-9fk2a0xQ\""), json)
-        assertFalse(json.contains("projectName"), "MCP surface must not emit camelCase projectName: $json")
-        assertFalse(json.contains("projectPath"), "MCP surface must not emit camelCase projectPath: $json")
+        // Structural, not wire-text: a `prettyPrint` flip inserts a space after every colon, which
+        // would break the positive substring checks and silently defeat the negative ones.
+        val entry = McpJson.parseToJsonElement(json).jsonObject
+        assertEquals("proj-9fk2a0xQ", entry["project_name"]?.jsonPrimitive?.content, json)
+        assertEquals("/p", entry["project_path"]?.jsonPrimitive?.content, json)
+        assertEquals("iu-9fk2a0xQ", entry["backend_name"]?.jsonPrimitive?.content, json)
+        assertFalse(entry.containsKey("projectName"), "MCP surface must not emit camelCase projectName: $json")
+        assertFalse(entry.containsKey("projectPath"), "MCP surface must not emit camelCase projectPath: $json")
         // #456: windowId stays camelCase — snake_case is the #381 convention for routing keys only,
         // and renaming would break shipped consumers of the output.
-        assertTrue(json.contains("\"windowId\":\"w1\""), json)
-        assertFalse(json.contains("\"window_id\""), "output key is camelCase windowId, not window_id: $json")
+        assertEquals("w1", entry["windowId"]?.jsonPrimitive?.content, json)
+        assertFalse(entry.containsKey("window_id"), "output key is camelCase windowId, not window_id: $json")
         val decoded = McpJson.decodeFromString(ListedWindow.serializer(), json)
         assertEquals(listed, decoded)
     }
@@ -110,21 +115,83 @@ class ListWindowsToolSpecSchemaTest {
     }
 
     @Test
-    fun `description names the live keys and never re-conflates the spellings`() {
-        // #456: the description used to promise a `window_id` field and deny `project_path` while the
-        // JSON carried camelCase `windowId` and included `project_path`. Both directions are pinned:
-        // the live keys must be named, and the two original false phrasings must never come back.
+    fun `every key the description names in backticks is a key the serializer really emits`() {
+        // #456's root cause: the prose named a key the serializer never emits (`window_id`) and denied
+        // one it does (`project_path`). Blacklisting past phrasings only catches phrasings already
+        // seen, so derive the guard from the serializer — every identifier the description backticks
+        // must be a real key of a fully-populated response, or an explicitly allowed cross-reference.
         val description = ListWindowsToolSpec { unreachableHandler() }.description
+        val liveKeys = liveResponseKeys()
+
+        // `window_id` is the INPUT parameter of the screenshot/input tools; `name`/`path` belong to
+        // steroid_list_projects; `intellij` is asserted separately by BackendRefSerializationTest.
+        val crossReferenced = setOf("window_id", "name", "path", "intellij")
+        val named = Regex("`([A-Za-z_][A-Za-z0-9_]*)`").findAll(description).map { it.groupValues[1] }.toSet()
+        assertEquals(
+            emptySet<String>(),
+            named - liveKeys - crossReferenced,
+            "the description names keys no ListWindowsResponse entry emits (live keys: $liveKeys): $description",
+        )
         assertTrue(description.contains("`windowId`"), "description must name the live output key: $description")
         assertTrue(description.contains("`project_path`"), "description must acknowledge project_path in the output: $description")
-        assertFalse(
-            description.contains("a `window_id` for"),
-            "the output key is windowId — the old claim of a window_id output field must not come back: $description",
+
+        // `window_id` may be mentioned ONLY as the input translation, never as an output field.
+        assertEquals(
+            0,
+            Regex("`window_id`(?! input)").findAll(description).count(),
+            "`window_id` is not an output key — name it only as the `window_id` input: $description",
         )
+        // Any phrasing that calls an absent routing field "null" is the #456 regression.
         assertFalse(
-            description.contains("is null for windows"),
-            "null routing fields are omitted, never explicit — the old null claim must not come back: $description",
+            Regex("`project_(name|path)` is null|is null for windows|null if not").containsMatchIn(description),
+            "absent routing fields are omitted, never explicit null — that claim must not come back: $description",
         )
+    }
+
+    /** Every JSON key a fully-populated [ListWindowsResponse] emits, at any depth. */
+    private fun liveResponseKeys(): Set<String> {
+        val response = ListWindowsResponse(
+            windows = listOf(
+                ListedWindow(
+                    projectName = "p",
+                    projectPath = "/p",
+                    title = "t",
+                    isActive = true,
+                    isVisible = true,
+                    bounds = WindowBounds(0, 0, 1, 1),
+                    windowId = "w1",
+                    modalDialogShowing = true,
+                    indexingInProgress = false,
+                    projectInitialized = true,
+                    backendName = "b1",
+                ),
+            ),
+            backgroundTasks = listOf(
+                ListedBackgroundTask(
+                    title = "t",
+                    text = "x",
+                    text2 = "y",
+                    fraction = 0.5,
+                    isIndeterminate = false,
+                    isCancellable = true,
+                    projectName = "p",
+                    backendName = "b1",
+                ),
+            ),
+            backends = listOf(
+                BackendRef("b1", IdeInfo(name = "IntelliJ IDEA", version = "2026.1", build = "IU-261").toIntelliJInfo()),
+            ),
+        )
+        val keys = mutableSetOf<String>()
+        fun walk(element: JsonElement) {
+            when (element) {
+                is JsonObject -> element.forEach { (k, v) -> keys += k; walk(v) }
+                is JsonArray -> element.forEach { walk(it) }
+                else -> Unit
+            }
+        }
+        walk(McpJson.parseToJsonElement(McpJson.encodeToString(ListWindowsResponse.serializer(), response)))
+        return keys
     }
 
     @Test
@@ -184,6 +251,11 @@ class ListWindowsToolSpecSchemaTest {
                     projectName = null,
                     backendName = null,
                 ),
+            ),
+            // Non-empty on purpose: with the default emptyList() the walk below never enters a
+            // backends[] element, and the description's never-null promise covers those too.
+            backends = listOf(
+                BackendRef("b-1", IdeInfo(name = "IntelliJ IDEA", version = "2026.1", build = "IU-261").toIntelliJInfo()),
             ),
         )
         val root = McpJson.parseToJsonElement(McpJson.encodeToString(ListWindowsResponse.serializer(), response))

--- a/mcp-steroid-server/src/test/kotlin/com/jonnyzzz/mcpSteroid/server/ListWindowsToolSpecSchemaTest.kt
+++ b/mcp-steroid-server/src/test/kotlin/com/jonnyzzz/mcpSteroid/server/ListWindowsToolSpecSchemaTest.kt
@@ -2,6 +2,10 @@
 package com.jonnyzzz.mcpSteroid.server
 
 import com.jonnyzzz.mcpSteroid.mcp.McpJson
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -38,6 +42,10 @@ class ListWindowsToolSpecSchemaTest {
         assertTrue(json.contains("\"backend_name\":\"iu-9fk2a0xQ\""), json)
         assertFalse(json.contains("projectName"), "MCP surface must not emit camelCase projectName: $json")
         assertFalse(json.contains("projectPath"), "MCP surface must not emit camelCase projectPath: $json")
+        // #456: windowId stays camelCase — snake_case is the #381 convention for routing keys only,
+        // and renaming would break shipped consumers of the output.
+        assertTrue(json.contains("\"windowId\":\"w1\""), json)
+        assertFalse(json.contains("\"window_id\""), "output key is camelCase windowId, not window_id: $json")
         val decoded = McpJson.decodeFromString(ListedWindow.serializer(), json)
         assertEquals(listed, decoded)
     }
@@ -99,6 +107,96 @@ class ListWindowsToolSpecSchemaTest {
         assertEquals(setOf("windows", "backgroundTasks", "backends"), root.keys, json)
         val backend = root["backends"]!!.jsonArray.single().jsonObject
         assertEquals(setOf("backend_name", "intellij"), backend.keys, json)
+    }
+
+    @Test
+    fun `description names the live keys and never re-conflates the spellings`() {
+        // #456: the description used to promise a `window_id` field and deny `project_path` while the
+        // JSON carried camelCase `windowId` and included `project_path`. Both directions are pinned:
+        // the live keys must be named, and the two original false phrasings must never come back.
+        val description = ListWindowsToolSpec { unreachableHandler() }.description
+        assertTrue(description.contains("`windowId`"), "description must name the live output key: $description")
+        assertTrue(description.contains("`project_path`"), "description must acknowledge project_path in the output: $description")
+        assertFalse(
+            description.contains("a `window_id` for"),
+            "the output key is windowId — the old claim of a window_id output field must not come back: $description",
+        )
+        assertFalse(
+            description.contains("is null for windows"),
+            "null routing fields are omitted, never explicit — the old null claim must not come back: $description",
+        )
+    }
+
+    @Test
+    fun `a window not tied to a project omits the project keys instead of null`() {
+        // #456 follow-up comment: a standalone dialog window carries no project binding. McpJson uses
+        // explicitNulls=false, so the keys are ABSENT, not explicit nulls — asserted structurally
+        // (parsed key set + no JsonNull values), not via wire-text substrings, so a prettyPrint flip
+        // cannot make this pass vacuously.
+        val unbound = ListedWindow(
+            projectName = null,
+            projectPath = null,
+            title = "MCP Battle Test",
+            isActive = false,
+            isVisible = true,
+            bounds = WindowBounds(679, 304, 370, 150),
+            windowId = "w-38057d0c",
+            modalDialogShowing = true,
+            backendName = "go-4778z40r",
+        )
+        val json = McpJson.encodeToString(ListedWindow.serializer(), unbound)
+        val entry = McpJson.parseToJsonElement(json).jsonObject
+        assertFalse(entry.containsKey("project_name"), "unbound window omits project_name entirely: $json")
+        assertFalse(entry.containsKey("project_path"), "unbound window omits project_path entirely: $json")
+        assertTrue(entry.values.none { it is JsonNull }, "no explicit null values in the entry: $json")
+        val decoded = McpJson.decodeFromString(ListedWindow.serializer(), json)
+        assertEquals(unbound, decoded)
+    }
+
+    @Test
+    fun `the whole response never serializes an explicit null anywhere`() {
+        // The tool description promises: "Any field whose value is unknown is omitted from the JSON
+        // entirely, never serialized as null" — for window AND background-task entries. Assert it over
+        // a full response whose every nullable field is null, walking the entire tree.
+        val response = ListWindowsResponse(
+            windows = listOf(
+                ListedWindow(
+                    projectName = null,
+                    projectPath = null,
+                    title = null,
+                    isActive = false,
+                    isVisible = true,
+                    bounds = null,
+                    windowId = "w-1",
+                    indexingInProgress = null,
+                    projectInitialized = null,
+                    backendName = null,
+                ),
+            ),
+            backgroundTasks = listOf(
+                ListedBackgroundTask(
+                    title = "Indexing",
+                    text = "scanning",
+                    text2 = "",
+                    fraction = null,
+                    isIndeterminate = true,
+                    isCancellable = false,
+                    projectName = null,
+                    backendName = null,
+                ),
+            ),
+        )
+        val root = McpJson.parseToJsonElement(McpJson.encodeToString(ListWindowsResponse.serializer(), response))
+
+        fun assertNoNulls(element: JsonElement, path: String) {
+            when (element) {
+                is JsonNull -> throw AssertionError("explicit null serialized at $path in: $root")
+                is JsonObject -> element.forEach { (k, v) -> assertNoNulls(v, "$path.$k") }
+                is JsonArray -> element.forEachIndexed { i, v -> assertNoNulls(v, "$path[$i]") }
+                else -> Unit
+            }
+        }
+        assertNoNulls(root, "$")
     }
 
     @Test

--- a/prompts/src/main/prompts/open-project/open-with-dialogs.md
+++ b/prompts/src/main/prompts/open-project/open-with-dialogs.md
@@ -64,7 +64,7 @@ val inputJson = """
     "project_name": "existing-project-9fk2a0xq",
     "task_id": "handle-trust-dialog",
     "reason": "Clicking Trust Project button",
-    "window_id": "window_id_from_list_windows",
+    "window_id": "windowId_value_from_list_windows",
     "sequence": "click:Left@x,y"
   }
 }

--- a/prompts/src/main/prompts/open-project/overview.md
+++ b/prompts/src/main/prompts/open-project/overview.md
@@ -48,7 +48,9 @@ the non-visual readiness path. Window flags also do not prove Maven/Gradle impor
 
 | Field | Description |
 |-------|-------------|
-| `project_name` | The single routing key for the window's project (null if not a project window). Look up that project's human-readable `name` and `path` via `steroid_list_projects` by this key. |
+| `project_name` | The single routing key for the window's project (omitted, not null, if not a project window). Only the human-readable display `name` needs `steroid_list_projects`. |
+| `project_path` | The project's base path, right on the entry. |
+| `windowId` | Window id — pass its value as the `window_id` input of `steroid_take_screenshot` / `steroid_input`. |
 | `modalDialogShowing` | True if any modal dialog is showing in IDE |
 | `indexingInProgress` | True if project is indexing (dumb mode) |
 | `projectInitialized` | True if the IDE project is initialized; does not prove Maven/Gradle model import |

--- a/prompts/src/main/prompts/prompt/skill.md
+++ b/prompts/src/main/prompts/prompt/skill.md
@@ -96,10 +96,12 @@ name, informational only), and `path`. To map a file/dir path to a project, pick
 
 ### `steroid_list_windows`
 List open IDE windows (and background tasks) and their associated projects. Some windows may not be tied to a project and a project can have multiple windows.
-Use this in multi-window setups to pick the correct `window_id` for screenshot/input tools. Each
-window and task entry references its project by `project_name` — the single routing key. Look up that
-project's human-readable `name` and `path` via `steroid_list_projects` by that key (they are not
-duplicated on window/task entries).
+Use this in multi-window setups to pick the correct window: each window entry carries a `windowId` —
+pass its value as the `window_id` input of the screenshot/input tools. Entries reference their
+project by `project_name` — the single routing key — and windows also carry the project's
+`project_path`; only the human-readable display `name` lives in `steroid_list_projects`. Any null
+field is omitted from the JSON entirely (never an explicit null): a window not tied to a project
+has no `project_name`/`project_path` keys, and each of the two can also be absent independently.
 
 ### `steroid_take_screenshot`
 Capture a screenshot of the IDE frame and return image content.
@@ -110,14 +112,14 @@ Capture a screenshot of the IDE frame and return image content.
 - `project_name` (required): the `project_name` from `steroid_list_projects` (a unique routing key, NOT the raw folder name)
 - `task_id` (required): Task identifier for logging
 - `reason` (required): Why the screenshot is needed
-- `window_id` (optional): Window id from `steroid_list_windows` to target a specific window
+- `window_id` (optional): the `windowId` value from a `steroid_list_windows` entry, to target a specific window
 
 **Artifacts (saved under the execution folder):**
 - `screenshot.png`
 - `screenshot-tree.md`
 - `screenshot-meta.json`
 
-The response includes `window_id` (also stored in `screenshot-meta.json`); pass it to `steroid_input` to target the same window. `window_id` is also returned by `steroid_list_windows`.
+The response includes `window_id` (also stored in `screenshot-meta.json`); pass it to `steroid_input` to target the same window. The same id appears as `windowId` on `steroid_list_windows` entries.
 
 ### `steroid_input`
 Send input events (keyboard + mouse) using a sequence string.
@@ -128,7 +130,7 @@ Send input events (keyboard + mouse) using a sequence string.
 - `project_name` (required): the `project_name` from `steroid_list_projects` (a unique routing key, NOT the raw folder name)
 - `task_id` (required): Task identifier for logging
 - `reason` (required): Why the input is needed
-- `window_id` (required): Window id from `steroid_list_windows` (also returned by `steroid_take_screenshot`)
+- `window_id` (required): the `windowId` value from a `steroid_list_windows` entry (the screenshot response echoes it as `window_id`)
 - `sequence` (required): Comma-separated or newline-separated input sequence (commas inside values are allowed unless they look like `, <step>:`; commas are optional when using newlines)
 
 **Sequence examples:**

--- a/prompts/src/main/prompts/prompt/skill.md
+++ b/prompts/src/main/prompts/prompt/skill.md
@@ -119,7 +119,7 @@ Capture a screenshot of the IDE frame and return image content.
 - `screenshot-tree.md`
 - `screenshot-meta.json`
 
-The response includes `window_id` (also stored in `screenshot-meta.json`); pass it to `steroid_input` to target the same window. The same id appears as `windowId` on `steroid_list_windows` entries.
+The response includes a `window_id:` line; pass its value to `steroid_input` to target the same window. The same id appears as `windowId` on `steroid_list_windows` entries and as `windowId` inside `screenshot-meta.json` — that file's keys are camelCase throughout (`windowId`, `projectName`, `projectPath`), unlike the snake_case routing keys of the list tools.
 
 ### `steroid_input`
 Send input events (keyboard + mouse) using a sequence string.

--- a/prompts/src/test/kotlin/com/jonnyzzz/mcpSteroid/prompts/ListWindowsMarkdownArticleContractTest.kt
+++ b/prompts/src/test/kotlin/com/jonnyzzz/mcpSteroid/prompts/ListWindowsMarkdownArticleContractTest.kt
@@ -19,13 +19,23 @@ import org.junit.jupiter.api.Test
 class ListWindowsMarkdownArticleContractTest {
 
     private val forbiddenConflations = listOf(
-        // The two original #456 phrasings — list_windows does NOT return a window_id key:
+        // list_windows does NOT return a window_id key. The first three are the exact pre-fix
+        // sentences (skill.md's screenshot line and its two parameter mirrors); the `targeting`
+        // variant lived in the Kotlin tool description and is pinned so copying it into an article
+        // is caught too.
         "`window_id` is also returned by `steroid_list_windows`",
+        "`window_id` for screenshot/input tools",
         "window_id` for screenshot/input targeting",
         "Window id from `steroid_list_windows`",
         // The null-vs-omitted lie:
         "null if not a project window",
         "is null for windows",
+        // The project_path misdirection: the path is ON the window entry — only the display name
+        // needs steroid_list_projects.
+        "not duplicated on window/task entries",
+        // screenshot-meta.json has camelCase keys (ScreenshotMeta declares no @SerialName), so the
+        // window_id spelling must never be attached to that file.
+        "also stored in `screenshot-meta.json`",
     )
 
     @Test
@@ -40,6 +50,14 @@ class ListWindowsMarkdownArticleContractTest {
         assertTrue(
             prompt.contains("has no `project_name`/`project_path` keys"),
             "the article must keep the absent-not-null note for unbound windows",
+        )
+        assertTrue(
+            prompt.contains("windows also carry the project's"),
+            "the article must state project_path is on the window entry, not only in steroid_list_projects",
+        )
+        assertTrue(
+            prompt.contains("that file's keys are camelCase throughout"),
+            "the screenshot section must say screenshot-meta.json uses camelCase keys, not window_id",
         )
         for (phrase in forbiddenConflations) {
             assertFalse(prompt.contains(phrase), "old #456 conflation must not come back: '$phrase'")

--- a/prompts/src/test/kotlin/com/jonnyzzz/mcpSteroid/prompts/ListWindowsMarkdownArticleContractTest.kt
+++ b/prompts/src/test/kotlin/com/jonnyzzz/mcpSteroid/prompts/ListWindowsMarkdownArticleContractTest.kt
@@ -1,0 +1,65 @@
+/* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
+package com.jonnyzzz.mcpSteroid.prompts
+
+import com.jonnyzzz.mcpSteroid.prompts.generated.openProject.OverviewPromptArticle
+import com.jonnyzzz.mcpSteroid.prompts.generated.prompt.SkillPromptArticle
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * #456: `steroid_list_windows` entries carry a camelCase `windowId` (the snake_case spelling is
+ * reserved for the `*_name`/`*_path` routing keys, #381), while `window_id` is the INPUT parameter
+ * of the screenshot/input tools. Prompt articles used to re-conflate the two and to claim absent
+ * routing keys are "null" — this pins the prose of the two highest-traffic articles.
+ *
+ * Named `*MarkdownArticleContract*` so it runs in the fast path CLAUDE.md documents for prose-only
+ * prompt edits (`./gradlew :prompts:test --tests '*MarkdownArticleContract*'`).
+ */
+class ListWindowsMarkdownArticleContractTest {
+
+    private val forbiddenConflations = listOf(
+        // The two original #456 phrasings — list_windows does NOT return a window_id key:
+        "`window_id` is also returned by `steroid_list_windows`",
+        "window_id` for screenshot/input targeting",
+        "Window id from `steroid_list_windows`",
+        // The null-vs-omitted lie:
+        "null if not a project window",
+        "is null for windows",
+    )
+
+    @Test
+    fun `skill article teaches the windowId to window_id translation and absent-not-null`() {
+        val prompt = SkillPromptArticle().readPayload(PromptsContext("IU", 261))
+
+        assertTrue(
+            prompt.contains("carries a `windowId`") &&
+                prompt.contains("pass its value as the `window_id` input"),
+            "the list_windows section must teach the output→input key translation explicitly",
+        )
+        assertTrue(
+            prompt.contains("has no `project_name`/`project_path` keys"),
+            "the article must keep the absent-not-null note for unbound windows",
+        )
+        for (phrase in forbiddenConflations) {
+            assertFalse(prompt.contains(phrase), "old #456 conflation must not come back: '$phrase'")
+        }
+    }
+
+    @Test
+    fun `open-project overview polling table names windowId and does not misdirect to list_projects`() {
+        val prompt = OverviewPromptArticle().readPayload(PromptsContext("IU", 261))
+
+        assertTrue(
+            prompt.contains("`windowId`"),
+            "the polling table must name the windowId output key",
+        )
+        assertTrue(
+            prompt.contains("omitted, not null"),
+            "the polling table must state routing keys are omitted, not null",
+        )
+        for (phrase in forbiddenConflations) {
+            assertFalse(prompt.contains(phrase), "old #456 conflation must not come back: '$phrase'")
+        }
+    }
+}

--- a/test-experiments/src/test/kotlin/com/jonnyzzz/mcpSteroid/integration/tests/DevrigCliAgentUsabilityExperimentTest.kt
+++ b/test-experiments/src/test/kotlin/com/jonnyzzz/mcpSteroid/integration/tests/DevrigCliAgentUsabilityExperimentTest.kt
@@ -1208,8 +1208,10 @@ class DevrigCliAgentUsabilityExperimentTest {
             "list_windows returned no window for project_name '$projectName': $this"
         }
         val selectedWindow = requireNotNull(window)
-        val id = selectedWindow["window_id"] ?: selectedWindow["windowId"]
-        assertTrue(id != null) { "list_windows returned a project window without a window id: $selectedWindow" }
+        // #456: the output key is camelCase windowId — pinned by ListWindowsToolSpecSchemaTest.
+        // No window_id fallback here: hedging both spellings would imply the contract is ambiguous.
+        val id = selectedWindow["windowId"]
+        assertTrue(id != null) { "list_windows returned a project window without a windowId: $selectedWindow" }
         return requireNotNull(id).jsonPrimitive.content
     }
 

--- a/test-experiments/src/test/kotlin/com/jonnyzzz/mcpSteroid/integration/tests/DevrigCliAgentUsabilityExperimentTest.kt
+++ b/test-experiments/src/test/kotlin/com/jonnyzzz/mcpSteroid/integration/tests/DevrigCliAgentUsabilityExperimentTest.kt
@@ -1210,9 +1210,12 @@ class DevrigCliAgentUsabilityExperimentTest {
         val selectedWindow = requireNotNull(window)
         // #456: the output key is camelCase windowId — pinned by ListWindowsToolSpecSchemaTest.
         // No window_id fallback here: hedging both spellings would imply the contract is ambiguous.
-        val id = selectedWindow["windowId"]
-        assertTrue(id != null) { "list_windows returned a project window without a windowId: $selectedWindow" }
-        return requireNotNull(id).jsonPrimitive.content
+        // jsonPrimitive rejects JsonNull, so `"windowId": null` fails here instead of flowing on as
+        // the literal string "null".
+        val id = requireNotNull(selectedWindow["windowId"] as? JsonPrimitive) {
+            "list_windows returned a project window without a string windowId: $selectedWindow"
+        }
+        return id.content
     }
 
     private fun JsonObject.executionId(): String {

--- a/test-integration/src/test/kotlin/com/jonnyzzz/mcpSteroid/integration/tests/DevrigFakeIdeBridgeIntegrationTest.kt
+++ b/test-integration/src/test/kotlin/com/jonnyzzz/mcpSteroid/integration/tests/DevrigFakeIdeBridgeIntegrationTest.kt
@@ -158,8 +158,8 @@ class DevrigFakeIdeBridgeIntegrationTest {
         val window = McpJson.parseToJsonElement(windowsText).jsonObject["windows"]?.jsonArray?.single()?.jsonObject
             ?: error("list_windows result missing windows: $windowsText")
         // devrig rewrites only the window's project_name to the routed (hash-suffixed) name; windowId is
-        // forwarded as-is (DevrigProjectRoutingService.rewriteWindow — "window_id is unique within the IDE
-        // resolved by project_name; forward it as-is"). Snake_case key since #381.
+        // forwarded as-is (DevrigListWindowsToolHandler.exposedProjectName() + WindowInfo.listed() — a
+        // window id is unique within the IDE resolved by project_name). Snake_case project key since #381.
         assertEquals(projectName, window["project_name"]?.jsonPrimitive?.content)
         assertEquals("fake-window", window["windowId"]?.jsonPrimitive?.content, "windowId must be forwarded as-is: $window")
     }


### PR DESCRIPTION
Fixes #456.

The `steroid_list_windows` description contradicted its own JSON on all three points the issue and its follow-up comment reported: it promised a `window_id` field (the live key is camelCase `windowId`), claimed the project path is "not duplicated here" (`project_path` is right on every window entry), and said `project_name` "is null" for unbound windows (McpJson uses `explicitNulls=false`, so the key is omitted entirely). The same conflations survived in the prompt/skill article, the open-project overview polling table, AGENT-STEROID-GUIDE (prose, field table, parameter mirrors), the screenshot/input tool descriptions, a recipe placeholder, the `window_id` parameter description + KDoc — and, from the other direction, in a claim that `window_id` is stored in `screenshot-meta.json` (that file is camelCase throughout: `ScreenshotMeta` declares no `@SerialName`).

## What changed (two commits)

**Commit 1 — every surface tells the same truth:**
- Output key is `windowId`; pass its value as the `window_id` *input* of the screenshot/input tools (the screenshot response echoes it as a `window_id:` text line).
- `project_path` is on the window entry; only the display `name` routes through `steroid_list_projects`.
- Any null field is omitted from the JSON entirely, never serialized as null — and the name/path pair can split independently (nullable `basePath` in-IDE; nullable exposed name via devrig on a transient route miss).
- The camelCase `windowId` spelling is deliberate: #381's snake_case covers only the routing keys; every other entry key is camelCase. Recorded in `docs/devrig-naming.md` (whose neighbouring paragraph also stops naming the nonexistent `rewriteWindow`).

**Commit 2 — hardened pins (found by re-review):**
- `ListWindowsToolSpecSchemaTest`: the description guard is now serializer-derived (every backticked identifier must be a key a fully-populated response really emits, with an explicit cross-reference allowlist; `window_id` may be named only as the input), assertions are structural (parsed key sets / no `JsonNull` walk incl. `backends[]`) so a `prettyPrint` flip can't make them vacuous.
- New `ListWindowsGuideDriftTest` pins AGENT-STEROID-GUIDE's field table to the live serializer keys (the guide was the most-edited surface with no pin; `mcp.repo.root` wired the way `ProductCatalogDocsDriftTest` does it).
- `ListWindowsMarkdownArticleContractTest` pins the skill + overview article prose, named to run inside the `*MarkdownArticleContract*` fast path.
- The `window_id`-or-`windowId` hedge in the CLI experiment harness is collapsed to the pinned spelling; `window_id` gains a `cliMissingHint` naming its source key.

## The rename/alias question (deliberately not done here)

Three options were weighed and recorded in `docs/devrig-naming.md`: renaming the output to `window_id` is #381-shaped breaking (every `windowId` reader); `@SerialName`+`@JsonNames` is NOT additive (it changes the emitted key — kotlinx has no dual-emit); the genuinely additive fix is widening the INPUT so `steroid_input`/`steroid_take_screenshot` accept both spellings — that needs a parameter-alias mechanism `InputSchemaElement` doesn't have, so it's logged in TODO.md as a follow-up feature rather than smuggled into a docs fix.

## Verification

`:mcp-steroid-server:test` (incl. both new test classes), `:prompts:test --tests '*MarkdownArticleContract*'`, `OpenWithDialogsKtBlocksCompilationTest` (the recipe placeholder sits in a kotlin fence; 32 compilations green), `:test-integration:compileTestKotlin`, `:test-experiments:compileTestKotlin` — all green. Each new guard was verified by reintroducing the corresponding falsehood and observing the failure.