### PR TITLE
Blank execute_code payloads are refused on every spelling and transport (#460)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -365,3 +365,16 @@
   stderr. Left as is deliberately: the parsed flag has no other consumer, `@argfile` is not a documented
   devrig invocation form, and the alternative is a logback `reset()` + `JoranConfigurator` re-read after
   parsing. Pick that up only if a real client trips on it.
+
+- [ ] **Declarative non-blank constraint on schema string parameters (#460 follow-up).** The blank-payload
+  rule now lives in three hand-synced layers: the CLI parse gates in `SchemaCliBinding.registerRequirednessChecks`
+  (file-source branch + the generic `cliRequired` blank gate), the content readers in `GeneratedToolRuntime`
+  (blank file/stdin, BOM strip in `decodeCliSourceBytes`), and per-tool MCP guards (`ExecuteCodeTool.call`'s
+  `code.isBlank()`, `ExecuteFeedbackTool.call`'s hand-rolled blank checks). A `.nonBlank()` builder on
+  `InputSchemaElement<String>` (the `required()`/`cliMinimum` idiom in mcp-core `McpSchema.kt`) would state
+  the rule once at the shared `context[param]` choke point for every tool and transport, let
+  `SchemaCliBinding` derive its CLI blank rule from the same spec flag, and close the remaining MCP-side
+  gaps a direct caller can still hit today: `task_id="  "`/`reason=""` on execute_code, `explanation=""`
+  on execute_feedback, `project_path=""` on open_project. The DEFINITION of blank is already unified —
+  `isEffectivelyBlank` in mcp-core (whitespace + BOM) backs the CLI parse gates, the file/stdin readers,
+  and execute_code's MCP guard — what is missing is declaring WHICH parameters it applies to, per schema.

--- a/docs/devrig-cli-contract.md
+++ b/docs/devrig-cli-contract.md
@@ -97,8 +97,9 @@ forwarded unchanged through `open_project`; `execute_feedback` forwards an optio
 CLI session can rate the exact execution it observed.
 
 For a schema-declared file source, `--<name>-file=<path>` reads that parameter from a file and
-`--<name>-file=-` reads stdin. File and stdin input must be non-empty, strict UTF-8, and no larger than
-10 MiB. Human mode announces a stdin read on stderr so a waiting process is understandable; JSON stdout
+`--<name>-file=-` reads stdin. File and stdin input must be non-blank (empty, whitespace-only, and
+BOM-only content is refused; a leading BOM is stripped), strict UTF-8, and no larger than 10 MiB. A blank
+inline value or a blank file path on a schema parameter fails at parse time the same way (#460). Human mode announces a stdin read on stderr so a waiting process is understandable; JSON stdout
 remains clean.
 
 ## Human and machine output

--- a/mcp-core/src/main/kotlin/com/jonnyzzz/mcpSteroid/mcp/EffectivelyBlank.kt
+++ b/mcp-core/src/main/kotlin/com/jonnyzzz/mcpSteroid/mcp/EffectivelyBlank.kt
@@ -1,0 +1,22 @@
+/* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
+package com.jonnyzzz.mcpSteroid.mcp
+
+/**
+ * True when the string carries no usable payload: empty, whitespace, or U+FEFF byte-order marks in any
+ * mix. `isBlank()` alone misses the BOM — `Character.isWhitespace('\uFEFF')` is false, yet a PowerShell
+ * redirect or a Notepad save of an "empty" file produces exactly a BOM-only payload (#460).
+ *
+ * This is the ONE definition of "blank" for parameter validation across transports — the devrig CLI
+ * parse gates, the CLI file/stdin content readers, and the MCP tool-boundary guards all delegate here,
+ * so no spelling of the same payload can be accepted by one layer and refused by another.
+ */
+fun String.isEffectivelyBlank(): Boolean = all { it.isWhitespace() || it == '\uFEFF' }
+
+/**
+ * Strips the leading run of U+FEFF byte-order marks — the encoding artifact a Notepad save or
+ * PowerShell redirect prepends. Deliberately leading-only: a U+FEFF elsewhere may be intentional
+ * string-literal content, and removing it would corrupt the payload. The pair to
+ * [isEffectivelyBlank]: every site that ships a payload strips with this, so all spellings of the
+ * same source deliver identical bytes.
+ */
+fun String.trimLeadingBoms(): String = trimStart('\uFEFF')

--- a/mcp-steroid-server/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/ExecuteCodeTool.kt
+++ b/mcp-steroid-server/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/ExecuteCodeTool.kt
@@ -10,11 +10,14 @@ import com.jonnyzzz.mcpSteroid.mcp.cliOptional
 import com.jonnyzzz.mcpSteroid.mcp.cliSynopsis
 import com.jonnyzzz.mcpSteroid.mcp.description
 import com.jonnyzzz.mcpSteroid.mcp.enumString
+import com.jonnyzzz.mcpSteroid.mcp.errorResult
 import com.jonnyzzz.mcpSteroid.mcp.get
 import com.jonnyzzz.mcpSteroid.mcp.int
+import com.jonnyzzz.mcpSteroid.mcp.isEffectivelyBlank
 import com.jonnyzzz.mcpSteroid.mcp.param
 import com.jonnyzzz.mcpSteroid.mcp.required
 import com.jonnyzzz.mcpSteroid.mcp.string
+import com.jonnyzzz.mcpSteroid.mcp.trimLeadingBoms
 import com.jonnyzzz.mcpSteroid.mcp.withDefaultValue
 import com.jonnyzzz.mcpSteroid.prompts.Generic
 import com.jonnyzzz.mcpSteroid.prompts.PromptsContext
@@ -179,9 +182,22 @@ class ExecuteCodeToolSpec(val handler: () -> ExecuteCodeToolHandler) : McpToolBa
         val timeout = context[timeout]
         val modal = context[modal]
 
+        // #460: a blank script — whitespace or BOM-only (a pasted "empty" Windows file) — would burn a
+        // full pre-flight + compiler round-trip and an execution_id only to produce the (then
+        // misleading) no-output hint. The devrig CLI refuses blank --code/--code-file/stdin at its own
+        // boundary with the same isEffectivelyBlank definition; this guard covers direct MCP callers.
+        if (code.isEffectivelyBlank()) {
+            return ToolCallResult.errorResult(
+                "code must not be blank — pass a non-empty Kotlin script"
+            )
+        }
+
         val execCodeParams = ExecCodeParams(
             taskId = taskId,
-            code = code,
+            // A leading U+FEFF is an encoding artifact (a pasted Windows file), not script content —
+            // wrapped mid-file it would fail compilation with an invisible-character error. The CLI's
+            // file/stdin decoder strips it the same way; inline and direct-MCP code get it here.
+            code = code.trimLeadingBoms(),
             reason = reason,
             timeout = timeout,
             modal = modal,

--- a/mcp-steroid-server/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/ExecuteFeedbackTool.kt
+++ b/mcp-steroid-server/src/main/kotlin/com/jonnyzzz/mcpSteroid/server/ExecuteFeedbackTool.kt
@@ -9,6 +9,8 @@ import com.jonnyzzz.mcpSteroid.mcp.cliSynopsis
 import com.jonnyzzz.mcpSteroid.mcp.description
 import com.jonnyzzz.mcpSteroid.mcp.errorResult
 import com.jonnyzzz.mcpSteroid.mcp.get
+import com.jonnyzzz.mcpSteroid.mcp.isEffectivelyBlank
+import com.jonnyzzz.mcpSteroid.mcp.trimLeadingBoms
 import com.jonnyzzz.mcpSteroid.mcp.maximum
 import com.jonnyzzz.mcpSteroid.mcp.minimum
 import com.jonnyzzz.mcpSteroid.mcp.number
@@ -89,11 +91,11 @@ class ExecuteFeedbackToolSpec(val handler: () -> ExecuteFeedbackToolHandler) : M
 
     override suspend fun call(context: ToolCallContext): ToolCallResult {
         val projectName = context[projectName]
-        if (projectName.isBlank()) {
+        if (projectName.isEffectivelyBlank()) {
             return ToolCallResult.errorResult("project_name is required (from the project-listing tool or command)")
         }
         val taskId = context[taskId]
-        if (taskId.isBlank()) {
+        if (taskId.isEffectivelyBlank()) {
             return ToolCallResult.errorResult("task_id is required (same id you passed to the code-execution tool or command)")
         }
         // Pre-check the raw arg so we can emit the helpful "do NOT send `rating`" hint
@@ -106,18 +108,25 @@ class ExecuteFeedbackToolSpec(val handler: () -> ExecuteFeedbackToolHandler) : M
             return ToolCallResult.errorResult("success_rating=$successRating is out of range (must be 0.00..1.00)")
         }
         val explanation = context[explanation]
-        if (explanation.isBlank()) {
+        if (explanation.isEffectivelyBlank()) {
             return ToolCallResult.errorResult("explanation is required (free-form: what worked, what didn't, what you'll try next)")
         }
         val executionId = context[executionId]
         val code = context[code]
+        // #460: a SUPPLIED blank snippet is a caller mistake, same verdict as the devrig CLI's blank
+        // --code/--code-file spellings — name it instead of storing whitespace; omit the field instead.
+        if (code != null && code.isEffectivelyBlank()) {
+            return ToolCallResult.errorResult("code was given blank — pass a non-empty snippet or omit the field")
+        }
 
         val params = FeedbackParams(
             taskId = taskId,
             executionId = executionId,
             successRating = successRating,
             explanation = explanation,
-            code = code,
+            // Same normalization execute_code applies: the stored snippet must byte-match the script
+            // the CLI's file spelling would deliver for the identical source.
+            code = code?.trimLeadingBoms(),
             executionBackend = context.executionBackendProvenance(),
         )
 

--- a/mcp-steroid-server/src/test/kotlin/com/jonnyzzz/mcpSteroid/server/ExecuteCodeToolBlankCodeTest.kt
+++ b/mcp-steroid-server/src/test/kotlin/com/jonnyzzz/mcpSteroid/server/ExecuteCodeToolBlankCodeTest.kt
@@ -1,0 +1,82 @@
+/* Copyright 2025-2026 Eugene Petrenko (mcp@jonnyzzz.com); Copyright 2025-2026 JetBrains. Use of this source code is governed by the Apache 2.0 license. */
+package com.jonnyzzz.mcpSteroid.server
+
+import com.jonnyzzz.mcpSteroid.mcp.ContentItem
+import com.jonnyzzz.mcpSteroid.mcp.ToolCallResult
+import com.jonnyzzz.mcpSteroid.mcp.successTextResult
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.fail
+
+/**
+ * #460 at the MCP boundary: a blank `code` used to reach the backend, burn the full pre-flight and
+ * compilation plus an execution_id, and end in the misleading no-output hint. The devrig CLI refuses
+ * blank `--code`/`--code-file`/stdin at parse/read time; this pins the guard that covers direct MCP
+ * callers, so no transport can ship an empty script.
+ */
+class ExecuteCodeToolBlankCodeTest {
+
+    private class RecordingHandler : ExecuteCodeToolHandler {
+        var received: ExecCodeParams? = null
+
+        override suspend fun executeCode(
+            projectName: String,
+            execCodeParams: ExecCodeParams,
+            callProgress: McpProgressReporter,
+        ): ToolCallResult {
+            received = execCodeParams
+            return ToolCallResult.successTextResult("Success")
+        }
+    }
+
+    private fun call(code: String): Pair<ToolCallResult, RecordingHandler> {
+        val handler = RecordingHandler()
+        val result = callToolSpecForTest(
+            ExecuteCodeToolSpec { handler },
+            buildJsonObject {
+                put("project_name", "proj")
+                put("code", code)
+                put("task_id", "t-1")
+                put("reason", "unit test")
+            },
+        )
+        return result to handler
+    }
+
+    @Test
+    fun `blank code is rejected with a focused error before the handler runs`() {
+        // "\uFEFF": a pasted "empty" Windows file is a BOM-only payload; isEffectivelyBlank knows it.
+        for (blank in listOf("", "   ", "\n\t", "\uFEFF", "\uFEFF \uFEFF")) {
+            val (result, handler) = call(blank)
+            assertTrue(result.isError, "blank code '${blank.replace("\n", "\\n")}' must be a tool error")
+            val text = result.content.filterIsInstance<ContentItem.Text>().joinToString("\n") { it.text }
+                .ifEmpty { fail("expected an error message") }
+            assertTrue("code" in text && "blank" in text, "names the parameter and the cause: $text")
+            assertFalse("Stacktrace" in text, "no internal stack trace in the tool error: $text")
+            assertNull(handler.received, "the handler (pre-flight + compile) must never run for blank code")
+        }
+    }
+
+    @Test
+    fun `non-blank code reaches the handler unchanged`() {
+        val (result, handler) = call("println(1)")
+        assertFalse(result.isError)
+        assertTrue(handler.received?.code == "println(1)")
+    }
+
+    @Test
+    fun `a leading BOM is stripped before the script ships`() {
+        // A pasted Windows file starts with U+FEFF; wrapped mid-file it would fail compilation with an
+        // invisible-character error. Same normalization the CLI's file/stdin decoder applies.
+        val (result, handler) = call("\uFEFF\uFEFFprintln(1)")
+        assertFalse(result.isError)
+        assertTrue(
+            handler.received?.code == "println(1)",
+            "the encoding artifact must not reach the compiler: '${handler.received?.code}'",
+        )
+    }
+}

--- a/mcp-steroid-server/src/test/kotlin/com/jonnyzzz/mcpSteroid/server/ExecuteFeedbackToolHandlerTest.kt
+++ b/mcp-steroid-server/src/test/kotlin/com/jonnyzzz/mcpSteroid/server/ExecuteFeedbackToolHandlerTest.kt
@@ -2,17 +2,12 @@
 package com.jonnyzzz.mcpSteroid.server
 
 import com.jonnyzzz.mcpSteroid.mcp.ContentItem
-import com.jonnyzzz.mcpSteroid.mcp.McpSession
-import com.jonnyzzz.mcpSteroid.mcp.ToolCallContext
-import com.jonnyzzz.mcpSteroid.mcp.ToolCallErrorException
-import com.jonnyzzz.mcpSteroid.mcp.ToolCallParams
 import com.jonnyzzz.mcpSteroid.mcp.ToolCallResult
 import com.jonnyzzz.mcpSteroid.mcp.successTextResult
-import com.jonnyzzz.mcpSteroid.server.McpProgressReporter
-import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
+import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -34,24 +29,54 @@ class ExecuteFeedbackToolHandlerTest {
                 }
             }
         }
-        val context = ToolCallContext(
-            params = ToolCallParams(name = spec.name, arguments = args),
-            session = McpSession(),
-            mcpProgressReporter = object : McpProgressReporter { override fun report(message: String) = Unit },
-        )
-        val result = runBlocking {
-            try {
-                spec.call(context)
-            } catch (e: ToolCallErrorException) {
-                e.toolCallResult
-            }
-        }
+        val result = callToolSpecForTest(spec, args)
 
         return if (result.isError) {
-            result.content.filterIsInstance<ContentItem.Text>().joinToString("\n") { it.text }
+            val text = result.content.filterIsInstance<ContentItem.Text>().joinToString("\n") { it.text }
+            // The registry converts a CRASH into isError text with a Stacktrace item; a validation error
+            // must never be one, so a crash fails every negative test here loudly instead of matching
+            // its substring assertions by accident.
+            assertFalse(text.contains("Stacktrace"), "validation must not crash: $text")
+            text
         } else {
             null
         }
+    }
+
+    @Test
+    fun `a supplied blank or BOM-only code snippet is rejected, matching the CLI verdict`() {
+        // #460: the devrig CLI refuses blank --code/--code-file spellings on this tool; the MCP
+        // boundary must give the same verdict for the same payload.
+        for (blank in listOf("", "   ", "\uFEFF")) {
+            val err = validate(
+                buildJsonObject {
+                    put("project_name", "proj")
+                    put("task_id", "t-1")
+                    put("success_rating", 0.75)
+                    put("explanation", "worked end-to-end")
+                    put("code", blank)
+                }
+            )
+            assertNotNull(err)
+            assertTrue(err!!.contains("blank"), "names the blank as the defect: $err")
+            assertTrue(err.contains("omit"), "offers omitting the optional field: $err")
+        }
+    }
+
+    @Test
+    fun `a BOM-only task_id is as missing as a whitespace one`() {
+        // #460: U+FEFF is not whitespace — isEffectivelyBlank is the one definition of blank, so the
+        // MCP verdict matches the CLI parse gate for the same payload.
+        val err = validate(
+            buildJsonObject {
+                put("project_name", "proj")
+                put("task_id", "\uFEFF")
+                put("success_rating", 0.75)
+                put("explanation", "worked end-to-end")
+            }
+        )
+        assertNotNull(err)
+        assertTrue(err!!.contains("task_id"), "mentions task_id: $err")
     }
 
     @Test

--- a/mcp-steroid-server/src/test/kotlin/com/jonnyzzz/mcpSteroid/server/ToolSpecSchemaAssertions.kt
+++ b/mcp-steroid-server/src/test/kotlin/com/jonnyzzz/mcpSteroid/server/ToolSpecSchemaAssertions.kt
@@ -3,6 +3,12 @@ package com.jonnyzzz.mcpSteroid.server
 
 import com.jonnyzzz.mcpSteroid.mcp.CliToolSpec
 import com.jonnyzzz.mcpSteroid.mcp.McpTool
+import com.jonnyzzz.mcpSteroid.mcp.McpSession
+import com.jonnyzzz.mcpSteroid.mcp.McpToolBase
+import com.jonnyzzz.mcpSteroid.mcp.McpToolRegistry
+import com.jonnyzzz.mcpSteroid.mcp.ToolCallParams
+import com.jonnyzzz.mcpSteroid.mcp.ToolCallResult
+import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonObject
@@ -198,6 +204,20 @@ private fun assertJsonStringEquals(
         ?: error("$label must be a JSON primitive; was ${obj[key]}")
     assertTrue(primitive.isString, "$label must be a string primitive")
     assertEquals(expected, primitive.content, label)
+}
+
+/**
+ * Drives one spec through a real [McpToolRegistry.callTool] dispatch, so a validation test asserts on
+ * the exact envelope an MCP client would see — including the registry's catch chain (a
+ * `ToolCallErrorException` unwraps to its result; a generic exception gains the `Stacktrace:` content
+ * item, so a no-stack-trace assertion is actually falsifiable here). Shared by the per-tool
+ * argument-validation tests (`ExecuteFeedbackToolHandlerTest`, `ExecuteCodeToolBlankCodeTest`, …)
+ * instead of each re-rolling the same scaffold.
+ */
+fun callToolSpecForTest(spec: McpToolBase, arguments: JsonObject): ToolCallResult = runBlocking {
+    val registry = McpToolRegistry()
+    registry.registerTool(spec)
+    registry.callTool(ToolCallParams(name = spec.name, arguments = arguments), McpSession())
 }
 
 /** Convenience for `*ToolSpec` constructor lambdas that must never be invoked. */

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/GeneratedToolRuntime.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/GeneratedToolRuntime.kt
@@ -9,6 +9,8 @@ import com.jonnyzzz.mcpSteroid.mcp.ContentItem
 import com.jonnyzzz.mcpSteroid.mcp.McpJson
 import com.jonnyzzz.mcpSteroid.mcp.ToolCallErrorException
 import com.jonnyzzz.mcpSteroid.mcp.ToolCallResult
+import com.jonnyzzz.mcpSteroid.mcp.isEffectivelyBlank
+import com.jonnyzzz.mcpSteroid.mcp.trimLeadingBoms
 import com.jonnyzzz.mcpSteroid.server.ListProjectsResponse
 import com.jonnyzzz.mcpSteroid.server.McpSteroidTools
 import com.jonnyzzz.mcpSteroid.server.NoOpProgressReporter
@@ -432,11 +434,14 @@ private fun readCliFileSource(
     }
     // Same contract as the stdin branch below: an empty value must fail here with a message that names
     // the cause, instead of being forwarded for the tool to answer with its own confusing complaint.
-    if (bytes.isEmpty()) throw CliInputException(
-        "'$paramName' was to be read from '$file', which is empty; put the value in the file or pass it directly",
+    val text = decodeCliSourceBytes(paramName, bytes)
+    // #460: empty, whitespace-only, or BOM-only content is one fault class — the same blank payload
+    // the parse layer refuses inline must not slip through the file spelling.
+    if (text.isEffectivelyBlank()) throw CliInputException(
+        "'$paramName' was to be read from '$file', which is blank; put the value in the file or pass it directly",
         CliExit.USAGE,
     )
-    return decodeCliSourceBytes(paramName, bytes)
+    return text
 }
 
 /**
@@ -473,7 +478,14 @@ private fun readCliStdin(paramName: String, stdin: InputStream, announce: Boolea
             "pipe the value or pass a file path instead",
         CliExit.USAGE,
     )
-    return decodeCliSourceBytes(paramName, bytes)
+    val text = decodeCliSourceBytes(paramName, bytes)
+    // #460: same rule as the file branch above — whitespace- or BOM-only stdin is a blank payload.
+    if (text.isEffectivelyBlank()) throw CliInputException(
+        "'$paramName' was to be read from standard input ('$CLI_STDIN_PATH' given) but the piped input " +
+            "is blank; pipe the value or pass a file path instead",
+        CliExit.USAGE,
+    )
+    return text
 }
 
 /**
@@ -495,7 +507,7 @@ private fun decodeCliSourceBytes(paramName: String, bytes: ByteArray): String {
             "'$paramName' exceeds the ${CLI_FILE_SOURCE_MAX_BYTES / (1024 * 1024)} MB limit", CliExit.DATA_ERROR,
         )
     }
-    return try {
+    val text = try {
         Charsets.UTF_8.newDecoder()
             .onMalformedInput(CodingErrorAction.REPORT)
             .onUnmappableCharacter(CodingErrorAction.REPORT)
@@ -504,4 +516,9 @@ private fun decodeCliSourceBytes(paramName: String, bytes: ByteArray): String {
     } catch (e: CharacterCodingException) {
         throw CliInputException("'$paramName' is not valid UTF-8 text: ${e.message}", CliExit.IO_ERROR)
     }
+    // A UTF-8 BOM is an encoding artifact (Notepad, PowerShell redirects), not content: strip every
+    // leading one (files re-saved through two BOM-adding tools stack them) so a BOM-only file registers
+    // as blank (#460 — U+FEFF is NOT whitespace, so isBlank alone misses it) and a BOM-prefixed script
+    // reaches the compiler clean.
+    return text.trimLeadingBoms()
 }

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/McpToolsCliHelp.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/McpToolsCliHelp.kt
@@ -114,8 +114,9 @@ private fun StringBuilder.appendUsageLine(prefix: String, tokens: List<String>) 
  * through.
  *
  * A required parameter that ALSO declares a file source is parenthesized rather than left bare, because its
- * two spellings are alternatives of which exactly one is mandatory: `SchemaCliBinding.parsed()` raises
- * `MissingCliValue` on `value == null && path == null && spec.required`. Such a parameter is `cliOptional`
+ * two spellings are alternatives of which exactly one is mandatory: the parse-time check
+ * `SchemaCliBinding` registers for file-source parameters raises `MissingCliValue` when `spec.required`
+ * and neither spelling supplied a non-blank token (#460). Such a parameter is `cliOptional`
  * by construction (`ToolSchema.register` enforces the pairing) purely so Clikt stops demanding the direct
  * flag — testing `cliRequired` here would wrongly bracket it as omissible, so `cliOptional` must not weaken
  * the rule above.

--- a/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/SchemaCliBinding.kt
+++ b/npx-kt/src/main/kotlin/com/jonnyzzz/mcpSteroid/devrig/SchemaCliBinding.kt
@@ -28,6 +28,7 @@ import com.jonnyzzz.mcpSteroid.mcp.CliExtraOption
 import com.jonnyzzz.mcpSteroid.mcp.CliOptionType
 import com.jonnyzzz.mcpSteroid.mcp.CliToolSpec
 import com.jonnyzzz.mcpSteroid.mcp.InputSchemaParamSpec
+import com.jonnyzzz.mcpSteroid.mcp.isEffectivelyBlank
 import kotlin.math.ceil
 import kotlin.math.floor
 import kotlinx.serialization.json.JsonArray
@@ -65,7 +66,9 @@ data class SchemaCliValues(
 )
 
 /**
- * A required parameter reached [SchemaCliBinding.parsed] with no value in any spelling the CLI accepts.
+ * A required parameter carried no usable value in any spelling the CLI accepts — raised by the
+ * parse-time checks [registerRequirednessChecks] registers, which run in Clikt's finalize pass (never
+ * by [SchemaCliBinding.parsed], which only copies already-validated values).
  * A distinct type rather than a plain [UsageError] so a command can tell "you left this out" — where the
  * parameter's own [InputSchemaParamSpec.cliMissingHint] is the better wording — apart from the exclusivity
  * failure ("you gave both"), which reports the same parameter name but must keep its own message.
@@ -313,12 +316,37 @@ private fun registerRequirednessChecks(
         command.registerCliParseCheck {
             val v = value()
             val path = filePath()
-            if (v != null && path != null) throw UsageError(
+            // #460: a blank spelling (--code=, --code-file=) is never a payload — it must neither ship
+            // an empty value to the backend nor defer the failure to the file-read stage. The generic
+            // blank rule for plain required parameters lives below under the `spec.cliRequired` gate —
+            // a change to what counts as blank must land in both.
+            // A blank PATH counts as not-given too: an empty-variable accident produces "" or spaces,
+            // never a real file name — the (Unix-only, pathological) file literally named ' ' loses to
+            // catching the accident at parse time; a conscious trade.
+            val valueEffective = v != null && !v.isBlankString()
+            val pathEffective = path != null && !path.isEffectivelyBlank()
+            // Nothing non-blank supplied on a required parameter — including the both-blank case, which
+            // must classify as missing (with the curated hint), not as an exclusivity conflict.
+            if (spec.required && !valueEffective && !pathEffective) throw MissingCliValue(
+                "'${spec.name}' is required: pass ${spec.cliParamName} or ${fileSource.flag}",
+                paramName = spec.cliParamName,
+            )
+            // Both spellings supplied and at least one carries a real value: silently preferring one
+            // would guess at intent. (Both-blank never reaches here: required both-blank is consumed
+            // above, optional both-blank falls through to the blank report below.)
+            if (v != null && path != null && (valueEffective || pathEffective)) throw UsageError(
                 "give either ${spec.cliParamName} or ${fileSource.flag} for '${spec.name}', not both",
                 paramName = spec.cliParamName,
             )
-            if (v == null && path == null && spec.required) throw MissingCliValue(
-                "'${spec.name}' is required: pass ${spec.cliParamName} or ${fileSource.flag}",
+            // A blank spelling that WAS supplied is a mistake to name (the content readers already
+            // reject blank files/stdin unconditionally): omit the flag, don't blank it. Only optional
+            // parameters actually reach this — every blank combination on a required one is consumed
+            // by the two checks above. This is deliberately narrower than the plain-optional rule
+            // ("a blank value for an optional string is left alone") — for a payload parameter every
+            // spelling must agree.
+            if (v.isBlankString() || (path != null && path.isEffectivelyBlank())) throw UsageError(
+                "'${spec.name}' was given blank: pass a non-empty ${spec.cliParamName} or " +
+                    "${fileSource.flag}, or omit it",
                 paramName = spec.cliParamName,
             )
         }
@@ -334,6 +362,9 @@ private fun registerRequirednessChecks(
     }
     if (spec.cliRequired) {
         command.registerCliParseCheck {
+            // The file-source branch above carries its own blank classification (a required file-source
+            // parameter is cliOptional by construction, so it never reaches this gate). What COUNTS as
+            // blank lives once in isEffectivelyBlank — only the classification spans the two gates.
             if (value().isBlankString()) throw MissingCliValue(
                 "'${spec.name}' must not be blank: pass a non-empty ${spec.cliParamName}",
                 paramName = spec.cliParamName,
@@ -561,8 +592,12 @@ val InputSchemaParamSpec.negativeCliFlag: String?
 /** An empty repetition means the flag never appeared, which must contribute no key at all. */
 private fun List<JsonPrimitive>.toJsonArrayOrNull(): JsonArray? = takeIf { it.isNotEmpty() }?.let { JsonArray(it) }
 
-/** A string value that is empty or whitespace only — supplied, yet carrying no usable value. */
-private fun JsonElement?.isBlankString(): Boolean = this is JsonPrimitive && isString && content.isBlank()
+/**
+ * A string value that is supplied yet carries no usable payload — empty, whitespace, or BOMs
+ * ([isEffectivelyBlank] is the one cross-transport definition of blank, #460).
+ */
+private fun JsonElement?.isBlankString(): Boolean =
+    this is JsonPrimitive && isString && content.isEffectivelyBlank()
 
 /** The only spelling of a boolean value the CLI accepts, for a boolean inside an array or a positional. */
 private val BOOLEAN_CHOICES = arrayOf("true" to true, "false" to false)

--- a/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/CliFileSourceRuntimeTest.kt
+++ b/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/CliFileSourceRuntimeTest.kt
@@ -36,6 +36,9 @@ class CliFileSourceRuntimeTest {
     @TempDir
     lateinit var work: Path
 
+    /** EF BB BF — the UTF-8 encoding of U+FEFF. */
+    private val utf8Bom = byteArrayOf(0xEF.toByte(), 0xBB.toByte(), 0xBF.toByte())
+
     /** Records the `code` the tool spec finally parsed, so a test can assert what the substitution produced. */
     private class RecordingExecuteCode : ExecuteCodeToolHandler {
         var seenCode: String? = null
@@ -147,9 +150,99 @@ class CliFileSourceRuntimeTest {
         assertEquals(CliExit.USAGE, run.exit, "stdout was:\n${run.stdout}")
         assertNull(seenCode, "the tool must not be called with an empty value read from an empty file")
         assertEquals(
-            "'code' was to be read from '$file', which is empty; put the value in the file or pass it directly",
+            "'code' was to be read from '$file', which is blank; put the value in the file or pass it directly",
             run.errorMessage(),
         )
+    }
+
+    @Test
+    fun `a whitespace-only file source fails as a usage error like the empty file`() {
+        // #460: a file holding only whitespace is the empty file in disguise — the blank payload the
+        // parse layer refuses inline (--code=) must not slip through the --code-file spelling.
+        val file = work.resolve("blank.kts")
+        Files.writeString(file, " \n\t\n")
+
+        val (run, seenCode) = runExecuteCode(file.toString())
+
+        assertEquals(CliExit.USAGE, run.exit, "stdout was:\n${run.stdout}")
+        assertNull(seenCode, "the tool must not be called with a blank value read from a whitespace-only file")
+        assertEquals(
+            "'code' was to be read from '$file', which is blank; put the value in the file or pass it directly",
+            run.errorMessage(),
+        )
+    }
+
+    @Test
+    fun `whitespace-only standard input fails as a usage error like empty stdin`() {
+        // #460: same rule through the stdin spelling — whitespace is not a script.
+        val (run, seenCode) = runExecuteCode("-", stdin = " \n\t\n".toByteArray())
+
+        assertEquals(CliExit.USAGE, run.exit, "stdout was:\n${run.stdout}")
+        assertNull(seenCode, "the tool must not be called with a blank value piped through stdin")
+        assertEquals(
+            "'code' was to be read from standard input ('-' given) but the piped input is blank; " +
+                "pipe the value or pass a file path instead",
+            run.errorMessage(),
+        )
+    }
+
+    @Test
+    fun `BOM-only standard input is blank, not content`() {
+        // #460 hardening: the same Windows encoding artifact through the stdin spelling.
+        val (run, seenCode) = runExecuteCode("-", stdin = byteArrayOf(0xEF.toByte(), 0xBB.toByte(), 0xBF.toByte()))
+
+        assertEquals(CliExit.USAGE, run.exit, "stdout was:\n${run.stdout}")
+        assertNull(seenCode, "BOM-only stdin must never ship as a script")
+        assertEquals(
+            "'code' was to be read from standard input ('-' given) but the piped input is blank; " +
+                "pipe the value or pass a file path instead",
+            run.errorMessage(),
+        )
+    }
+
+    @Test
+    fun `a double-BOM-only file is still blank`() {
+        // Files re-saved through two BOM-adding tools stack the marks; the strip is idempotent.
+        val file = work.resolve("double-bom.kts")
+        Files.write(file, utf8Bom + utf8Bom)
+
+        val (run, seenCode) = runExecuteCode(file.toString())
+
+        assertEquals(CliExit.USAGE, run.exit, "stdout was:\n${run.stdout}")
+        assertNull(seenCode, "a double-BOM-only file must never ship as a script")
+        assertEquals(
+            "'code' was to be read from '$file', which is blank; put the value in the file or pass it directly",
+            run.errorMessage(),
+        )
+    }
+
+    @Test
+    fun `a BOM-only file source is blank, not content`() {
+        // #460 hardening: U+FEFF is NOT whitespace, so isBlank alone misses it — a PowerShell
+        // redirect or Notepad save of an "empty" file writes exactly this. The shared decoder strips
+        // the BOM, so the payload registers as blank.
+        val file = work.resolve("bom-only.kts")
+        Files.write(file, utf8Bom)
+
+        val (run, seenCode) = runExecuteCode(file.toString())
+
+        assertEquals(CliExit.USAGE, run.exit, "stdout was:\n${run.stdout}")
+        assertNull(seenCode, "a BOM-only file must never ship as a script")
+        assertEquals(
+            "'code' was to be read from '$file', which is blank; put the value in the file or pass it directly",
+            run.errorMessage(),
+        )
+    }
+
+    @Test
+    fun `a BOM-prefixed script ships without the BOM`() {
+        val file = work.resolve("bom-code.kts")
+        Files.write(file, utf8Bom + "println(1)".toByteArray())
+
+        val (run, seenCode) = runExecuteCode(file.toString())
+
+        assertEquals(CliExit.OK, run.exit, "stdout was:\n${run.stdout}")
+        assertEquals("println(1)", seenCode, "the encoding artifact must not reach the compiler")
     }
 
     @Test

--- a/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/CliFileSourceUsageTokenTest.kt
+++ b/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/CliFileSourceUsageTokenTest.kt
@@ -17,7 +17,8 @@ import kotlin.test.assertTrue
  * [com.jonnyzzz.mcpSteroid.mcp.CliFileSource] — `execute_code`'s `code`. It is the case where the two
  * branches of the renderer test requiredness differently (`required && !cliOptional` without a file source,
  * plain `required` with one), and reading the renderer alone cannot tell you which is right. The parser
- * settles it: `SchemaCliBinding.parsed()` raises `MissingCliValue` on `required` alone, because a required
+ * settles it: the parse-time check `SchemaCliBinding` registers raises `MissingCliValue` when `required` and
+ * neither spelling supplied a non-blank token (#460), because a required
  * parameter offering a file source is `cliOptional` only so Clikt stops demanding the direct flag — not
  * because the value became optional.
  *

--- a/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/McpAsCliParseTest.kt
+++ b/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/McpAsCliParseTest.kt
@@ -39,6 +39,21 @@ class McpAsCliParseTest {
     }
 
     @Test
+    fun `execute_code rejects an explicit empty --code= at parse with the missing-code hint`() {
+        // #460: an empty (or blank) --code= used to count as provided and ship the empty script to the
+        // backend — a full compiler round-trip, a burned execution_id, and the misleading no-output
+        // hint — while every sibling required parameter treats an empty string as missing. Blank inline
+        // code must fail at parse time with the same curated missing-code hint as omitting it entirely.
+        for (blank in listOf("--code=", "--code=   ")) {
+            val error = parseError(
+                "execute_code", "--project_name=demo", blank, "--task_id=t", "--reason=r",
+            )
+            assertTrue("missing code" in error, "expected the curated missing-code hint for '$blank'; got:\n$error")
+            assertTrue("--code-file" in error, "the hint must offer the --code-file alternative; got:\n$error")
+        }
+    }
+
+    @Test
     fun `execute_feedback rejects NaN and Infinity success_rating at parse`() {
         for (badValue in listOf("NaN", "Infinity", "-Infinity")) {
             val error = parseError(

--- a/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/SchemaCliBindingTest.kt
+++ b/npx-kt/src/test/kotlin/com/jonnyzzz/mcpSteroid/devrig/SchemaCliBindingTest.kt
@@ -553,6 +553,112 @@ class SchemaCliBindingTest {
     // ------------------------------- file sources -------------------------------
 
     @Test
+    fun `a blank inline value on a required file-source parameter counts as missing`() {
+        // #460: --code= and --code='   ' used to count as provided and ship an empty script to the
+        // backend. Blank routes through the same missing-value outcome as omitting the pair entirely.
+        for (blank in listOf("--code=", "--code=   ")) {
+            val error = assertFailsWith<UsageError> {
+                ToolCommand(executeCode()).parse(
+                    listOf(blank, "--task_id=t1", "--reason=r", "--project_name=key"),
+                )
+            }
+            assertTrue(
+                "'code' is required" in error.message.orEmpty(),
+                "expected the missing-code classification for '$blank'; got: ${error.message}",
+            )
+        }
+    }
+
+    @Test
+    fun `a blank file-source path on a required parameter counts as missing at parse`() {
+        // #460 sibling: --code-file= (empty path) used to count as provided and fail only at the
+        // file-read stage with a degenerate IO error; it must fail at parse like blank --code=.
+        val error = assertFailsWith<UsageError> {
+            ToolCommand(executeCode()).parse(
+                listOf("--code-file=", "--task_id=t1", "--reason=r", "--project_name=key"),
+            )
+        }
+        assertTrue(
+            "'code' is required" in error.message.orEmpty(),
+            "expected the missing-code classification for a blank --code-file=; got: ${error.message}",
+        )
+    }
+
+    @Test
+    fun `both spellings blank on a required parameter classify as missing, not as a conflict`() {
+        // #460: a wrapper expanding two empty shell variables supplied nothing — steer the caller to
+        // the missing-code guidance (curated hint), not toward removing one of the flags.
+        val error = assertFailsWith<MissingCliValue> {
+            ToolCommand(executeCode()).parse(
+                listOf("--code=", "--code-file=", "--task_id=t1", "--reason=r", "--project_name=key"),
+            )
+        }
+        assertTrue("'code' is required" in error.message.orEmpty(), error.message.orEmpty())
+    }
+
+    @Test
+    fun `a BOM-only inline value counts as missing — U+FEFF is not a payload`() {
+        // #460 hardening: a pasted "empty" Windows file is a BOM, which isBlank() alone misses. The
+        // inline spelling never passes through the file decoder, so the blank predicate itself must
+        // know the BOM (isEffectivelyBlank — the one cross-transport definition).
+        val error = assertFailsWith<MissingCliValue> {
+            ToolCommand(executeCode()).parse(
+                listOf("--code=\uFEFF", "--task_id=t1", "--reason=r", "--project_name=key"),
+            )
+        }
+        assertTrue("'code' is required" in error.message.orEmpty(), error.message.orEmpty())
+    }
+
+    @Test
+    fun `both spellings blank on an OPTIONAL parameter report the blank error, not the conflict`() {
+        // The caller effectively supplied nothing twice — "give either, not both" would send them
+        // deleting a flag and failing again; name the blank as the defect in one step.
+        val error = assertFailsWith<UsageError> {
+            ToolCommand(executeFeedback()).parse(
+                listOf(
+                    "--code=", "--code-file=",
+                    "--project_name=key", "--task_id=t1", "--success_rating=0.9", "--explanation=worked",
+                ),
+            )
+        }
+        assertTrue(
+            "given blank" in error.message.orEmpty() && "omit it" in error.message.orEmpty(),
+            "expected the blank-spelling error, got: ${error.message}",
+        )
+    }
+
+    @Test
+    fun `a blank spelling on an OPTIONAL file-source parameter is a parse error, not a payload`() {
+        // #460 sibling on execute_feedback's optional code: the content readers already reject blank
+        // files/stdin unconditionally, so the inline and path spellings must agree — a blank flag is
+        // a mistake to surface, not an empty payload to ship or an IO error to defer to.
+        val requiredArgs = arrayOf(
+            "--project_name=key", "--task_id=t1", "--success_rating=0.9", "--explanation=worked",
+        )
+        for (blank in listOf("--code=   ", "--code-file=")) {
+            val error = assertFailsWith<UsageError> {
+                ToolCommand(executeFeedback()).parse(listOf(blank, *requiredArgs))
+            }
+            assertTrue(
+                "given blank" in error.message.orEmpty() && "omit it" in error.message.orEmpty(),
+                "expected the blank-spelling error for '$blank'; got: ${error.message}",
+            )
+        }
+    }
+
+    @Test
+    fun `a blank inline value alongside a file source still reports the exclusivity error`() {
+        // Blank --code= plus --code-file is a scripting mistake, not a preference for the file: keep
+        // the strict "not both" report rather than silently picking the file.
+        val error = assertFailsWith<UsageError> {
+            ToolCommand(executeCode()).parse(
+                listOf("--code=", "--code-file=repro.kts", "--task_id=t1", "--reason=r", "--project_name=key"),
+            )
+        }
+        assertTrue("not both" in error.message.orEmpty(), error.message.orEmpty())
+    }
+
+    @Test
     fun `a file source flag yields a deferred path and no tool argument`() {
         val values = bind(
             executeCode(),


### PR DESCRIPTION
Fixes #460.

`devrig execute_code` treated an explicit empty `--code=` as a provided value and shipped the empty script to the backend — a full compiler round-trip, a burned `execution_id`, and the misleading no-output hint — while every sibling required parameter treats an empty string as missing. Root cause: the generic blank-counts-as-missing parse gate is keyed on `cliRequired`, and a file-source parameter is `cliOptional` by construction (its requiredness is the `--code`/`--code-file` pair), so `code` was exempt.

## What changed

**One definition of blank, one normalization, in mcp-core:**
- `String.isEffectivelyBlank()` — whitespace AND U+FEFF byte-order marks (`isBlank()` alone misses the BOM; a PowerShell redirect or Notepad save of an "empty" file is exactly a BOM-only payload).
- `String.trimLeadingBoms()` — strips the leading encoding artifact (deliberately leading-only: an interior U+FEFF may be intentional string-literal content), so every spelling of the same source delivers identical bytes and a BOM-prefixed script reaches kotlinc clean.

**Every layer delegates to them:**
- *CLI parse*: a required file-source parameter with no non-blank spelling — `--code` omitted, `--code=`, `--code='  '`, a BOM-only inline value, `--code-file=` (blank path), or both spellings blank — fails at parse with the curated "missing code…" hint, exit 64, before any backend/file/`--out` side effect. Both-blank classifies as *missing* (curated hint), never as the misleading "give either, not both". A blank spelling on an OPTIONAL file-source parameter (`execute_feedback`'s code) is a focused "given blank … or omit it" parse error.
- *CLI readers*: whitespace-only and BOM-only files/stdin are refused; the shared UTF-8 decoder strips leading BOMs idempotently; the redundant empty-file branch is folded into the blank rule.
- *MCP boundary*: `steroid_execute_code` rejects effectively-blank code before the handler (no pre-flight, no compile) and BOM-strips what ships — one site that covers CLI-inline and direct MCP alike; `steroid_execute_feedback` gives the same verdicts (guards widened to `isEffectivelyBlank`, supplied-blank snippet refused, stored snippet BOM-stripped to byte-match the file spelling).

**Docs/tests**: `docs/devrig-cli-contract.md` file/stdin rule updated from non-empty to non-blank; three stale KDocs quoting the superseded `value == null && path == null` rule corrected; the shared `callToolSpecForTest` helper drives a real `McpToolRegistry` dispatch so no-stack-trace assertions are falsifiable; every error message is pinned character-for-character across parse, reader, and MCP layers (incl. BOM-only, double-BOM, and both-blank payloads).

## Deliberately deferred (TODO.md)

A declarative `.nonBlank()` builder on `InputSchemaElement<String>` — one schema-level rule per parameter for every tool and transport — would replace today's hand-wired guards and close the remaining MCP-side gaps (`task_id="  "`, `explanation=""`, `project_path=""`). It needs a new mcp-core builder plus CLI derivation, so it is a feature, not part of this fix.

## Verification

Five iterative /code-review rounds drove the hardening (whitespace file → blank path → BOM class → cross-transport parity → storage parity); the final round found no behavioral defects in the required path. `:npx-kt:test`, `:mcp-steroid-server:test`, `:mcp-core:test` all green; test-first throughout (each guard's test failed on the live bug before the fix).

Note: touches `ExecuteCodeToolSpec.call` like #485 (#469) does — whichever merges second has a trivial conflict in that method.